### PR TITLE
protocol v2: signed checkpoint identity, crash-safe mirror, hardened accept path

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,9 +50,12 @@ Costo a caldo: un lookup `fdmap[fd]` + un test di bitmap per blocco toccato.
 ## Protocollo (lumabri_proto.h)
 
 Frame: `{u32 magic "LMB1", u32 op, u32 body_len, u32 pay_len}` + body + pay,
-little-endian, stringhe con prefisso u16. Cap: body 16 MiB, pay 64 MiB —
-ogni allocazione è limitata prima di leggere. Op sconosciuta → `ERR`
-esplicito (mai indovinare).
+little-endian, stringhe con prefisso u16. Il pay bulk ha cap 64 MiB;
+REGISTER può portare fino a 64 MiB di hash, i controlli normali 4 MiB e i
+messaggi piccoli 64 KiB. Forma e limiti sono verificati dai soli 16 byte di
+header, prima di allocare o attendere il body. Timeout I/O e numero massimo
+di connessioni sono configurabili e hanno limiti di default. Op sconosciuta
+→ `ERR` esplicito (mai indovinare).
 
 | op | flusso | uso |
 |---|---|---|
@@ -69,8 +72,18 @@ silenzioso da >30 s → escluso dai placement.
 ## Lato chatter (lumishim.c)
 
 - **Mirror**: `cache/data/<rel>` sparse + `cache/maps/<rel>.lmap` (1 byte
-  per blocco, persistita con `pwrite` dopo il blocco: prima i dati, poi il
-  bit — un crash rifetcha, mai zeri spacciati per dati).
+  per blocco). I nuovi bit sono visibili subito al processo ma persistiti in
+  batch: prima `fdatasync` dei dati, poi bitmap e relativo `fdatasync`. Si
+  evita una sync per MiB; un crash rifetcha, mai zeri spacciati per dati.
+- **Identità checkpoint**: la root canonica del modello completo lega
+  inventario, path, size e vettori sha256. Le bitmap sono legate a quella
+  root; un file sostituito con la stessa size invalida il mirror caldo.
+- **Concorrenza tra processi**: più chatter sullo stesso checkpoint tengono
+  un lock condiviso per tutta la vita; cambio identità o riparazione del
+  layout prendono il lock esclusivo. Un secondo lock elegge un solo resetter,
+  e i commit delle bitmap fanno OR con i bit già pubblicati dagli altri
+  processi. Dati e directory vengono sincronizzati prima dei bit e della
+  nuova identità, quindi anche il primo avvio simultaneo resta crash-safe.
 - **Blocchi**: default 8 MiB (`LUMABRI_BLOCK_MIB`). Fetch con dedup
   in-flight (mutex+condvar per file): N thread del motore che toccano lo
   stesso blocco = un solo fetch.
@@ -92,11 +105,13 @@ silenzioso da >30 s → escluso dai placement.
 3. A mirror caldo, il costo per lettura ≈ costo locale (page cache inclusa).
 4. Selftest: cold = warm = offline, byte-identici (test_shim).
 
-## Limiti noti (MVP)
+## Limiti noti
 
-- Nessuna verifica hash dei blocchi → solo peer fidati/localhost per ora.
-  Primo requisito per la rete aperta: manifest firmato con sha256 per blocco.
-- Niente NAT traversal (serve rendezvous UDP/QUIC per peer domestici).
+- Il relay rende raggiungibili i maintainer dietro NAT, ma l'esecuzione
+  esperti non ha ancora hole punching o relay EXEC.
+- Mancano rotazione e revoca delle chiavi dell'operatore.
+- Il mirror è crash-consistent e legato al checkpoint, ma non è ancora un
+  content-addressed store condiviso tra checkpoint.
 - `dup()`/`fork()+exec` sull'fd del modello non tracciati (i motori non li
   usano sugli shard; LD_PRELOAD sopravvive comunque all'exec).
 - fd ≥ 65536 su file del modello → EMFILE (limite tabella).
@@ -169,9 +184,10 @@ delega man mano che i donatori arrivano, e resta l'ultima istanza.**
   con refcount (mai evizione sotto una matmul in corso), loader del motore
   serializzato da un mutex, un miss = una lettura NVMe. Identità provata con
   cache 8 su 128 esperti — 80% di cold load, zero byte cambiati.
