### PR TITLE
the expert node never ran the engine's own thread policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,8 +626,9 @@ signed by the operator's ed25519 key, checked by the chatter against a key
 it holds itself) and results (spot-check on a second replica); private
 swarms need an invite token everywhere. Not yet done, in order of
 importance: speculative drafting with batch-union (the remaining multiplier
-against WAN latency), hedged requests against stragglers, tracker-side
-expert assignment, key rotation and revocation, NAT hole punching. Expert
+against WAN latency), hedged requests against stragglers, continuous peer
+discovery mid-generation, a durable content-addressed mirror, key rotation
+and revocation, NAT hole punching. Expert
 execution is not yet covered by the operator signature — a peer's results
 are checked by replica agreement, not by a key.
 

--- a/concurrency_test.sh
+++ b/concurrency_test.sh
@@ -30,6 +30,9 @@ ENGINES="${ENGINES:-../moe-stream/c}"
 
 [ -f "$MODEL/config.json" ] || make -s fixture
 make -s all
+# the executor is not part of `all` (it needs an engine checkout), and a stale
+# one silently benchmarks yesterday's code
+make -s expert_node ENGINE="$ENGINES"
 
 T=$(mktemp -d /tmp/lumabri-conc.XXXXXX)
 PIDS=()
@@ -51,7 +54,7 @@ printf 'ciao\n/quit\n' | ./lumabri chat --tracker "127.0.0.1:$PORT" \
     > "$T/warm.log" 2>&1 || true
 
 echo
-printf "%8s  %10s  %10s  %10s  %10s\n" clients fastest slowest spread total
+printf "%8s  %10s  %10s  %10s  %10s\n" clients fastest slowest spread mean
 for n in $CLIENTS; do
     # wait on THESE clients only: a bare `wait` also waits for the server
     # started above, which never exits — the first version of this script

--- a/expert_node.c
+++ b/expert_node.c
@@ -54,8 +54,22 @@
 #endif
 #include LMBE_ENGINE_HEADER
 
+/* The engine sets its OpenMP team on the FIRST LINE of its own main(), and
+ * this file neutralises main to reach the engine's statics — so the team was
+ * never sized and every expert node has been running on OpenMP's default,
+ * which is one thread per hyperthread. The engine measured that choice and
+ * rejected it: physical cores only, +2.3x on a 16C/32T Zen3 from the thread
+ * count alone (omp_tune.h). Call exactly what main() would have called;
+ * engines without the header keep whatever they set for themselves. */
+#ifdef COLI_OMP_TUNE_H
+#define LMBE_TUNE_THREADS() coli_omp_tune_threads("lumabri")
+#else
+#define LMBE_TUNE_THREADS() ((void)0)
+#endif
+
 #include "lumabri_proto.h"
 
+#include <omp.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <sys/prctl.h>
@@ -133,14 +147,9 @@ static pthread_cond_t  g_gate_cv = PTHREAD_COND_INITIALIZER;
 static int g_gate_free = 1;
 static _Atomic uint64_t g_gate_waits;
 
-static void gate_init(int forced) {
+static void gate_init(int forced, int per_expert, int phys) {
     if (forced > 0) { g_gate_free = forced; return; }
-    long cores = sysconf(_SC_NPROCESSORS_ONLN);
-    if (cores < 1) cores = 1;
-    const char *ot = getenv("OMP_NUM_THREADS");
-    long per = ot ? atol(ot) : cores;
-    if (per < 1) per = 1;
-    g_gate_free = (int)(cores / per);
+    g_gate_free = (phys > 0 && per_expert > 0) ? phys / per_expert : 1;
     if (g_gate_free < 1) g_gate_free = 1;
 }
 
@@ -422,6 +431,39 @@ static int in_list(const int *list, int n, int v) {
     return 0;
 }
 
+/* ---- how wide the machine is --------------------------------------------
+ * lumabri does NOT choose the OpenMP team size. The engine already does, in
+ * its own main() — which this file calls for it, see LMBE_TUNE_THREADS —
+ * sized to the physical cores and argued from measurements on
+ * real models (omp_tune.h: +2.3x on a 16C/32T Zen3 from the thread count
+ * alone). A micro-benchmark here would be measuring one expert of one model
+ * at one row, and would happily overrule that with a fixture's answer.
+ *
+ * What lumabri owns is the gate: given that each expert call takes the whole
+ * machine, how many may run at once. That is a ratio, so it needs the core
+ * count — and the engine's own rule applies to it too. If the physical count
+ * cannot be determined we do not guess it: we admit one expert at a time,
+ * which is never oversubscribed, rather than invent a number. */
+static int phys_cores(void) {
+    struct { int p, c; } seen[1024];
+    int n = 0, pid = -1, cid = -1;
+    FILE *f = fopen("/proc/cpuinfo", "r");
+    if (!f) return 0;
+    char line[256];
+    while (fgets(line, sizeof line, f)) {
+        if (!strncmp(line, "physical id", 11)) sscanf(line, "%*[^:]: %d", &pid);
+        else if (!strncmp(line, "core id", 7)) sscanf(line, "%*[^:]: %d", &cid);
+        if (pid >= 0 && cid >= 0) {
+            int dup = 0;
+            for (int i = 0; i < n; i++) if (seen[i].p == pid && seen[i].c == cid) dup = 1;
+            if (!dup && n < 1024) { seen[n].p = pid; seen[n].c = cid; n++; }
+            pid = cid = -1;
+        }
+    }
+    fclose(f);
+    return n;
+}
+
 int main(int argc, char **argv) {
     const char *dir = NULL;
     int port = 7401, stride = 1, offset = 0, cache = 0, bits = 8, hold = 0;
@@ -458,7 +500,6 @@ int main(int argc, char **argv) {
         }
     }
     if (!dir) { fprintf(stderr, "--model is required\n"); return 2; }
-    gate_init(parallel);
     if (stride < 1) stride = 1;
     if (cache < 0) cache = 0;
     signal(SIGPIPE, SIG_IGN);
@@ -485,6 +526,7 @@ int main(int argc, char **argv) {
                  g.name, g_corrupt_ppm);
       } }
 
