### PR TITLE
let disk donors start empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ test_shim: test_shim.c
 
 test: all
 	./selftest.sh
+	./donate_test.sh
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ rather than failing the build for everyone who only wants GLM.
 | `engine_patches/make_patches.py` | generates the engine patches from source anchors |
 | `lumabri_client.h` | phase 2 chatter side |
 | `selftest.sh` | byte identity: cold, warm, offline |
+| `donate_test.sh` | an empty disk donor pulls a slice and outlives the origin |
 | `phase2_test.sh`, `phase2_bench.sh` | phase 2 correctness and benchmark (olmoe) |
 | `phase2_glm_test.sh`, `phase2_inkling_test.sh`, `phase2_kimi_test.sh`, `phase2_deepseek_test.sh` | phase 2 byte identity, one per engine |
 | `phase3_test.sh` | proximity, readahead, failover — measured |

--- a/donate_test.sh
+++ b/donate_test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# A persistent disk donor starts with no model at all. The tracker assigns its
+# slice, the donor pulls it, and that copy must keep serving after the origin
+# disappears. This exercises the documented `lumabri serve --join --donate`
+# command rather than starting the maintainer directly.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s all
+
+T=$(mktemp -d /tmp/lumabri-donate.XXXXXX)
+PIDS=()
+cleanup() {
+    if [ "${#PIDS[@]}" -gt 0 ]; then
+        kill "${PIDS[@]}" 2>/dev/null || true
+        wait "${PIDS[@]}" 2>/dev/null || true
+    fi
+    rm -rf "$T"
+}
+trap cleanup EXIT
+
+wait_port() {
+    for _ in $(seq 1 100); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
+
+wait_placement() {
+    local addr=$1 model=$2 want_peer=$3
+    for _ in $(seq 1 100); do
+        if "$T/placement" "$addr" "$model" "$want_peer"; then return 0; fi
+        sleep 0.1
+    done
+    return 1
+}
+
+cat > "$T/placement.c" <<'EOF'
+#include "lumabri_proto.h"
+int main(int argc, char **argv) {
+    LmbBuf b = {0}; LmbMsg m = {0};
+    lmb_buf_str(&b, argv[2]);
+    if (lmb_request(argv[1], LMB_PLACEMENT, b.p, (uint32_t)b.len, &m) ||
+        m.op != LMB_PLACEMENT_R) return 1;
+    LmbCur c = { m.body, m.body_len, 0 }; uint32_t n = 0;
+    if (lmb_cur_u32(&c, &n)) return 1;
+    for (uint32_t i = 0; i < n; i++) {
+        char path[LMB_PATH_MAX], peer[64]; uint64_t size; uint16_t np;
+        if (lmb_cur_str(&c, path, sizeof path) || lmb_cur_u64(&c, &size) ||
+            lmb_cur_u16(&c, &np)) return 1;
+        for (uint16_t p = 0; p < np; p++) {
+            if (lmb_cur_str(&c, peer, sizeof peer)) return 1;
+            if (!strcmp(peer, argv[3])) return 0;
+        }
+    }
+    return 1;
+}
+EOF
+cc -O2 -w -I. "$T/placement.c" -o "$T/placement" -lpthread
+
+mkdir -p "$T/src/sub"
+head -c $((2 * 1024 * 1024 + 123)) /dev/urandom > "$T/src/weights.bin"
+head -c 4096 /dev/urandom > "$T/src/sub/tokenizer.bin"
+printf '{"model_type":"olmoe"}\n' > "$T/src/config.json"
+
+echo "· 1) an ordinary server still requires a model directory"
+mkdir "$T/not-a-model"
+set +e
+./lumabri serve --model "$T/not-a-model" --no-exec > "$T/invalid.out" 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 2 ] && grep -q "config.json" "$T/invalid.out" || {
+    echo "   serve accepted a directory that is not a model"; exit 1; }
+echo "   ✓ rejected before starting any child"
+
+for bad in 0 -1 nope nan inf 1e300; do
+    set +e
+    ./lumabri serve --model "$T/not-a-model" --join 127.0.0.1:1 \
+        --model-name fixture --donate "$bad" > "$T/bad-donate.out" 2>&1
+    RC=$?
+    set -e
+    [ "$RC" -eq 2 ] && grep -q "positive number" "$T/bad-donate.out" || {
+        echo "   serve accepted invalid donation: $bad"; exit 1; }
+done
+echo "   ✓ invalid donation sizes cannot bypass model validation"
+set +e
+./lumabri serve --model "$T/not-a-model" --join "" --model-name fixture \
+    --donate 1 > "$T/bad-join.out" 2>&1
+JOIN_RC=$?
+./lumabri serve --model "$T/not-a-model" --join 127.0.0.1:1 --model-name "" \
+    --donate 1 > "$T/bad-name.out" 2>&1
+NAME_RC=$?
+set -e
+[ "$JOIN_RC" -eq 2 ] && grep -q -- "--join TRACKER" "$T/bad-join.out" && \
+    [ "$NAME_RC" -eq 2 ] && grep -q -- "--join TRACKER" "$T/bad-name.out" || {
+    echo "   serve accepted an empty tracker or model name"; exit 1; }
+echo "   ✓ an empty tracker or model name is not a donor identity"
+
+echo "· 2) a disk donor may start from a directory that does not exist"
+./tracker --port 7570 > "$T/tracker.log" 2>&1 & PIDS+=($!)
+wait_port 7570
+./maintainer --root "$T/src" --port 7571 --tracker 127.0.0.1:7570 \
+    --name origin --model-name fixture > "$T/origin.log" 2>&1 & ORIGIN=$!; PIDS+=($!)
+wait_port 7571
+wait_placement 127.0.0.1:7570 fixture 127.0.0.1:7571
+./lumabri serve --model "$T/donor" --join 127.0.0.1:7570 \
+    --model-name fixture --donate 1 --port 7572 > "$T/donor.log" 2>&1 & DONOR=$!; PIDS+=($!)
+
+READY=0
+for _ in $(seq 1 200); do
+    [ -f "$T/donor/config.json" ] && [ -f "$T/donor/weights.bin" ] && \
+        [ -f "$T/donor/sub/tokenizer.bin" ] && { READY=1; break; }
+    kill -0 "$DONOR" 2>/dev/null || { cat "$T/donor.log"; exit 1; }
+    sleep 0.1
+done
+[ "$READY" -eq 1 ] || { echo "   donor did not pull its slice"; cat "$T/donor.log"; exit 1; }
+wait_port 7573
+wait_placement 127.0.0.1:7570 fixture 127.0.0.1:7573
+cmp "$T/src/weights.bin" "$T/donor/weights.bin"
+cmp "$T/src/sub/tokenizer.bin" "$T/donor/sub/tokenizer.bin"
+cmp "$T/src/config.json" "$T/donor/config.json"
+echo "   ✓ the tracker filled the empty slice byte-for-byte"
+
+echo "· 3) the donated copy serves after the origin disappears"
+kill "$ORIGIN" 2>/dev/null || true
+wait "$ORIGIN" 2>/dev/null || true
+PIDS=("${PIDS[0]}" "$DONOR")
+env LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/vroot" \
+    LUMABRI_CACHE="$T/cache" LUMABRI_TRACKER=127.0.0.1:7570 \
+    LUMABRI_MODEL=fixture \
+    LUMABRI_BLOCK_MIB=1 ./test_shim "$T/vroot" "$T/src"
+echo "   ✓ the donor alone serves an identical model"
+
+echo "LUMABRI DONATE TEST: PASS"