-- **Scoperta dal tracker** (EREG/EPEERS): gli expert node fanno heartbeat
-  come i maintainer; il client chiede EPEERS{model} quando LUMABRI_EXPERTS
-  non è impostata. Zero configurazione lato chatter.
+- **Scoperta continua dal tracker** (EREG/EPEERS): gli expert node fanno
+  heartbeat come i maintainer; il client chiede EPEERS{model} all'avvio e
+  periodicamente durante la generazione quando LUMABRI_EXPERTS non è
+  impostata. Un donatore tardivo entra senza riavviare il chatter.
 - **La scala di degrado**, ogni gradino rumoroso, nessuno può cambiare un
   byte: replica più vicina → altra replica → ri-query del tracker (un
   donatore può essere arrivato *dopo* l'avvio) → e se all'avvio lo sciame
@@ -184,11 +200,9 @@ generazione → failover al server, token identici al riferimento locale.
 `make install` porta tutto in PREFIX/bin + PREFIX/lib/lumabri; i binari si
 trovano l'un l'altro via /proc/self/exe.
 
-Aperto, in ordine: hash per blocco (fase 1) e verifica a campione dei
-risultati (fase 2) prima dei peer sconosciuti; batch-union speculativo lato
-motore; assegnazione degli esperti dal tracker (oggi il donatore sceglie
-con --stride/--layers; dovrebbe decidere il server, rarest-first come per i
-byte); relay EXEC per esecutori dietro NAT.
+Aperto, in ordine: batch-union speculativo lato motore, richieste hedged
+contro gli straggler, rotazione/revoca delle chiavi, store content-addressed
+condiviso e relay o hole punching EXEC per esecutori dietro NAT.
 
 ## Fase 5 — sciame aperto e sciame a inviti (2026-08-05)
 
@@ -198,9 +212,12 @@ Due modelli di fiducia, entrambi completi.
 nell'operatore dello sciame, mai nel peer che serve i byte:
 
 - sha256 per MiB (`LMB_HASH_CHUNK`) calcolato dal maintainer, in cache in
-  `.lumabri_hashes/<rel>.sha` (invalidata dal cambio di size): solo il primo
+  `.lumabri_hashes/<rel>.sha` (invalidata da size, mtime o ctime): solo il primo
   avvio paga. Spedito dentro REGISTER come sezione opzionale (magic "SHAH",
   i peer vecchi semplicemente non la mandano).
+- L'origine calcola una root canonica dell'intero modello e la firma con
+  Ed25519. Tracker, mirror ed expert manifest usano la stessa identità, così
+  checkpoint o profili di build diversi non possono essere mescolati.
 - Il tracker tiene la **prima** dichiarazione di ogni (model, path) come
   verità — l'origine registra prima che esista un donatore — e **rimuove
   dall'offerta** di ogni registrante successivo i file i cui hash

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,29 @@ ENGINE_NODES    = $(foreach e,$(HAVE_ENGINES),$(NODE_$(e)))
 ENGINE_CHATTERS = $(foreach e,$(HAVE_ENGINES),$(e)_p2p)
 MISSING_ENGINES = $(filter-out $(HAVE_ENGINES),olmoe colibri inkling kimi_k3 deepseek)
 
+# A strict distributed run must not mix engine sources or numeric build
+# profiles. Hash contents only (not absolute paths), then inject the same ID
+# into the chatter and expert-node build for that family. Compiler/ISA/OpenMP
+# details are appended at runtime by lmb_build_profile().
+ENGINE_PROFILE_DEPS := $(sort $(wildcard $(ENGINE)/*.h)) \
+                       lumabri_client.h lumabri_proto.h
+define engine_source_id
+$(shell sha256sum $(ENGINE)/$(1).c $(ENGINE_PROFILE_DEPS) \
+        expert_engines/$(2).h engine_patches/$(1)-p2p.diff 2>/dev/null | \
+        awk '{print $$1}' | sha256sum | cut -c1-16)
+endef
+SRCID_olmoe   := $(call engine_source_id,olmoe,olmoe)
+SRCID_colibri := $(call engine_source_id,colibri,colibri)
+SRCID_inkling := $(call engine_source_id,inkling,inkling)
+SRCID_kimi_k3 := $(call engine_source_id,kimi_k3,kimi_k3)
+SRCID_deepseek:= $(call engine_source_id,deepseek,deepseek)
+
+PROFILE_olmoe   = -DLMBE_ENGINE_ID='"olmoe"'      -DLMBE_SOURCE_ID='"$(SRCID_olmoe)"'   -DLMBE_EXPECT_BITS=0
+PROFILE_colibri = -DLMBE_ENGINE_ID='"colibri"'    -DLMBE_SOURCE_ID='"$(SRCID_colibri)"' -DLMBE_EXPECT_BITS=8
+PROFILE_inkling = -DLMBE_ENGINE_ID='"inkling"'    -DLMBE_SOURCE_ID='"$(SRCID_inkling)"' -DLMBE_EXPECT_BITS=8
+PROFILE_kimi_k3 = -DLMBE_ENGINE_ID='"kimi_k3"'    -DLMBE_SOURCE_ID='"$(SRCID_kimi_k3)"' -DLMBE_EXPECT_BITS=0
+PROFILE_deepseek= -DLMBE_ENGINE_ID='"deepseek_v4"' -DLMBE_SOURCE_ID='"$(SRCID_deepseek)"' -DLMBE_EXPECT_BITS=0
+
 # every engine's peer in one go — the ones this checkout has
 engines: $(ENGINE_NODES)
 	@$(if $(MISSING_ENGINES),echo "  skipped (not in $(ENGINE)): $(MISSING_ENGINES)";\
@@ -47,19 +70,23 @@ phase2-all: engines chatters
 # own source so remote and local run the same kernels on the same weights.
 EXPERT_DEPS = expert_node.c lumabri_proto.h
 
-expert_node: $(EXPERT_DEPS) expert_engines/olmoe.h $(ENGINE)/olmoe.c
-	$(CC) $(P2P_CFLAGS) expert_node.c -o $@ -lm -lpthread
+expert_node: $(EXPERT_DEPS) expert_engines/olmoe.h $(ENGINE)/olmoe.c \
+             engine_patches/olmoe-p2p.diff $(ENGINE_PROFILE_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_olmoe) expert_node.c -o $@ -lm -lpthread
 
-expert_node_glm: $(EXPERT_DEPS) expert_engines/colibri.h $(ENGINE)/colibri.c
-	$(CC) $(P2P_CFLAGS) -DLMBE_ENGINE_HEADER='"expert_engines/colibri.h"' \
+expert_node_glm: $(EXPERT_DEPS) expert_engines/colibri.h $(ENGINE)/colibri.c \
+                 engine_patches/colibri-p2p.diff $(ENGINE_PROFILE_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_colibri) -DLMBE_ENGINE_HEADER='"expert_engines/colibri.h"' \
 	      expert_node.c -o $@ -lm -lpthread
 
-expert_node_inkling: $(EXPERT_DEPS) expert_engines/inkling.h $(ENGINE)/inkling.c
-	$(CC) $(P2P_CFLAGS) -DLMBE_ENGINE_HEADER='"expert_engines/inkling.h"' \
+expert_node_inkling: $(EXPERT_DEPS) expert_engines/inkling.h $(ENGINE)/inkling.c \
+                     engine_patches/inkling-p2p.diff $(ENGINE_PROFILE_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_inkling) -DLMBE_ENGINE_HEADER='"expert_engines/inkling.h"' \
 	      expert_node.c -o $@ -lm -lpthread
 
-expert_node_kimi: $(EXPERT_DEPS) expert_engines/kimi_k3.h $(ENGINE)/kimi_k3.c
-	$(CC) $(P2P_CFLAGS) -DLMBE_ENGINE_HEADER='"expert_engines/kimi_k3.h"' \
+expert_node_kimi: $(EXPERT_DEPS) expert_engines/kimi_k3.h $(ENGINE)/kimi_k3.c \
+                  engine_patches/kimi_k3-p2p.diff $(ENGINE_PROFILE_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) -DLMBE_ENGINE_HEADER='"expert_engines/kimi_k3.h"' \
 	      expert_node.c -o $@ -lm -lpthread
 
 # DeepSeek V4 needs two extra things at build time.
@@ -84,8 +111,9 @@ build/deepseek_noentry.c: $(ENGINE)/deepseek.c
 	@grep -q deepseek_cli_main_unused $@ || \
 	  { echo "deepseek.c: main() signature changed — update the rule"; exit 1; }
 
-expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h build/deepseek_noentry.c
-	$(CC) $(P2P_CFLAGS) $(DS_CFLAGS) -Ibuild \
+expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h build/deepseek_noentry.c \
+                      engine_patches/deepseek-p2p.diff $(ENGINE_PROFILE_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -Ibuild \
 	      -DLMBE_ENGINE_HEADER='"expert_engines/deepseek.h"' \
 	      expert_node.c -o $@ -lm -lpthread
 
@@ -105,31 +133,34 @@ patches-check:
 #
 # The engine is never modified: the patch is applied to a COPY under build/.
 # A working copy that already has the patch applied is taken as-is, so an
-# engine tree someone patched by hand still builds.
+# engine tree someone patched by hand still builds. Early OLMoE patches used
+# `L.on` directly; normalize that old hook in the build copy so periodic
+# discovery still runs while phase 2 is active.
 #
 # -DLUMIBRI_P2P: the patches predate the rename and test that macro; both
 # spellings are defined so either vintage compiles.
-build/%_p2p.c: $(ENGINE)/%.c engine_patches/%-p2p.diff
+build/%_p2p.c: $(ENGINE)/%.c engine_patches/%-p2p.diff Makefile
 	@mkdir -p build
 	@if grep -q LUMIBRI_P2P $<; then cp $< $@; \
 	 else patch -s -p2 -o $@ $< engine_patches/$*-p2p.diff; fi
+	@sed -i 's/if (L\.on) {/if (lumi_layer_on(layer)) {/' $@
 
 ENGINE_P2P_DEPS = lumabri_client.h lumibri_client.h lumabri_proto.h
 
 olmoe_p2p: build/olmoe_p2p.c $(ENGINE_P2P_DEPS)
-	$(CC) $(P2P_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+	$(CC) $(P2P_CFLAGS) $(PROFILE_olmoe) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
 colibri_p2p: build/colibri_p2p.c $(ENGINE_P2P_DEPS)
-	$(CC) $(P2P_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+	$(CC) $(P2P_CFLAGS) $(PROFILE_colibri) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
 inkling_p2p: build/inkling_p2p.c $(ENGINE_P2P_DEPS)
-	$(CC) $(P2P_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+	$(CC) $(P2P_CFLAGS) $(PROFILE_inkling) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
 kimi_k3_p2p: build/kimi_k3_p2p.c $(ENGINE_P2P_DEPS)
-	$(CC) $(P2P_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
 deepseek_p2p: build/deepseek_p2p.c $(ENGINE_P2P_DEPS)
-	$(CC) $(P2P_CFLAGS) $(DS_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
 # what a CHATTER needs; `engines` is what a compute DONOR needs
 chatters: $(ENGINE_CHATTERS)
@@ -187,6 +218,7 @@ test: all
 	./donate_test.sh
 	./signed_donor_test.sh
 	./role_test.sh
+	./security_test.sh
 	./expert_input_test.sh
 
 # ---- deploy -------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ test: all
 	./role_test.sh
 	./security_test.sh
 	./expert_input_test.sh
+	./prefetch_policy_test.sh
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)

--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ rather than failing the build for everyone who only wants GLM.
 | `donate_test.sh` | an empty disk donor pulls a slice and outlives the origin |
 | `signed_donor_test.sh` | a donor on a signed swarm verifies, republishes the signature, and refuses the wrong key |
 | `role_test.sh` | `--role` takes whole words: chat is not compute |
+| `prefetch_policy_test.sh` | readahead stops when experts run on peers, so no expert weight is pulled |
 | `expert_input_test.sh` | phase-2 peers reject out-of-range network indices |
 | `phase2_test.sh`, `phase2_bench.sh` | phase 2 correctness and benchmark (olmoe) |
 | `phase2_glm_test.sh`, `phase2_inkling_test.sh`, `phase2_kimi_test.sh`, `phase2_deepseek_test.sh` | phase 2 byte identity, one per engine |

--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ Where contention actually lives, so those numbers can be read honestly:
   connection, but a cache *miss* holds a single loader lock, because the
   engine loaders are engine-internal state and not re-entrant. Size
   `--cache` so the working set fits and misses are rare; that is the knob.
-- **the tracker is not on the hot path at all.** It is consulted at boot and
-  on a 10 s heartbeat, never per token.
+- **the tracker is not on the hot path at all.** Expert discovery is checked
+  at most once every 5 s by default, while activations still travel directly
+  between chatter and expert peers. `LUMABRI_DISCOVERY_MS` changes that
+  interval.
 
 ## How it works
 
@@ -285,7 +287,13 @@ plus a normal local read: there is no FUSE and no daemon on the read path.
 Correctness rule, inherited from colibri: the network may only change where
 bytes come from, never which bytes. Writing to model files returns `EROFS`.
 A block no peer can serve is a loud `EIO`, never silent zeros. The selftest
-verifies byte identity cold, warm, and with every peer dead.
+verifies byte identity cold, warm, and with every peer dead. The data file is
+synced before its bitmap bits are committed in a background batch, and every
+bitmap is bound to the complete model root. This avoids an `fdatasync` per MiB
+while ensuring a crash or same-size checkpoint replacement cannot bless stale
+bytes as cached. Concurrent chatters share the same mirror under a checkpoint
+lock: ordinary reads remain concurrent, reset is exclusive, and persisted
+bitmaps are merged so one process cannot erase another process's warm blocks.
 
 ## Phase 2: peers execute experts
 
@@ -295,6 +303,13 @@ only the dense weights, router and KV cache, and sends the activation row
 reach the chatter. Both sides are built from the engine's own source
 (`expert_node.c` includes `olmoe.c`), so local and remote runs are one code
 path and produce identical tokens.
+
+An expert manifest also commits to the engine family, content fingerprint of
+the engine source and generated patch, compiler and ISA profile, effective
+quantization, tensor shape, model name, and complete model root. A chatter
+refuses an incompatible peer before the first activation is sent. This keeps
+`-march=native`, a changed checkout, or another checkpoint from creating a
+mixed-arithmetic swarm that only drifts several tokens later.
 
 Measured on one machine with pinned cores and network emulated in the peer
 (`phase2_bench.sh`, details and limits in `RESULTS_PHASE2.md`):
@@ -441,6 +456,7 @@ the fallback of last resort.**
   server alone.
 - A donor joins with `expert_node --model DIR --tracker H:P [--cache N]
   [--stride N:OFF]`, is discovered, and wins the calls it is nearest for.
+  Discovery continues during generation, so no chatter restart is needed.
   If it dies mid-generation the call fails over — replica, then a fresh
   tracker query, ultimately the server. If the swarm cannot cover every
   expert at startup, phase 2 simply stays off and the engine runs experts
@@ -487,7 +503,10 @@ LUMABRI_PUBKEY=<the 64 hex chars> lumabri chat --tracker HOST:7300
 
 The origin signs each file's hash vector (bound to model, path, chunk size
 and file size, under a domain tag, so a signature cannot be replayed onto
-another file). The tracker stores and forwards the signature and — given
+another file). It separately signs one canonical root over the complete file
+inventory, paths, sizes, and every per-MiB hash. That root binds phase 1 and
+phase 2 to one checkpoint and invalidates a warm mirror even when a replaced
+file has the same size. The tracker stores and forwards the signatures and — given
 `--pubkey`, which `serve --key` passes automatically — refuses any claim
 that is not signed. The chatter rebuilds the signed message itself and
 checks it against the key it obtained **out of band**: a compromised
@@ -572,7 +591,7 @@ rather than failing the build for everyone who only wants GLM.
 | `expert_engines/*.h` | one per engine: the only engine-shaped code |
 | `engine_patches/make_patches.py` | generates the engine patches from source anchors |
 | `lumabri_client.h` | phase 2 chatter side |
-| `selftest.sh` | byte identity: cold, warm, offline |
+| `selftest.sh` | byte identity: cold, warm, offline, NAT relay, same-size checkpoint replacement |
 | `donate_test.sh` | an empty disk donor pulls a slice and outlives the origin |
 | `signed_donor_test.sh` | a donor on a signed swarm verifies, republishes the signature, and refuses the wrong key |
 | `role_test.sh` | `--role` takes whole words: chat is not compute |
@@ -583,7 +602,7 @@ rather than failing the build for everyone who only wants GLM.
 | `phase4_test.sh` | SSD cache, tracker discovery, delegate & fall back |
 | `phase5_test.sh` | integrity: lying peers caught, poison stripped |
 | `sign_test.sh` | sha512/ed25519 vs RFC 8032 and OpenSSL, signed swarm |
-| `security_test.sh` | path escape from a hostile peer, tracker, or slice assignment |
+| `security_test.sh` | path escape, hostile frame lengths, and bounded idle connections |
 | `assign_test.sh` | three uncoordinated compute donors split the experts by themselves |
 | `concurrency_test.sh` | N chatters at once: does anyone get starved |
 | `chat_proto_test.sh` | both engine dialects, and a dying engine that explains itself |
@@ -622,14 +641,14 @@ engine binaries.
 
 ## Status
 
-Working prototype, deployable. Open swarms verify bytes (sha256 per MiB,
-signed by the operator's ed25519 key, checked by the chatter against a key
-it holds itself) and results (spot-check on a second replica); private
+Working prototype, deployable. Open swarms verify bytes (sha256 per MiB and
+a signed complete-model root, checked by the chatter against a key it holds
+itself) and results (spot-check on a second replica); private
 swarms need an invite token everywhere. Not yet done, in order of
 importance: speculative drafting with batch-union (the remaining multiplier
-against WAN latency), hedged requests against stragglers, continuous peer
-discovery mid-generation, a durable content-addressed mirror, key rotation
-and revocation, NAT hole punching. Expert
+against WAN latency), hedged requests against stragglers, a content-addressed
+mirror shared across checkpoints, key rotation and revocation, NAT hole
+punching. Expert
 execution is not yet covered by the operator signature — a peer's results
 are checked by replica agreement, not by a key.
 

--- a/assign_test.sh
+++ b/assign_test.sh
@@ -64,14 +64,26 @@ int main(int argc, char **argv) {
     if (lmb_request(argv[1], LMB_EMANIFEST, NULL, 0, &m) || m.op != LMB_EMANIFEST_R)
         return 1;
     LmbCur c = { m.body, m.body_len, 0 };
-    uint32_t n = 0;
-    if (lmb_cur_u32(&c, &n)) return 1;
+    uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0, n = 0, hidden = 0;
+    uint8_t root[32], sig[64];
+    char engine[64], profile[LMB_BUILD_PROFILE_MAX], model[64];
+    if (lmb_cur_u32(&c, &magic) || magic != LMB_EXPERT_MANIFEST_MAGIC ||
+        lmb_cur_str(&c, engine, sizeof engine) ||
+        lmb_cur_str(&c, profile, sizeof profile) ||
+        lmb_cur_str(&c, model, sizeof model) ||
+        lmb_cur_u32(&c, &bits) || lmb_cur_u32(&c, &have_id) || have_id > 1)
+        return 2;
+    if (have_id && (lmb_cur_bytes(&c, root, sizeof root) ||
+                    lmb_cur_u32(&c, &has_sig) || has_sig > 1 ||
+                    (has_sig && lmb_cur_bytes(&c, sig, sizeof sig))))
+        return 2;
+    if (lmb_cur_u32(&c, &n)) return 2;
     for (uint32_t i = 0; i < n; i++) {
         uint32_t l, e;
-        if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e)) break;
+        if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e)) return 2;
         printf("%u:%u\n", l, e);
     }
-    return 0;
+    return lmb_cur_u32(&c, &hidden) || c.off != c.len ? 2 : 0;
 }
 EOF
 cc -O2 -w -I. "$T/ask.c" -o "$T/ask" -lpthread

--- a/concurrency_test.sh
+++ b/concurrency_test.sh
@@ -45,13 +45,42 @@ for _ in $(seq 1 400); do
     (exec 3<>/dev/tcp/127.0.0.1/$PORT) 2>/dev/null && { exec 3<&-; break; }
     sleep 0.2
 done
-sleep 3
+# The tracker listens first.  The byte peer opens PORT+1 only after hashing
+# the model, and the executor opens PORT+2 after loading it.  Waiting for all
+# three prevents the warm-up from racing a cold `lumabri serve` startup.
+for p in $((PORT + 1)) $((PORT + 2)); do
+    ready=0
+    for _ in $(seq 1 400); do
+        (exec 3<>/dev/tcp/127.0.0.1/$p) 2>/dev/null && { exec 3<&-; ready=1; break; }
+        sleep 0.2
+    done
+    [ "$ready" -eq 1 ] || { echo "server component on port $p never became ready"; exit 1; }
+done
+
+# Two processes must be allowed to bind a brand-new shared mirror to the same
+# checkpoint at once.  This used to make the loser wait for the winner's whole
+# process lifetime after both tried to upgrade the cache lock.
+echo "· simultaneous cold mirror initialization"
+IPIDS=()
+for i in 1 2; do
+    env LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_CACHE="$T/cache" \
+        LUMABRI_VROOT="$T/vroot" LUMABRI_TRACKER="127.0.0.1:$PORT" \
+        LUMABRI_MODEL=tiny_olmoe LUMABRI_BLOCK_MIB=1 \
+        head -c 1 "$T/vroot/config.json" > "$T/init$i" 2> "$T/init$i.err" &
+    IPIDS+=($!)
+done
+for pid in "${IPIDS[@]}"; do
+    wait "$pid" || { cat "$T"/init*.err; exit 1; }
+done
+cmp "$T/init1" "$T/init2" || { echo "cold initializers read different bytes"; exit 1; }
+echo "  ✓ both initializers completed on one checkpoint"
 
 # one warm-up so every timed client starts from the same warm mirror — the
 # first chatter always pays for the dense weights and would dominate
-printf 'ciao\n/quit\n' | ./lumabri chat --tracker "127.0.0.1:$PORT" \
+printf 'ciao\n/quit\n' | env LUMABRI_CACHE="$T/cache" LUMABRI_VROOT="$T/vroot" \
+    ./lumabri chat --tracker "127.0.0.1:$PORT" \
     --engines-dir "$ENGINES" --plain --max-new "$GEN" --role chat \
-    > "$T/warm.log" 2>&1 || true
+    > "$T/warm.log" 2>&1 || { cat "$T/warm.log"; exit 1; }
 
 echo
 printf "%8s  %10s  %10s  %10s  %10s\n" clients fastest slowest spread mean
@@ -62,14 +91,21 @@ for n in $CLIENTS; do
     CPIDS=()
     for i in $(seq 1 "$n"); do
         ( start=$(date +%s.%N)
-          printf 'ciao\n/quit\n' | ./lumabri chat --tracker "127.0.0.1:$PORT" \
+          printf 'ciao\n/quit\n' | env LUMABRI_CACHE="$T/cache" LUMABRI_VROOT="$T/vroot" \
+              ./lumabri chat --tracker "127.0.0.1:$PORT" \
               --engines-dir "$ENGINES" --plain --max-new "$GEN" --role chat \
               > "$T/c$i.log" 2>&1
           end=$(date +%s.%N)
           echo "$end - $start" | bc > "$T/t$i" ) &
         CPIDS+=($!)
     done
-    for pid in "${CPIDS[@]}"; do wait "$pid" || true; done
+    FAILED=0
+    for pid in "${CPIDS[@]}"; do wait "$pid" || FAILED=1; done
+    if [ "$FAILED" -ne 0 ]; then
+        echo "one or more chatter processes failed"
+        for log in "$T"/c*.log; do echo "== $log =="; tail -40 "$log"; done
+        exit 1
+    fi
     STATS=$(cat "$T"/t* 2>/dev/null | sort -n | awk '
         {v[NR]=$1; s+=$1}
         END {if (NR) printf "%.1f %.1f %.1f %.1f", v[1], v[NR], v[NR]-v[1], s/NR;

--- a/engine_patches/deepseek-p2p.diff
+++ b/engine_patches/deepseek-p2p.diff
@@ -43,7 +43,7 @@ diff --git a/c/deepseek.c b/c/deepseek.c
      for (int current = 0; !result && current < selected; current++) {
          int slot = current % DUAL_EXPERT_LOADER_COUNT;
          if (!loader_active[slot] ||
-@@ -6232,6 +6253,13 @@
+@@ -6324,6 +6345,13 @@
              inputs + (size_t)item * d, config->swiglu_limit);
      if (!result)
          memset(outputs, 0, (size_t)batch * d * sizeof(*outputs));
@@ -57,7 +57,7 @@ diff --git a/c/deepseek.c b/c/deepseek.c
  
      int key_count = 0;
      for (int expert = 0; expert < n; expert++)
-@@ -8784,6 +8812,12 @@
+@@ -8914,6 +8942,12 @@
      engine->owns_experts = 1;
      engine->summary.dense_resident = engine->runtime.dense_resident;
      engine->summary.head_resident = engine->head_cache.data != NULL;

--- a/expert_engines/colibri.h
+++ b/expert_engines/colibri.h
@@ -24,12 +24,15 @@
 #include "colibri.c"
 #undef main
 
+#define LMBE_NEEDS_HOT_OMP_REEXEC 1
+
 typedef ESlot LmbeSlot;
 
 static Model lmbe_M;
 static int lmbe_slots;
 
 static const char *lmbe_engine_name(void) { return "colibri"; }
+static int lmbe_effective_bits(int bits) { return bits; }
 
 /* `bits` is the engine's expert quantization and it MUST match the chatter's,
  * because for a model without pre-quantized .qs tensors the loader quantizes

--- a/expert_engines/deepseek.h
+++ b/expert_engines/deepseek.h
@@ -35,6 +35,7 @@ static ColiDeepSeekV4Config lmbe_cfg;
 static ColiExpertStore *lmbe_store;
 
 static const char *lmbe_engine_name(void) { return "deepseek_v4"; }
+static int lmbe_effective_bits(int bits) { (void)bits; return 0; }
 
 /* `cap` is expert slots; the store wants bytes, so it is scaled by the
  * record size the store itself reports back through its stats. Before that

--- a/expert_engines/inkling.h
+++ b/expert_engines/inkling.h
@@ -22,11 +22,14 @@
 #include "inkling.c"
 #undef main
 
+#define LMBE_NEEDS_HOT_OMP_REEXEC 1
+
 typedef Slot LmbeSlot;
 
 static Model lmbe_M;
 
 static const char *lmbe_engine_name(void) { return "inkling"; }
+static int lmbe_effective_bits(int bits) { return bits; }
 
 static void lmbe_open(const char *dir, int cap, int bits) {
     (void)cap;

--- a/expert_engines/kimi_k3.h
+++ b/expert_engines/kimi_k3.h
@@ -25,6 +25,7 @@ typedef Slot LmbeSlot;
 static Model lmbe_M;
 
 static const char *lmbe_engine_name(void) { return "kimi_k3"; }
+static int lmbe_effective_bits(int bits) { (void)bits; return 0; }
 
 static void lmbe_open(const char *dir, int cap, int bits) {
     (void)cap; (void)bits;            /* MXFP4 comes as it is on disk */

--- a/expert_engines/olmoe.h
+++ b/expert_engines/olmoe.h
@@ -16,6 +16,7 @@ typedef Slot LmbeSlot;
 static Model lmbe_M;
 
 static const char *lmbe_engine_name(void) { return "olmoe"; }
+static int lmbe_effective_bits(int bits) { (void)bits; return 0; }
 
 static void lmbe_open(const char *dir, int cap, int bits) {
     (void)cap; (void)bits;            /* olmoe reads the container's own format */

--- a/expert_input_test.sh
+++ b/expert_input_test.sh
@@ -34,6 +34,7 @@ typedef struct { int unused; } LmbeSlot;
 static const char *lmbe_engine_name(void) { return "test"; }
 static void lmbe_open(const char *dir, int cap, int bits)
     { (void)dir; (void)cap; (void)bits; }
+static int lmbe_effective_bits(int bits) { (void)bits; return 8; }
 static int lmbe_n_slots(void) { return 2; }
 static int lmbe_n_experts(void) { return 2; }
 static int lmbe_hidden(void) { return 4; }
@@ -60,6 +61,23 @@ cc -O1 -g $SAN -fopenmp -pthread -I"$T" -I. \
 cat > "$T/wire_test.c" <<'EOF'
 #include "lumabri_proto.h"
 
+/* An EMANIFEST_R the chatter will accept as far as the ownership table: the
+ * v2 header must match the chatter's own engine, build profile and bits, or
+ * the frame is refused for incompatibility before any index is looked at —
+ * which would make this a test of the wrong rejection. wire_test and
+ * client_test are built the same way, so both derive the same profile and
+ * the default "unknown" engine / 8-bit experts. */
+static void put_v2_header(LmbBuf *b) {
+    char profile[LMB_BUILD_PROFILE_MAX];
+    lmb_build_profile(profile, sizeof profile);
+    lmb_buf_u32(b, LMB_EXPERT_MANIFEST_MAGIC);
+    lmb_buf_str(b, LMBE_ENGINE_ID);
+    lmb_buf_str(b, profile);
+    lmb_buf_str(b, "test");            /* model name */
+    lmb_buf_u32(b, 8);                 /* expert bits: LMBE_EXPECT_BITS default */
+    lmb_buf_u32(b, 0);                 /* have_id = 0 */
+}
+
 static int bad_manifest(int port, int bad_eid) {
     int lfd = lmb_listen(port), fd; LmbMsg m = {0}; LmbBuf b = {0};
     if (lfd < 0) return 1;
@@ -69,11 +87,12 @@ static int bad_manifest(int port, int bad_eid) {
         if (!lmb_recv(fd, &m) && m.op == LMB_EMANIFEST) break;
         lmb_msg_free(&m); close(fd);
     }
+    put_v2_header(&b);
     lmb_buf_u32(&b, 2);
     lmb_buf_u32(&b, 0); lmb_buf_u32(&b, 0);
     lmb_buf_u32(&b, bad_eid ? 0 : UINT32_MAX);
     lmb_buf_u32(&b, bad_eid ? UINT32_MAX : 0);
-    lmb_buf_u32(&b, 4);
+    lmb_buf_u32(&b, 4);                /* peer hidden */
     int rc = lmb_send(fd, LMB_EMANIFEST_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p); lmb_msg_free(&m); close(fd); close(lfd); return rc != 0;
 }
@@ -108,12 +127,24 @@ static int dense_assignment(int port) {
     free(b.p); lmb_msg_free(&m); close(fd); close(lfd); return rc != 0;
 }
 
+/* Skip the v2 EMANIFEST_R header and read the expert count that follows. */
 static int manifest_count(const char *addr, uint32_t expected) {
     LmbMsg m = {0};
     if (lmb_request(addr, LMB_EMANIFEST, NULL, 0, &m) ||
         m.op != LMB_EMANIFEST_R) return 1;
-    LmbCur c = { m.body, m.body_len, 0 }; uint32_t n = 0;
-    int rc = lmb_cur_u32(&c, &n) || n != expected;
+    LmbCur c = { m.body, m.body_len, 0 };
+    uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0, n = 0;
+    char engine[64], profile[LMB_BUILD_PROFILE_MAX], model[64];
+    uint8_t root[LMB_MODEL_ROOT_LEN], sig[64];
+    int rc = lmb_cur_u32(&c, &magic) || magic != LMB_EXPERT_MANIFEST_MAGIC ||
+             lmb_cur_str(&c, engine, sizeof engine) ||
+             lmb_cur_str(&c, profile, sizeof profile) ||
+             lmb_cur_str(&c, model, sizeof model) ||
+             lmb_cur_u32(&c, &bits) || lmb_cur_u32(&c, &have_id);
+    if (!rc && have_id)
+        rc = lmb_cur_bytes(&c, root, sizeof root) || lmb_cur_u32(&c, &has_sig) ||
+             (has_sig && lmb_cur_bytes(&c, sig, sizeof sig));
+    if (!rc) rc = lmb_cur_u32(&c, &n) || n != expected;
     lmb_msg_free(&m); return rc;
 }
 
@@ -186,7 +217,7 @@ set +e
 "$T/client_test" 127.0.0.1:7582 > "$T/client.out" 2> "$T/client.err"
 RC=$?
 set -e
-[ "$RC" -ne 0 ] && grep -q "bad or mismatched manifest" "$T/client.err" && \
+[ "$RC" -ne 0 ] && grep -q "incompatible manifest" "$T/client.err" && \
     ! grep -q "Sanitizer" "$T/client.err" && \
     ! grep -q "runtime error:" "$T/client.err" || {
     cat "$T/client.err"; echo "   chatter did not reject the bad manifest cleanly"; exit 1; }
@@ -199,7 +230,7 @@ set +e
 "$T/client_test" 127.0.0.1:7587 > "$T/client-eid.out" 2> "$T/client-eid.err"
 RC=$?
 set -e
-[ "$RC" -ne 0 ] && grep -q "bad or mismatched manifest" "$T/client-eid.err" && \
+[ "$RC" -ne 0 ] && grep -q "incompatible manifest" "$T/client-eid.err" && \
     ! grep -q "Sanitizer" "$T/client-eid.err" && \
     ! grep -q "runtime error:" "$T/client-eid.err" || {
     cat "$T/client-eid.err"; echo "   chatter did not reject the bad expert ID"; exit 1; }

--- a/expert_node.c
+++ b/expert_node.c
@@ -71,6 +71,7 @@
 
 #include <omp.h>
 #include <pthread.h>
+#include <sched.h>
 #include <stdatomic.h>
 #include <sys/prctl.h>
 
@@ -117,11 +118,20 @@ static struct {
     pthread_cond_t c_cv;
     pthread_mutex_t load_lk;    /* the engine loader is used one call at a time */
     char name[64], model[64], advertise[64], tracker[64], token[128];
+    char profile[LMB_BUILD_PROFILE_MAX];
+    int bits;
+    LmbModelIdentity identity; int have_identity;
+    pthread_mutex_t identity_lk;
     _Atomic uint64_t calls, cold;
     double busy_s;
     pthread_mutex_t stat_lk;
 } g = { .c_lk = PTHREAD_MUTEX_INITIALIZER, .load_lk = PTHREAD_MUTEX_INITIALIZER,
-        .stat_lk = PTHREAD_MUTEX_INITIALIZER };
+        .stat_lk = PTHREAD_MUTEX_INITIALIZER,
+        .identity_lk = PTHREAD_MUTEX_INITIALIZER };
+
+static LmbConnGate g_conn_gate = LMB_CONN_GATE_INIT;
+static __thread void *t_scratch;
+static __thread int t_scratch_rows;
 
 /* Plain malloc, not the engine's falloc: not every engine has one (the V4
  * glue links its store, not a colibri model loader) and this buffer is only
@@ -276,12 +286,10 @@ static int handle_exec(int fd, LmbMsg *m) {
     gate_enter();
 
     /* one scratch per connection thread: the kernels are called concurrently */
-    static __thread void *scratch;
-    static __thread int scratch_rows;
-    if (!scratch || scratch_rows < (int)nrows) {
-        if (scratch) lmbe_scratch_free(scratch);
-        scratch = lmbe_scratch_new((int)nrows);
-        scratch_rows = (int)nrows;
+    if (!t_scratch || t_scratch_rows < (int)nrows) {
+        if (t_scratch) lmbe_scratch_free(t_scratch);
+        t_scratch = lmbe_scratch_new((int)nrows);
+        t_scratch_rows = (int)nrows;
     }
 
     size_t obytes = (size_t)want;
@@ -289,11 +297,11 @@ static int handle_exec(int fd, LmbMsg *m) {
     double t0 = nowd();
     if (g.ncs) {
         CSlot *s = cache_acquire((int)layer, (int)eid);
-        lmbe_apply(&s->slot, (int)layer, (const float *)m->pay, out, (int)nrows, rw, scratch);
+        lmbe_apply(&s->slot, (int)layer, (const float *)m->pay, out, (int)nrows, rw, t_scratch);
         cache_release(s);
     } else {
         lmbe_apply(&g.held[g.index[gid]].slot, (int)layer,
-                   (const float *)m->pay, out, (int)nrows, rw, scratch);
+                   (const float *)m->pay, out, (int)nrows, rw, t_scratch);
     }
     double dt = nowd() - t0;
     gate_leave();
@@ -307,8 +315,38 @@ static int handle_exec(int fd, LmbMsg *m) {
     return rc;
 }
 
+static void node_refresh_identity(void) {
+    if (!g.tracker[0] || !g.model[0]) return;
+    LmbModelIdentity id;
+    if (lmb_model_identity_get(g.tracker, g.model, &id)) return;
+    pthread_mutex_lock(&g.identity_lk);
+    g.identity = id;
+    g.have_identity = 1;
+    pthread_mutex_unlock(&g.identity_lk);
+}
+
 static int handle_emanifest(int fd) {
+    LmbModelIdentity id = {0};
+    pthread_mutex_lock(&g.identity_lk);
+    int have_id = g.have_identity;
+    pthread_mutex_unlock(&g.identity_lk);
+    if (!have_id) node_refresh_identity();
+    pthread_mutex_lock(&g.identity_lk);
+    have_id = g.have_identity;
+    if (have_id) id = g.identity;
+    pthread_mutex_unlock(&g.identity_lk);
     LmbBuf b = {0};
+    lmb_buf_u32(&b, LMB_EXPERT_MANIFEST_MAGIC);
+    lmb_buf_str(&b, lmbe_engine_name());
+    lmb_buf_str(&b, g.profile);
+    lmb_buf_str(&b, g.model);
+    lmb_buf_u32(&b, (uint32_t)g.bits);
+    lmb_buf_u32(&b, have_id ? 1u : 0u);
+    if (have_id) {
+        lmb_buf_bytes(&b, id.root, sizeof id.root);
+        lmb_buf_u32(&b, id.has_sig ? 1u : 0u);
+        if (id.has_sig) lmb_buf_bytes(&b, id.sig, sizeof id.sig);
+    }
     lmb_buf_u32(&b, (uint32_t)g.nholds);
     for (int l = 0; l < g.n_slots; l++)
         for (int e = 0; e < g.n_experts; e++)
@@ -353,7 +391,12 @@ static void *conn_thread(void *arg) {
         lmb_msg_free(&m);
         if (rc) break;
     }
+    if (t_scratch) {
+        lmbe_scratch_free(t_scratch);
+        t_scratch = NULL; t_scratch_rows = 0;
+    }
     close(fd);
+    lmb_conn_gate_leave(&g_conn_gate);
     return NULL;
 }
 
@@ -404,6 +447,10 @@ static void *control_thread(void *arg) {
                 break;
             }
             lmb_msg_free(&m);
+            pthread_mutex_lock(&g.identity_lk);
+            int need_identity = !g.have_identity;
+            pthread_mutex_unlock(&g.identity_lk);
+            if (need_identity) node_refresh_identity();
             sleep(HEARTBEAT_S);
         }
         close(fd);
@@ -437,39 +484,86 @@ static int in_list(const int *list, int n, int v) {
 }
 
 /* ---- how wide the machine is --------------------------------------------
- * lumabri does NOT choose the OpenMP team size. The engine already does, in
- * its own main() — which this file calls for it, see LMBE_TUNE_THREADS —
- * sized to the physical cores and argued from measurements on
- * real models (omp_tune.h: +2.3x on a 16C/32T Zen3 from the thread count
- * alone). A micro-benchmark here would be measuring one expert of one model
- * at one row, and would happily overrule that with a fixture's answer.
- *
- * What lumabri owns is the gate: given that each expert call takes the whole
- * machine, how many may run at once. That is a ratio, so it needs the core
- * count — and the engine's own rule applies to it too. If the physical count
- * cannot be determined we do not guess it: we admit one expert at a time,
- * which is never oversubscribed, rather than invent a number. */
+ * Count physical cores inside this process's allowed CPU set. Reading every
+ * host CPU from /proc made a taskset/container report cores it could not use,
+ * so the gate still oversubscribed constrained deployments. The pre-reexec
+ * value is carried in an internal env var because libgomp may bind the main
+ * thread to one place after OMP_PROC_BIND becomes active. */
 static int phys_cores(void) {
-    struct { int p, c; } seen[1024];
-    int n = 0, pid = -1, cid = -1;
-    FILE *f = fopen("/proc/cpuinfo", "r");
-    if (!f) return 0;
-    char line[256];
-    while (fgets(line, sizeof line, f)) {
-        if (!strncmp(line, "physical id", 11)) sscanf(line, "%*[^:]: %d", &pid);
-        else if (!strncmp(line, "core id", 7)) sscanf(line, "%*[^:]: %d", &cid);
-        if (pid >= 0 && cid >= 0) {
+    const char *saved = getenv("LUMABRI_PHYSICAL_CORES");
+    if (saved && atoi(saved) > 0) return atoi(saved);
+#if defined(__linux__) && defined(CPU_SETSIZE)
+    cpu_set_t allowed;
+    CPU_ZERO(&allowed);
+    if (sched_getaffinity(0, sizeof allowed, &allowed) == 0) {
+        struct { int package, core; } seen[CPU_SETSIZE];
+        int n = 0, logical = 0;
+        for (int cpu = 0; cpu < CPU_SETSIZE; cpu++) {
+            if (!CPU_ISSET(cpu, &allowed)) continue;
+            logical++;
+            char path[160];
+            int package = -1, core = -1;
+            snprintf(path, sizeof path,
+                     "/sys/devices/system/cpu/cpu%d/topology/physical_package_id", cpu);
+            FILE *fp = fopen(path, "r");
+            if (fp) {
+                if (fscanf(fp, "%d", &package) != 1) package = -1;
+                fclose(fp);
+            }
+            snprintf(path, sizeof path,
+                     "/sys/devices/system/cpu/cpu%d/topology/core_id", cpu);
+            fp = fopen(path, "r");
+            if (fp) {
+                if (fscanf(fp, "%d", &core) != 1) core = -1;
+                fclose(fp);
+            }
+            if (package < 0 || core < 0) continue;
             int dup = 0;
-            for (int i = 0; i < n; i++) if (seen[i].p == pid && seen[i].c == cid) dup = 1;
-            if (!dup && n < 1024) { seen[n].p = pid; seen[n].c = cid; n++; }
-            pid = cid = -1;
+            for (int i = 0; i < n; i++)
+                if (seen[i].package == package && seen[i].core == core) { dup = 1; break; }
+            if (!dup) { seen[n].package = package; seen[n].core = core; n++; }
         }
+        if (n > 0) return n;
+        if (logical > 0) return logical; /* topology unknown, still honor cpuset */
     }
-    fclose(f);
-    return n;
+#endif
+    int n = omp_get_num_procs();
+    return n > 0 ? n : 0;
+}
+
+/* GLM and Inkling set their hot-wait policy in the main() that the adapter
+ * deliberately renames away. libgomp reads those variables before main, so
+ * reproducing the policy requires the same one-time self re-exec. Engines
+ * using omp_tune.h need no re-exec and keep their native helper below. */
+static void runtime_prepare(int argc, char **argv) {
+    (void)argc;
+#ifdef LMBE_NEEDS_HOT_OMP_REEXEC
+    if (getenv("COLI_OMP_TUNED") || getenv("COLI_NO_OMP_TUNE")) return;
+    /* An explicit bind policy may already have narrowed this main thread in
+     * libgomp's constructor. Re-execing that one-core mask would be worse
+     * than leaving the user's existing runtime policy untouched. */
+    if (getenv("OMP_PROC_BIND")) return;
+    int phys = phys_cores();
+    if (phys > 0) {
+        char s[24]; snprintf(s, sizeof s, "%d", phys);
+        setenv("LUMABRI_PHYSICAL_CORES", s, 1);
+    }
+    setenv("OMP_WAIT_POLICY", "active", 0);
+    setenv("GOMP_SPINCOUNT", "200000", 0);
+    setenv("KMP_BLOCKTIME", "200", 0);
+    setenv("OMP_PROC_BIND", "close", 0);
+    setenv("OMP_DYNAMIC", "FALSE", 0);
+    setenv("COLI_OMP_TUNED", "1", 1);
+#ifdef __linux__
+    fprintf(stderr, "[OMP] lumabri: applying the engine hot-thread policy (one re-exec)\n");
+    execv("/proc/self/exe", argv);
+    perror("[OMP] execv self-reexec failed, running without hot-thread tuning");
+#endif
+#endif
 }
 
 int main(int argc, char **argv) {
+    runtime_prepare(argc, argv); /* must precede every other main-side action */
     const char *dir = NULL;
     int port = 7401, stride = 1, offset = 0, cache = 0, bits = 8, hold = 0;
     int layers[512], nlayers = 0, parallel = 0;
@@ -531,8 +625,21 @@ int main(int argc, char **argv) {
                  g.name, g_corrupt_ppm);
       } }
 
+    int runtime_phys = phys_cores();
     LMBE_TUNE_THREADS();
+    /* GLM/Inkling do not include omp_tune.h. Clamp their untouched OpenMP
+     * default, and any affinity-constrained engine, unless the user chose an
+     * explicit team or disabled tuning. */
+    if (!getenv("OMP_NUM_THREADS") && !getenv("COLI_NO_OMP_TUNE") &&
+        runtime_phys > 0 && omp_get_max_threads() > runtime_phys) {
+        int logical = omp_get_max_threads();
+        omp_set_num_threads(runtime_phys);
+        fprintf(stderr, "[OMP] lumabri: %d physical-core threads instead of %d logical\n",
+                runtime_phys, logical);
+    }
     lmbe_open(dir, cache, bits);
+    g.bits = lmbe_effective_bits(bits);
+    lmb_build_profile(g.profile, sizeof g.profile);
     g.n_slots   = lmbe_n_slots();
     g.n_experts = lmbe_n_experts();
     g.hidden    = lmbe_hidden();
@@ -647,7 +754,8 @@ int main(int argc, char **argv) {
     fflush(stdout);
 
     /* whatever the engine settled on during lmbe_open */
-    int phys = phys_cores(), per_expert = omp_get_max_threads();
+    node_refresh_identity();
+    int phys = runtime_phys, per_expert = omp_get_max_threads();
     if (per_expert < 1) per_expert = 1;
     gate_init(parallel, per_expert, phys);
 
@@ -668,6 +776,7 @@ int main(int argc, char **argv) {
     fflush(stdout);
 
     pthread_t t;
+    lmb_conn_gate_init(&g_conn_gate);
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }
     pthread_create(&t, NULL, stats_thread, NULL); pthread_detach(t);
 
@@ -676,8 +785,11 @@ int main(int argc, char **argv) {
         if (fd < 0) { if (errno == EINTR) continue; break; }
         int one = 1;
         setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+        lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
+                                           LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
+        if (!lmb_conn_gate_enter(&g_conn_gate)) { close(fd); continue; }
         if (pthread_create(&t, NULL, conn_thread, (void *)(intptr_t)fd) == 0) pthread_detach(t);
-        else close(fd);
+        else { lmb_conn_gate_leave(&g_conn_gate); close(fd); }
     }
     return 0;
 }

--- a/lumabri.c
+++ b/lumabri.c
@@ -823,8 +823,12 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
                         int ctx, int max_new, int cap_experts, Engine *e) {
     const char *home = getenv("HOME") ? getenv("HOME") : ".";
     char vroot[1024], cache[1024];
-    snprintf(vroot, sizeof vroot, "%s/.lumabri/%s/vroot", home, model);
-    snprintf(cache, sizeof cache, "%s/.lumabri/%s/cache", home, model);
+    const char *vroot_env = getenv("LUMABRI_VROOT");
+    const char *cache_env = getenv("LUMABRI_CACHE");
+    if (vroot_env && vroot_env[0]) snprintf(vroot, sizeof vroot, "%s", vroot_env);
+    else snprintf(vroot, sizeof vroot, "%s/.lumabri/%s/vroot", home, model);
+    if (cache_env && cache_env[0]) snprintf(cache, sizeof cache, "%s", cache_env);
+    else snprintf(cache, sizeof cache, "%s/.lumabri/%s/cache", home, model);
     if (!local_dir) mkdir_p(cache);   /* vroot stays virtual on purpose */
 
     /* olmoe takes <cap> <bits>; the SERVE-mode engines take <cap> alone and

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -30,8 +30,9 @@
 #include <limits.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_sign.h"
 
-#define LUMI_MAX_PEERS 32
+#define LUMI_MAX_PEERS 64
 #define LUMI_MAX_K     64
 #define LUMI_MAX_REP   4      /* replicas remembered per expert */
 #define LUMI_WAIT_S    30     /* how long a vanished peer is given to come back */
@@ -45,16 +46,25 @@ typedef struct {
 } LumiPeer;
 
 static struct {
-    int on;
+    int on, initialized, discovery;
     LumiPeer peers[LUMI_MAX_PEERS];
     int npeers;
     int *own;                   /* [gid * LUMI_MAX_REP] → peer index, -1 = free */
     unsigned char *routed;      /* [n_layers] 1 = this slot routes to experts */
     int n_layers, n_experts, hidden;
+    int expected, expected_bits;
+    char expected_model[64], profile[LMB_BUILD_PROFILE_MAX];
+    LmbModelIdentity identity; int have_identity;
+    uint8_t pubkey[32]; int have_pubkey;
+    double next_discover, discover_period_s;
     int verify_pct;             /* LUMABRI_VERIFY: % of calls double-checked */
     unsigned long long calls, layers_done, failovers, verified;
     double wait_s;
 } L = {0};
+
+#ifndef LMBE_EXPECT_BITS
+#define LMBE_EXPECT_BITS 8
+#endif
 
 static double lumi_now(void) {
     struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
@@ -108,15 +118,60 @@ static int lumi_index_ok(uint32_t layer, uint32_t eid) {
            layer < (uint32_t)L.n_layers && eid < (uint32_t)L.n_experts;
 }
 
+static void lumi_load_pubkey(void) {
+    const char *spec = getenv("LUMABRI_PUBKEY");
+    if (!spec || !*spec) return;
+    char hex[80] = "";
+    FILE *fp = fopen(spec, "r");
+    if (fp) { if (fscanf(fp, "%78s", hex) != 1) hex[0] = 0; fclose(fp); }
+    else snprintf(hex, sizeof hex, "%s", spec);
+    if (strlen(hex) == 64 && !lmb_unhex(L.pubkey, hex, 32)) L.have_pubkey = 1;
+    else fprintf(stderr, "[lumabri] invalid LUMABRI_PUBKEY: expert execution stays local\n");
+}
+
+static int lumi_identity_valid(const char *model, const LmbModelIdentity *id) {
+    if (strcmp(model, id->model)) return 0;
+    if (!L.have_pubkey) return 1;
+    if (!id->has_sig) return 0;
+    size_t n = 0;
+    uint8_t *msg = lmb_model_id_msg(model, id->root, &n);
+    int ok = msg && lmb_sign_verify(id->sig, msg, n, L.pubkey) == 0;
+    free(msg);
+    return ok;
+}
+
+static int lumi_refresh_identity(void) {
+    const char *tracker = getenv("LUMABRI_TRACKER");
+    if (!tracker || !*tracker || !L.expected_model[0]) return 0;
+    LmbModelIdentity id;
+    if (lmb_model_identity_get(tracker, L.expected_model, &id) ||
+        !lumi_identity_valid(L.expected_model, &id)) return 0;
+    if (L.have_identity && memcmp(L.identity.root, id.root, 32)) {
+        fprintf(stderr, "[lumabri] model identity changed during this process — "
+                        "refusing to mix checkpoints\n");
+        exit(1);
+    }
+    L.identity = id; L.have_identity = 1;
+    return 1;
+}
+
 /* Learn one peer: manifest, replica claims, distance. Returns 0, or -1 on
  * any failure (already-known addresses are a no-op success). */
 static int lumi_add_peer(const char *addr) {
+    int reprobe = -1;
     for (int i = 0; i < L.npeers; i++)
-        if (!strcmp(L.peers[i].addr, addr)) return 0;
-    if (L.npeers == LUMI_MAX_PEERS) return -1;
-    LumiPeer *p = &L.peers[L.npeers];
-    snprintf(p->addr, sizeof p->addr, "%s", addr);
-    p->nsocks = 0; p->dead = 0;
+        if (!strcmp(L.peers[i].addr, addr)) {
+            LumiPeer *known = &L.peers[i];
+            if (!known->dead) return 0;
+            while (known->nsocks) close(known->socks[--known->nsocks]);
+            reprobe = i;
+            break;
+        }
+    if (reprobe < 0 && L.npeers == LUMI_MAX_PEERS) return -1;
+    int pi = reprobe >= 0 ? reprobe : L.npeers;
+    LumiPeer *p = &L.peers[pi];
+    if (reprobe < 0) snprintf(p->addr, sizeof p->addr, "%s", addr);
+    p->nsocks = 0;
 
     LmbMsg m = {0};
     if (lmb_request(p->addr, LMB_EMANIFEST, NULL, 0, &m) || m.op != LMB_EMANIFEST_R) {
@@ -125,41 +180,83 @@ static int lumi_add_peer(const char *addr) {
         return -1;
     }
     LmbCur c = { m.body, m.body_len, 0 };
+    uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0;
     uint32_t n = 0, peer_hidden = 0;
-    int bad = lmb_cur_u32(&c, &n) != 0;
-    size_t cells = (size_t)L.n_layers * (size_t)L.n_experts;
-    if (!bad && (size_t)n > cells) bad = 1;
+    char engine[64] = "", profile[LMB_BUILD_PROFILE_MAX] = "", peer_model[64] = "";
+    LmbModelIdentity peer_id = {0};
+    int bad = lmb_cur_u32(&c, &magic) || magic != LMB_EXPERT_MANIFEST_MAGIC ||
+              lmb_cur_str(&c, engine, sizeof engine) ||
+              lmb_cur_str(&c, profile, sizeof profile) ||
+              lmb_cur_str(&c, peer_model, sizeof peer_model) ||
+              lmb_cur_u32(&c, &bits) || lmb_cur_u32(&c, &have_id) || have_id > 1;
+    if (!bad && have_id) {
+        snprintf(peer_id.model, sizeof peer_id.model, "%s", peer_model);
+        bad = lmb_cur_bytes(&c, peer_id.root, sizeof peer_id.root) ||
+              lmb_cur_u32(&c, &has_sig) || has_sig > 1 ||
+              (has_sig && lmb_cur_bytes(&c, peer_id.sig, sizeof peer_id.sig));
+        peer_id.has_sig = has_sig != 0;
+    }
+    if (!bad) bad = lmb_cur_u32(&c, &n) ||
+                    n > (uint64_t)L.n_layers * (uint64_t)L.n_experts;
+    if (!bad && (strcmp(engine, LMBE_ENGINE_ID) || strcmp(profile, L.profile) ||
+                 bits != (uint32_t)L.expected_bits ||
+                 (L.expected_model[0] && strcmp(peer_model, L.expected_model)) ||
+                 ((L.have_identity || L.have_pubkey) && !have_id) ||
+                 (have_id && !lumi_identity_valid(peer_model, &peer_id)) ||
+                 (L.have_identity && memcmp(L.identity.root, peer_id.root, 32)))) {
+        bad = 1;
+    }
+    size_t gids = (size_t)L.n_layers * L.n_experts;
+    uint8_t *seen = reprobe >= 0 ? (uint8_t *)calloc(gids, 1) : NULL;
+    if (reprobe >= 0 && !seen) bad = 1;
     int claimed = 0;
     for (uint32_t i = 0; !bad && i < n; i++) {
         uint32_t l, e;
         if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e) ||
             !lumi_index_ok(l, e)) { bad = 1; break; }
+        size_t gid = (size_t)l * (size_t)L.n_experts + e;
+        if (seen) { seen[gid] = 1; continue; }
         int *own = &L.own[((size_t)l * (size_t)L.n_experts + e) * LUMI_MAX_REP];
         for (int r = 0; r < LUMI_MAX_REP; r++) {
-            if (own[r] == L.npeers) break;                /* duplicate entry */
-            if (own[r] < 0) { own[r] = L.npeers; claimed += r == 0; break; }
+            if (own[r] == pi) break;                       /* duplicate entry */
+            if (own[r] < 0) { own[r] = pi; claimed += r == 0; break; }
         }
     }
+    if (!bad && seen)
+        for (size_t gid = 0; gid < gids && !bad; gid++)
+            for (int r = 0; r < LUMI_MAX_REP; r++)
+                if (L.own[gid * LUMI_MAX_REP + r] == pi && !seen[gid]) {
+                    bad = 1;
+                    break;
+                }
     if (bad || lmb_cur_u32(&c, &peer_hidden) ||
         peer_hidden != (uint32_t)L.hidden || c.off != c.len || m.pay_len != 0) {
         /* roll the claims back: this peer must not own anything */
-        for (size_t i = 0; i < (size_t)L.n_layers * L.n_experts * LUMI_MAX_REP; i++)
-            if (L.own[i] == L.npeers) L.own[i] = -1;
+        if (reprobe < 0)
+            for (size_t i = 0; i < gids * LUMI_MAX_REP; i++)
+                if (L.own[i] == pi) L.own[i] = -1;
+        free(seen);
         lmb_msg_free(&m);
-        fprintf(stderr, "[lumabri] peer %s: bad or mismatched manifest — skipped\n",
-                p->addr);
+        fprintf(stderr, "[lumabri] peer %s: incompatible manifest "
+                        "(model/build/engine/bits/shape) — skipped\n", p->addr);
         return -1;
     }
+    if (!L.expected_model[0]) snprintf(L.expected_model, sizeof L.expected_model,
+                                       "%s", peer_model);
+    if (!L.have_identity && have_id) { L.identity = peer_id; L.have_identity = 1; }
+    free(seen);
     lmb_msg_free(&m);
+    p->dead = 0;
     lumi_probe(p);
     if (p->rtt_us == LONG_MAX) {
-        for (size_t i = 0; i < (size_t)L.n_layers * L.n_experts * LUMI_MAX_REP; i++)
-            if (L.own[i] == L.npeers) L.own[i] = -1;
+        if (reprobe < 0)
+            for (size_t i = 0; i < gids * LUMI_MAX_REP; i++)
+                if (L.own[i] == pi) L.own[i] = -1;
         return -1;
     }
     fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms\n",
             p->addr, n, claimed, (double)p->rtt_us / 1000.0);
-    L.npeers++;
+    if (reprobe < 0) L.npeers++;
     return 0;
 }
 
@@ -188,6 +285,44 @@ static int lumi_discover(void) {
     return added;
 }
 
+static int lumi_missing_experts(void) {
+    int missing = 0, expected = 0;
+    for (int l = 0; l < L.n_layers; l++) {
+        if (L.routed && !L.routed[l]) continue;
+        for (int e = 0; e < L.n_experts; e++) {
+            expected++;
+            if (L.own[((size_t)l * L.n_experts + e) * LUMI_MAX_REP] < 0) missing++;
+        }
+    }
+    L.expected = expected;
+    return missing;
+}
+
+static void lumi_enable_if_complete(void) {
+    if (L.on) return;
+    int missing = lumi_missing_experts();
+    if (missing) return;
+    L.on = 1;
+    fprintf(stderr, "[lumabri] phase 2 active: every expert runs on a peer, "
+                    "%d peer(s), %d experts, hidden=%d, nearest replica "
+                    "preferred%s\n",
+            L.npeers, L.expected, L.hidden,
+            L.verify_pct ? " · spot-check verification on" : "");
+}
+
+static void lumi_maybe_discover(void) {
+    if (!L.initialized || !L.discovery) return;
+    double now = lumi_now();
+    if (now < L.next_discover) return;
+    L.next_discover = now + L.discover_period_s;
+    if (!L.have_identity) lumi_refresh_identity();
+    int added = lumi_discover();
+    if (added)
+        fprintf(stderr, "[lumabri] discovered %d new expert peer(s) mid-generation\n",
+                added);
+    lumi_enable_if_complete();
+}
+
 /* The bootstrap-and-delegate policy, chatter side. Peer list from
  * LUMABRI_EXPERTS when set (explicit, any gap is fatal); otherwise
  * discovered from the tracker — and if the swarm cannot cover every
@@ -205,26 +340,48 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
     const char *tracker = getenv("LUMABRI_TRACKER");
     int discovery = !spec || !*spec;
     if (discovery && (!tracker || !tracker[0])) return;
+    if (n_layers <= 0 || n_experts <= 0 || hidden <= 0 ||
+        (size_t)n_layers > SIZE_MAX / (size_t)n_experts / LUMI_MAX_REP)
+        lumi_die("invalid expert topology");
 
     L.n_layers = n_layers; L.n_experts = n_experts; L.hidden = hidden;
+    L.discovery = discovery;
+    L.discover_period_s = (double)lmb_env_int("LUMABRI_DISCOVERY_MS", 5000,
+                                              100, 600000) / 1000.0;
+    L.next_discover = lumi_now() + L.discover_period_s;
+    lmb_build_profile(L.profile, sizeof L.profile);
+    L.expected_bits = lmb_env_int("LUMABRI_EXPERT_BITS", LMBE_EXPECT_BITS,
+                                  0, 32);
+    const char *model = getenv("LUMABRI_MODEL");
+    if (model) snprintf(L.expected_model, sizeof L.expected_model, "%s", model);
+    lumi_load_pubkey();
+    if (getenv("LUMABRI_PUBKEY") && !L.have_pubkey) return;
+    if (tracker && tracker[0] && L.expected_model[0]) lumi_refresh_identity();
     size_t cells = (size_t)n_layers * n_experts * LUMI_MAX_REP;
     L.own = (int *)malloc(cells * sizeof(int));
+    if (!L.own) lumi_die("out of memory creating expert map");
     for (size_t i = 0; i < cells; i++) L.own[i] = -1;
     L.routed = NULL;
     if (routed) {
         L.routed = (unsigned char *)malloc((size_t)n_layers);
         if (L.routed) memcpy(L.routed, routed, (size_t)n_layers);
     }
+    const char *v = getenv("LUMABRI_VERIFY");
+    if (v) {
+        L.verify_pct = atoi(v);
+        if (L.verify_pct < 0) L.verify_pct = 0;
+        if (L.verify_pct > 100) L.verify_pct = 100;
+    }
+    L.initialized = 1;
 
     if (discovery) {
         int found = lumi_discover();
         if (!found) {
             fprintf(stderr, "[lumabri] no expert peers on the swarm — "
                             "running experts locally\n");
-            return;
-        }
-        fprintf(stderr, "[lumabri] discovered %d expert peer(s) from the tracker\n",
-                found);
+        } else
+            fprintf(stderr, "[lumabri] discovered %d expert peer(s) from the tracker\n",
+                    found);
     } else {
         char list[1024];
         snprintf(list, sizeof list, "%s", spec);
@@ -233,37 +390,19 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
             if (lumi_add_peer(tok)) lumi_die("configured expert peer failed");
     }
 
-    int missing = 0, expected = 0;
-    for (int l = 0; l < n_layers; l++) {
-        if (L.routed && !L.routed[l]) continue;      /* dense slot: no experts */
-        for (int e = 0; e < n_experts; e++) {
-            expected++;
-            if (L.own[((size_t)l * n_experts + e) * LUMI_MAX_REP] < 0) missing++;
-        }
-    }
+    int missing = lumi_missing_experts();
     if (missing) {
         fprintf(stderr, "[lumabri] %d of %d experts have no peer — ", missing,
-                expected);
+                L.expected);
         if (discovery) {
             fprintf(stderr, "running experts locally\n");
-            return;                    /* partial swarm: phase 2 stays off */
+            return; /* layer_on keeps discovering and enables once complete */
         }
         fprintf(stderr, "refusing to run "
                 "(a partial explicit network would silently change the model)\n");
         exit(1);
     }
-    const char *v = getenv("LUMABRI_VERIFY");
-    if (v) {
-        L.verify_pct = atoi(v);
-        if (L.verify_pct < 0) L.verify_pct = 0;
-        if (L.verify_pct > 100) L.verify_pct = 100;
-    }
-    L.on = 1;
-    fprintf(stderr, "[lumabri] phase 2 active: every expert runs on a peer, "
-                    "%d peer(s), %d experts, hidden=%d, nearest replica "
-                    "preferred%s\n",
-            L.npeers, expected, hidden,
-            L.verify_pct ? " · spot-check verification on" : "");
+    lumi_enable_if_complete();
 }
 
 /* olmoe's shape: every layer routes */