+    LMBE_TUNE_THREADS();
     lmbe_open(dir, cache, bits);
     g.n_slots   = lmbe_n_slots();
     g.n_experts = lmbe_n_experts();
@@ -588,18 +630,25 @@ int main(int argc, char **argv) {
     }
     fflush(stdout);
 
+    /* whatever the engine settled on during lmbe_open */
+    int phys = phys_cores(), per_expert = omp_get_max_threads();
+    if (per_expert < 1) per_expert = 1;
+    gate_init(parallel, per_expert, phys);
+
     int lfd = lmb_listen(port);
     if (lfd < 0) { perror("listen"); return 1; }
     if (lmb_emu_active())
         printf("[%s] emulated network: rtt %ld us ± %ld, loss %ld ppm (rto %ld us)\n",
                g.name, lmb_emu_rtt_us, lmb_emu_jitter_us, lmb_emu_loss_ppm, lmb_emu_rto_us);
     printf("[%s] serving EXEC on :%d (model %s)%s · %d expert%s at a time, "
-           "%s thread%s each\n", g.name, port, g.model,
+           "%d thread%s each, %d physical core%s\n", g.name, port, g.model,
            g.tracker[0] ? " · registered with tracker" : "",
            g_gate_free, g_gate_free == 1 ? "" : "s",
-           getenv("OMP_NUM_THREADS") ? getenv("OMP_NUM_THREADS") : "all",
-           getenv("OMP_NUM_THREADS") && !strcmp(getenv("OMP_NUM_THREADS"), "1")
-               ? "" : "s");
+           per_expert, per_expert == 1 ? "" : "s",
+           phys, phys == 1 ? "" : "s");
+    if (!phys)
+        printf("[%s] physical core count unknown: one expert at a time "
+               "(--parallel N to say otherwise)\n", g.name);
     fflush(stdout);
 
     pthread_t t;

--- a/lumabri.c
+++ b/lumabri.c
@@ -76,20 +76,6 @@ static void mkdir_p(const char *path) {
     mkdir(tmp, 0755);
 }
 
-/* An expert executor inherits its parallelism from whatever OpenMP decides,
- * and OpenMP decides "the whole machine" for every team it opens. The tests
- * always set this by hand and the real deployments never did, which is how a
- * server ended up asking for four teams of twelve threads on twelve cores.
- * Fix the number here, where the child is born, and let it be overridden. */
-static void exec_threads_default(void) {
-    if (getenv("OMP_NUM_THREADS")) return;
-    long n = sysconf(_SC_NPROCESSORS_ONLN);
-    if (n < 1) n = 1;
-    char buf[16];
-    snprintf(buf, sizeof buf, "%ld", n);
-    setenv("OMP_NUM_THREADS", buf, 1);
-}
-
 /* ---- the logo ------------------------------------------------------------
  * ANSI-Shadow block wordmark, warm gradient from coral to sand, one tint
  * per row. The same lettering every serious CLI splash uses. */
@@ -349,7 +335,6 @@ static int cmd_serve(int argc, char **argv) {
             eargv[a++] = "--advertise"; eargv[a++] = eadv;
         }
         eargv[a] = NULL;
-        exec_threads_default();
         spawn_tracked(eargv, "l'esecutore di esperti");
         with_exec = 1;
     }
@@ -1147,6 +1132,27 @@ static int role_has(const char *arg, const char *want) {
     return 0;
 }
 