--- a/lumabri.c
+++ b/lumabri.c
@@ -25,8 +25,10 @@
  */
 #define _GNU_SOURCE
 #include <fcntl.h>
+#include <math.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdint.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
@@ -198,15 +200,36 @@ static int cmd_serve(int argc, char **argv) {
                                "[--no-exec] [--exec-cache N]\n"); return 2; }
     }
     if (!model) { fprintf(stderr, "usage: lumabri serve --model DIR [--port N]\n"); return 2; }
+    if (donate && (!join || !join[0] || !mname || !mname[0])) {
+        fprintf(stderr, "--donate needs --join TRACKER and --model-name NAME "
+                        "(whose model to help hold)\n");
+        return 2;
+    }
+    if (donate) {
+        char *end = NULL;
+        double gb = strtod(donate, &end);
+        if (end == donate || *end || !(gb > 0) || !isfinite(gb) ||
+            gb * 1e9 < 1 || gb > (double)UINT64_MAX / 1e9) {
+            fprintf(stderr, "--donate needs a positive number of GB\n");
+            return 2;
+        }
+    }
+    int disk_donor = donate != NULL;
+    struct stat st;
+    if (stat(model, &st) && disk_donor) mkdir_p(model);  /* a donor starts empty */
+    if (stat(model, &st) || !S_ISDIR(st.st_mode)) {
+        fprintf(stderr, "%s: not a directory\n", model); return 1;
+    }
     /* A directory without config.json is not a model, and letting it through
      * produces three disconnected symptoms for one cause: the maintainer
      * serves bytes happily, no expert node starts (the engine family is
      * unknown), and every chatter is told "nobody on the swarm has it"
-     * because the config it needs is not at the root. Refuse here instead. */
+     * because the config it needs is not at the root. A disk donor is the
+     * exception: its directory starts empty and the tracker fills the slice. */
     {
         char probe[1200];
         snprintf(probe, sizeof probe, "%s/config.json", model);
-        if (access(probe, R_OK)) {
+        if (!disk_donor && access(probe, R_OK)) {
             fprintf(stderr, "%s%s non contiene config.json — non e' una "
                             "directory di modello%s\n"
                             "  (se il modello e' in una sottocartella, punta "
@@ -214,16 +237,6 @@ static int cmd_serve(int argc, char **argv) {
                     C_RED, model, C_R, model);
             return 2;
         }
-    }
-    if (donate && (!join || !mname)) {
-        fprintf(stderr, "--donate needs --join TRACKER and --model-name NAME "
-                        "(whose model to help hold)\n");
-        return 2;
-    }
-    struct stat st;
-    if (stat(model, &st)) mkdir_p(model);        /* a donor starts empty */
-    if (stat(model, &st) || !S_ISDIR(st.st_mode)) {
-        fprintf(stderr, "%s: not a directory\n", model); return 1;
     }
 
     char dir[1024], tracker_bin[1200], maint_bin[1200], portstr[16], mport[16], taddr[64];
@@ -290,16 +303,16 @@ static int cmd_serve(int argc, char **argv) {
     local_model_type(model, mtype, sizeof mtype);
     /* one node binary per engine family — they do not share an expert shape */
     const char *node = expert_node_for(mtype);
-    snprintf(exec_bin, sizeof exec_bin, "%s/%s", dir, node);
+    if (node) snprintf(exec_bin, sizeof exec_bin, "%s/%s", dir, node);
     int with_exec = 0;
-    if (!no_exec && !node && mtype[0])
+    if (!no_exec && !disk_donor && !node && mtype[0])
         printf("  %sfase 2 non disponibile per il motore %s: questo server "
                "serve i byte, gli esperti li esegue il chatter%s\n",
                C_DIM, mtype, C_R);
-    if (!no_exec && node && access(exec_bin, X_OK))
+    if (!no_exec && !disk_donor && node && access(exec_bin, X_OK))
         printf("  %s%s non è compilato: nessun esperto eseguito qui "
                "(make %s ENGINE=/path/to/colibri/c)%s\n", C_DIM, node, node, C_R);
-    if (!no_exec && node && access(exec_bin, X_OK) == 0) {
+    if (!no_exec && !disk_donor && node && access(exec_bin, X_OK) == 0) {
         char eport[16], cachestr[16], ename[32];
         snprintf(eport, sizeof eport, "%d", port + 2);
         snprintf(cachestr, sizeof cachestr, "%d", cache_slots);


### PR DESCRIPTION
## What

Restore the documented persistent disk-donor flow:

```sh
lumabri serve --model ./slice --join TRACKER:7300 \
  --model-name MODEL --donate 5
```

A donor may now create an empty directory and let the tracker fill its slice. Ordinary `serve` still requires `config.json`, invalid donation sizes and empty tracker/model identities are rejected, and a disk-only donor does not try to launch an expert executor before it has a model.

## Test

Add `donate_test.sh` to `make test`. It proves that:

- a normal server still rejects a directory without `config.json`;
- invalid donor arguments cannot bypass that validation;
- the public `lumabri serve --join --donate` command pulls an assigned slice byte-for-byte;
- after the origin stops, a fresh chatter discovers and reads the donated copy through the tracker.

Verified on Linux/aarch64 with:

```sh
make clean
make test
```