@@ -274,6 +413,7 @@ static void lumi_init(int n_layers, int n_experts, int hidden) {
 /* Does this (slot, expert) pair belong on the swarm? The engines call it
  * before handing a layer over, so an unrouted slot is never a wire error. */
 static int lumi_layer_on(int layer) {
+    lumi_maybe_discover();
     if (!L.on || layer < 0 || layer >= L.n_layers) return 0;
     return !L.routed || L.routed[layer];
 }
@@ -345,10 +485,15 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
                             "viva — aspetto che torni (fino a %d s)\n",
                             layer, eid, LUMI_WAIT_S);
                 tried = 0;                    /* a returning peer deserves a retry */
-                for (int i = 0; i < L.npeers; i++) L.peers[i].dead = 0;
                 sleep(2);
                 waited += 2;
-                lumi_discover();
+                if (L.discovery) lumi_discover();
+                else for (int i = 0; i < L.npeers; i++)
+                    if (L.peers[i].dead) {
+                        char addr[64];
+                        snprintf(addr, sizeof addr, "%s", L.peers[i].addr);
+                        lumi_add_peer(addr);   /* revalidates manifest before reuse */
+                    }
                 continue;
             }
             fprintf(stderr, "[lumabri] layer %d expert %d: nessuna replica viva "

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -303,6 +303,10 @@ static void lumi_enable_if_complete(void) {
     int missing = lumi_missing_experts();
     if (missing) return;
     L.on = 1;
+    /* Tell the byte-mirror in this same process to stop reading ahead: from
+     * here on the experts run on peers, and a readahead past a dense block
+     * would pull adjacent expert weights the chatter will never execute. */
+    setenv("LUMABRI_REMOTE_EXPERTS", "1", 1);
     fprintf(stderr, "[lumabri] phase 2 active: every expert runs on a peer, "
                     "%d peer(s), %d experts, hidden=%d, nearest replica "
                     "preferred%s\n",

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -25,6 +25,7 @@
 #include <netdb.h>
 #include <poll.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <stdint.h>
@@ -32,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -39,6 +41,19 @@
 #define LMB_MAX_BODY  (64u << 20)   /* a REGISTER carrying block hashes for a
                                        whole huge model must fit: 32 B/MiB */
 #define LMB_MAX_PAY   (64u << 20)
+#define LMB_MAX_CONTROL_BODY (4u << 20)
+#define LMB_MAX_PLACEMENT_BODY (8u << 20) /* 4096 long paths, eight replicas */
+#define LMB_MAX_SMALL_BODY   (64u << 10)
+/* A DeepSeek prefill may queue dozens of cold experts behind one CPU gate;
+ * 30 s incorrectly declared a healthy disk-backed node dead.  Connections
+ * remain bounded separately, so five minutes is a safe default for bulk
+ * work while deployments may lower it with LUMABRI_IO_TIMEOUT_MS. */
+#define LMB_DEFAULT_IO_TIMEOUT_MS 300000
+#define LMB_DEFAULT_MAX_CONNECTIONS 256u
+#define LMB_EXPERT_MANIFEST_MAGIC 0x324D454Cu /* "LEM2": versioned EXEC manifest */
+#define LMB_MODEL_ID_MAGIC         0x3144494Du /* "MID1": signed model identity */
+#define LMB_MODEL_ROOT_LEN 32
+#define LMB_BUILD_PROFILE_MAX 384
 /* Rows an EXEC may carry. A real batch is a prompt's worth of positions, so
  * this is generous; it exists so a length can never be chosen to overflow
  * the size arithmetic on a model with a large hidden dimension. */
@@ -122,6 +137,11 @@ enum {
      * restart does not re-download. A node that passes --layers/--stride
      * opts out and is simply counted like any other replica. */
     LMB_EASSIGN = 28, LMB_EASSIGN_R = 29,
+    /* A single signed identity for the complete model. The origin hashes the
+     * canonical list of {path,size,block hashes}, signs that 32-byte root,
+     * and the tracker only carries it. Expert nodes include the same record
+     * in EMANIFEST, so a chatter cannot accidentally mix checkpoints. */
+    LMB_MODEL_ID = 30, LMB_MODEL_ID_R = 31,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -133,6 +153,13 @@ typedef struct {
     uint8_t *body; uint32_t body_len;
     uint8_t *pay;  uint32_t pay_len;
 } LmbMsg;
+
+typedef struct {
+    char model[64];
+    uint8_t root[LMB_MODEL_ROOT_LEN];
+    uint8_t sig[64];
+    int has_sig;
+} LmbModelIdentity;
 
 /* ---- full-buffer socket I/O ------------------------------------------- */
 
@@ -168,8 +195,53 @@ static uint32_t lmb_get32(const uint8_t *p) {
            ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
 }
 
+/* A frame's legal shape is determined before allocating it. REGISTER is the
+ * only large-body request because it may carry every block hash of a huge
+ * model. Bulk byte and activation frames may have a large payload but only a
+ * small body. Thus no unknown or control op can reserve 64+64 MiB merely by
+ * writing a hostile preamble. */
+static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
+    *body_cap = LMB_MAX_SMALL_BODY;
+    *pay_cap = 0;
+    switch (op) {
+    case LMB_REGISTER:
+        *body_cap = LMB_MAX_BODY;
+        break;
+    case LMB_MANIFEST_R:
+    case LMB_SWARM_R:
+    case LMB_EPEERS_R:
+    case LMB_EMANIFEST_R:
+    case LMB_EASSIGN_R:
+        *body_cap = LMB_MAX_CONTROL_BODY;
+        break;
+    case LMB_PLACEMENT_R:
+        *body_cap = LMB_MAX_PLACEMENT_BODY;
+        break;
+    case LMB_READ_R:
+    case LMB_RREAD_R:
+    case LMB_HASHES_R:
+    case LMB_EXEC_R:
+        *pay_cap = LMB_MAX_PAY;
+        break;
+    case LMB_RREAD_FWD:
+    case LMB_EXEC:
+        *body_cap = LMB_MAX_CONTROL_BODY;
+        *pay_cap = LMB_MAX_PAY;
+        break;
+    default:
+        break;
+    }
+}
+
+static int lmb_frame_shape_ok(uint32_t op, uint32_t body_len, uint32_t pay_len) {
+    uint32_t bc, pc;
+    lmb_frame_caps(op, &bc, &pc);
+    return body_len <= bc && pay_len <= pc;
+}
+
 static int lmb_send(int fd, uint32_t op, const void *body, uint32_t body_len,
                     const void *pay, uint32_t pay_len) {
+    if (!lmb_frame_shape_ok(op, body_len, pay_len)) { errno = EMSGSIZE; return -1; }
     uint8_t pre[16];
     lmb_put32(pre, LMB_MAGIC); lmb_put32(pre + 4, op);
     lmb_put32(pre + 8, body_len); lmb_put32(pre + 12, pay_len);
@@ -188,7 +260,10 @@ static int lmb_recv(int fd, LmbMsg *m) {
     m->op = lmb_get32(pre + 4);
     m->body_len = lmb_get32(pre + 8);
     m->pay_len = lmb_get32(pre + 12);
-    if (m->body_len > LMB_MAX_BODY || m->pay_len > LMB_MAX_PAY) return -1;
+    if (!lmb_frame_shape_ok(m->op, m->body_len, m->pay_len)) {
+        errno = EMSGSIZE;
+        return -1;
+    }
     if (m->body_len) {
         if (!(m->body = (uint8_t *)malloc(m->body_len))) return -1;
         if (lmb_read_full(fd, m->body, m->body_len)) { free(m->body); m->body = NULL; return -1; }
@@ -212,9 +287,14 @@ static void lmb_msg_free(LmbMsg *m) {
 typedef struct { uint8_t *p; size_t len, cap; } LmbBuf;
 
 static int lmb_buf_reserve(LmbBuf *b, size_t extra) {
-    if (b->len + extra <= b->cap) return 0;
+    if (extra > SIZE_MAX - b->len) return -1;
+    size_t need = b->len + extra;
+    if (need <= b->cap) return 0;
     size_t cap = b->cap ? b->cap : 256;
-    while (cap < b->len + extra) cap *= 2;
+    while (cap < need) {
+        if (cap > SIZE_MAX / 2) { cap = need; break; }
+        cap *= 2;
+    }
     uint8_t *p = (uint8_t *)realloc(b->p, cap);
     if (!p) return -1;
     b->p = p; b->cap = cap;
@@ -251,7 +331,7 @@ static int lmb_buf_str(LmbBuf *b, const char *s) {  /* u16 len + bytes */
 typedef struct { const uint8_t *p; size_t len, off; } LmbCur;
 
 static int lmb_cur_u16(LmbCur *c, uint16_t *v) {
-    if (c->off + 2 > c->len) return -1;
+    if (c->off > c->len || 2 > c->len - c->off) return -1;
     *v = (uint16_t)(c->p[c->off] | (c->p[c->off + 1] << 8));
     c->off += 2;
     return 0;
@@ -289,8 +369,64 @@ static int lmb_rel_ok(const char *rel) {
     return 1;
 }
 
+/* Numeric compatibility is stricter than an engine family name. Different
+ * source trees, compilers, ISA paths or fast-math settings may all produce a
+ * different last bit while still accepting the same tensors. Official builds
+ * inject a stable source hash; the rest is derived from compiler macros so an
+ * EMANIFEST comparison is cheap and deterministic. */
+#ifndef LMBE_ENGINE_ID
+#define LMBE_ENGINE_ID "unknown"
+#endif
+#ifndef LMBE_SOURCE_ID
+#define LMBE_SOURCE_ID "unversioned"
+#endif
+#define LMB_STR_INNER(x) #x
+#define LMB_STR(x) LMB_STR_INNER(x)
+#ifdef _OPENMP
+#define LMB_PROFILE_OMP LMB_STR(_OPENMP)
+#else
+#define LMB_PROFILE_OMP "none"
+#endif
+#ifdef __FAST_MATH__
+#define LMB_PROFILE_MATH "fast"
+#else
+#define LMB_PROFILE_MATH "strict"
+#endif
+#if defined(__AVX512BF16__)
+#define LMB_PROFILE_ISA "avx512bf16"
+#elif defined(__AVX512VNNI__)
+#define LMB_PROFILE_ISA "avx512vnni"
+#elif defined(__AVX512F__)
+#define LMB_PROFILE_ISA "avx512f"
+#elif defined(__AVXVNNI__)
+#define LMB_PROFILE_ISA "avxvnni"
+#elif defined(__AVX2__)
+#define LMB_PROFILE_ISA "avx2"
+#elif defined(__ARM_FEATURE_MATMUL_INT8)
+#define LMB_PROFILE_ISA "arm-i8mm"
+#elif defined(__ARM_FEATURE_DOTPROD)
+#define LMB_PROFILE_ISA "arm-dotprod"
+#elif defined(__aarch64__)
+#define LMB_PROFILE_ISA "aarch64"
+#elif defined(__x86_64__)
+#define LMB_PROFILE_ISA "x86_64"
+#else
+#define LMB_PROFILE_ISA "generic"
+#endif
+#ifdef __VERSION__
+#define LMB_PROFILE_CC __VERSION__
+#else
+#define LMB_PROFILE_CC "unknown-cc"
+#endif
+
+static void lmb_build_profile(char *out, size_t cap) {
+    snprintf(out, cap, "abi=2;engine=%s;src=%s;cc=%s;isa=%s;omp=%s;math=%s;f32=%zu",
+             LMBE_ENGINE_ID, LMBE_SOURCE_ID, LMB_PROFILE_CC, LMB_PROFILE_ISA,
+             LMB_PROFILE_OMP, LMB_PROFILE_MATH, sizeof(float));
+}
+
 static int lmb_cur_u32(LmbCur *c, uint32_t *v) {
-    if (c->off + 4 > c->len) return -1;
+    if (c->off > c->len || 4 > c->len - c->off) return -1;
     *v = lmb_get32(c->p + c->off); c->off += 4;
     return 0;
 }
@@ -301,19 +437,59 @@ static int lmb_cur_u64(LmbCur *c, uint64_t *v) {
     return 0;
 }
 static int lmb_cur_bytes(LmbCur *c, void *dst, size_t n) {
-    if (c->off + n > c->len) return -1;
+    if (c->off > c->len || n > c->len - c->off) return -1;
     memcpy(dst, c->p + c->off, n); c->off += n;
     return 0;
 }
 static int lmb_cur_str(LmbCur *c, char *dst, size_t cap) {
     uint16_t n;
     if (lmb_cur_u16(c, &n)) return -1;
-    if (c->off + n > c->len || (size_t)n + 1 > cap) return -1;
+    if (c->off > c->len || n > c->len - c->off || (size_t)n + 1 > cap) return -1;
     memcpy(dst, c->p + c->off, n); dst[n] = 0; c->off += n;
     return 0;
 }
 
 /* ---- sockets ----------------------------------------------------------- */
+
+static int lmb_env_int(const char *name, int fallback, int lo, int hi) {
+    const char *s = getenv(name);
+    if (!s || !*s) return fallback;
+    char *end = NULL;
+    long v = strtol(s, &end, 10);
+    if (end == s || *end || v < lo || v > hi) return fallback;
+    return (int)v;
+}
+
+static void lmb_set_io_timeout(int fd, int timeout_ms) {
+    if (timeout_ms <= 0) return;
+    struct timeval tv = { timeout_ms / 1000, (timeout_ms % 1000) * 1000 };
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof tv);
+}
+
+/* Thread-per-connection keeps persistent pooled sockets simple, but it must
+ * have an admission boundary. This small atomic gate is shared by tracker,
+ * byte peers and expert peers; excess connections are closed before a stack
+ * or request buffer is allocated. */
+typedef struct { _Atomic unsigned active; unsigned limit; } LmbConnGate;
+#define LMB_CONN_GATE_INIT { .active = 0, .limit = LMB_DEFAULT_MAX_CONNECTIONS }
+
+static void lmb_conn_gate_init(LmbConnGate *g) {
+    g->limit = (unsigned)lmb_env_int("LUMABRI_MAX_CONNECTIONS",
+                                     (int)LMB_DEFAULT_MAX_CONNECTIONS, 1, 65536);
+}
+
+static int lmb_conn_gate_enter(LmbConnGate *g) {
+    unsigned n = atomic_load(&g->active);
+    while (n < g->limit) {
+        if (atomic_compare_exchange_weak(&g->active, &n, n + 1)) return 1;
+    }
+    return 0;
+}
+
+static void lmb_conn_gate_leave(LmbConnGate *g) {
+    atomic_fetch_sub(&g->active, 1);
+}
 
 /* addr is "host:port". Bounded connect: an unreachable peer must cost
  * `timeout_ms`, not the kernel's minutes — the caller has a relay to fall
@@ -349,6 +525,8 @@ static int lmb_connect_ms(const char *addr, int timeout_ms) {
     if (fd >= 0) {
         int one = 1;
         setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+        lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
+                                           LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
     }
     return fd;
 }
@@ -451,6 +629,32 @@ static int lmb_request(const char *addr, uint32_t op,
     if (rc == 0) rc = lmb_recv(fd, resp);
     close(fd);
     return rc;
+}
+
+/* Fetch the operator-bound identity of a complete model. Signature checking
+ * stays with the caller because only the caller owns the public key. */
+static int lmb_model_identity_get(const char *tracker, const char *model,
+                                  LmbModelIdentity *id) {
+    memset(id, 0, sizeof *id);
+    if (!tracker || !*tracker || !model || !*model) return -1;
+    LmbBuf b = {0};
+    if (lmb_buf_str(&b, model)) return -1;
+    LmbMsg m = {0};
+    int rc = lmb_request(tracker, LMB_MODEL_ID, b.p, (uint32_t)b.len, &m);
+    free(b.p);
+    if (rc || m.op != LMB_MODEL_ID_R) { lmb_msg_free(&m); return -1; }
+    LmbCur c = { m.body, m.body_len, 0 };
+    uint32_t magic = 0, has_sig = 0;
+    int bad = lmb_cur_u32(&c, &magic) || magic != LMB_MODEL_ID_MAGIC ||
+              lmb_cur_str(&c, id->model, sizeof id->model) ||
+              lmb_cur_bytes(&c, id->root, sizeof id->root) ||
+              lmb_cur_u32(&c, &has_sig) || has_sig > 1 ||
+              (has_sig && lmb_cur_bytes(&c, id->sig, sizeof id->sig)) ||
+              c.off != c.len;
+    id->has_sig = has_sig != 0;
+    lmb_msg_free(&m);
+    if (bad || strcmp(id->model, model)) { memset(id, 0, sizeof *id); return -1; }
+    return 0;
 }
 
 #endif /* LUMABRI_PROTO_H */

--- a/lumabri_sha.h
+++ b/lumabri_sha.h
@@ -5,6 +5,7 @@
 #define LUMABRI_SHA_H
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 typedef struct { uint32_t h[8]; uint64_t len; uint8_t buf[64]; size_t off; } LmbSha;
@@ -87,6 +88,71 @@ static void lmb_sha256(const void *data, size_t n, uint8_t out[32]) {
     lmb_sha_init(&s);
     lmb_sha_update(&s, data, n);
     lmb_sha_final(&s, out);
+}
+
+/* Canonical identity of a complete model. Paths are sorted here, rather than
+ * trusting readdir or registration order, and every field has an explicit
+ * little-endian encoding. The root commits to the inventory as well as all
+ * per-MiB hashes, so replacing, adding or removing a file changes it. */
+typedef struct {
+    const char *path;
+    uint64_t size;
+    uint32_t nh;
+    const uint8_t *hashes;
+} LmbModelItem;
+
+static int lmb_model_item_cmp(const void *a, const void *b) {
+    const LmbModelItem *const *aa = (const LmbModelItem *const *)a;
+    const LmbModelItem *const *bb = (const LmbModelItem *const *)b;
+    return strcmp((*aa)->path, (*bb)->path);
+}
+
+static void lmb_sha_le32(LmbSha *s, uint32_t v) {
+    uint8_t b[4];
+    for (int i = 0; i < 4; i++) b[i] = (uint8_t)(v >> (8 * i));
+    lmb_sha_update(s, b, sizeof b);
+}
+
+static void lmb_sha_le64(LmbSha *s, uint64_t v) {
+    uint8_t b[8];
+    for (int i = 0; i < 8; i++) b[i] = (uint8_t)(v >> (8 * i));
+    lmb_sha_update(s, b, sizeof b);
+}
+
+static int lmb_model_root(const char *model, const LmbModelItem *items, size_t n,
+                          uint8_t out[32]) {
+    static const char tag[] = "lumabri-model-root-v1";
+    if (!model || (!items && n) || n > UINT32_MAX) return -1;
+    const LmbModelItem **ord = (const LmbModelItem **)malloc((n ? n : 1) * sizeof *ord);
+    if (!ord) return -1;
+    for (size_t i = 0; i < n; i++) {
+        if (!items[i].path || (items[i].nh && !items[i].hashes)) { free(ord); return -1; }
+        ord[i] = &items[i];
+    }
+    qsort(ord, n, sizeof *ord, lmb_model_item_cmp);
+    LmbSha s;
+    lmb_sha_init(&s);
+    lmb_sha_update(&s, tag, sizeof tag);
+    size_t ml = strlen(model);
+    if (ml > UINT32_MAX) { free(ord); return -1; }
+    lmb_sha_le32(&s, (uint32_t)ml);
+    lmb_sha_update(&s, model, ml);
+    lmb_sha_le32(&s, (uint32_t)n);
+    for (size_t i = 0; i < n; i++) {
+        const LmbModelItem *it = ord[i];
+        size_t pl = strlen(it->path);
+        /* nh is a uint32_t, so nh * 32 cannot overflow size_t on the
+         * supported 64-bit targets.  Keep the path conversion explicit. */
+        if (pl > UINT32_MAX) { free(ord); return -1; }
+        lmb_sha_le32(&s, (uint32_t)pl);
+        lmb_sha_update(&s, it->path, pl);
+        lmb_sha_le64(&s, it->size);
+        lmb_sha_le32(&s, it->nh);
+        lmb_sha_update(&s, it->hashes, (size_t)it->nh * 32);
+    }
+    free(ord);
+    lmb_sha_final(&s, out);
+    return 0;
 }
 
 #endif /* LUMABRI_SHA_H */

--- a/lumabri_sign.h
+++ b/lumabri_sign.h
@@ -452,6 +452,27 @@ static uint8_t *lmb_truth_msg(const char *model, const char *path,
     return m;
 }
 
+/* A separate domain binds the signature to a complete-model root. It cannot
+ * be replayed as a per-file truth signature, and the model name prevents a
+ * valid root from being relabelled by a tracker. */
+#define LMB_MODEL_ID_TAG "lumabri-model-id-v1"
+
+static uint8_t *lmb_model_id_msg(const char *model, const uint8_t root[32],
+                                 size_t *out_len) {
+    size_t ml = strlen(model);
+    if (ml > SIZE_MAX - sizeof(LMB_MODEL_ID_TAG) - 1 - 32) return NULL;
+    size_t n = sizeof(LMB_MODEL_ID_TAG) + ml + 1 + 32;
+    uint8_t *m = (uint8_t *)malloc(n);
+    if (!m) return NULL;
+    size_t o = 0;
+    memcpy(m + o, LMB_MODEL_ID_TAG, sizeof(LMB_MODEL_ID_TAG));
+    o += sizeof(LMB_MODEL_ID_TAG);
+    memcpy(m + o, model, ml); o += ml; m[o++] = 0;
+    memcpy(m + o, root, 32); o += 32;
+    *out_len = o;
+    return m;
+}
+
 /* ---- hex helpers (keys live in files as hex, easy to paste) ------------- */
 
 static void lmb_hex(char *dst, const uint8_t *src, size_t n) {

--- a/lumashim.c
+++ b/lumashim.c
@@ -618,13 +618,38 @@ static void probe_peers(void) {
  * read path uses — the in-flight map dedups, the bitmap makes a wasted
  * prefetch impossible to double-fetch, and a prefetch failure is silent
  * because the read path will retry it loudly if the block is ever needed.
- * LUMABRI_PREFETCH sets the readahead depth in blocks (default 2, 0 = off). */
+ * LUMABRI_PREFETCH sets the readahead depth in blocks (default 2, 0 = off).
+ *
+ * One exception the byte-mirror cannot see for itself: when the experts run
+ * on peers, the chatter is meant to touch only the dense part, and a
+ * readahead of 2 blocks past a dense read walks straight into the adjacent
+ * expert region at 1 MiB granularity — pulling expert weights it will never
+ * execute, a little more on every run. The engine's phase-2 client sets
+ * LUMABRI_REMOTE_EXPERTS the moment delegation goes live (same process), and
+ * from then on readahead is off, unless the operator asked for a specific
+ * depth explicitly. A skip-range-aware prefetcher could restore the latency
+ * hiding without entering declared expert ranges; this is the safe floor. */
 
 #define PF_QLEN 64
 static struct {
     RFile *f; uint32_t blk;
 } pf_q[PF_QLEN];
 static int pf_head, pf_tail, pf_depth;
+static int pf_user_set;          /* LUMABRI_PREFETCH given explicitly: it wins */
+static int pf_expert_off;        /* latches once remote experts are active */
+
+static int prefetch_suppressed(void) {
+    if (pf_user_set) return 0;
+    if (pf_expert_off) return 1;
+    const char *e = getenv("LUMABRI_REMOTE_EXPERTS");
+    if (e && e[0] == '1') {
+        pf_expert_off = 1;
+        fprintf(stderr, "[lumabri] remote experts active: readahead off so the "
+                        "chatter never pulls expert weights it will not run\n");
+        return 1;
+    }
+    return 0;
+}
 static pthread_mutex_t pf_lk = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t pf_cv = PTHREAD_COND_INITIALIZER;
 
@@ -646,7 +671,7 @@ static void *prefetch_thread(void *arg) {
 
 /* queue the blocks after the range just read; full queue = drop, no harm */
 static void prefetch_after(RFile *f, uint64_t off, uint64_t len) {
-    if (!pf_depth || !f->nblocks) return;
+    if (!pf_depth || !f->nblocks || prefetch_suppressed()) return;
     uint64_t end = off + len;
     if (end > f->size) end = f->size;
     uint32_t last = (uint32_t)((end ? end - 1 : 0) / g.block);
@@ -961,7 +986,7 @@ static void shim_init_impl(void) {
     }
     pf_depth = 2;
     const char *pf = getenv("LUMABRI_PREFETCH");
-    if (pf) pf_depth = atoi(pf);
+    if (pf) { pf_depth = atoi(pf); pf_user_set = 1; }
     if (pf_depth < 0) pf_depth = 0;
     if (pf_depth > 16) pf_depth = 16;
     if (pf_depth && g.npeers) {

--- a/lumashim.c
+++ b/lumashim.c
@@ -43,6 +43,7 @@
 #include <stdarg.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -118,11 +119,13 @@ typedef struct {
     int peer_idx[MAX_FPEERS]; int npeers;
     int wfd;              /* mirror write fd, opened on first fetch */
     int map_fd;           /* persisted bitmap */
+    uint64_t dirty_gen, durable_gen; /* batched data-before-map commits */
     uint8_t *hash;        /* ground truth: sha256 per LMB_HASH_CHUNK */
     uint32_t nh;
     int hstate;           /* 0 unknown · 1 have · 2 tracker has none */
     int signed_;          /* the truth carried a valid operator signature */
     pthread_mutex_t lk;
+    pthread_mutex_t commit_lk;
     pthread_cond_t cv;
 } RFile;
 
@@ -130,6 +133,8 @@ static struct {
     int ok;                       /* full init succeeded */
     char vroot[LMB_PATH_MAX]; size_t vroot_len;
     char data_dir[LMB_PATH_MAX], maps_dir[LMB_PATH_MAX];
+    int cache_lock_fd;              /* shared for process lifetime; exclusive on reset */
+    int reset_lock_fd;              /* elects one resetter without queuing behind its chat */
     uint32_t block;
     RFile *files; int nfiles;
     RPeer peers[MAX_RPEERS]; int npeers;
@@ -137,7 +142,109 @@ static struct {
     RFile *_Atomic fdmap[FD_LIMIT];
     _Atomic uint64_t net_bytes, net_blocks, warm_reads;
     pthread_once_t once;
-} g = { .once = PTHREAD_ONCE_INIT };
+} g = { .cache_lock_fd = -1, .reset_lock_fd = -1, .once = PTHREAD_ONCE_INIT };
+
+/* Persist bitmap claims in batches.  A fetched block is immediately usable
+ * from the in-process map, but the on-disk map is updated only after the data
+ * fd has reached stable storage.  This preserves crash safety without paying
+ * two fdatasync calls on every MiB, which destroys cold-stream throughput. */
+static int mirror_commit_file(RFile *f) {
+    pthread_mutex_lock(&f->commit_lk);
+    pthread_mutex_lock(&f->lk);
+    if (f->dirty_gen == f->durable_gen || f->wfd < 0) {
+        pthread_mutex_unlock(&f->lk);
+        pthread_mutex_unlock(&f->commit_lk);
+        return 0;
+    }
+    uint64_t target = f->dirty_gen;
+    size_t n = f->nblocks ? f->nblocks : 1;
+    uint8_t *snapshot = (uint8_t *)calloc(n, 1);
+    if (snapshot) memcpy(snapshot, f->map, f->nblocks);
+    int wfd = f->wfd, mfd = f->map_fd;
+    pthread_mutex_unlock(&f->lk);
+    if (!snapshot) { pthread_mutex_unlock(&f->commit_lk); return -1; }
+
+    /* Several chatters may share this mirror.  Serialize the persisted-map
+     * merge across processes and OR in bits published by the others, or an
+     * older in-memory snapshot could erase their warm blocks. */
+    int rc = flock(mfd, LOCK_EX);
+    uint8_t *ondisk = NULL;
+    if (!rc) rc = fdatasync(wfd);       /* data is durable before any map bit */
+    if (!rc) {
+        ondisk = (uint8_t *)calloc(n, 1);
+        if (!ondisk) rc = -1;
+    }
+    if (!rc) {
+        size_t got = 0;
+        while (got < n) {
+            ssize_t r = real_pread(mfd, ondisk + got, n - got, (off_t)got);
+            if (r < 0) { if (errno == EINTR) continue; rc = -1; break; }
+            if (r == 0) break;
+            got += (size_t)r;
+        }
+        for (size_t i = 0; i < n; i++) snapshot[i] |= ondisk[i];
+    }
+    size_t put = 0;
+    while (!rc && put < n) {
+        ssize_t w = pwrite(mfd, snapshot + put, n - put, (off_t)put);
+        if (w < 0) { if (errno == EINTR) continue; rc = -1; break; }
+        put += (size_t)w;
+    }
+    if (!rc && fdatasync(mfd)) rc = -1;
+    free(ondisk);
+    if (flock(mfd, LOCK_UN) && !rc) rc = -1;
+    free(snapshot);
+    if (!rc) {
+        pthread_mutex_lock(&f->lk);
+        if (f->durable_gen < target) f->durable_gen = target;
+        pthread_mutex_unlock(&f->lk);
+    }
+    pthread_mutex_unlock(&f->commit_lk);
+    return rc;
+}
+
+static void mirror_commit_all(void) {
+    for (int i = 0; i < g.nfiles; i++)
+        if (mirror_commit_file(&g.files[i]))
+            fprintf(stderr, "[lumabri] cannot make the mirror map durable for %s\n",
+                    g.files[i].rel);
+}
+
+static void *mirror_commit_thread(void *arg) {
+    (void)arg;
+    for (;;) {
+        sleep(1);
+        mirror_commit_all();
+    }
+    return NULL;
+}
+
+static int cache_flock(int op) {
+    int rc;
+    do rc = flock(g.cache_lock_fd, op); while (rc && errno == EINTR);
+    return rc;
+}
+
+static void cache_reset_unlock(void) {
+    if (g.reset_lock_fd < 0) return;
+    flock(g.reset_lock_fd, LOCK_UN);
+    real_close(g.reset_lock_fd);
+    g.reset_lock_fd = -1;
+}
+
+static void cache_lock_release(void) {
+    if (g.cache_lock_fd >= 0) {
+        cache_flock(LOCK_UN);
+        real_close(g.cache_lock_fd);
+        g.cache_lock_fd = -1;
+    }
+    cache_reset_unlock();
+}
+
+__attribute__((destructor)) static void shim_dtor(void) {
+    if (g.ok) mirror_commit_all();
+    cache_lock_release();
+}
 
 static void shim_learn_vroot(void) {
     const char *v = getenv("LUMABRI_VROOT");
@@ -151,7 +258,7 @@ static void shim_learn_vroot(void) {
 /* ---- small helpers ----------------------------------------------------- */
 
 static void mkdir_p(const char *path) {
-    char tmp[LMB_PATH_MAX * 2];
+    char tmp[LMB_PATH_MAX * 2 + 64];
     snprintf(tmp, sizeof tmp, "%s", path);
     for (char *p = tmp + 1; *p; p++)
         if (*p == '/') { *p = 0; mkdir(tmp, 0755); *p = '/'; }
@@ -159,10 +266,24 @@ static void mkdir_p(const char *path) {
 }
 
 static void mkdir_parent(const char *path) {
-    char tmp[LMB_PATH_MAX * 2];
+    char tmp[LMB_PATH_MAX * 2 + 64];
     snprintf(tmp, sizeof tmp, "%s", path);
     char *slash = strrchr(tmp, '/');
     if (slash && slash != tmp) { *slash = 0; mkdir_p(tmp); }
+}
+
+static int fsync_parent_dir(const char *path) {
+    char dir[LMB_PATH_MAX * 2 + 64];
+    snprintf(dir, sizeof dir, "%s", path);
+    char *slash = strrchr(dir, '/');
+    if (!slash) return 0;
+    if (slash == dir) slash[1] = 0;
+    else *slash = 0;
+    int fd = real_open(dir, O_RDONLY | O_DIRECTORY);
+    if (fd < 0) return -1;
+    int rc = fsync(fd);
+    real_close(fd);
+    return rc;
 }
 
 static uint32_t fnv1a(const char *s, uint32_t extra) {
@@ -303,16 +424,18 @@ static int placement_from_peer(const char *addr) {
 /* The manifest survives on disk so a warm cache keeps working with every
  * peer AND the tracker offline: reads of present blocks never need the
  * network; only a miss does, and a miss with no peers is a loud EIO. */
-static void manifest_save(void) {
-    char path[LMB_PATH_MAX * 2], tmp[LMB_PATH_MAX * 2];
+static int manifest_save(void) {
+    char path[LMB_PATH_MAX * 2], tmp[LMB_PATH_MAX * 2 + 32];
     snprintf(path, sizeof path, "%s/manifest.txt", g.maps_dir);
-    snprintf(tmp, sizeof tmp, "%s.tmp", path);
+    snprintf(tmp, sizeof tmp, "%s.tmp.%ld", path, (long)getpid());
     FILE *fp = real_fopen(tmp, "w");
-    if (!fp) return;
+    if (!fp) return -1;
     for (int i = 0; i < g.nfiles; i++)
         fprintf(fp, "%llu\t%s\n", (unsigned long long)g.files[i].size, g.files[i].rel);
-    fclose(fp);
-    rename(tmp, path);
+    int ok = fflush(fp) == 0 && fsync(fileno(fp)) == 0;
+    if (fclose(fp)) ok = 0;
+    if (!ok || rename(tmp, path)) { unlink(tmp); return -1; }
+    return fsync_parent_dir(path);
 }
 
 static int manifest_load(void) {
@@ -335,6 +458,115 @@ static int manifest_load(void) {
     }
     fclose(fp);
     return g.nfiles ? 0 : -1;
+}
+
+typedef struct {
+    uint32_t magic, version;
+    char model[64];
+    uint8_t root[32];
+    uint32_t has_sig;
+    uint8_t sig[64];
+    uint32_t block;
+} CacheIdentity;
+
+static int cache_identity_load(CacheIdentity *rec) {
+    char path[LMB_PATH_MAX * 2];
+    snprintf(path, sizeof path, "%s/identity.bin", g.maps_dir);
+    FILE *fp = real_fopen(path, "rb");
+    if (!fp) return -1;
+    int ok = fread(rec, sizeof *rec, 1, fp) == 1 &&
+             rec->magic == LMB_MODEL_ID_MAGIC && rec->version == 2 &&
+             rec->has_sig <= 1 && rec->block >= (1u << 20);
+    fclose(fp);
+    return ok ? 0 : -1;
+}
+
+static int cache_identity_save(const LmbModelIdentity *id) {
+    CacheIdentity rec;
+    memset(&rec, 0, sizeof rec);
+    rec.magic = LMB_MODEL_ID_MAGIC; rec.version = 2;
+    snprintf(rec.model, sizeof rec.model, "%s", id->model);
+    memcpy(rec.root, id->root, 32);
+    rec.has_sig = id->has_sig ? 1u : 0u;
+    if (id->has_sig) memcpy(rec.sig, id->sig, 64);
+    rec.block = g.block;
+    char path[LMB_PATH_MAX * 2], tmp[LMB_PATH_MAX * 2 + 32];
+    snprintf(path, sizeof path, "%s/identity.bin", g.maps_dir);
+    snprintf(tmp, sizeof tmp, "%s.tmp.%ld", path, (long)getpid());
+    FILE *fp = real_fopen(tmp, "wb");
+    if (!fp) return -1;
+    int ok = fwrite(&rec, sizeof rec, 1, fp) == 1 &&
+             fflush(fp) == 0 && fsync(fileno(fp)) == 0;
+    if (fclose(fp)) ok = 0;
+    if (!ok) { unlink(tmp); return -1; }
+    if (rename(tmp, path)) return -1;
+    return fsync_parent_dir(path);
+}
+
+static int model_identity_signature_ok(const LmbModelIdentity *id) {
+    if (!g.have_pubkey) return 1;
+    if (!id->has_sig) return 0;
+    size_t n = 0;
+    uint8_t *msg = lmb_model_id_msg(id->model, id->root, &n);
+    int ok = msg && lmb_sign_verify(id->sig, msg, n, g.pubkey) == 0;
+    free(msg);
+    return ok;
+}
+
+static int cache_identity_get(CacheIdentity *rec, LmbModelIdentity *id) {
+    memset(rec, 0, sizeof *rec);
+    memset(id, 0, sizeof *id);
+    if (cache_identity_load(rec) || rec->block != g.block) return -1;
+    snprintf(id->model, sizeof id->model, "%s", rec->model);
+    memcpy(id->root, rec->root, sizeof id->root);
+    id->has_sig = rec->has_sig != 0;
+    if (id->has_sig) memcpy(id->sig, rec->sig, sizeof id->sig);
+    return model_identity_signature_ok(id) ? 0 : -1;
+}
+
+static int cache_identity_differs(const LmbModelIdentity *current,
+                                  const LmbModelIdentity *saved, int have_saved) {
+    return !have_saved || strcmp(current->model, saved->model) ||
+           memcmp(current->root, saved->root, sizeof current->root);
+}
+
+static int cache_lock_shared_open(void) {
+    char path[LMB_PATH_MAX * 2];
+    snprintf(path, sizeof path, "%s/cache.lock", g.maps_dir);
+    g.cache_lock_fd = real_open(path, O_RDWR | O_CREAT, 0644);
+    return g.cache_lock_fd < 0 || cache_flock(LOCK_SH) ? -1 : 0;
+}
+
+static int cache_reset_lock(void) {
+    char path[LMB_PATH_MAX * 2];
+    snprintf(path, sizeof path, "%s/reset.lock", g.maps_dir);
+    g.reset_lock_fd = real_open(path, O_RDWR | O_CREAT, 0644);
+    if (g.reset_lock_fd < 0) return -1;
+    int rc;
+    do rc = flock(g.reset_lock_fd, LOCK_EX); while (rc && errno == EINTR);
+    return rc;
+}
+
+/* A nonzero file/map with a different expected length means somebody altered
+ * the mirror outside Lumabri or an old layout survived.  Repair needs the
+ * process-wide exclusive cache lock so a running chatter never observes the
+ * truncate between its bitmap check and pread. */
+static int cache_has_stale_layout(void) {
+    char path[LMB_PATH_MAX * 2 + 16];
+    struct stat st;
+    for (int i = 0; i < g.nfiles; i++) {
+        RFile *f = &g.files[i];
+        data_path(path, sizeof path, f->rel);
+        int have_data = stat(path, &st) == 0;
+        int bad_data = have_data && (uint64_t)st.st_size != f->size;
+        uint64_t nb = (f->size + g.block - 1) / g.block;
+        off_t want = (off_t)(nb ? nb : 1);
+        snprintf(path, sizeof path, "%s/%s.lmap", g.maps_dir, f->rel);
+        int have_map = stat(path, &st) == 0;
+        if (!have_data || !have_map || bad_data || st.st_size != want)
+            return 1;
+    }
+    return 0;
 }
 
 /* ---- the distance map ---------------------------------------------------
@@ -484,6 +716,15 @@ static void shim_init_impl(void) {
     if (bs && atol(bs) >= 1 && atol(bs) <= 64) mib = atol(bs);
     g.block = (uint32_t)(mib << 20);
 
+    /* Lock before reading either online placement or the offline manifest.
+     * Otherwise an offline starter could observe an old inventory, wait for
+     * an online reset, then pair that inventory with the newly saved root. */
+    if (cache_lock_shared_open()) {
+        fprintf(stderr, "[lumabri] cannot lock the shared mirror — disabled\n");
+        cache_lock_release();
+        return;
+    }
+
     /* placement: tracker, or peers directly, or the persisted manifest */
     const char *tracker = getenv("LUMABRI_TRACKER");
     const char *peers = getenv("LUMABRI_PEERS");
@@ -499,15 +740,104 @@ static void shim_init_impl(void) {
     }
     if (placed == 0) {
         qsort(g.files, (size_t)g.nfiles, sizeof(RFile), rfile_cmp);
-        manifest_save();
     } else {
         if (manifest_load()) {
             fprintf(stderr, "[lumabri] no tracker, no peers, no saved manifest — disabled\n");
+            cache_lock_release();
             return;
         }
         qsort(g.files, (size_t)g.nfiles, sizeof(RFile), rfile_cmp);
         fprintf(stderr, "[lumabri] offline: serving from the local mirror only "
                         "(a cold block will be EIO)\n");
+    }
+
+    /* Bind every persisted bitmap to the signed identity of the complete
+     * model. File size alone cannot detect a checkpoint replaced in place;
+     * the model root changes for any byte or inventory change. On the first
+     * run after this format was introduced, old unbound maps are reset once.
+     * Offline mode keeps using the last verified identity. */
+    LmbModelIdentity current_id = {0}, saved_id = {0};
+    CacheIdentity saved_rec = {0};
+    const char *model = getenv("LUMABRI_MODEL");
+    int online_placement = placed == 0;
+    int have_current_id = online_placement && tracker && tracker[0] && model && model[0] &&
+                          lmb_model_identity_get(tracker, model, &current_id) == 0;
+    if (have_current_id && !model_identity_signature_ok(&current_id)) {
+        fprintf(stderr, "[lumabri] model identity is not signed by the operator — disabled\n");
+        cache_lock_release();
+        return;
+    }
+    if (online_placement && g.have_pubkey && !have_current_id) {
+        fprintf(stderr, "[lumabri] signed swarm has no complete model identity — disabled\n");
+        cache_lock_release();
+        return;
+    }
+    int have_saved_id = cache_identity_get(&saved_rec, &saved_id) == 0;
+    if (!online_placement && g.have_pubkey && !have_saved_id) {
+        fprintf(stderr, "[lumabri] offline mirror has no verified model identity — disabled\n");
+        cache_lock_release();
+        return;
+    }
+    int identity_reset = have_current_id &&
+                         cache_identity_differs(&current_id, &saved_id, have_saved_id);
+    int stale_layout = cache_has_stale_layout();
+
+    /* Same identity: keep the shared lock for the whole process, allowing any
+     * number of chatters.  reset.lock elects one upgrader. Contenders wait
+     * there without holding cache.lock, then reacquire shared and recheck; if
+     * the elected process already repaired the mirror they never queue behind
+     * that process's full chat lifetime. */
+    int exclusive = 0;
+    if (identity_reset || stale_layout) {
+        cache_flock(LOCK_UN);
+        if (cache_reset_lock() || cache_flock(LOCK_SH)) {
+            fprintf(stderr, "[lumabri] cannot coordinate mirror reset — disabled\n");
+            cache_lock_release();
+            return;
+        }
+        have_saved_id = cache_identity_get(&saved_rec, &saved_id) == 0;
+        identity_reset = have_current_id &&
+                         cache_identity_differs(&current_id, &saved_id, have_saved_id);
+        stale_layout = cache_has_stale_layout();
+        if (identity_reset || stale_layout) {
+            cache_flock(LOCK_UN);
+            if (cache_flock(LOCK_EX)) {
+                fprintf(stderr, "[lumabri] cannot exclusively lock mirror reset — disabled\n");
+                cache_lock_release();
+                return;
+            }
+            /* The tracker may have restarted while an old-checkpoint chatter
+             * kept us waiting. Never reset a placement using a stale root. */
+            if (have_current_id) {
+                LmbModelIdentity fresh = {0};
+                if (lmb_model_identity_get(tracker, model, &fresh) ||
+                    !model_identity_signature_ok(&fresh) ||
+                    strcmp(fresh.model, current_id.model) ||
+                    memcmp(fresh.root, current_id.root, sizeof fresh.root)) {
+                    fprintf(stderr, "[lumabri] model identity changed during mirror init — disabled\n");
+                    cache_lock_release();
+                    return;
+                }
+            }
+            have_saved_id = cache_identity_get(&saved_rec, &saved_id) == 0;
+            identity_reset = have_current_id &&
+                             cache_identity_differs(&current_id, &saved_id, have_saved_id);
+            stale_layout = cache_has_stale_layout();
+            exclusive = identity_reset || stale_layout;
+            if (!exclusive && cache_flock(LOCK_SH)) {
+                fprintf(stderr, "[lumabri] cannot retain the shared mirror lock — disabled\n");
+                cache_lock_release();
+                return;
+            }
+        }
+        if (!exclusive) cache_reset_unlock();
+    }
+    if (identity_reset)
+        fprintf(stderr, "[lumabri] model identity changed — cached block maps reset\n");
+    if (placed == 0 && manifest_save()) {
+        fprintf(stderr, "[lumabri] cannot persist the mirror manifest — disabled\n");
+        cache_lock_release();
+        return;
     }
 
     /* materialize the sparse mirror + load the block maps */
@@ -516,40 +846,108 @@ static void shim_init_impl(void) {
         RFile *f = &g.files[i];
         f->nblocks = (uint32_t)((f->size + g.block - 1) / g.block);
         pthread_mutex_init(&f->lk, NULL);
+        pthread_mutex_init(&f->commit_lk, NULL);
         pthread_cond_init(&f->cv, NULL);
         f->wfd = -1;
 
-        char path[LMB_PATH_MAX * 2];
-        data_path(path, sizeof path, f->rel);
-        mkdir_parent(path);
-        int fd = real_open(path, O_RDWR | O_CREAT, 0644);
-        if (fd < 0) { fprintf(stderr, "[lumabri] cannot create mirror %s\n", path); return; }
+        char dpath[LMB_PATH_MAX * 2 + 16], mpath[LMB_PATH_MAX * 2 + 16];
+        struct stat before;
+        data_path(dpath, sizeof dpath, f->rel);
+        mkdir_parent(dpath);
+        int data_new = stat(dpath, &before) != 0;
+        int fd = real_open(dpath, O_RDWR | O_CREAT, 0644);
+        if (fd < 0) {
+            fprintf(stderr, "[lumabri] cannot create mirror %s\n", dpath);
+            cache_lock_release(); return;
+        }
         struct stat st;
-        int stale = fstat(fd, &st) == 0 && st.st_size != 0 &&
+        int stale = !data_new && fstat(fd, &st) == 0 &&
                     (uint64_t)st.st_size != f->size;
-        if (ftruncate(fd, (off_t)f->size))
-            { fprintf(stderr, "[lumabri] ftruncate %s failed\n", path); real_close(fd); return; }
-        real_close(fd);
 
-        snprintf(path, sizeof path, "%s/%s.lmap", g.maps_dir, f->rel);
-        mkdir_parent(path);
+        snprintf(mpath, sizeof mpath, "%s/%s.lmap", g.maps_dir, f->rel);
+        mkdir_parent(mpath);
+        int map_new = stat(mpath, &before) != 0;
         f->map = (uint8_t *)calloc(f->nblocks ? f->nblocks : 1, 1);
         f->inflight = (uint8_t *)calloc(f->nblocks ? f->nblocks : 1, 1);
-        f->map_fd = real_open(path, O_RDWR | O_CREAT, 0644);
-        if (!f->map || !f->inflight || f->map_fd < 0)
-            { fprintf(stderr, "[lumabri] map alloc failed for %s\n", f->rel); return; }
-        if (stale) {
-            /* the upstream file changed size: every cached block is suspect */
-            fprintf(stderr, "[lumabri] %s changed size upstream — mirror reset\n", f->rel);
-            if (ftruncate(f->map_fd, 0)) { /* map cleared, blocks refetch */ }
+        f->map_fd = real_open(mpath, O_RDWR | O_CREAT, 0644);
+        off_t map_size = (off_t)(f->nblocks ? f->nblocks : 1);
+        struct stat mst;
+        int map_stale = !map_new && f->map_fd >= 0 &&
+                        fstat(f->map_fd, &mst) == 0 && mst.st_size != map_size;
+        int pair_stale = data_new != map_new;
+        if (!f->map || !f->inflight || f->map_fd < 0) {
+            fprintf(stderr, "[lumabri] map alloc failed for %s\n", f->rel);
+            real_close(fd); cache_lock_release(); return;
         }
-        if (ftruncate(f->map_fd, (off_t)(f->nblocks ? f->nblocks : 1))) { /* keep going */ }
+        if ((stale || map_stale || pair_stale) && !exclusive) {
+            fprintf(stderr, "[lumabri] mirror layout changed while shared — disabled\n");
+            real_close(fd); cache_lock_release(); return;
+        }
+        if (stale || map_stale || pair_stale || identity_reset) {
+            /* size or signed content identity changed: cached blocks suspect */
+            if (stale)
+                fprintf(stderr, "[lumabri] %s changed size upstream — mirror reset\n", f->rel);
+            if (ftruncate(f->map_fd, 0)) {
+                fprintf(stderr, "[lumabri] cannot clear map for %s — disabled\n", f->rel);
+                real_close(fd); cache_lock_release(); return;
+            }
+        }
+        if ((map_new || stale || map_stale || pair_stale || identity_reset) &&
+            ftruncate(f->map_fd, map_size)) {
+            fprintf(stderr, "[lumabri] cannot size map for %s — disabled\n", f->rel);
+            real_close(fd); cache_lock_release(); return;
+        }
+        /* Publish the cleared bitmap before resizing data.  If the machine
+         * dies between these operations, no future process can mistake
+         * sparse/truncated bytes for a durable warm block. */
+        if ((map_new || stale || map_stale || pair_stale || identity_reset) &&
+            fdatasync(f->map_fd)) {
+            fprintf(stderr, "[lumabri] cannot durably reset map for %s — disabled\n",
+                    f->rel);
+            real_close(fd); cache_lock_release(); return;
+        }
+        if (map_new && fsync_parent_dir(mpath)) {
+            fprintf(stderr, "[lumabri] cannot persist map directory for %s — disabled\n",
+                    f->rel);
+            real_close(fd); cache_lock_release(); return;
+        }
+        if ((data_new || stale) && ftruncate(fd, (off_t)f->size)) {
+            fprintf(stderr, "[lumabri] ftruncate mirror data for %s failed\n", f->rel);
+            real_close(fd); cache_lock_release(); return;
+        }
+        if ((data_new || stale) && fdatasync(fd)) {
+            fprintf(stderr, "[lumabri] cannot persist mirror data for %s — disabled\n",
+                    f->rel);
+            real_close(fd); cache_lock_release(); return;
+        }
+        if (data_new && fsync_parent_dir(dpath)) {
+            fprintf(stderr, "[lumabri] cannot persist mirror directory for %s — disabled\n",
+                    f->rel);
+            real_close(fd); cache_lock_release(); return;
+        }
+        real_close(fd);
+        flock(f->map_fd, LOCK_SH);
         ssize_t r = real_pread ? real_pread(f->map_fd, f->map, f->nblocks, 0) : -1;
+        flock(f->map_fd, LOCK_UN);
         if (r < 0) memset(f->map, 0, f->nblocks);
         total += f->size;
         for (uint32_t b = 0; b < f->nblocks; b++)
             if (f->map[b]) have += b + 1 == f->nblocks ? f->size - (uint64_t)b * g.block : g.block;
     }
+    /* Written last: a crash halfway through clearing maps leaves the old
+     * identity in place, so the next start repeats the reset instead of
+     * blessing a half-reset cache. */
+    if (have_current_id && identity_reset && cache_identity_save(&current_id)) {
+        fprintf(stderr, "[lumabri] cannot persist model identity — disabled\n");
+        cache_lock_release();
+        return;
+    }
+    if (exclusive && cache_flock(LOCK_SH)) {
+        fprintf(stderr, "[lumabri] cannot retain mirror lock after reset — disabled\n");
+        cache_lock_release();
+        return;
+    }
+    if (exclusive) cache_reset_unlock();
 
     /* measure the distance map, then start the readahead workers */
     probe_peers();
@@ -573,6 +971,12 @@ static void shim_init_impl(void) {
             if (pthread_create(&t, NULL, prefetch_thread, NULL) == 0)
                 pthread_detach(t);
         }
+    }
+
+    {
+        pthread_t t;
+        if (pthread_create(&t, NULL, mirror_commit_thread, NULL) == 0)
+            pthread_detach(t);
     }
 
     const char *stats = getenv("LUMABRI_STATS");
@@ -766,6 +1170,19 @@ static int ensure_block(RFile *f, uint32_t blk) {
         if (!f->inflight[blk]) break;
         pthread_cond_wait(&f->cv, &f->lk);
     }
+    /* Another process sharing this checkpoint may have published the block
+     * since our startup snapshot. The persisted bit is safe to trust because
+     * every committer fdatasyncs mirror data before setting it. */
+    uint8_t shared = 0;
+    if (f->map_fd >= 0 && flock(f->map_fd, LOCK_SH) == 0) {
+        ssize_t r = real_pread(f->map_fd, &shared, 1, (off_t)blk);
+        flock(f->map_fd, LOCK_UN);
+        if (r == 1 && shared == 1) {
+            f->map[blk] = 1;
+            pthread_mutex_unlock(&f->lk);
+            return 0;
+        }
+    }
     f->inflight[blk] = 1;
     if (f->wfd < 0) {
         char path[LMB_PATH_MAX * 2];
@@ -834,11 +1251,10 @@ static int ensure_block(RFile *f, uint32_t blk) {
             if (w < 0) { if (errno == EINTR) continue; werr = errno; break; }
             put += (uint32_t)w;
         }
-        if (put == len) {
-            uint8_t one = 1;
-            if (pwrite(f->map_fd, &one, 1, (off_t)blk) == 1) ok = 1;
-            else werr = errno;
-        }
+        /* The background committer makes data durable before publishing this
+         * bit on disk.  Until then the bit exists only in memory, so a crash
+         * causes a safe refetch rather than exposing sparse zeros. */
+        if (put == len && !werr) ok = 1;
         atomic_fetch_add(&g.net_bytes, len);
         atomic_fetch_add(&g.net_blocks, 1);
     }
@@ -859,7 +1275,7 @@ static int ensure_block(RFile *f, uint32_t blk) {
 
     pthread_mutex_lock(&f->lk);
     f->inflight[blk] = 0;
-    if (ok) f->map[blk] = 1;
+    if (ok) { f->map[blk] = 1; f->dirty_gen++; }
     pthread_cond_broadcast(&f->cv);
     pthread_mutex_unlock(&f->lk);
     return ok ? 0 : -1;

--- a/maintainer.c
+++ b/maintainer.c
@@ -32,6 +32,7 @@
 
 typedef struct {
     char rel[LMB_PATH_MAX]; uint64_t size; int fd;
+    uint64_t mtime_ns, ctime_ns; /* invalidate same-size hash sidecars */
     uint8_t *hash; uint32_t nh;   /* sha256 per LMB_HASH_CHUNK */
     uint8_t sig[64]; int signed_;  /* operator signature over the truth */
 } MFile;
@@ -41,11 +42,13 @@ static struct {
     char name[64], advertise[64], tracker[64], model[64], token[128];
     uint8_t sk[64]; int have_key;   /* --key: this peer is the origin */
     uint8_t pk[32]; int have_pub;   /* --pubkey: a donor that checks the origin */
+    LmbModelIdentity identity; int have_identity;
     MFile files[MAX_FILES]; int nfiles;
     const char *includes[MAX_INCLUDES]; int nincl;
     pthread_mutex_t fd_lk;
     _Atomic uint64_t served_bytes, served_reads;
 } g = { .fd_lk = PTHREAD_MUTEX_INITIALIZER };
+static LmbConnGate g_conn_gate = LMB_CONN_GATE_INIT;
 
 static int want(const char *rel) {
     if (!g.nincl) return 1;
@@ -73,6 +76,10 @@ static void scan_dir(const char *dir) {
         MFile *f = &g.files[g.nfiles++];
         snprintf(f->rel, sizeof f->rel, "%s", rel);
         f->size = (uint64_t)st.st_size;
+        f->mtime_ns = (uint64_t)st.st_mtim.tv_sec * 1000000000ull +
+                      (uint64_t)st.st_mtim.tv_nsec;
+        f->ctime_ns = (uint64_t)st.st_ctim.tv_sec * 1000000000ull +
+                      (uint64_t)st.st_ctim.tv_nsec;
         f->fd = -1;
     }
     closedir(d);
@@ -158,16 +165,24 @@ static int sidecar_write(const char *path, const void *a, size_t na,
     FILE *fp = fopen(tmp, "wb");
     if (!fp) return -1;
     int ok = (!na || fwrite(a, 1, na, fp) == na) &&
-             (!nb || fwrite(b, 1, nb, fp) == nb);
-    fclose(fp);
+             (!nb || fwrite(b, 1, nb, fp) == nb) &&
+             fflush(fp) == 0 && fsync(fileno(fp)) == 0;
+    if (fclose(fp)) ok = 0;
     if (!ok) { unlink(tmp); return -1; }
     return rename(tmp, path);
 }
 
 static void save_truth(const MFile *f) {
+    struct {
+        uint32_t magic, version;
+        uint64_t size, mtime_ns, ctime_ns;
+        uint32_t nh, reserved;
+    } hdr = { 0x3148534Cu, 1, f->size, f->mtime_ns, f->ctime_ns,
+              f->nh, 0 }; /* "LSH1" */
     char p[LMB_PATH_MAX * 2];
     sidecar_path(f, "sha", p, sizeof p);
-    if (f->hash) sidecar_write(p, &f->size, 8, f->hash, (size_t)f->nh * 32);
+    if (f->hash) sidecar_write(p, &hdr, sizeof hdr,
+                               f->hash, (size_t)f->nh * 32);
     if (f->signed_) {
         sidecar_path(f, "sig", p, sizeof p);
         sidecar_write(p, f->sig, 64, NULL, 0);
@@ -184,25 +199,58 @@ static void load_sig(MFile *f) {
 }
 
 static int hash_file(MFile *f) {
-    f->nh = (uint32_t)((f->size + LMB_HASH_CHUNK - 1) / LMB_HASH_CHUNK);
-    f->hash = malloc((size_t)f->nh * 32 + 1);
-    if (!f->hash) return -1;
-    char sc[LMB_PATH_MAX * 2];
-    snprintf(sc, sizeof sc, "%s/.lumabri_hashes/%s.sha", g.root, f->rel);
-    FILE *fp = fopen(sc, "rb");
-    if (fp) {
-        uint64_t sz = 0;
-        if (fread(&sz, 8, 1, fp) == 1 && sz == f->size &&
-            fread(f->hash, 32, f->nh, fp) == f->nh)
-            { fclose(fp); g_hash_done += f->size; return 0; }   /* cached: free */
-        fclose(fp);
-    }
     char full[LMB_PATH_MAX * 2];
     snprintf(full, sizeof full, "%s/%s", g.root, f->rel);
     int fd = open(full, O_RDONLY);
     if (fd < 0) return -1;
+    struct stat st;
+    if (fstat(fd, &st)) { close(fd); return -1; }
+    f->size = (uint64_t)st.st_size;
+    f->mtime_ns = (uint64_t)st.st_mtim.tv_sec * 1000000000ull +
+                  (uint64_t)st.st_mtim.tv_nsec;
+    f->ctime_ns = (uint64_t)st.st_ctim.tv_sec * 1000000000ull +
+                  (uint64_t)st.st_ctim.tv_nsec;
+    f->nh = (uint32_t)((f->size + LMB_HASH_CHUNK - 1) / LMB_HASH_CHUNK);
+    free(f->hash);
+    f->hash = malloc((size_t)f->nh * 32 + 1);
+    if (!f->hash) { close(fd); return -1; }
+    char sc[LMB_PATH_MAX * 2];
+    snprintf(sc, sizeof sc, "%s/.lumabri_hashes/%s.sha", g.root, f->rel);
+    FILE *fp = fopen(sc, "rb");
+    if (fp) {
+        struct {
+            uint32_t magic, version;
+            uint64_t size, mtime_ns, ctime_ns;
+            uint32_t nh, reserved;
+        } hdr = {0};
+        if (fread(&hdr, sizeof hdr, 1, fp) == 1 &&
+            hdr.magic == 0x3148534Cu && hdr.version == 1 &&
+            hdr.size == f->size && hdr.mtime_ns == f->mtime_ns &&
+            hdr.ctime_ns == f->ctime_ns && hdr.nh == f->nh &&
+            fread(f->hash, 32, f->nh, fp) == f->nh) {
+            struct stat after;
+            int stable = fstat(fd, &after) == 0 &&
+                (uint64_t)after.st_size == f->size &&
+                (uint64_t)after.st_mtim.tv_sec * 1000000000ull +
+                    (uint64_t)after.st_mtim.tv_nsec == f->mtime_ns &&
+                (uint64_t)after.st_ctim.tv_sec * 1000000000ull +
+                    (uint64_t)after.st_ctim.tv_nsec == f->ctime_ns;
+            fclose(fp); close(fd);
+            if (stable) { g_hash_done += f->size; return 0; }
+            free(f->hash); f->hash = NULL;
+            return -1;
+        }
+        fclose(fp);
+    }
+    /* A rehash invalidates any signature stored beside the old vector.  An
+     * origin with the secret key will create a new one after this returns; a
+     * donor must obtain the new proof from the swarm, never reuse the old. */
+    char sigp[LMB_PATH_MAX * 2];
+    sidecar_path(f, "sig", sigp, sizeof sigp);
+    unlink(sigp);
+    f->signed_ = 0;
     uint8_t *buf = malloc(LMB_HASH_CHUNK);
-    if (!buf) { close(fd); return -1; }
+    if (!buf) { free(f->hash); f->hash = NULL; close(fd); return -1; }
     for (uint32_t c = 0; c < f->nh; c++) {
         uint64_t off = (uint64_t)c * LMB_HASH_CHUNK;
         uint32_t len = (uint32_t)(f->size - off < LMB_HASH_CHUNK ? f->size - off
@@ -213,11 +261,26 @@ static int hash_file(MFile *f) {
             if (r <= 0) { if (r < 0 && errno == EINTR) continue; break; }
             got += (uint32_t)r;
         }
-        if (got != len) { free(buf); close(fd); return -1; }
+        if (got != len) {
+            free(buf); free(f->hash); f->hash = NULL; close(fd); return -1;
+        }
         lmb_sha256(buf, len, f->hash + (size_t)c * 32);
         hash_tick(len, f->rel);
     }
     free(buf);
+    struct stat after;
+    uint64_t after_mtime = 0, after_ctime = 0;
+    int after_ok = fstat(fd, &after) == 0;
+    if (after_ok) {
+        after_mtime = (uint64_t)after.st_mtim.tv_sec * 1000000000ull +
+                      (uint64_t)after.st_mtim.tv_nsec;
+        after_ctime = (uint64_t)after.st_ctim.tv_sec * 1000000000ull +
+                      (uint64_t)after.st_ctim.tv_nsec;
+    }
+    if (!after_ok || after_mtime != f->mtime_ns || after_ctime != f->ctime_ns ||
+        (uint64_t)after.st_size != f->size) {
+        free(f->hash); f->hash = NULL; close(fd); return -1;
+    }
     close(fd);
     save_truth(f);
     return 0;
@@ -286,6 +349,13 @@ static void hash_section(LmbBuf *b) {
         lmb_buf_u32(b, g.files[i].signed_ ? 1u : 0u);
         if (g.files[i].signed_) lmb_buf_bytes(b, g.files[i].sig, 64);
     }
+    if (g.have_identity) {
+        lmb_buf_u32(b, LMB_MODEL_ID_MAGIC);
+        lmb_buf_bytes(b, g.identity.root, sizeof g.identity.root);
+        lmb_buf_u32(b, g.identity.has_sig ? 1u : 0u);
+        if (g.identity.has_sig)
+            lmb_buf_bytes(b, g.identity.sig, sizeof g.identity.sig);
+    }
 }
 
 /* sign one file's truth with the operator key (origin peers only) */
@@ -298,6 +368,123 @@ static void sign_truth(MFile *f) {
     lmb_sign(f->sig, msg, mlen, g.sk);
     free(msg);
     f->signed_ = 1;
+}
+
+static int model_identity_valid(const LmbModelIdentity *id) {
+    if (strcmp(id->model, g.model)) return 0;
+    if (!g.have_pub) return 1;
+    if (!id->has_sig) return 0;
+    size_t n = 0;
+    uint8_t *msg = lmb_model_id_msg(id->model, id->root, &n);
+    int ok = msg && lmb_sign_verify(id->sig, msg, n, g.pk) == 0;
+    free(msg);
+    return ok;
+}
+
+static int model_identity_local(LmbModelIdentity *id) {
+    LmbModelItem *items = (LmbModelItem *)calloc(g.nfiles ? (size_t)g.nfiles : 1,
+                                                 sizeof *items);
+    if (!items) return -1;
+    for (int i = 0; i < g.nfiles; i++) {
+        if (!g.files[i].hash) { free(items); return -1; }
+        items[i].path = g.files[i].rel;
+        items[i].size = g.files[i].size;
+        items[i].nh = g.files[i].nh;
+        items[i].hashes = g.files[i].hash;
+    }
+    memset(id, 0, sizeof *id);
+    snprintf(id->model, sizeof id->model, "%s", g.model);
+    int rc = lmb_model_root(g.model, items, (size_t)g.nfiles, id->root);
+    free(items);
+    return rc;
+}
+
+static void model_identity_path(char *out, size_t cap) {
+    snprintf(out, cap, "%s/.lumabri_hashes/model.mid", g.root);
+}
+
+static int model_identity_load(LmbModelIdentity *id) {
+    struct {
+        uint32_t magic, version;
+        char model[64];
+        uint8_t root[32];
+        uint32_t has_sig;
+        uint8_t sig[64];
+    } rec;
+    char path[LMB_PATH_MAX * 2];
+    model_identity_path(path, sizeof path);
+    FILE *fp = fopen(path, "rb");
+    if (!fp) return -1;
+    int ok = fread(&rec, sizeof rec, 1, fp) == 1 &&
+             rec.magic == LMB_MODEL_ID_MAGIC && rec.version == 1 &&
+             rec.has_sig <= 1 && !strcmp(rec.model, g.model);
+    fclose(fp);
+    if (!ok) return -1;
+    memset(id, 0, sizeof *id);
+    snprintf(id->model, sizeof id->model, "%s", rec.model);
+    memcpy(id->root, rec.root, 32);
+    id->has_sig = rec.has_sig != 0;
+    if (id->has_sig) memcpy(id->sig, rec.sig, 64);
+    return model_identity_valid(id) ? 0 : -1;
+}
+
+static void model_identity_save(const LmbModelIdentity *id) {
+    struct {
+        uint32_t magic, version;
+        char model[64];
+        uint8_t root[32];
+        uint32_t has_sig;
+        uint8_t sig[64];
+    } rec;
+    memset(&rec, 0, sizeof rec);
+    rec.magic = LMB_MODEL_ID_MAGIC; rec.version = 1;
+    snprintf(rec.model, sizeof rec.model, "%s", id->model);
+    memcpy(rec.root, id->root, 32);
+    rec.has_sig = id->has_sig ? 1u : 0u;
+    if (id->has_sig) memcpy(rec.sig, id->sig, 64);
+    char path[LMB_PATH_MAX * 2];
+    model_identity_path(path, sizeof path);
+    sidecar_write(path, &rec, sizeof rec, NULL, 0);
+}
+
+static int model_identity_prepare(int disk_donor) {
+    LmbModelIdentity local = {0}, saved = {0}, remote = {0};
+    int complete_local = !disk_donor && g.nincl == 0;
+    int have_local = complete_local && model_identity_local(&local) == 0;
+    int have_saved = model_identity_load(&saved) == 0;
+    int have_remote = g.tracker[0] &&
+                      lmb_model_identity_get(g.tracker, g.model, &remote) == 0 &&
+                      model_identity_valid(&remote);
+
+    if (g.have_key && complete_local) {
+        if (!have_local) return -1;
+        size_t n = 0;
+        uint8_t *msg = lmb_model_id_msg(g.model, local.root, &n);
+        if (!msg) return -1;
+        lmb_sign(local.sig, msg, n, g.sk);
+        free(msg);
+        local.has_sig = 1;
+        g.identity = local; g.have_identity = 1;
+    } else if (disk_donor || !complete_local) {
+        if (have_remote) { g.identity = remote; g.have_identity = 1; }
+        else if (have_saved) { g.identity = saved; g.have_identity = 1; }
+    } else if (have_local) {
+        if (have_remote && memcmp(local.root, remote.root, 32)) {
+            fprintf(stderr, "[maintainer %s] local model root differs from the "
+                            "swarm identity — refusing to advertise it\n", g.name);
+            return -1;
+        }
+        if (have_remote) local = remote;
+        else if (have_saved && !memcmp(local.root, saved.root, 32)) local = saved;
+        g.identity = local; g.have_identity = 1;
+    }
+    if (g.have_pub && (!g.have_identity || !model_identity_valid(&g.identity))) {
+        fprintf(stderr, "[maintainer %s] no operator-signed identity for model %s\n",
+                g.name, g.model);
+        return -1;
+    }
+    if (g.have_identity) model_identity_save(&g.identity);
+    return 0; /* unsigned legacy/partial origins may have no complete root */
 }
 
 static int handle_read(int fd, LmbMsg *m) {
@@ -357,6 +544,7 @@ static void *conn_thread(void *arg) {
         if (rc) break;
     }
     close(fd);
+    lmb_conn_gate_leave(&g_conn_gate);
     return NULL;
 }
 
@@ -617,6 +805,15 @@ static void pull_slice(uint64_t budget) {
             f->hash = t.hash; f->nh = t.nh;
             f->signed_ = t.has_sig;
             if (t.has_sig) memcpy(f->sig, t.sig, 64);
+            char full[LMB_PATH_MAX * 2];
+            struct stat st;
+            snprintf(full, sizeof full, "%s/%s", g.root, rel);
+            if (!stat(full, &st)) {
+                f->mtime_ns = (uint64_t)st.st_mtim.tv_sec * 1000000000ull +
+                              (uint64_t)st.st_mtim.tv_nsec;
+                f->ctime_ns = (uint64_t)st.st_ctim.tv_sec * 1000000000ull +
+                              (uint64_t)st.st_ctim.tv_nsec;
+            }
             save_truth(f);
             pulled += size; done++;
         } else {
@@ -784,6 +981,7 @@ int main(int argc, char **argv) {
     const char *tok = getenv("LUMABRI_TOKEN");
     if (tok) snprintf(g.token, sizeof g.token, "%s", tok);
     signal(SIGPIPE, SIG_IGN);   /* a vanished chatter must not kill the peer */
+    lmb_conn_gate_init(&g_conn_gate);
     size_t rl = strlen(g.root);
     while (rl > 1 && g.root[rl - 1] == '/') g.root[--rl] = 0;
     if (!g.name[0]) snprintf(g.name, sizeof g.name, "peer-%d", port);
@@ -829,7 +1027,14 @@ int main(int argc, char **argv) {
         else {
             load_sig(&g.files[i]);   /* a donor's proof, kept across restarts */
             sign_truth(&g.files[i]);
+            save_truth(&g.files[i]); /* persist a newly made signature too */
         }
+    }
+    if (model_identity_prepare(donate_gb > 0)) {
+        fprintf(stderr, "[maintainer %s] cannot establish the complete model "
+                        "identity — refusing to serve an ambiguous checkpoint\n",
+                g.name);
+        return 1;
     }
     if (g.have_key) {
         char pub[70];
@@ -857,10 +1062,12 @@ int main(int argc, char **argv) {
     for (;;) {
         int fd = accept(lfd, NULL, NULL);
         if (fd < 0) { if (errno == EINTR) continue; perror("[maintainer] accept"); break; }
+        lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
+                                           LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
+        if (!lmb_conn_gate_enter(&g_conn_gate)) { close(fd); continue; }
         if (pthread_create(&t, NULL, conn_thread, (void *)(intptr_t)fd) == 0)
             pthread_detach(t);
-        else
-            close(fd);
+        else { lmb_conn_gate_leave(&g_conn_gate); close(fd); }
     }
     return 0;
 }

--- a/phase2_deepseek_test.sh
+++ b/phase2_deepseek_test.sh
@@ -34,26 +34,16 @@ NODE_CACHE="${NODE_CACHE:-6}"  # expert slots per layer on the peer
     echo "set MODEL=<dir> (tools/download_deepseek_v4.py fetches one)"
     exit 1; }
 
-make -s expert_node_deepseek ENGINE="$ENGINE"
+make -s expert_node_deepseek deepseek_p2p ENGINE="$ENGINE"
 
 T=$(mktemp -d /tmp/lumabri-ds.XXXXXX)
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
 
-# built from a COPY: deepseek.c itself is never modified
-cp "$ENGINE/deepseek.c" "$T/deepseek.c"
-( cd "$T" && patch -s -p2 < "$OLDPWD/engine_patches/deepseek-p2p.diff" )
-DS_CFLAGS="-DCOLI_V4_MAX_PIN_SLOTS_PER_LAYER=16 -DCOLI_V4_PIN_RAMP_REQUESTS=24
-           -DCOLI_V4_EXPERIMENTAL_BLOCK_OTHER_PROFILE
-           -DCOLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER"
-# shellcheck disable=SC2086
-cc -O2 -fopenmp -w -I. -I"$ENGINE" $DS_CFLAGS -DLUMABRI_P2P -DLUMIBRI_P2P \
-   "$T/deepseek.c" -o "$T/deepseek_p2p" -lm -lpthread
-
 echo
 echo "══ A) LOCAL — experts read and run by the engine itself"
-OMP_NUM_THREADS="${THREADS:-6}" "$T/deepseek_p2p" "$MODEL" "$PROMPT" \
+OMP_NUM_THREADS="${THREADS:-6}" ./deepseek_p2p "$MODEL" "$PROMPT" \
     --max-tokens "$GEN" --memory-gb "$CHAT_GB" --no-dspark \
     --record-oracle "$T/oracle.json" > "$T/local.log" 2>&1 \
     || { tail -20 "$T/local.log"; exit 1; }
@@ -74,7 +64,7 @@ grep -h "holding" "$T/node.log" || { tail -10 "$T/node.log"; exit 1; }
 echo
 echo "══ B) P2P — every routed expert runs on the peer, scored against local"
 OMP_NUM_THREADS="${THREADS:-6}" LUMABRI_EXPERTS="127.0.0.1:$PORT" \
-    "$T/deepseek_p2p" "$MODEL" --oracle "$T/oracle.json" --greedy "$GEN" \
+    ./deepseek_p2p "$MODEL" --oracle "$T/oracle.json" --greedy "$GEN" \
     --memory-gb "$CHAT_GB" --no-dspark > "$T/p2p.log" 2>&1 \
     || { tail -20 "$T/p2p.log"; exit 1; }
 grep -E "^\[lumabri\]" "$T/p2p.log" || true

--- a/phase2_glm_test.sh
+++ b/phase2_glm_test.sh
@@ -27,21 +27,36 @@ CAP="${CAP:-8}"
 [ -d "$MODEL" ] || { echo "no GLM fixture at $MODEL — set MODEL=<dir>"; exit 1; }
 [ -f "$REF" ]   || { echo "no oracle at $REF — set REF=<file>"; exit 1; }
 
-make -s phase2-glm ENGINE="$ENGINE"
+make -s phase2-glm colibri_p2p ENGINE="$ENGINE"
 
 T=$(mktemp -d /tmp/lumabri-glm.XXXXXX)
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
 
-# The patched engine is built from a COPY: colibri itself is never modified.
-cp "$ENGINE/colibri.c" "$T/colibri.c"
-( cd "$T" && patch -s -p2 < "$OLDPWD/engine_patches/colibri-p2p.diff" )
-cc -O2 -fopenmp -Wall -I. -I"$ENGINE" -Wno-unused-function -Wno-unused-parameter \
-   -DLUMABRI_P2P -DLUMIBRI_P2P "$T/colibri.c" -o "$T/colibri_p2p" -lm -lpthread
-
 run() { SNAP="$MODEL" REF="$REF" COLI_NO_OMP_TUNE=1 OMP_NUM_THREADS="${THREADS:-4}" \
-        "$@" "$T/colibri_p2p" "$CAP"; }
+        "$@" ./colibri_p2p "$CAP"; }
+
+echo
+echo "══ THREAD POLICY — default GLM node uses physical cores, not SMT threads"
+POLICY_PORT=$((PORT0+60))
+env -u OMP_NUM_THREADS -u OMP_PROC_BIND -u COLI_NO_OMP_TUNE -u COLI_OMP_TUNED \
+    ./expert_node_glm --model "$MODEL" --port "$POLICY_PORT" --name glm-policy \
+                      --bits "$BITS" --cache 1 > "$T/policy.log" 2>&1 & POLICY_PID=$!; PIDS+=($!)
+for _ in $(seq 1 300); do
+    (exec 3<>/dev/tcp/127.0.0.1/$POLICY_PORT) 2>/dev/null && { exec 3<&-; break; }
+    sleep 0.1
+done
+grep -q "applying the engine hot-thread policy" "$T/policy.log" || {
+    echo "GLM node did not apply its OpenMP hot-thread policy"; cat "$T/policy.log"; exit 1; }
+POLICY_LINE=$(grep "thread.* each, .* physical core" "$T/policy.log" | tail -1)
+PT=$(printf '%s\n' "$POLICY_LINE" | sed -nE 's/.* ([0-9]+) threads? each, ([0-9]+) physical cores?.*/\1/p')
+PC=$(printf '%s\n' "$POLICY_LINE" | sed -nE 's/.* ([0-9]+) threads? each, ([0-9]+) physical cores?.*/\2/p')
+[ -n "$PT" ] && [ -n "$PC" ] && [ "$PT" -le "$PC" ] || {
+    echo "GLM node oversubscribed its physical cores: $POLICY_LINE"; exit 1; }
+kill "$POLICY_PID" 2>/dev/null || true
+wait "$POLICY_PID" 2>/dev/null || true
+echo "✓ GLM default: $PT OpenMP threads on $PC available physical cores"
 
 echo
 echo "══ A) LOCAL — experts read and run by the engine itself"

--- a/phase2_inkling_test.sh
+++ b/phase2_inkling_test.sh
@@ -19,7 +19,7 @@ PORT0="${PORT0:-7481}"   # clear of phase5 (745x) and sign_test (746x)
 CAP="${CAP:-4}"
 BITS=0
 
-make -s expert_node_inkling ENGINE="$ENGINE"
+make -s expert_node_inkling inkling_p2p ENGINE="$ENGINE"
 
 T=$(mktemp -d /tmp/lumabri-ink.XXXXXX)
 PIDS=()
@@ -41,14 +41,29 @@ p = [3, 7, 11, 19, 23, 29, 31, 37]
 json.dump({"prompt_ids": p, "full_ids": p + [0] * 16}, open(sys.argv[1], "w"))
 EOF
 
-# built from a COPY: inkling.c itself is never modified
-cp "$ENGINE/inkling.c" "$T/inkling.c"
-( cd "$T" && patch -s -p2 < "$OLDPWD/engine_patches/inkling-p2p.diff" )
-cc -O2 -fopenmp -w -I. -I"$ENGINE" -DLUMABRI_P2P -DLUMIBRI_P2P \
-   "$T/inkling.c" -o "$T/inkling_p2p" -lm -lpthread
-
 run() { SNAP="$MODEL" OMP_NUM_THREADS="${THREADS:-2}" "$@" \
-        "$T/inkling_p2p" "$CAP" "$BITS" "$T/ref.json"; }
+        LUMABRI_EXPERT_BITS="$BITS" ./inkling_p2p "$CAP" "$BITS" "$T/ref.json"; }
+
+echo
+echo "══ THREAD POLICY — default Inkling node uses physical cores, not SMT threads"
+POLICY_PORT=$((PORT0+60))
+env -u OMP_NUM_THREADS -u OMP_PROC_BIND -u COLI_NO_OMP_TUNE -u COLI_OMP_TUNED \
+    ./expert_node_inkling --model "$MODEL" --port "$POLICY_PORT" --name ink-policy \
+                          --bits "$BITS" --cache 1 > "$T/policy.log" 2>&1 & POLICY_PID=$!; PIDS+=($!)
+for _ in $(seq 1 300); do
+    (exec 3<>/dev/tcp/127.0.0.1/$POLICY_PORT) 2>/dev/null && { exec 3<&-; break; }
+    sleep 0.1
+done
+grep -q "applying the engine hot-thread policy" "$T/policy.log" || {
+    echo "Inkling node did not apply its OpenMP hot-thread policy"; cat "$T/policy.log"; exit 1; }
+POLICY_LINE=$(grep "thread.* each, .* physical core" "$T/policy.log" | tail -1)
+PT=$(printf '%s\n' "$POLICY_LINE" | sed -nE 's/.* ([0-9]+) threads? each, ([0-9]+) physical cores?.*/\1/p')
+PC=$(printf '%s\n' "$POLICY_LINE" | sed -nE 's/.* ([0-9]+) threads? each, ([0-9]+) physical cores?.*/\2/p')
+[ -n "$PT" ] && [ -n "$PC" ] && [ "$PT" -le "$PC" ] || {
+    echo "Inkling node oversubscribed its physical cores: $POLICY_LINE"; exit 1; }
+kill "$POLICY_PID" 2>/dev/null || true
+wait "$POLICY_PID" 2>/dev/null || true
+echo "✓ Inkling default: $PT OpenMP threads on $PC available physical cores"
 
 echo
 echo "══ A) LOCAL — experts read and run by the engine itself"

--- a/phase2_kimi_test.sh
+++ b/phase2_kimi_test.sh
@@ -19,7 +19,7 @@ NGEN="${NGEN:-8}"
 IDS="${IDS:-3 7 11 19}"
 export K3_BITS=32          # f32 dense side: the question is the experts
 
-make -s expert_node_kimi ENGINE="$ENGINE"
+make -s expert_node_kimi kimi_k3_p2p ENGINE="$ENGINE"
 
 T=$(mktemp -d /tmp/lumabri-k3.XXXXXX)
 PIDS=()
@@ -29,14 +29,8 @@ trap cleanup EXIT
 MODEL="${MODEL:-$T/tiny_kimi}"
 [ -f "$MODEL/config.json" ] || python3 make_tiny_kimi.py "$MODEL" > /dev/null
 
-# built from a COPY: kimi_k3.c itself is never modified
-cp "$ENGINE/kimi_k3.c" "$T/kimi_k3.c"
-( cd "$T" && patch -s -p2 < "$OLDPWD/engine_patches/kimi_k3-p2p.diff" )
-cc -O2 -fopenmp -w -I. -I"$ENGINE" -DLUMABRI_P2P -DLUMIBRI_P2P \
-   "$T/kimi_k3.c" -o "$T/kimi_p2p" -lm -lpthread
-
 run() { OMP_NUM_THREADS="${THREADS:-2}" "$@" \
-        "$T/kimi_p2p" "$MODEL" --ids "$IDS" --ngen "$NGEN"; }
+        ./kimi_k3_p2p "$MODEL" --ids "$IDS" --ngen "$NGEN"; }
 
 echo
 echo "══ A) LOCAL — experts read and run by the engine itself"

--- a/phase2_test.sh
+++ b/phase2_test.sh
@@ -22,7 +22,8 @@ make -s phase2
 [ -f "$MODEL/config.json" ] || make -s fixture
 
 PIDS=()
-cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; }
+T=$(mktemp -d /tmp/lumabri-phase2.XXXXXX)
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
 
 echo
@@ -73,3 +74,57 @@ else
     echo "  p2p  : $B"
     exit 1
 fi
+
+echo
+echo "══ C) COMPATIBILITY — a different engine build must be refused"
+cat > "$T/wrong_build.c" <<'EOF'
+#include "lumabri_proto.h"
+int main(int argc, char **argv) {
+    int lfd = lmb_listen(atoi(argv[1]));
+    if (lfd < 0) return 1;
+    signal(SIGPIPE, SIG_IGN);
+    for (;;) {
+        int fd = accept(lfd, NULL, NULL);
+        if (fd < 0) continue;
+        LmbMsg m;
+        while (lmb_recv(fd, &m) == 0) {
+            if (m.op == LMB_PING) lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
+            else if (m.op == LMB_EMANIFEST) {
+                LmbBuf b = {0};
+                lmb_buf_u32(&b, LMB_EXPERT_MANIFEST_MAGIC);
+                lmb_buf_str(&b, "olmoe");
+                lmb_buf_str(&b, "source=definitely-not-this-build");
+                lmb_buf_str(&b, "tiny_olmoe");
+                lmb_buf_u32(&b, 0);       /* effective quant bits */
+                lmb_buf_u32(&b, 0);       /* no model identity */
+                lmb_buf_u32(&b, 0);       /* no expert claims */
+                lmb_buf_u32(&b, 0);       /* deliberately wrong hidden size */
+                lmb_send(fd, LMB_EMANIFEST_R, b.p, (uint32_t)b.len, NULL, 0);
+                free(b.p);
+            } else lmb_send(fd, LMB_ERR, NULL, 0, NULL, 0);
+            lmb_msg_free(&m);
+        }
+        close(fd);
+    }
+}
+EOF
+cc -O2 -w -I. "$T/wrong_build.c" -o "$T/wrong_build" -lpthread
+BAD_PORT=$((PORT0+NODES+50))
+"$T/wrong_build" "$BAD_PORT" & PIDS+=($!)
+for _ in $(seq 1 100); do
+    (exec 3<>/dev/tcp/127.0.0.1/$BAD_PORT) 2>/dev/null && { exec 3<&-; break; }
+    sleep 0.05
+done
+set +e
+SNAP="$MODEL" OMP_NUM_THREADS=2 LUMABRI_EXPERTS="127.0.0.1:$BAD_PORT" \
+    ./olmoe_p2p "$CACHE" 8 "$MODEL/ref.json" \
+    > "$T/wrong.out" 2> "$T/wrong.err"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || { echo "✗ incompatible expert node was accepted"; exit 1; }
+grep -q "incompatible manifest" "$T/wrong.err" || {
+    echo "✗ refusal did not identify the manifest mismatch"
+    cat "$T/wrong.err"
+    exit 1
+}
+echo "✓ incompatible model/build/engine profile refused before execution"

--- a/phase4_test.sh
+++ b/phase4_test.sh
@@ -67,25 +67,44 @@ grep -q "discovered" "$T/boot.err" || { echo "   BOOTSTRAP FAILED: no discovery"
 echo "   ✓ zero configuration: tracker → server executor → identical tokens"
 
 echo "· 3) delegate & fall back: nearer donor joins, then dies mid-run"
-# the server sits 3 ms away; the donor holds HALF the experts at 0 ms and
-# must win those calls while it lives
+# The server starts alone and sits 100 ms away.  Only after generation is
+# active does a nearby donor holding half the experts join.  The chatter must
+# discover it without restarting, use it, then survive its disappearance.
 kill "$SRV_PID" 2>/dev/null || true
-OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 LUMABRI_RTT_US=3000 \
+OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 LUMABRI_RTT_US=100000 \
     ./expert_node --model "$MODEL" --port 7433 --name srv-far --cache 32 \
                   --tracker 127.0.0.1:7430 > "$T/far.log" 2>&1 & PIDS+=($!)
-OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 \
-    ./expert_node --model "$MODEL" --port 7434 --name donor --stride 2:0 \
-                  --tracker 127.0.0.1:7430 > "$T/donor.log" 2>&1 & DONOR_PID=$!; PIDS+=($!)
-wait_port 7433; wait_port 7434
+wait_port 7433
 sleep 1
 SNAP="$MODEL" OMP_NUM_THREADS=6 \
     LUMABRI_TRACKER=127.0.0.1:7430 LUMABRI_MODEL=tiny_olmoe \
+    LUMABRI_DISCOVERY_MS=100 \
     ./olmoe_p2p 16 8 "$MODEL/ref.json" > "$T/del.out" 2>"$T/del.err" & CHAT=$!
-for _ in $(seq 1 100); do
+for _ in $(seq 1 300); do
     grep -q "phase 2 active" "$T/del.err" 2>/dev/null && break
     sleep 0.1
 done
-sleep 1.0
+grep -q "phase 2 active" "$T/del.err" || {
+    echo "   DELEGATE FAILED: generation never entered phase 2"
+    cat "$T/del.err"
+    exit 1
+}
+OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 \
+    ./expert_node --model "$MODEL" --port 7434 --name donor --stride 2:0 \
+                  --cache 8 --tracker 127.0.0.1:7430 \
+                  > "$T/donor.log" 2>&1 & DONOR_PID=$!; PIDS+=($!)
+wait_port 7434
+for _ in $(seq 1 300); do
+    grep -q "discovered .*mid-generation" "$T/del.err" 2>/dev/null && break
+    kill -0 "$CHAT" 2>/dev/null || break
+    sleep 0.1
+done
+grep -q "discovered .*mid-generation" "$T/del.err" || {
+    echo "   DELEGATE FAILED: late donor was not discovered during generation"
+    cat "$T/del.err"
+    exit 1
+}
+sleep 0.5
 kill "$DONOR_PID" 2>/dev/null || true
 wait "$CHAT" || { cat "$T/del.err"; exit 1; }
 B=$(grep "^C engine" "$T/del.out")
@@ -98,7 +117,7 @@ echo "   failovers away from the dead donor: $DONOR_USED · total failovers: $FO
 [ "$REF" = "$B" ] || { echo "   DELEGATE FAILED: tokens diverged"; exit 1; }
 [ "$FO" -gt 0 ] || { echo "   DELEGATE UNPROVEN: no failover happened"; exit 1; }
 [ "$DONOR_USED" -gt 0 ] || { echo "   DELEGATE UNPROVEN: donor never used"; exit 1; }
-echo "   ✓ the swarm delegated to the donor, lost it, fell back to the server —"
-echo "     and not one token changed"
+echo "   ✓ late donor discovered, used, lost, and failed over to the server"
+echo "     without changing one token"
 
 echo "LUMABRI PHASE 4: PASS"

--- a/phase5_test.sh
+++ b/phase5_test.sh
@@ -61,7 +61,7 @@ mkdir -p "$T/evil"
 head -c $((12 * 1024 * 1024)) /dev/urandom > "$T/evil/w.bin"   # different bytes!
 head -c 777 /dev/urandom > "$T/evil/config.json"
 ./maintainer --root "$T/evil" --port 7453 --tracker 127.0.0.1:7450 \
-    --name poisoner --model-name src > "$T/evil.log" 2>&1 & PIDS+=($!)
+    --name poisoner --model-name src --include '*' > "$T/evil.log" 2>&1 & PIDS+=($!)
 wait_port 7453
 sleep 1.5
 # assert on the tracker's own answer: the poisoner must hold zero placeable

--- a/prefetch_policy_test.sh
+++ b/prefetch_policy_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# lumabri — readahead must stop at the dense/expert line.
+#
+# The byte-mirror reads ahead to hide latency: touch a block and the next few
+# arrive before they are asked for. That is right while a chatter is pulling a
+# whole model. It is wrong the moment the experts run on peers, because at
+# 1 MiB granularity a readahead past a dense block walks into the adjacent
+# expert region and pulls weights the chatter will never execute — a little
+# more on every run.
+#
+# This reads exactly ONE block of an eight-block file and counts how many the
+# mirror actually fetched, in three worlds:
+#
+#   1) default            — readahead on, more than one block arrives;
+#   2) remote experts      — the engine signalled delegation, only the one
+#                            requested block arrives;
+#   3) remote experts + an explicit LUMABRI_PREFETCH — the operator's choice
+#                            wins over the automatic suppression.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s liblumabri.so tracker maintainer
+
+T=$(mktemp -d /tmp/lumabri-prefetch.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+
+wait_port() {
+    for _ in $(seq 1 100); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
+
+# eight distinct 1 MiB blocks so a readahead is unambiguous
+mkdir -p "$T/src"
+head -c $((8 * 1024 * 1024)) /dev/urandom > "$T/src/w.bin"
+printf '{"model_type":"olmoe"}\n' > "$T/src/config.json"
+
+# a reader that touches only the first block, waits for any readahead to run,
+# then leaves — so the mirror map reflects exactly what the policy fetched
+cat > "$T/touch1.c" <<'EOF'
+#include <fcntl.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+    int fd = open(argv[1], O_RDONLY);
+    if (fd < 0) return 1;
+    char buf[4096];
+    if (pread(fd, buf, sizeof buf, 0) != sizeof buf) return 1;
+    usleep(700000);            /* let prefetch workers drain, if any */
+    close(fd);
+    return 0;
+}
+EOF
+cc -O2 -w "$T/touch1.c" -o "$T/touch1"
+
+./tracker --port 7620 > "$T/tracker.log" 2>&1 & PIDS+=($!)
+wait_port 7620
+./maintainer --root "$T/src" --port 7621 --tracker 127.0.0.1:7620 \
+             --name origin --model-name fx > "$T/origin.log" 2>&1 & PIDS+=($!)
+wait_port 7621
+sleep 1
+
+# count present blocks in the mirror map for w.bin (one byte per block, 1=present)
+present() {
+    python3 - "$1/maps/w.bin.lmap" <<'PY'
+import sys
+try:
+    d = open(sys.argv[1], "rb").read()
+except FileNotFoundError:
+    print(0); raise SystemExit
+print(sum(1 for b in d if b))
+PY
+}
+
+run() {   # run VROOT CACHE  [extra env...]
+    local v=$1 c=$2; shift 2
+    env "$@" LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$v" \
+        LUMABRI_CACHE="$c" LUMABRI_TRACKER=127.0.0.1:7620 \
+        LUMABRI_MODEL=fx LUMABRI_BLOCK_MIB=1 \
+        "$T/touch1" "$v/w.bin" > /dev/null 2>&1
+}
+
+echo "· 1) default: readahead pulls more than the one block touched"
+run "$T/v1" "$T/c1"
+N1=$(present "$T/c1")
+echo "   fetched $N1 block(s)"
+[ "$N1" -gt 1 ] || { echo "   readahead did not run — test cannot distinguish the cases"; exit 1; }
+
+echo "· 2) remote experts: only the requested block is fetched"
+run "$T/v2" "$T/c2" LUMABRI_REMOTE_EXPERTS=1
+N2=$(present "$T/c2")
+echo "   fetched $N2 block(s)"
+[ "$N2" -eq 1 ] || { echo "   readahead still crossed into unrequested blocks"; exit 1; }
+
+echo "· 3) an explicit prefetch depth wins over the automatic suppression"
+run "$T/v3" "$T/c3" LUMABRI_REMOTE_EXPERTS=1 LUMABRI_PREFETCH=3
+N3=$(present "$T/c3")
+echo "   fetched $N3 block(s)"
+[ "$N3" -gt 1 ] || { echo "   an explicit override was ignored"; exit 1; }
+
+echo "LUMABRI PREFETCH POLICY TEST: PASS"

--- a/security_test.sh
+++ b/security_test.sh
@@ -158,4 +158,84 @@ set -e
 grep -q "REJECTED" "$T/tracker.log" || { echo "   the tracker said nothing"; cat "$T/tracker.log"; exit 1; }
 echo "   ✓ refused at the index, so it never reaches a client"
 
+echo "· 4) oversized control frames are rejected before their body is read"
+env LUMABRI_MAX_CONNECTIONS=2 LUMABRI_IO_TIMEOUT_MS=5000 \
+    ./tracker --port 7554 > "$T/limits.log" 2>&1 & LIMIT_PID=$!; PIDS+=($LIMIT_PID)
+sleep 0.4
+python3 - 7554 <<'PY'
+import socket, struct, sys
+port = int(sys.argv[1])
+s = socket.create_connection(("127.0.0.1", port))
+s.settimeout(1.0)
+# PING has a 64 KiB control-body cap.  Announce 1 MiB but deliberately send
+# no body: a hardened receiver closes from the header alone instead of
+# allocating memory and waiting for attacker-controlled bytes.
+s.sendall(struct.pack("<IIII", 0x31424D4C, 1, 1 << 20, 0))
+try:
+    data = s.recv(1)
+except socket.timeout:
+    raise SystemExit("tracker waited for an oversized PING body")
+if data:
+    raise SystemExit("tracker accepted an oversized PING body")
+PY
+echo "   ✓ hostile length refused from the 16-byte header"
+
+echo "· 5) idle connections cannot grow the server thread count without bound"
+python3 - 7554 "$T/held.ready" <<'PY' &
+import pathlib, socket, sys, time
+port = int(sys.argv[1])
+socks = [socket.create_connection(("127.0.0.1", port)) for _ in range(2)]
+pathlib.Path(sys.argv[2]).write_text("ready")
+time.sleep(10)
+PY
+HOLDER_PID=$!; PIDS+=($HOLDER_PID)
+for _ in $(seq 1 100); do [ -f "$T/held.ready" ] && break; sleep 0.05; done
+[ -f "$T/held.ready" ] || { echo "   connection holders did not start"; exit 1; }
+sleep 0.2
+python3 - 7554 <<'PY'
+import socket, sys
+s = socket.create_connection(("127.0.0.1", int(sys.argv[1])))
+s.settimeout(1.0)
+try:
+    data = s.recv(1)
+except socket.timeout:
+    raise SystemExit("third idle connection was admitted past the configured cap")
+if data:
+    raise SystemExit("unexpected response on rejected connection")
+PY
+kill "$HOLDER_PID" 2>/dev/null || true
+wait "$HOLDER_PID" 2>/dev/null || true
+echo "   ✓ configured connection cap rejects excess idle clients"
+
+echo "· 6) stale peer names do not exhaust the tracker's lifetime capacity"
+env LUMABRI_STALE_MS=100 ./tracker --port 7555 > "$T/reuse.log" 2>&1 & PIDS+=($!)
+sleep 0.3
+python3 - 7555 <<'PY'
+import socket, struct, sys, time
+port = int(sys.argv[1])
+def string(s):
+    b = s.encode()
+    return struct.pack("<H", len(b)) + b
+def register(i):
+    body = string(f"gone-{i}") + string("127.0.0.1:9") + string("model")
+    body += struct.pack("<I", 0)
+    s = socket.create_connection(("127.0.0.1", port))
+    s.sendall(struct.pack("<IIII", 0x31424D4C, 23, len(body), 0) + body)
+    pre = b""
+    while len(pre) < 16:
+        part = s.recv(16 - len(pre))
+        if not part:
+            raise SystemExit(f"peer {i}: tracker closed without a reply")
+        pre += part
+    op = struct.unpack("<IIII", pre)[1]
+    s.close()
+    if op != 2:
+        raise SystemExit(f"peer {i}: tracker table was not reusable")
+for i in range(64):
+    register(i)
+time.sleep(0.2)
+register(64)
+PY
+echo "   ✓ stale slot recycled; the cap applies to live peers, not history"
+
 echo "LUMABRI SECURITY TEST: PASS"

--- a/selftest.sh
+++ b/selftest.sh
@@ -8,6 +8,8 @@
 #   pass 2  warm   — served from the local mirror
 #   pass 3  offline — tracker and maintainers are DEAD; the warm mirror must
 #                     still serve everything (the whole point of the design)
+#   pass 5  replaced — same path and size, different bytes; the complete-model
+#                     identity must invalidate every old block map
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -17,6 +19,14 @@ T=$(mktemp -d /tmp/lumabri-selftest.XXXXXX)
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
+
+wait_port() {
+    for _ in $(seq 1 200); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
 
 mkdir -p "$T/src/sub" "$T/cache"
 head -c $((3 * 1024 * 1024 + 12345)) /dev/urandom > "$T/src/a.bin"
@@ -30,6 +40,7 @@ sleep 0.3
              --name half-a --include 'a.bin' --include '*.json' & PIDS+=($!)
 ./maintainer --root "$T/src" --port 7392 --tracker 127.0.0.1:7390 \
              --name half-b --include 'sub/*' --include 'empty.bin' & PIDS+=($!)
+wait_port 7391; wait_port 7392
 sleep 0.5
 
 ENV=(LD_PRELOAD="$PWD/liblumabri.so"
@@ -60,12 +71,57 @@ sleep 0.3
 ./maintainer --root "$T/src" --port 7392 --tracker 127.0.0.1:7390 \
              --name nat-b --advertise 127.0.0.1:1 \
              --include 'sub/*' --include 'empty.bin' & PIDS+=($!)
-sleep 0.7
+wait_port 7391; wait_port 7392
+sleep 0.5
 NATENV=(LD_PRELOAD="$PWD/liblumabri.so"
         LUMABRI_VROOT="$T/vroot2"
         LUMABRI_CACHE="$T/cache2"
         LUMABRI_TRACKER=127.0.0.1:7390
         LUMABRI_BLOCK_MIB=1)
 env "${NATENV[@]}" ./test_shim "$T/vroot2" "$T/src"
+
+echo "· pass 5: same-size checkpoint replacement invalidates the warm mirror"
+kill "${PIDS[@]}" 2>/dev/null || true
+wait 2>/dev/null || true
+PIDS=()
+
+# First bind a fully warm mirror to the identity of the complete model.  The
+# earlier split maintainers intentionally hold only slices and therefore
+# cannot originate a complete-model root.
+./tracker --port 7390 & PIDS+=($!)
+sleep 0.3
+./maintainer --root "$T/src" --port 7391 --tracker 127.0.0.1:7390 \
+             --name complete --model-name src & PIDS+=($!)
+wait_port 7391
+sleep 0.5
+IDENV=(LD_PRELOAD="$PWD/liblumabri.so"
+       LUMABRI_VROOT="$T/vroot3"
+       LUMABRI_CACHE="$T/cache3"
+       LUMABRI_TRACKER=127.0.0.1:7390
+       LUMABRI_MODEL=src
+       LUMABRI_BLOCK_MIB=1)
+env "${IDENV[@]}" ./test_shim "$T/vroot3" "$T/src" >/dev/null
+
+kill "${PIDS[@]}" 2>/dev/null || true
+wait 2>/dev/null || true
+PIDS=()
+ASZ=$(stat -c %s "$T/src/a.bin")
+head -c "$ASZ" /dev/urandom > "$T/a.new"
+mv "$T/a.new" "$T/src/a.bin"             # new bytes, exactly the same size
+
+./tracker --port 7390 & PIDS+=($!)
+sleep 0.3
+./maintainer --root "$T/src" --port 7391 --tracker 127.0.0.1:7390 \
+             --name complete --model-name src & PIDS+=($!)
+wait_port 7391
+sleep 0.5
+env "${IDENV[@]}" ./test_shim "$T/vroot3" "$T/src" \
+    > "$T/replaced.out" 2> "$T/replaced.err"
+grep -q "model identity changed" "$T/replaced.err" || {
+    echo "   REPLACEMENT FAILED: old cache identity was not invalidated"
+    cat "$T/replaced.err"
+    exit 1
+}
+echo "   ✓ new model root detected; stale maps cleared and bytes refetched"
 
 echo "LUMABRI SELFTEST: PASS"

--- a/sign_test.sh
+++ b/sign_test.sh
@@ -113,7 +113,8 @@ sleep 0.3
              --key "$T/swarm.key" > "$T/origin.log" 2>&1 & PIDS+=($!)
 sleep 1.2
 env LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v" LUMABRI_CACHE="$T/c" \
-    LUMABRI_TRACKER=127.0.0.1:7460 LUMABRI_BLOCK_MIB=1 LUMABRI_PUBKEY="$PUB" \
+    LUMABRI_TRACKER=127.0.0.1:7460 LUMABRI_MODEL=src \
+    LUMABRI_BLOCK_MIB=1 LUMABRI_PUBKEY="$PUB" \
     ./test_shim "$T/v" "$T/src" 2> "$T/shim.err"
 grep -q "signed by the operator key" "$T/shim.err" || {
     echo "   SIGNED SWARM FAILED: the chatter never saw a valid signature"
@@ -124,7 +125,8 @@ echo "· 3b) an unsigned peer cannot get its files into a signed swarm"
 mkdir -p "$T/rogue"
 head -c $((3 * 1024 * 1024)) /dev/urandom > "$T/rogue/w.bin"
 ./maintainer --root "$T/rogue" --port 7462 --tracker 127.0.0.1:7460 \
-             --name rogue --model-name src > "$T/rogue.log" 2>&1 & PIDS+=($!)
+             --name rogue --model-name src --include '*' \
+             > "$T/rogue.log" 2>&1 & PIDS+=($!)
 sleep 1.5
 grep -q "REJECTED: rogue" "$T/tracker.log" || {
     echo "   REJECTION FAILED: the tracker accepted unsigned truth"
@@ -141,11 +143,12 @@ sleep 0.3
 sleep 1.2
 set +e
 env LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v2" LUMABRI_CACHE="$T/c2" \
-    LUMABRI_TRACKER=127.0.0.1:7463 LUMABRI_BLOCK_MIB=1 LUMABRI_PUBKEY="$PUB" \
+    LUMABRI_TRACKER=127.0.0.1:7463 LUMABRI_MODEL=src \
+    LUMABRI_BLOCK_MIB=1 LUMABRI_PUBKEY="$PUB" \
     ./test_shim "$T/v2" "$T/rogue" > /dev/null 2> "$T/evil_shim.err"
 RC=$?
 set -e
-grep -q "not signed by the operator key" "$T/evil_shim.err" || {
+grep -q "not signed by the operator" "$T/evil_shim.err" || {
     echo "   LYING TRACKER UNPROVEN: no signature complaint"
     cat "$T/evil_shim.err"; exit 1; }
 [ "$RC" -ne 0 ] || { echo "   LYING TRACKER FAILED: the chatter used its bytes"; exit 1; }

--- a/tracker.c
+++ b/tracker.c
@@ -22,6 +22,7 @@
 #include <time.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_sha.h"
 #include "lumabri_sign.h"
 
 #define MAX_PEERS  64
@@ -37,6 +38,7 @@ typedef struct {
     PFile *files; uint32_t nfiles;
     double ts;
     int used;
+    unsigned refs;              /* control/relay users holding this slot */
     int is_expert;              /* EREG peer: executes experts, holds no files */
     uint32_t nexperts;
     /* WHICH experts, not just how many: one bit per (slot, expert). Without
@@ -63,6 +65,8 @@ static Peer g_peers[MAX_PEERS];
 static pthread_mutex_t g_lk = PTHREAD_MUTEX_INITIALIZER;
 static int g_known_logged[MAX_PEERS];
 static char g_token[128];        /* --token: private swarm, invite required */
+static LmbConnGate g_conn_gate = LMB_CONN_GATE_INIT;
+static double g_stale_s = STALE_S;
 
 /* Ground truth: sha256 per LMB_HASH_CHUNK of every (model, path), taken
  * from the FIRST registrant — the origin server registers before any donor
@@ -79,6 +83,53 @@ static GTruth g_truth[MAX_FILES];
 static int g_ntruth;
 static uint8_t g_pubkey[32];
 static int g_have_pubkey;    /* --pubkey: only signed truth is accepted */
+
+#define MAX_MODELS 128
+typedef struct { LmbModelIdentity id; int used; } GModel;
+static GModel g_models[MAX_MODELS];
+
+/* under g_lk. A first identity must describe exactly the hash inventory in
+ * that registration; later partial donors may forward the already accepted
+ * full root. Signed swarms additionally require the operator's signature. */
+static int model_identity_check(const char *model, const LmbModelIdentity *id,
+                                const PFile *files, uint32_t n,
+                                uint8_t *const *hashes, const uint32_t *nh) {
+    if (strcmp(model, id->model)) return 0;
+    if (g_have_pubkey) {
+        if (!id->has_sig) return 0;
+        size_t ml = 0;
+        uint8_t *msg = lmb_model_id_msg(model, id->root, &ml);
+        int ok = msg && lmb_sign_verify(id->sig, msg, ml, g_pubkey) == 0;
+        free(msg);
+        if (!ok) return 0;
+    }
+    for (int i = 0; i < MAX_MODELS; i++)
+        if (g_models[i].used && !strcmp(g_models[i].id.model, model)) {
+            if (memcmp(g_models[i].id.root, id->root, 32)) return 0;
+            if (g_models[i].id.has_sig && !id->has_sig) return 0;
+            if (!g_models[i].id.has_sig && id->has_sig) g_models[i].id = *id;
+            return 1;
+        }
+    LmbModelItem *items = (LmbModelItem *)calloc(n ? n : 1, sizeof *items);
+    if (!items) return 0;
+    for (uint32_t i = 0; i < n; i++) {
+        /* Empty files legitimately have a zero-length hash vector. */
+        if (nh[i] && !hashes[i]) { free(items); return 0; }
+        items[i].path = files[i].path; items[i].size = files[i].size;
+        items[i].nh = nh[i]; items[i].hashes = hashes[i];
+    }
+    uint8_t root[32];
+    int ok = lmb_model_root(model, items, n, root) == 0 &&
+             memcmp(root, id->root, 32) == 0;
+    free(items);
+    if (!ok) return 0;
+    for (int i = 0; i < MAX_MODELS; i++)
+        if (!g_models[i].used) {
+            g_models[i].used = 1; g_models[i].id = *id;
+            return 1;
+        }
+    return 0;
+}
 
 /* under g_lk; steals *hash on first sight. Returns 1 ok / 0 rejected.
  *
@@ -103,7 +154,7 @@ static int truth_check(const char *model, const char *path, uint64_t size,
     }
     for (int i = 0; i < g_ntruth; i++)
         if (!strcmp(g_truth[i].model, model) && !strcmp(g_truth[i].path, path)) {
-            if (g_truth[i].nh != nh ||
+            if (g_truth[i].nh != nh || g_truth[i].size != size ||
                 memcmp(g_truth[i].hash, *hash, (size_t)nh * 32)) return 0;
             if (!g_truth[i].has_sig && has_sig) {    /* upgrade to signed */
                 memcpy(g_truth[i].sig, sig, 64);
@@ -111,7 +162,7 @@ static int truth_check(const char *model, const char *path, uint64_t size,
             }
             return 1;
         }
-    if (g_ntruth == MAX_FILES) return 1;      /* table full: cannot judge */
+    if (g_ntruth == MAX_FILES) return 0;      /* full means reject, never accept blind */
     GTruth *t = &g_truth[g_ntruth++];
     snprintf(t->model, sizeof t->model, "%s", model);
     snprintf(t->path, sizeof t->path, "%s", path);
@@ -128,6 +179,42 @@ static double now_s(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+/* Reuse history slots after their peer has been stale long enough.  The
+ * table is a cap on simultaneous live peers, not on every temporary name a
+ * tracker has seen since boot.  refs keeps a relay waiter or an old control
+ * connection from losing its mutex/storage underneath it.  Called with
+ * g_lk held. */
+static Peer *peer_slot_new(int is_expert, int *idx) {
+    int pick = -1;
+    for (int i = 0; i < MAX_PEERS; i++)
+        if (!g_peers[i].used) { pick = i; break; }
+    if (pick < 0) {
+        double now = now_s();
+        for (int i = 0; i < MAX_PEERS; i++) {
+            Peer *p = &g_peers[i];
+            if (now - p->ts <= g_stale_s || p->ctrl_fd >= 0 || p->refs) continue;
+            pick = i;
+            break;
+        }
+    }
+    if (pick < 0) return NULL;
+    Peer *p = &g_peers[pick];
+    if (p->used) {
+        free(p->files); free(p->ebits); free(p->rq_resp);
+        if (p->evfd >= 0) close(p->evfd);
+        pthread_mutex_destroy(&p->rq_lk);
+        pthread_cond_destroy(&p->rq_cv);
+    }
+    memset(p, 0, sizeof *p);
+    p->ctrl_fd = -1;
+    p->evfd = is_expert ? -1 : eventfd(0, EFD_NONBLOCK);
+    pthread_mutex_init(&p->rq_lk, NULL);
+    pthread_cond_init(&p->rq_cv, NULL);
+    g_known_logged[pick] = 0;
+    if (idx) *idx = pick;
+    return p;
 }
 
 static void send_err(int fd, const char *msg) {
@@ -191,9 +278,34 @@ static Peer *handle_register(int fd, LmbMsg *m) {
         }
     } else c.off = save;
 
+    LmbModelIdentity mid = {0};
+    uint32_t mmagic = 0, mhas = 0;
+    int have_mid = 0, bad_mid = 0;
+    if (have_h && c.off < c.len) {
+        snprintf(mid.model, sizeof mid.model, "%s", model);
+        bad_mid = lmb_cur_u32(&c, &mmagic) || mmagic != LMB_MODEL_ID_MAGIC ||
+                  lmb_cur_bytes(&c, mid.root, sizeof mid.root) ||
+                  lmb_cur_u32(&c, &mhas) || mhas > 1 ||
+                  (mhas && lmb_cur_bytes(&c, mid.sig, sizeof mid.sig)) ||
+                  c.off != c.len;
+        mid.has_sig = mhas != 0;
+        have_mid = !bad_mid;
+    } else if (have_h && c.off != c.len) bad_mid = 1;
+
     Peer *slot = NULL;
     int idx = -1, fresh = 0;
     pthread_mutex_lock(&g_lk);
+    if (bad_mid || (g_have_pubkey && !have_mid) ||
+        (have_mid && !model_identity_check(model, &mid, files, n, fh, fnh))) {
+        pthread_mutex_unlock(&g_lk);
+        printf("[tracker] REJECTED: %s has a bad or mismatched model identity for %s\n",
+               name, model);
+        fflush(stdout);
+        for (uint32_t i = 0; i < n; i++) free(fh[i]);
+        free(fh); free(fnh); free(fsig); free(fhas); free(files);
+        send_err(fd, "bad model identity");
+        return NULL;
+    }
     if (have_h) {
         /* poison dies here: a file whose announced hashes contradict the
          * swarm's ground truth — or, with --pubkey, is not signed by the
@@ -221,17 +333,10 @@ static Peer *handle_register(int fd, LmbMsg *m) {
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && !g_peers[i].is_expert &&
             !strcmp(g_peers[i].name, name)) { slot = &g_peers[i]; idx = i; break; }
-    if (!slot)
-        for (int i = 0; i < MAX_PEERS; i++)
-            if (!g_peers[i].used) {
-                slot = &g_peers[i]; idx = i; fresh = 1;
-                memset(slot, 0, sizeof *slot);
-                slot->ctrl_fd = -1;
-                slot->evfd = eventfd(0, EFD_NONBLOCK);
-                pthread_mutex_init(&slot->rq_lk, NULL);
-                pthread_cond_init(&slot->rq_cv, NULL);
-                break;
-            }
+    if (!slot) {
+        slot = peer_slot_new(0, &idx);
+        fresh = slot != NULL;
+    }
     /* observed address: a maintainer that advertises localhost from another
      * machine gets its host part corrected to what this connection shows —
      * the --advertise footgun dies here, ports stay as declared */
@@ -293,17 +398,10 @@ static int handle_ereg(int fd, LmbMsg *m) {
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert &&
             !strcmp(g_peers[i].name, name)) { slot = &g_peers[i]; break; }
-    if (!slot)
-        for (int i = 0; i < MAX_PEERS; i++)
-            if (!g_peers[i].used) {
-                slot = &g_peers[i]; fresh = 1;
-                memset(slot, 0, sizeof *slot);
-                slot->ctrl_fd = -1;
-                slot->evfd = -1;
-                pthread_mutex_init(&slot->rq_lk, NULL);
-                pthread_cond_init(&slot->rq_cv, NULL);
-                break;
-            }
+    if (!slot) {
+        slot = peer_slot_new(1, NULL);
+        fresh = slot != NULL;
+    }
     const char *use_addr = addr;
     char fixed[64];
     struct sockaddr_in sin;
@@ -350,12 +448,12 @@ static int handle_epeers(int fd, LmbMsg *m) {
     uint32_t n = 0;
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert &&
-            now - g_peers[i].ts <= STALE_S &&
+            now - g_peers[i].ts <= g_stale_s &&
             (!want[0] || !strcmp(g_peers[i].model, want))) n++;
     lmb_buf_u32(&b, n);
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert &&
-            now - g_peers[i].ts <= STALE_S &&
+            now - g_peers[i].ts <= g_stale_s &&
             (!want[0] || !strcmp(g_peers[i].model, want)))
             lmb_buf_str(&b, g_peers[i].addr);
     pthread_mutex_unlock(&g_lk);
@@ -407,6 +505,34 @@ static int handle_hashes(int fd, LmbMsg *m) {
     return rc;
 }
 
+/* ---- MODEL_ID: signed identity of the complete checkpoint --------------- */
+
+static int handle_model_id(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    char model[64];
+    if (lmb_cur_str(&c, model, sizeof model) || c.off != c.len) {
+        send_err(fd, "bad model identity request"); return -1;
+    }
+    LmbModelIdentity id = {0};
+    int found = 0;
+    pthread_mutex_lock(&g_lk);
+    for (int i = 0; i < MAX_MODELS; i++)
+        if (g_models[i].used && !strcmp(g_models[i].id.model, model)) {
+            id = g_models[i].id; found = 1; break;
+        }
+    pthread_mutex_unlock(&g_lk);
+    if (!found) { send_err(fd, "no complete model identity"); return 0; }
+    LmbBuf b = {0};
+    lmb_buf_u32(&b, LMB_MODEL_ID_MAGIC);
+    lmb_buf_str(&b, id.model);
+    lmb_buf_bytes(&b, id.root, sizeof id.root);
+    lmb_buf_u32(&b, id.has_sig ? 1u : 0u);
+    if (id.has_sig) lmb_buf_bytes(&b, id.sig, sizeof id.sig);
+    int rc = lmb_send(fd, LMB_MODEL_ID_R, b.p, (uint32_t)b.len, NULL, 0);
+    free(b.p);
+    return rc;
+}
+
 /* ---- PLACEMENT ---------------------------------------------------------- */
 
 static int handle_placement(int fd, LmbMsg *m) {
@@ -422,7 +548,7 @@ static int handle_placement(int fd, LmbMsg *m) {
     double now = now_s();
     pthread_mutex_lock(&g_lk);
     for (int p = 0; p < MAX_PEERS; p++) {
-        if (!g_peers[p].used || now - g_peers[p].ts > STALE_S) continue;
+        if (!g_peers[p].used || now - g_peers[p].ts > g_stale_s) continue;
         if (want[0] && strcmp(g_peers[p].model, want)) continue;
         for (uint32_t i = 0; i < g_peers[p].nfiles; i++) {
             const PFile *f = &g_peers[p].files[i];
@@ -460,11 +586,11 @@ static int handle_swarm(int fd) {
     uint32_t live = 0;
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && !g_peers[i].is_expert &&
-            now - g_peers[i].ts <= STALE_S) live++;
+            now - g_peers[i].ts <= g_stale_s) live++;
     lmb_buf_u32(&b, live);
     for (int i = 0; i < MAX_PEERS; i++) {
         Peer *p = &g_peers[i];
-        if (!p->used || p->is_expert || now - p->ts > STALE_S) continue;
+        if (!p->used || p->is_expert || now - p->ts > g_stale_s) continue;
         lmb_buf_str(&b, p->model);
         lmb_buf_u64(&b, p->held_bytes);
         lmb_buf_u64(&b, p->served_bytes);
@@ -531,7 +657,7 @@ static int handle_eassign(int fd, LmbMsg *m) {
                                     ? (cells + 7) / 8 : (p->enbits + 7) / 8));
             continue;
         }
-        if (now - p->ts > STALE_S) continue;
+        if (now - p->ts > g_stale_s) continue;
         for (size_t k = 0; k < cells && k < p->enbits; k++)
             if (p->ebits[k >> 3] & (1u << (k & 7))) cnt[k]++;
     }
@@ -585,10 +711,10 @@ static int handle_rread(int fd, LmbMsg *m) {
     pthread_mutex_lock(&g_lk);
     for (int i = 0; i < MAX_PEERS && !p; i++) {
         Peer *q = &g_peers[i];
-        if (!q->used || now - q->ts > STALE_S || q->ctrl_fd < 0) continue;
+        if (!q->used || now - q->ts > g_stale_s || q->ctrl_fd < 0) continue;
         if (model[0] && strcmp(q->model, model)) continue;
         for (uint32_t j = 0; j < q->nfiles; j++)
-            if (!strcmp(q->files[j].path, path)) { p = q; break; }
+            if (!strcmp(q->files[j].path, path)) { p = q; p->refs++; break; }
     }
     pthread_mutex_unlock(&g_lk);
     if (!p) { send_err(fd, "no relay-capable peer holds it"); return 0; }
@@ -627,6 +753,9 @@ static int handle_rread(int fd, LmbMsg *m) {
         free(b.p);
     }
     free(resp);
+    pthread_mutex_lock(&g_lk);
+    if (p->refs) p->refs--;
+    pthread_mutex_unlock(&g_lk);
     return rc;
 }
 
@@ -657,7 +786,7 @@ static int handle_assign(int fd, LmbMsg *m) {
     pthread_mutex_lock(&g_lk);
     for (int p = 0; p < MAX_PEERS; p++) {
         Peer *q = &g_peers[p];
-        if (!q->used || now - q->ts > STALE_S) continue;
+        if (!q->used || now - q->ts > g_stale_s) continue;
         if (model[0] && strcmp(q->model, model)) continue;
         for (uint32_t i = 0; i < q->nfiles; i++) {
             Cand *e = NULL;
@@ -733,6 +862,9 @@ static void ctrl_teardown(Peer *p, int fd) {
     pthread_mutex_lock(&p->rq_lk);
     if (p->rq_busy && !p->rq_done) { p->rq_done = 1; p->rq_ok = 0; pthread_cond_broadcast(&p->rq_cv); }
     pthread_mutex_unlock(&p->rq_lk);
+    pthread_mutex_lock(&g_lk);
+    if (p->refs) p->refs--;
+    pthread_mutex_unlock(&g_lk);
 }
 
 /* ---- connections -------------------------------------------------------- */
@@ -790,7 +922,20 @@ static void *conn_thread(void *arg) {
         case LMB_PING:      rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0); break;
         case LMB_REGISTER: {
             Peer *p = handle_register(fd, &m);
-            if (p) ctrl = p; else rc = -1;
+            if (p) {
+                if (!ctrl) {
+                    pthread_mutex_lock(&g_lk);
+                    p->refs++;
+                    pthread_mutex_unlock(&g_lk);
+                    ctrl = p;
+                } else if (ctrl != p) {
+                    pthread_mutex_lock(&g_lk);
+                    if (p->ctrl_fd == fd) p->ctrl_fd = -1;
+                    pthread_mutex_unlock(&g_lk);
+                    send_err(fd, "one maintainer identity per control connection");
+                    rc = -1;
+                }
+            } else rc = -1;
             break;
         }
         case LMB_RREAD_R:   if (ctrl) rread_complete(ctrl, &m); break;
@@ -798,6 +943,7 @@ static void *conn_thread(void *arg) {
         case LMB_EASSIGN:   rc = handle_eassign(fd, &m); break;
         case LMB_EPEERS:    rc = handle_epeers(fd, &m); break;
         case LMB_HASHES:    rc = handle_hashes(fd, &m); break;
+        case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;
         case LMB_SWARM:     rc = handle_swarm(fd); break;
         case LMB_RREAD:     rc = handle_rread(fd, &m); break;
@@ -809,6 +955,7 @@ static void *conn_thread(void *arg) {
     }
     if (ctrl) ctrl_teardown(ctrl, fd);
     close(fd);
+    lmb_conn_gate_leave(&g_conn_gate);
     return NULL;
 }
 
@@ -835,6 +982,9 @@ int main(int argc, char **argv) {
         else { fprintf(stderr, "usage: %s [--port N] [--token S] [--pubkey FILE]\n",
                        argv[0]); return 2; }
     signal(SIGPIPE, SIG_IGN);   /* a vanished peer must not kill the tracker */
+    g_stale_s = (double)lmb_env_int("LUMABRI_STALE_MS", (int)(STALE_S * 1000),
+                                    100, 3600000) / 1000.0;
+    lmb_conn_gate_init(&g_conn_gate);
     int lfd = lmb_listen(port);
     if (lfd < 0) { perror("[tracker] listen"); return 1; }
     printf("[tracker] listening on :%d\n", port);
@@ -847,11 +997,13 @@ int main(int argc, char **argv) {
     for (;;) {
         int fd = accept(lfd, NULL, NULL);
         if (fd < 0) { if (errno == EINTR) continue; perror("[tracker] accept"); break; }
+        lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
+                                           LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
+        if (!lmb_conn_gate_enter(&g_conn_gate)) { close(fd); continue; }
         pthread_t t;
         if (pthread_create(&t, NULL, conn_thread, (void *)(intptr_t)fd) == 0)
             pthread_detach(t);
-        else
-            close(fd);
+        else { lmb_conn_gate_leave(&g_conn_gate); close(fd); }
     }
     return 0;
 }


### PR DESCRIPTION
Takes lumabri from a demonstrated prototype to something with the properties a public swarm needs.

## What changed

- **Signed checkpoint identity** — the origin signs a 32-byte root over the canonical `{path,size,block-hashes}` list; the tracker carries it (`MODEL_ID`), nodes echo it in `EMANIFEST`. A chatter refuses to mix checkpoints and refuses a peer whose **build profile** differs (engine, source hash, ISA, OpenMP, fast-math, `sizeof float`). The compatibility boundary is the arithmetic profile, not the ISA or vendor — an independent evaluation on heterogeneous x86 reached the same conclusion.
- **Crash-safe mirror** — a fetched block is usable immediately from the in-process map; the on-disk map advances only after the data fd is durable, in 1 s batches, under an `flock` that OR-merges other processes' bits (a chatter and a donor can share one cache). Hash sidecars invalidate on mtime/ctime, so a same-size checkpoint replacement no longer serves a mix.
- **Accept path that cannot be exhausted** — shared connection gate + per-socket read/write deadlines across tracker, maintainer and expert node; per-op frame-size caps decided before allocation; stale peer-history slots reclaimed.
- **Continuous discovery + safe re-entry** — the chatter re-checks the tracker mid-generation, so a late donor wins its nearest calls; a returning peer is re-validated against its manifest with a coverage bitmap before its claims are trusted.

## Merged with #3

PR #3's out-of-range index rejection is preserved inside the rewritten paths (`expert_index_ok`, `lumi_index_ok` guard every network index in its unsigned domain). `expert_input_test.sh` is updated to speak the v2 manifest.

## Protocol break

`EMANIFEST_R` opens with a magic; an old chatter and a new node reject each other cleanly. **A swarm must upgrade all at once.** Suggest tagging `v0.6.0` on merge.

## Tests

Full regression green on the combined tree (15 suites): selftest, security, assign, chat_proto, sign, donate, signed_donor, role, expert_input, phase2 (olmoe/glm/inkling/kimi), phase4, phase5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)