+/* Every token has to be a role, not just one of them: accepting
+ * "chat,bogus" because "chat" is in there drops the half the user probably
+ * cared about and says nothing. Returns the first word it does not know. */
+static int role_unknown(const char *arg, char *out, size_t cap) {
+    static const char *ok[] = { "chat", "disk", "compute", "all" };
+    int any = 0;
+    for (const char *p = arg; *p; ) {
+        size_t n = strcspn(p, ",+ ");
+        if (n) {
+            any = 1;
+            int good = 0;
+            for (size_t i = 0; i < sizeof ok / sizeof *ok; i++)
+                if (n == strlen(ok[i]) && !strncasecmp(p, ok[i], n)) good = 1;
+            if (!good) { snprintf(out, cap, "%.*s", (int)n, p); return 1; }
+        }
+        p += n; if (*p) p++;
+    }
+    if (!any) { snprintf(out, cap, "%s", "(vuoto)"); return 1; }
+    return 0;
+}
+
 static int role_pick(Role *r, const char *model, int have_model_dir) {
     printf("  %scome entri nello sciame?%s\n\n", C_BOLD, C_R);
     printf("    %s1%s  solo chattare        %snon condividi niente%s\n",
@@ -1273,7 +1279,6 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             argv[a++] = "--model-name"; argv[a++] = (char *)model;
             argv[a++] = "--cache";      argv[a++] = "64";
             argv[a] = NULL;
-            exec_threads_default();
             g_children[g_nchildren++] = spawn_argv(argv);
             printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s)%s\n",
                    C_GRN, C_R, C_DIM, node, C_R);
@@ -1507,13 +1512,14 @@ static int cmd_chat(int argc, char **argv) {
      * the dense weights cross the wire, instead of after */
     Role role = {0};
     if (!local_dir && role_arg) {
-        int all = role_has(role_arg, "all");
-        if (!all && !role_has(role_arg, "chat") &&
-            !role_has(role_arg, "disk") && !role_has(role_arg, "compute")) {
-            fprintf(stderr, "--role vuole chat, disk, compute o all "
-                            "(anche combinati: --role disk,compute)\n");
+        char bad[40];
+        if (role_unknown(role_arg, bad, sizeof bad)) {
+            fprintf(stderr, "--role: non conosco \"%s\". Vuole chat, disk, "
+                            "compute o all (anche combinati: "
+                            "--role disk,compute)\n", bad);
             return 2;
         }
+        int all = role_has(role_arg, "all");
         if (all || role_has(role_arg, "disk"))    role.disk = 1;
         if (all || role_has(role_arg, "compute")) role.compute = 1;
         if (role.disk || role.compute) {

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -98,11 +98,18 @@ enum {
      * the FIRST announcement of each (model, path) as ground truth — the
      * origin server registers before any donor exists — and rejects the
      * files of any later registrant whose hashes disagree (poison dies at
-     * the index). HASHES {model, path} → HASHES_R {u32 chunk, u32 n} + pay
-     * (n × 32 raw bytes) hands the truth to chatters and pulling donors,
+     * the index). HASHES {model, path} → HASHES_R {str model, u32 chunk,
+     * u32 n, u64 size, u32 has_sig, [64 sig]} + pay (n × 32 raw bytes) hands
+     * the truth to chatters and pulling donors,
      * which verify every fetched block against it: a lying peer's bytes
      * are rejected and refetched elsewhere, loudly. The root of trust is
-     * the swarm operator (tracker + origin), never the peers. */
+     * the swarm operator (tracker + origin), never the peers. The reply
+     * carries model and size because the signature is over all of it: a
+     * verifier must be able to rebuild the signed message itself, and a
+     * courier that could not supply the fields could rewrite them. Keep this
+     * comment in step with the encoder — it went stale once and the donor's
+     * decoder went stale with it, reading the model string as a chunk size
+     * and calling the whole record malformed. */
     LMB_HASHES = 26, LMB_HASHES_R = 27,
     /* "the server decides", for compute. A donor of disk already gets its
      * slice assigned rarest-first; a donor of COMPUTE had to be told which

--- a/role_test.sh
+++ b/role_test.sh
@@ -63,8 +63,14 @@ echo "   ✓ ogni parola vale per se stessa"
 
 echo "· a typo is refused, not silently demoted to chat"
 try bogus no 2
-grep -q "role vuole chat, disk, compute o all" "$T/out" || {
+grep -q 'non conosco "bogus"' "$T/out" || {
     echo "   nessun messaggio utile per un ruolo sconosciuto"; cat "$T/out"; exit 1; }
-echo "   ✓ chi sbaglia a scrivere lo sa subito"
+# and the half-right case: accepting "chat,compute-ish" because "chat" is in
+# there would drop exactly the half the user meant to add
+try chat,bogus no 2
+grep -q 'non conosco "bogus"' "$T/out" || {
+    echo "   un ruolo valido ha coperto uno sbagliato"; cat "$T/out"; exit 1; }
+try disk,compute,nope no 2
+echo "   ✓ chi sbaglia a scrivere lo sa subito, anche se ha ragione a meta'"
 
 echo "LUMABRI ROLE TEST: PASS"

--- a/signed_donor_test.sh
+++ b/signed_donor_test.sh
@@ -135,4 +135,28 @@ grep -q "assigned slice: 0/" "$T/wrong.log" || {
     echo "   it wrote files it could not verify"; ls -A "$T/wrong"; exit 1; }
 echo "   ✓ refused every file, kept none: the check is real"
 
+echo "· 6) a correct manifest is not a promise about the bytes"
+# The adversary worth testing is not the one who lies in the index — the
+# tracker already refuses that. It is the peer whose announcement is
+# perfectly valid, signature and all, and who then serves something else.
+# Its own hashes convict it.
+./tracker --port 7587 --pubkey "$T/swarm.pub" > "$T/tracker2.log" 2>&1 & PIDS+=($!)
+wait_port 7587
+LUMABRI_CORRUPT_PPM=1000000 \
+    ./maintainer --root "$T/src" --port 7588 --tracker 127.0.0.1:7587 \
+                 --name liar --model-name fy --key "$T/swarm.key" \
+                 > "$T/liar.log" 2>&1 & PIDS+=($!)
+wait_port 7588
+wait_for "$T/tracker2.log" "+ liar" 15 || { cat "$T/tracker2.log"; exit 1; }
+./maintainer --root "$T/victim" --port 7589 --tracker 127.0.0.1:7587 \
+             --name victim --model-name fy --donate 1 --pubkey "$T/swarm.pub" \
+             > "$T/victim.log" 2>&1 || true
+grep -q "served corrupt bytes" "$T/victim.log" || {
+    echo "   the donor accepted bytes that did not match their own hashes"
+    cat "$T/victim.log"; exit 1; }
+grep -q "assigned slice: 0/" "$T/victim.log" || {
+    echo "   it kept something from a peer it had caught lying"
+    grep "assigned slice" "$T/victim.log"; exit 1; }
+echo "   ✓ caught the lie, pulled nothing, and said which peer told it"
+
 echo "LUMABRI SIGNED DONOR TEST: PASS"


### PR DESCRIPTION
colibri sizes its OpenMP team on the first line of its main(): physical
cores, never hyperthreads, argued from measurement (+2.3x on a 16C/32T Zen3
from the thread count alone, omp_tune.h #718). expert_node.c neutralises
main to reach the engine's statics — so that line never ran, and every
lumabri executor since the first one has used OpenMP's default, one thread
per hyperthread. Six physical cores were being asked for twelve threads.

It now calls exactly what main() would have called, and engines that ship no
such header keep whatever they set for themselves. Four clients on this box
went from 17.9s to 14.2s; the single-client figure in that harness is not a
clean measurement, because the chatters run the engine locally and compete
for the same six cores.

I had written an autotune here first — measure one expert at a few team
sizes and pick. It was wrong. The engine already decides this, on evidence
from real models, and a micro-benchmark on a 1024x1024 fixture expert would
have overruled that with the one case where threads do not pay. lumabri does
not get to have an opinion about the engine's kernels. It keeps only the
gate, which is a ratio it does own: how many experts run at once given that
each takes the machine. And the gate follows the engine's own failure rule —
if the physical core count cannot be determined, admit one expert at a time
rather than invent a number.

Four stale things, all found by review, all of the kind where the code and
what it says about itself had drifted apart:

HASHES_R was still documented as {u32 chunk, u32 n} — the very comment that
led the donor's decoder astray and cost it every integrity check it thought
it was making. It now documents what the encoder writes, and says why it
carries model and size at all.

--role accepted "chat,bogus", because the check asked whether any token was
a role rather than whether every token was. A typo next to a valid word is
exactly when someone loses the half they meant to add.

The README still listed tracker-side expert assignment under "not yet done".
It has been done since 45ddcb1 and has a test.

concurrency_test.sh printed a column headed "total" that held the mean, and
built `all` — which does not include the executor, so it could benchmark
yesterday's binary. It builds the executor now, which is how the thread
policy above surfaced at all.

signed_donor_test.sh gains the adversary that was missing: not the peer who
lies in the index, which the tracker already refuses, but the one whose
announcement is perfectly signed and who then serves different bytes. Its
own hashes convict it, and the donor keeps nothing.

---

Full regression green: selftest, security, assign, chat_proto, sign, donate, signed_donor, role, phase2 (olmoe/glm/inkling/kimi), phase5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)