### PR TITLE
WAN multipliers, cross-checkpoint CAS, key rotation, relayed EXEC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ deepseek_p2p
 # engine sitting in our tree would be exactly that — plus a licence question
 # nobody needs.
 build/
+
+# compiled unit-test binaries
+test_hedge
+test_key_rotation
+test_relay_exec

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -159,6 +159,26 @@ it, put it in the README of your swarm, read it over the phone:
 cat swarm.pub
 ```
 
+### Manual key rotation
+
+Create the replacement key, then distribute a trust file containing the old
+and new public keys, one per line:
+
+```sh
+lumabri key --out swarm-next
+cat swarm.pub swarm-next.pub > swarm-trust.pub
+```
+
+Point tracker/maintainers at `--pubkey swarm-trust.pub` and clients at
+`LUMABRI_PUBKEY=/path/to/swarm-trust.pub` before signing anything with
+`swarm-next.key`. Once every verifier has the overlap trust file, switch the
+origin to the new secret and restart it. After the new signatures have been
+observed and old clients are gone, remove the old line. A comma-separated pair
+also works. Keep the newest key last: valid signatures from later keys replace
+earlier ones at the tracker, never the reverse. Restart long-running verifiers
+after changing the trust file. This is manual rotation and manual revocation; KMS/HSM policy and
+audit are outside the dependency-free core.
+
 ---
 
 ## 4. The model
@@ -220,15 +240,16 @@ systemctl enable --now lumabri
 journalctl -u lumabri -f
 ```
 
-**`--advertise` is what makes the swarm reachable from anywhere else.** The
+**`--advertise` is what gives the swarm its fastest direct path.** The
 peers register with the tracker under the address they are told to publish,
 and without it they publish `127.0.0.1` — which is correct for this machine
 and useless for everyone. The tracker cannot fix it either: it rewrites a
 localhost registration only when it arrives from off-machine, and these
 arrive over loopback. A remote chatter then gets `127.0.0.1`, cannot connect,
-falls back to the relay for bytes, and phase 2 never starts at all because
-expert execution has no relay. It looks like a slow swarm rather than a
-misconfigured one. `serve` warns loudly when the flag is missing.
+and falls back to the outbound heartbeat tunnel for both bytes and expert
+execution. That is correct behind symmetric NAT, but it adds a second network
+leg and tracker load. `serve` still warns because direct P2P should be used
+whenever an inbound address is available.
 
 You should see, in order: the maintainer announcing how much it holds, the
 line `ORIGIN: signed the truth of N files with <pubkey>`, the executor
@@ -288,6 +309,12 @@ unsigned. Without it the client still works, but it is trusting the server.
 The first answer is slow while the dense weights cross the network; after
 that `~/.lumabri` serves them locally and the swarm is only touched for
 experts. `/swarm` shows the network, `/model` switches model.
+
+Verified chunks are shared across models in `~/.lumabri/cas`; override it
+with `LUMABRI_CAS=/fast/local/path`. To enable the basic straggler hedge, set
+for example `LUMABRI_HEDGE_MS=40`. Keep it disabled (`0`, the default) until
+there are at least two replicas per expert, otherwise there is nowhere to
+hedge. Prefill and speculative target verification are batched automatically.
 
 The boot narrates itself, so you can see where the time goes:
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -87,6 +87,9 @@ silenzioso da >30 s → escluso dai placement.
 - **Blocchi**: default 8 MiB (`LUMABRI_BLOCK_MIB`). Fetch con dedup
   in-flight (mutex+condvar per file): N thread del motore che toccano lo
   stesso blocco = un solo fetch.
+- **CAS locale**: ogni chunk verificato da 1 MiB viene pubblicato come
+  `sha256` sotto `LUMABRI_CAS`. Il caricamento ricalcola sempre l'hash, poi
+  assembla il mirror sparso. La CLI usa `~/.lumabri/cas`, comune ai modelli.
 - **Peer**: pool di 4 connessioni persistenti per peer; scelta per blocco
   via FNV(rel,blk) % npeers (spreading deterministico); failover sugli
   altri peer del file; socket morto → 1 retry fresco.
@@ -107,11 +110,12 @@ silenzioso da >30 s → escluso dai placement.
 
 ## Limiti noti
 
-- Il relay rende raggiungibili i maintainer dietro NAT, ma l'esecuzione
-  esperti non ha ancora hole punching o relay EXEC.
-- Mancano rotazione e revoca delle chiavi dell'operatore.
-- Il mirror è crash-consistent e legato al checkpoint, ma non è ancora un
-  content-addressed store condiviso tra checkpoint.
+- READ ed EXEC hanno un relay tracker come floor NAT; non c'è ancora hole
+  punching, quindi il fallback paga il doppio tratto e carica il tracker.
+- La rotazione chiavi è manuale con trust set old+new; revoca automatica,
+  KMS/HSM e audit non fanno parte del core.
+- Il CAS è locale. Distribuzione tra server o object storage resta fuori dal
+  core; il nome sha256 non viene mai fidato senza ricalcolarlo.
 - `dup()`/`fork()+exec` sull'fd del modello non tracciati (i motori non li
   usano sugli shard; LD_PRELOAD sopravvive comunque all'exec).
 - fd ≥ 65536 su file del modello → EMFILE (limite tabella).
@@ -160,14 +164,17 @@ metodologia del banco di fase 2):
 
 La lettura: il muro dell'RTT è il muro della *replica più vicina*, non della
 media dello sciame. Con sciami che clusterizzano geograficamente (città,
-campus), il conto 30 ms diventa un conto 2-8 ms — e il resto lo devono fare
-le due leve rimanenti:
+campus), il conto 30 ms diventa un conto 2-8 ms. Le leve successive sono:
 
-4. **Draft speculativo con batch-union** (appunti in fase 2): un round di
-   layer per l'intero draft → ×3-5. Richiede il drafting del motore: lavoro
-   lato colibri, il protocollo qui è pronto (EXEC porta già più righe in
-   linea di principio).
-5. **Predizione degli esperti + cache LRU dei caldi sul chatter**: spedire le
+4. **Draft speculativo con batch-union**: prefill e verifica del target
+   conservano le righe raggruppate dal motore; EXEC porta `nrows` e il peer
+   esegue lo stesso kernel multi-riga. Un draft intero paga un round per
+   esperto/layer, non uno per token. Il drafter resta locale e il target
+   verifica sempre i token proposti.
+5. **Hedging base**: `LUMABRI_HEDGE_MS=N` duplica una chiamata deterministica
+   sulla replica successiva dopo N ms e prende il primo risultato valido. La
+   policy è fissa e opt-in; stima adattiva e SLA non sono nel core.
+6. **Predizione degli esperti + cache LRU dei caldi sul chatter**: spedire le
    chiamate del layer N+1 in anticipo sulla predizione del router, e tenere
    localmente (via il mirror di fase 1) gli esperti più chiamati. Ogni hit è
    un round trip in meno.
@@ -200,9 +207,10 @@ generazione → failover al server, token identici al riferimento locale.
 `make install` porta tutto in PREFIX/bin + PREFIX/lib/lumabri; i binari si
 trovano l'un l'altro via /proc/self/exe.
 
-Aperto, in ordine: batch-union speculativo lato motore, richieste hedged
-contro gli straggler, rotazione/revoca delle chiavi, store content-addressed
-condiviso e relay o hole punching EXEC per esecutori dietro NAT.
+Aperto: predizione degli esperti e cache calda sul chatter, hole punching per
+togliere il tracker dal fallback NAT, e misure su sciami reali multi-host. Il
+core ora include batch-union, hedging fisso, rotazione manuale, CAS locale e
+relay EXEC; policy SLA, CAS distribuito e gestione KMS restano livelli sopra.
 
 ## Fase 5 — sciame aperto e sciame a inviti (2026-08-05)
 
@@ -272,7 +280,8 @@ nostre firme verificano lì, le sue verificano qui). Più lo sciame firmato
 end-to-end: un peer non firmato non entra nell'indice, e un tracker che
 inventa la verità viene beccato dalla chiave del chatter.
 
-Restano scoperti: rotazione e revoca delle chiavi, e soprattutto
+Restano scoperti: revoca automatica delle chiavi (la rotazione manuale usa un
+trust set old+new), e soprattutto
 l'**esecuzione** degli esperti, che oggi è garantita dall'accordo tra
 repliche (fase 5) e non da una firma — un peer non può firmare un calcolo
 che dipende dall'input, servirebbe attestazione o prova, ed è un problema

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ENGINE  ?= ../moe-stream/c
 
 all: tracker maintainer liblumabri.so test_shim lumabri
 
-lumabri: lumabri.c lumabri_proto.h
+lumabri: lumabri.c lumabri_proto.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread lumabri.c -o $@
 
 # ---- phase 2: peers execute experts ------------------------------------
@@ -39,7 +39,7 @@ MISSING_ENGINES = $(filter-out $(HAVE_ENGINES),olmoe colibri inkling kimi_k3 dee
 # into the chatter and expert-node build for that family. Compiler/ISA/OpenMP
 # details are appended at runtime by lmb_build_profile().
 ENGINE_PROFILE_DEPS := $(sort $(wildcard $(ENGINE)/*.h)) \
-                       lumabri_client.h lumabri_proto.h
+                       lumabri_client.h lumabri_proto.h lumabri_sign.h lumabri_sha.h
 define engine_source_id
 $(shell sha256sum $(ENGINE)/$(1).c $(ENGINE_PROFILE_DEPS) \
         expert_engines/$(2).h engine_patches/$(1)-p2p.diff 2>/dev/null | \
@@ -68,7 +68,7 @@ phase2-all: engines chatters
 # One expert-node binary per engine. The body is the same file; everything
 # engine-shaped lives in expert_engines/<name>.h, which pulls in the engine's
 # own source so remote and local run the same kernels on the same weights.
-EXPERT_DEPS = expert_node.c lumabri_proto.h
+EXPERT_DEPS = expert_node.c lumabri_proto.h lumabri_sign.h
 
 expert_node: $(EXPERT_DEPS) expert_engines/olmoe.h $(ENGINE)/olmoe.c \
              engine_patches/olmoe-p2p.diff $(ENGINE_PROFILE_DEPS)
@@ -145,7 +145,7 @@ build/%_p2p.c: $(ENGINE)/%.c engine_patches/%-p2p.diff Makefile
 	 else patch -s -p2 -o $@ $< engine_patches/$*-p2p.diff; fi
 	@sed -i 's/if (L\.on) {/if (lumi_layer_on(layer)) {/' $@
 
-ENGINE_P2P_DEPS = lumabri_client.h lumibri_client.h lumabri_proto.h
+ENGINE_P2P_DEPS = lumabri_client.h lumibri_client.h lumabri_proto.h lumabri_sign.h
 
 olmoe_p2p: build/olmoe_p2p.c $(ENGINE_P2P_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_olmoe) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
@@ -199,21 +199,42 @@ test-engines: test-phase2 test-phase2-glm test-phase2-inkling test-phase2-kimi
 	    echo "   it has no synthetic fixture — MODEL=<dir> make test-engines"; \
 	fi
 
-tracker: tracker.c lumabri_proto.h
+tracker: tracker.c lumabri_proto.h lumabri_sha.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread tracker.c -o $@
 
-maintainer: maintainer.c lumabri_proto.h
+maintainer: maintainer.c lumabri_proto.h lumabri_sha.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread maintainer.c -o $@
 
 # The shim interposes libc symbols, so it must not itself be interposable
 # state: -fPIC shared object, resolved via RTLD_NEXT at load time.
-liblumabri.so: lumashim.c lumabri_proto.h
+liblumabri.so: lumashim.c lumabri_proto.h lumabri_sha.h lumabri_sign.h
 	$(CC) $(CFLAGS) -shared -fPIC -pthread lumashim.c -o $@ -ldl
 
 test_shim: test_shim.c
 	$(CC) $(CFLAGS) test_shim.c -o $@
 
-test: all
+test_relay_exec: test_relay_exec.c lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_relay_exec.c -o $@
+
+test_key_rotation: test_key_rotation.c lumabri_sign.h
+	$(CC) $(CFLAGS) -pthread test_key_rotation.c -o $@
+
+test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h
+	$(CC) $(CFLAGS) -pthread test_hedge.c -o $@
+
+test-relay-exec: tracker expert_node test_relay_exec fixture
+	./relay_exec_test.sh
+
+test-cas: tracker maintainer liblumabri.so test_shim
+	./cas_test.sh
+
+test-key-rotation: test_key_rotation
+	./test_key_rotation
+
+test-hedge: test_hedge
+	./test_hedge
+
+test: all test_key_rotation test_hedge
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -221,6 +242,10 @@ test: all
 	./security_test.sh
 	./expert_input_test.sh
 	./prefetch_policy_test.sh
+	./cas_test.sh
+	./relay_exec_test.sh
+	./test_key_rotation
+	./test_hedge
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)
@@ -242,6 +267,7 @@ install: all
 
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim lumabri \
+	      test_relay_exec test_key_rotation test_hedge \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	      expert_node_deepseek
@@ -251,4 +277,4 @@ clean:
         fixture test-phase2 \
         test-phase2-glm test-phase2-inkling test-phase2-kimi \
         test-phase2-deepseek test-engines \
-        patches patches-check
+        patches patches-check test-relay-exec test-cas test-key-rotation test-hedge

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ model directory (`open`, `fopen`, `opendir`, `pread`). Files appear as sparse
 local mirrors of the true size, so `fstat`, `readdir` and the page cache work
 natively. A missing block is fetched from a peer, written to the mirror, and
 then the engine's own `pread` proceeds. A warm read is a table lookup plus a
-normal local read: no FUSE, no daemon on the read path.
+normal local read: no FUSE, no daemon on the read path. Every verified MiB is
+also stored by sha256 in a local content-addressed store. The default CLI path,
+`~/.lumabri/cas`, is shared by every checkpoint, so equal chunks are downloaded
+once and can rebuild a different sparse mirror without a byte server.
 
 **One rule, inherited from colibri:** the network may change where bytes come
 from, never which bytes. Writing a model file returns `EROFS`. A block no peer
@@ -91,6 +94,14 @@ lying peer has its bytes rejected and refetched elsewhere. Remote compute is
 checked the only way it can be: `LUMABRI_VERIFY=N` reruns N percent of expert
 calls on a second replica and demands identical output. Two honest peers cannot
 disagree, so a disagreement is proof of a lie and the run stops.
+
+Prefill and target verification already arrive at the MoE as multiple rows.
+lumabri keeps that union intact and sends one multi-row EXEC per selected
+expert, including speculative-draft verification; it never serializes a batch
+into row-sized requests. `LUMABRI_HEDGE_MS=N` optionally sends a duplicate to
+the next replica when the nearest has not replied after N milliseconds and
+uses the first valid deterministic result. The fixed delay is deliberately the
+public mechanism, not an automatic SLA policy.
 
 ## Engines
 
@@ -130,8 +141,11 @@ sudo make install                                    # or PREFIX=$HOME/.local
 ```
 
 On the server, `lumabri serve --model /srv/model` opens TCP 7300 to 7302
-(tracker, maintainer, executor). Add `--advertise <public-ip>` so peers publish
-an address other machines can reach, and `--key swarm.key` to sign the model.
+(tracker, maintainer, executor). Add `--advertise <public-ip>` for the fastest
+direct path, and `--key swarm.key` to sign the model. If a byte or compute donor
+cannot accept inbound traffic, its outbound heartbeat doubles as a tracker
+relay. Direct P2P remains preferred; symmetric NAT no longer excludes it from
+the swarm.
 
 On every other machine, pick a role:
 
@@ -147,6 +161,17 @@ compute donor says only how many experts it can carry (`--hold N`) and the
 tracker gives it the set nobody else covers. Neither needs to know the others
 exist. While a reply is generating you can kill a donor: you get one failover
 line and the tokens continue, identical.
+
+For a manual signing-key rotation, distribute a keyring containing one public
+key per line. `--pubkey keyring` and `LUMABRI_PUBKEY=keyring` accept every key
+in it (up to 16). First deploy `old+new`, then restart the origin signing with
+the new secret, and only after clients and donors have moved remove the old
+line. Put the newest key last: the tracker keeps the valid signature made by
+the highest-priority (latest) key, so old donor heartbeats cannot roll it back.
+Comma-separated public keys are accepted too; the low-level tracker and
+maintainer commands also accept repeated `--pubkey`.
+There is still one signature per object; the overlap belongs to the verifier,
+so the wire format does not change during rotation.
 
 The server also runs an expert node on the whole model, so a fresh swarm works
 on day zero with the server executing everything, and donors that join later win
@@ -166,7 +191,9 @@ validation and prefetch policy. Per-engine expert identity runs with fixtures
 (`make test-engines`), and DeepSeek V4 against a real model
 (`make test-phase2-deepseek MODEL=<dir>`). Assignment, concurrency and signing
 have their own scripts (`assign_test.sh`, `concurrency_test.sh`,
-`sign_test.sh`). Every claim in this README has a script behind it.
+`sign_test.sh`). The newer mechanisms have focused targets:
+`make test-cas test-key-rotation test-hedge test-relay-exec`. Every claim in
+this README has a script behind it.
 
 ## How it compares
 
@@ -188,13 +215,14 @@ binaries.
 ## Status
 
 Working prototype, deployable. Open swarms verify bytes (sha256 per MiB and a
-signed complete-model root, checked by the chatter against its own key) and
-results (spot-check on a second replica). Private swarms add an invite token
-everywhere with `LUMABRI_TOKEN`. Still to come, in order of importance:
-speculative drafting to cut wide-area latency, hedged requests against slow
-peers, a content-addressed mirror shared across checkpoints, and key rotation.
-Expert execution is checked by replica agreement, not yet by the operator
-signature.
+signed complete-model root, checked by the chatter against its own trust set)
+and results (spot-check on a second replica). Private swarms add an invite token
+everywhere with `LUMABRI_TOKEN`. Multi-row speculative verification, fixed-delay
+hedging, a local cross-checkpoint CAS, manual old+new key rotation and NAT relay
+for both READ and EXEC are implemented. Automatic SLA tuning, distributed/S3
+CAS, KMS/HSM integration and automatic revocation are intentionally not part of
+this dependency-free base. Expert execution is checked by replica agreement,
+not by the operator signature.
 
 ## License
 

--- a/cas_test.sh
+++ b/cas_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s tracker maintainer liblumabri.so test_shim
+T=$(mktemp -d /tmp/lumabri-cas.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+mkdir -p "$T/src" "$T/cache-a" "$T/cache-b" "$T/cas"
+head -c $((2 * 1024 * 1024 + 777)) /dev/urandom >"$T/src/weights.bin"
+printf '{"model":"cas-test"}\n' >"$T/src/config.json"
+
+./tracker --port 7562 >"$T/tracker.log" 2>&1 & TRACKER_PID=$!; PIDS+=($!)
+./maintainer --root "$T/src" --port 7563 --tracker 127.0.0.1:7562 \
+    --name cas-origin --model-name cas-test >"$T/node.log" 2>&1 & NODE_PID=$!; PIDS+=($!)
+for _ in $(seq 1 200); do
+    (exec 3<>/dev/tcp/127.0.0.1/7563) 2>/dev/null && { exec 3<&-; break; }
+    sleep .1
+done
+sleep .3
+
+COMMON=(LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_TRACKER=127.0.0.1:7562
+        LUMABRI_MODEL=cas-test LUMABRI_BLOCK_MIB=1 LUMABRI_CAS="$T/cas")
+env "${COMMON[@]}" LUMABRI_VROOT="$T/vroot-a" LUMABRI_CACHE="$T/cache-a" \
+    ./test_shim "$T/vroot-a" "$T/src" >/dev/null
+find "$T/cas" -type f -name '[0-9a-f]*' -print -quit | grep -q . || {
+    echo "CAS was not populated"; exit 1;
+}
+
+# A fresh sparse mirror must now work with the byte server gone. The tracker
+# remains only to provide the signed/hash inventory; no model byte may cross
+# the network on this second run.
+kill "$NODE_PID" 2>/dev/null || true
+wait "$NODE_PID" 2>/dev/null || true
+env "${COMMON[@]}" LUMABRI_STATS=1 LUMABRI_VROOT="$T/vroot-b" \
+    LUMABRI_CACHE="$T/cache-b" ./test_shim "$T/vroot-b" "$T/src" \
+    >/dev/null 2>"$T/cas.err"
+echo "LOCAL CAS: PASS (fresh mirror rebuilt with origin offline)"

--- a/expert_node.c
+++ b/expert_node.c
@@ -245,11 +245,11 @@ static void cache_release(CSlot *s) {
  * to be all of them at once: an engine that computes nr rows in one call
  * does not produce the same floats as nr calls of one row, and byte identity
  * with the local path is the entire claim of this project. */
-static int handle_exec(int fd, LmbMsg *m) {
+static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
     LmbCur cur = { m->body, m->body_len, 0 };
     uint32_t layer, eid, dim, nrows = 1;
     if (lmb_cur_u32(&cur, &layer) || lmb_cur_u32(&cur, &eid) || lmb_cur_u32(&cur, &dim)) {
-        send_err(fd, "bad exec header"); return -1;
+        return -1;
     }
     lmb_cur_u32(&cur, &nrows);            /* absent in the single-row dialect */
     /* The cap is not decoration. The size check below used to be computed in
@@ -259,7 +259,7 @@ static int handle_exec(int fd, LmbMsg *m) {
      * NULL payload. Everything here is 64-bit now, and a real batch is a
      * prompt's worth of rows — thousands, never tens of thousands. */
     if (nrows < 1 || nrows > LMB_MAX_EXEC_ROWS) {
-        send_err(fd, "bad row count"); return -1;
+        return -1;
     }
     /* Router weights follow the header only when the engine needs them
      * applied HERE — DeepSeek V4 folds the weight in before the down
@@ -268,14 +268,14 @@ static int handle_exec(int fd, LmbMsg *m) {
     const float *rw = NULL;
     if (m->body_len == 16 + (uint64_t)nrows * sizeof(float))
         rw = (const float *)(m->body + 16);
-    else if (m->body_len != 16) { send_err(fd, "bad exec body"); return -1; }
+    else if (m->body_len != 16) return -1;
     uint64_t want = (uint64_t)nrows * dim * sizeof(float);
     if (!expert_index_ok(layer, eid) || dim != (uint32_t)g.hidden ||
         want > LMB_MAX_PAY || m->pay_len != want) {
-        send_err(fd, "exec shape mismatch"); return -1;
+        return -1;
     }
     size_t gid = (size_t)layer * (size_t)g.n_experts + eid;
-    if (!g.holds[gid]) { send_err(fd, "expert not held by this node"); return 0; }
+    if (!g.holds[gid]) return -1;
 
     /* How many experts may be multiplied at once. Every connection gets its
      * own thread and every expert call opens a full OpenMP team, so without a
@@ -306,12 +306,48 @@ static int handle_exec(int fd, LmbMsg *m) {
     double dt = nowd() - t0;
     gate_leave();
     maybe_corrupt_out(out);
+    { const char *slow = getenv("LUMABRI_EXEC_DELAY_MS");
+      if (slow && atoi(slow) > 0) usleep((useconds_t)atoi(slow) * 1000u); }
     lmb_emu_delay();   /* the reply's flight time, when one is being emulated */
-    int rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, out, (uint32_t)obytes);
-    free(out);
-
     atomic_fetch_add(&g.calls, 1);
     pthread_mutex_lock(&g.stat_lk); g.busy_s += dt; pthread_mutex_unlock(&g.stat_lk);
+    *outp = out; *out_len = (uint32_t)obytes;
+    return 0;
+}
+
+static int handle_exec(int fd, LmbMsg *m) {
+    float *out = NULL; uint32_t out_len = 0;
+    if (exec_compute(m, &out, &out_len)) {
+        send_err(fd, "bad exec request or expert not held");
+        return -1;
+    }
+    int rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, out, out_len);
+    free(out);
+    return rc;
+}
+
+/* The tracker prepends only its correlation id; the remaining body and pay
+ * are byte-for-byte the ordinary EXEC request, so direct and relayed compute
+ * necessarily enter the same validation and numeric path. */
+static int handle_rexec_fwd(int fd, LmbMsg *m) {
+    if (m->body_len < 4) return -1;
+    uint32_t id = lmb_get32(m->body);
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[%s] relay exec id=%u body=%u pay=%u\n",
+                g.name, id, m->body_len - 4, m->pay_len);
+    LmbMsg inner = { .op = LMB_EXEC, .body = m->body + 4,
+                     .body_len = m->body_len - 4,
+                     .pay = m->pay, .pay_len = m->pay_len };
+    float *out = NULL; uint32_t out_len = 0;
+    int ok = exec_compute(&inner, &out, &out_len) == 0;
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[%s] relay exec id=%u %s out=%u\n",
+                g.name, id, ok ? "ok" : "refused", out_len);
+    LmbBuf b = {0};
+    lmb_buf_u32(&b, id); lmb_buf_u32(&b, ok ? 1u : 0u);
+    int rc = lmb_send(fd, LMB_REXEC_R, b.p, (uint32_t)b.len,
+                      out, ok ? out_len : 0);
+    free(b.p); free(out);
     return rc;
 }
 
@@ -402,6 +438,35 @@ static void *conn_thread(void *arg) {
 
 /* ---- tracker heartbeat: this is how chatters find us --------------------- */
 
+static int send_ereg(int fd) {
+    LmbBuf b = {0};
+    lmb_buf_str(&b, g.name);
+    lmb_buf_str(&b, g.advertise);
+    lmb_buf_str(&b, g.model);
+    lmb_buf_u32(&b, (uint32_t)g.nholds);
+    size_t cells = (size_t)g.n_slots * g.n_experts;
+    size_t nb = (cells + 7) / 8;
+    uint8_t *bits = (uint8_t *)calloc(nb ? nb : 1, 1);
+    if (!bits) { free(b.p); return -1; }
+    for (size_t k = 0; k < cells; k++)
+        if (g.holds[k]) bits[k >> 3] |= (uint8_t)(1u << (k & 7));
+    lmb_buf_u32(&b, (uint32_t)nb);
+    lmb_buf_bytes(&b, bits, nb);
+    free(bits);
+    /* Metadata lets a chatter validate relay-only coverage without first
+     * reaching the node's advertised inbound address. */
+    lmb_buf_u32(&b, LMB_EXPERT_MANIFEST_MAGIC);
+    lmb_buf_str(&b, lmbe_engine_name());
+    lmb_buf_str(&b, g.profile);
+    lmb_buf_u32(&b, (uint32_t)g.bits);
+    lmb_buf_u32(&b, (uint32_t)g.hidden);
+    lmb_buf_u32(&b, (uint32_t)g.n_slots);
+    lmb_buf_u32(&b, (uint32_t)g.n_experts);
+    int rc = lmb_send(fd, LMB_EREG, b.p, (uint32_t)b.len, NULL, 0);
+    free(b.p);
+    return rc;
+}
+
 static void *control_thread(void *arg) {
     (void)arg;
     int warned = 0;
@@ -419,39 +484,24 @@ static void *control_thread(void *arg) {
         warned = 0;
         struct timeval tv = { HEARTBEAT_S, 0 };
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+        if (send_ereg(fd)) { close(fd); sleep(1); continue; }
         for (;;) {
-            LmbBuf b = {0};
-            lmb_buf_str(&b, g.name);
-            lmb_buf_str(&b, g.advertise);
-            lmb_buf_str(&b, g.model);
-            lmb_buf_u32(&b, (uint32_t)g.nholds);
-            /* WHICH ones, not just how many: the tracker needs it to tell a
-             * newcomer what nobody covers. One bit per cell, 2.4 KB for a
-             * 19456-expert model — cheap enough to resend every heartbeat. */
-            { size_t cells = (size_t)g.n_slots * g.n_experts;
-              size_t nb = (cells + 7) / 8;
-              uint8_t *bits = (uint8_t *)calloc(nb, 1);
-              if (bits) {
-                  for (size_t k = 0; k < cells; k++)
-                      if (g.holds[k]) bits[k >> 3] |= (uint8_t)(1u << (k & 7));
-                  lmb_buf_u32(&b, (uint32_t)nb);
-                  lmb_buf_bytes(&b, bits, nb);
-                  free(bits);
-              } }
-            int rc = lmb_send(fd, LMB_EREG, b.p, (uint32_t)b.len, NULL, 0);
-            free(b.p);
-            if (rc) break;
             LmbMsg m;
             if (lmb_recv(fd, &m) != 0) {
-                if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                    if (send_ereg(fd)) break;
+                    continue;
+                }
                 break;
             }
+            int rc = 0;
+            if (m.op == LMB_REXEC_FWD) rc = handle_rexec_fwd(fd, &m);
             lmb_msg_free(&m);
+            if (rc) break;
             pthread_mutex_lock(&g.identity_lk);
             int need_identity = !g.have_identity;
             pthread_mutex_unlock(&g.identity_lk);
             if (need_identity) node_refresh_identity();
-            sleep(HEARTBEAT_S);
         }
         close(fd);
         sleep(1);

--- a/lumabri.c
+++ b/lumabri.c
@@ -822,13 +822,14 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
                         const char *model, const char *local_dir,
                         int ctx, int max_new, int cap_experts, Engine *e) {
     const char *home = getenv("HOME") ? getenv("HOME") : ".";
-    char vroot[1024], cache[1024];
+    char vroot[1024], cache[1024], cas[1024];
     const char *vroot_env = getenv("LUMABRI_VROOT");
     const char *cache_env = getenv("LUMABRI_CACHE");
     if (vroot_env && vroot_env[0]) snprintf(vroot, sizeof vroot, "%s", vroot_env);
     else snprintf(vroot, sizeof vroot, "%s/.lumabri/%s/vroot", home, model);
     if (cache_env && cache_env[0]) snprintf(cache, sizeof cache, "%s", cache_env);
     else snprintf(cache, sizeof cache, "%s/.lumabri/%s/cache", home, model);
+    snprintf(cas, sizeof cas, "%s/.lumabri/cas", home);
     if (!local_dir) mkdir_p(cache);   /* vroot stays virtual on purpose */
 
     /* olmoe takes <cap> <bits>; the SERVE-mode engines take <cap> alone and
@@ -853,6 +854,7 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
             setenv("LD_PRELOAD", shim, 1);
             setenv("LUMABRI_VROOT", vroot, 1);
             setenv("LUMABRI_CACHE", cache, 1);
+            setenv("LUMABRI_CAS", cas, 0);       /* shared across model mirrors */
             setenv("LUMABRI_TRACKER", tracker, 1);
             setenv("LUMABRI_MODEL", model, 1);
             setenv("LUMABRI_STATS", "2", 1);       /* boot progress, not a log */
@@ -984,7 +986,7 @@ static void disk_preflight(const char *model, uint64_t model_bytes) {
  *
  * ~/.lumabri/config, one key=value per line. Flags still win when given:
  * a script is not a person and should not inherit somebody's saved answers. */
-typedef struct { char tracker[80], pubkey[80], engines[1024]; } Cfg;
+typedef struct { char tracker[80], pubkey[LMB_PATH_MAX], engines[1024]; } Cfg;
 
 static void cfg_path(char *dst, size_t cap) {
     const char *home = getenv("HOME") ? getenv("HOME") : ".";

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -43,6 +43,7 @@ typedef struct {
     int nsocks;
     long rtt_us;
     int dead;
+    double retry_at;          /* do not redial a relay-only/NAT address per layer */
 } LumiPeer;
 
 static struct {
@@ -50,15 +51,18 @@ static struct {
     LumiPeer peers[LUMI_MAX_PEERS];
     int npeers;
     int *own;                   /* [gid * LUMI_MAX_REP] → peer index, -1 = free */
+    unsigned char *relay;       /* tracker tunnel covers this (slot,expert) */
     unsigned char *routed;      /* [n_layers] 1 = this slot routes to experts */
     int n_layers, n_experts, hidden;
     int expected, expected_bits;
     char expected_model[64], profile[LMB_BUILD_PROFILE_MAX];
     LmbModelIdentity identity; int have_identity;
-    uint8_t pubkey[32]; int have_pubkey;
+    LmbTrustKeys trust;
     double next_discover, discover_period_s;
     int verify_pct;             /* LUMABRI_VERIFY: % of calls double-checked */
-    unsigned long long calls, layers_done, failovers, verified;
+    int hedge_ms;               /* 0 disables; base policy, fixed delay */
+    unsigned long long calls, layers_done, failovers, verified, relays;
+    unsigned long long hedges, hedge_wins, batch_calls, batch_rows;
     double wait_s;
 } L = {0};
 
@@ -121,21 +125,18 @@ static int lumi_index_ok(uint32_t layer, uint32_t eid) {
 static void lumi_load_pubkey(void) {
     const char *spec = getenv("LUMABRI_PUBKEY");
     if (!spec || !*spec) return;
-    char hex[80] = "";
-    FILE *fp = fopen(spec, "r");
-    if (fp) { if (fscanf(fp, "%78s", hex) != 1) hex[0] = 0; fclose(fp); }
-    else snprintf(hex, sizeof hex, "%s", spec);
-    if (strlen(hex) == 64 && !lmb_unhex(L.pubkey, hex, 32)) L.have_pubkey = 1;
-    else fprintf(stderr, "[lumabri] invalid LUMABRI_PUBKEY: expert execution stays local\n");
+    if (lmb_trust_load_spec(&L.trust, spec))
+        fprintf(stderr, "[lumabri] invalid LUMABRI_PUBKEY/keyring: "
+                        "expert execution stays local\n");
 }
 
 static int lumi_identity_valid(const char *model, const LmbModelIdentity *id) {
     if (strcmp(model, id->model)) return 0;
-    if (!L.have_pubkey) return 1;
+    if (!L.trust.n) return 1;
     if (!id->has_sig) return 0;
     size_t n = 0;
     uint8_t *msg = lmb_model_id_msg(model, id->root, &n);
-    int ok = msg && lmb_sign_verify(id->sig, msg, n, L.pubkey) == 0;
+    int ok = msg && lmb_trust_verify(&L.trust, id->sig, msg, n) == 0;
     free(msg);
     return ok;
 }
@@ -163,6 +164,7 @@ static int lumi_add_peer(const char *addr) {
         if (!strcmp(L.peers[i].addr, addr)) {
             LumiPeer *known = &L.peers[i];
             if (!known->dead) return 0;
+            if (lumi_now() < known->retry_at) return -1;
             while (known->nsocks) close(known->socks[--known->nsocks]);
             reprobe = i;
             break;
@@ -177,6 +179,8 @@ static int lumi_add_peer(const char *addr) {
     if (lmb_request(p->addr, LMB_EMANIFEST, NULL, 0, &m) || m.op != LMB_EMANIFEST_R) {
         fprintf(stderr, "[lumabri] no expert manifest from %s — skipped\n", p->addr);
         lmb_msg_free(&m);
+        p->dead = 1; p->retry_at = lumi_now() + 30.0;
+        if (reprobe < 0) L.npeers++;       /* remember NAT-only addresses */
         return -1;
     }
     LmbCur c = { m.body, m.body_len, 0 };
@@ -201,7 +205,7 @@ static int lumi_add_peer(const char *addr) {
     if (!bad && (strcmp(engine, LMBE_ENGINE_ID) || strcmp(profile, L.profile) ||
                  bits != (uint32_t)L.expected_bits ||
                  (L.expected_model[0] && strcmp(peer_model, L.expected_model)) ||
-                 ((L.have_identity || L.have_pubkey) && !have_id) ||
+                 ((L.have_identity || L.trust.n) && !have_id) ||
                  (have_id && !lumi_identity_valid(peer_model, &peer_id)) ||
                  (L.have_identity && memcmp(L.identity.root, peer_id.root, 32)))) {
         bad = 1;
@@ -247,6 +251,7 @@ static int lumi_add_peer(const char *addr) {
     free(seen);
     lmb_msg_free(&m);
     p->dead = 0;
+    p->retry_at = 0;
     lumi_probe(p);
     if (p->rtt_us == LONG_MAX) {
         if (reprobe < 0)
@@ -285,13 +290,49 @@ static int lumi_discover(void) {
     return added;
 }
 
+/* Relay-only nodes cannot be queried at their advertised address, so the
+ * tracker returns the union of holder bitmaps whose engine/build/shape
+ * metadata exactly matches this chatter. */
+static int lumi_relay_coverage(void) {
+    const char *tracker = getenv("LUMABRI_TRACKER");
+    if (!tracker || !*tracker || !L.expected_model[0]) return 0;
+    LmbBuf b = {0};
+    lmb_buf_str(&b, L.expected_model);
+    lmb_buf_str(&b, LMBE_ENGINE_ID);
+    lmb_buf_str(&b, L.profile);
+    lmb_buf_u32(&b, (uint32_t)L.expected_bits);
+    lmb_buf_u32(&b, (uint32_t)L.hidden);
+    lmb_buf_u32(&b, (uint32_t)L.n_layers);
+    lmb_buf_u32(&b, (uint32_t)L.n_experts);
+    LmbMsg m = {0};
+    int rc = lmb_request(tracker, LMB_ECOVER, b.p, (uint32_t)b.len, &m);
+    free(b.p);
+    if (rc || m.op != LMB_ECOVER_R) { lmb_msg_free(&m); return 0; }
+    LmbCur c = { m.body, m.body_len, 0 };
+    uint32_t slots = 0, nexp = 0, nb = 0;
+    size_t cells = (size_t)L.n_layers * L.n_experts;
+    int bad = lmb_cur_u32(&c, &slots) || lmb_cur_u32(&c, &nexp) ||
+              lmb_cur_u32(&c, &nb) || slots != (uint32_t)L.n_layers ||
+              nexp != (uint32_t)L.n_experts || nb != (cells + 7) / 8 ||
+              c.off + nb != c.len;
+    if (!bad) {
+        if (!L.relay) L.relay = (unsigned char *)calloc(cells ? cells : 1, 1);
+        if (!L.relay) bad = 1;
+        else for (size_t gid = 0; gid < cells; gid++)
+            L.relay[gid] = (c.p[c.off + (gid >> 3)] >> (gid & 7)) & 1;
+    }
+    lmb_msg_free(&m);
+    return bad ? 0 : 1;
+}
+
 static int lumi_missing_experts(void) {
     int missing = 0, expected = 0;
     for (int l = 0; l < L.n_layers; l++) {
         if (L.routed && !L.routed[l]) continue;
         for (int e = 0; e < L.n_experts; e++) {
             expected++;
-            if (L.own[((size_t)l * L.n_experts + e) * LUMI_MAX_REP] < 0) missing++;
+            size_t gid = (size_t)l * L.n_experts + e;
+            if (L.own[gid * LUMI_MAX_REP] < 0 && (!L.relay || !L.relay[gid])) missing++;
         }
     }
     L.expected = expected;
@@ -307,10 +348,12 @@ static void lumi_enable_if_complete(void) {
      * here on the experts run on peers, and a readahead past a dense block
      * would pull adjacent expert weights the chatter will never execute. */
     setenv("LUMABRI_REMOTE_EXPERTS", "1", 1);
+    int direct = 0;
+    for (int i = 0; i < L.npeers; i++) if (!L.peers[i].dead) direct++;
     fprintf(stderr, "[lumabri] phase 2 active: every expert runs on a peer, "
-                    "%d peer(s), %d experts, hidden=%d, nearest replica "
+                    "%d direct peer(s), %d experts, hidden=%d, nearest replica "
                     "preferred%s\n",
-            L.npeers, L.expected, L.hidden,
+            direct, L.expected, L.hidden,
             L.verify_pct ? " · spot-check verification on" : "");
 }
 
@@ -321,6 +364,7 @@ static void lumi_maybe_discover(void) {
     L.next_discover = now + L.discover_period_s;
     if (!L.have_identity) lumi_refresh_identity();
     int added = lumi_discover();
+    lumi_relay_coverage();
     if (added)
         fprintf(stderr, "[lumabri] discovered %d new expert peer(s) mid-generation\n",
                 added);
@@ -359,7 +403,7 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
     const char *model = getenv("LUMABRI_MODEL");
     if (model) snprintf(L.expected_model, sizeof L.expected_model, "%s", model);
     lumi_load_pubkey();
-    if (getenv("LUMABRI_PUBKEY") && !L.have_pubkey) return;
+    if (getenv("LUMABRI_PUBKEY") && !L.trust.n) return;
     if (tracker && tracker[0] && L.expected_model[0]) lumi_refresh_identity();
     size_t cells = (size_t)n_layers * n_experts * LUMI_MAX_REP;
     L.own = (int *)malloc(cells * sizeof(int));
@@ -376,13 +420,17 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
         if (L.verify_pct < 0) L.verify_pct = 0;
         if (L.verify_pct > 100) L.verify_pct = 100;
     }
+    L.hedge_ms = lmb_env_int("LUMABRI_HEDGE_MS", 0, 0, 60000);
     L.initialized = 1;
 
     if (discovery) {
         int found = lumi_discover();
+        int relay = lumi_relay_coverage();
         if (!found) {
-            fprintf(stderr, "[lumabri] no expert peers on the swarm — "
-                            "running experts locally\n");
+            fprintf(stderr, relay ? "[lumabri] no directly reachable expert peers; "
+                                    "checking tracker relay coverage\n"
+                                  : "[lumabri] no expert peers on the swarm — "
+                                    "running experts locally\n");
         } else
             fprintf(stderr, "[lumabri] discovered %d expert peer(s) from the tracker\n",
                     found);
@@ -465,6 +513,103 @@ static int lumi_send_exec(int fd, int layer, int eid, const float *x, int D, int
     return rc;
 }
 
+/* Fixed-delay hedging, intentionally a mechanism rather than an SLA policy.
+ * If the nearest replica has not produced a readable reply after
+ * LUMABRI_HEDGE_MS, issue the identical deterministic call to the next one
+ * and accept the first valid result. The losing socket is closed so its late
+ * frame can never be mistaken for a future request. */
+static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr,
+                               const float *w, int primary_fd, LumiPeer *primary,
+                               uint32_t *tried, LumiPeer **from) {
+    if (from) *from = NULL;
+    if (primary_fd < 0 || !primary) return NULL;
+    int fd[2] = { primary_fd, -1 };
+    LumiPeer *p[2] = { primary, NULL };
+    uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
+    if (L.hedge_ms > 0) {
+        struct pollfd one = { fd[0], POLLIN, 0 };
+        int pr;
+        do pr = poll(&one, 1, L.hedge_ms); while (pr < 0 && errno == EINTR);
+        if (pr == 0) {
+            int gid = layer * L.n_experts + eid;
+            int r = lumi_pick(gid, *tried);
+            if (r >= 0) {
+                *tried |= 1u << r;
+                p[1] = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
+                fd[1] = lumi_take_sock(p[1]);
+                if (fd[1] >= 0 && lumi_send_exec(fd[1], layer, eid, x, D, nr, w)) {
+                    close(fd[1]); p[1]->dead = 1; fd[1] = -1;
+                }
+                if (fd[1] >= 0) L.hedges++;
+            }
+        }
+    }
+    int alive = 1 + (fd[1] >= 0);
+    while (alive) {
+        struct pollfd pf[2]; int map[2], np = 0;
+        for (int i = 0; i < 2; i++) if (fd[i] >= 0) {
+            pf[np].fd = fd[i]; pf[np].events = POLLIN; pf[np].revents = 0;
+            map[np++] = i;
+        }
+        int pr;
+        do pr = poll(pf, np, LMB_DEFAULT_IO_TIMEOUT_MS); while (pr < 0 && errno == EINTR);
+        if (pr <= 0) break;
+        for (int q = 0; q < np; q++) if (pf[q].revents) {
+            int i = map[q];
+            LmbMsg m = {0};
+            if (lmb_recv(fd[i], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
+                float *res = (float *)m.pay; m.pay = NULL; lmb_msg_free(&m);
+                lumi_put_sock(p[i], fd[i]); fd[i] = -1;
+                if (i == 1) L.hedge_wins++;
+                for (int j = 0; j < 2; j++) if (fd[j] >= 0) close(fd[j]);
+                if (from) *from = p[i];
+                return res;
+            }
+            lmb_msg_free(&m);
+            close(fd[i]); fd[i] = -1; p[i]->dead = 1; alive--;
+        }
+    }
+    for (int i = 0; i < 2; i++) if (fd[i] >= 0) {
+        close(fd[i]); p[i]->dead = 1;
+    }
+    return NULL;
+}
+
+static float *lumi_exec_relay(int layer, int eid, const float *x, int D, int nr,
+                              const float *w) {
+    const char *tracker = getenv("LUMABRI_TRACKER");
+    size_t gid = (size_t)layer * L.n_experts + eid;
+    if (!tracker || !*tracker || !L.discovery || !L.relay || !L.relay[gid]) return NULL;
+    LmbBuf b = {0};
+    lmb_buf_str(&b, L.expected_model);
+    lmb_buf_u32(&b, (uint32_t)L.n_experts);
+    lmb_buf_u32(&b, (uint32_t)layer);
+    lmb_buf_u32(&b, (uint32_t)eid);
+    lmb_buf_u32(&b, (uint32_t)D);
+    lmb_buf_u32(&b, (uint32_t)nr);
+    if (w) lmb_buf_bytes(&b, w, (size_t)nr * sizeof(float));
+    LmbMsg m = {0};
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[lumabri] relay request layer=%d expert=%d rows=%d\n",
+                layer, eid, nr);
+    int rc = lmb_request_pay(tracker, LMB_REXEC, b.p, (uint32_t)b.len,
+                             x, (uint32_t)((size_t)nr * D * sizeof(float)), &m);
+    free(b.p);
+    uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
+    float *out = NULL;
+    if (!rc && m.op == LMB_REXEC_R && m.pay_len == want) {
+        out = (float *)m.pay; m.pay = NULL; L.relays++;
+    } else if (!rc && m.op == LMB_ERR) {
+        char why[160] = "relay refused the call";
+        LmbCur c = { m.body, m.body_len, 0 };
+        lmb_cur_str(&c, why, sizeof why);
+        fprintf(stderr, "[lumabri] tracker EXEC relay unavailable for layer %d "
+                        "expert %d: %s\n", layer, eid, why);
+    }
+    lmb_msg_free(&m);
+    return out;
+}
+
 /* the failover path: run one expert synchronously on the next replicas.
  * Costs a full extra round trip — it is the price of a peer dying, paid
  * once, instead of the generation dying with it. */
@@ -476,6 +621,8 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
     for (;;) {
         int r = lumi_pick(gid, tried);
         if (r < 0) {
+            float *relayed = lumi_exec_relay(layer, eid, x, D, nr, w);
+            if (relayed) return relayed;
             /* Every known replica is gone. Giving up here is correct in the
              * sense that inventing a result is never allowed — but it threw
              * away a whole generation for a peer that was rebooting, or a
@@ -491,7 +638,7 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
                 tried = 0;                    /* a returning peer deserves a retry */
                 sleep(2);
                 waited += 2;
-                if (L.discovery) lumi_discover();
+                if (L.discovery) { lumi_discover(); lumi_relay_coverage(); }
                 else for (int i = 0; i < L.npeers; i++)
                     if (L.peers[i].dead) {
                         char addr[64];
@@ -599,23 +746,17 @@ static void lumi_moe_apply(int layer, const int *idx, const float *val, int K,
     static unsigned vseed = 0x9e3779b9u;
     for (int k = 0; k < K; k++) {
         if (fds[k] >= 0) {
-            LmbMsg m = {0};
-            if (lmb_recv(fds[k], &m) == 0 && m.op == LMB_EXEC_R &&
-                m.pay_len == (uint32_t)(D * sizeof(float))) {
-                res[k] = (float *)m.pay;
-                m.pay = NULL;
-                lmb_msg_free(&m);
-                lumi_put_sock(ps[k], fds[k]);
+            LumiPeer *winner = NULL;
+            res[k] = lumi_finish_exec(layer, idx[k], x, D, 1, NULL,
+                                      fds[k], ps[k], &tried[k], &winner);
+            if (res[k]) {
                 if (L.verify_pct) {
                     vseed = vseed * 1664525u + 1013904223u;
                     if ((int)(vseed % 100u) < L.verify_pct)
-                        lumi_spot_check(layer, idx[k], x, D, 1, NULL, res[k], ps[k], tried[k]);
+                        lumi_spot_check(layer, idx[k], x, D, 1, NULL, res[k], winner, tried[k]);
                 }
                 continue;
             }
-            close(fds[k]);
-            ps[k]->dead = 1;
-            lmb_msg_free(&m);
             fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                             "trying next replica\n", ps[k]->addr, layer, idx[k]);
         }
@@ -712,29 +853,24 @@ static void lumi_moe_apply_batch(int layer, const int *idxs, const float *ws,
         }
         for (int j = 0; j < nb; j++) {
             int eid = uniq[base + j], nr = nrs[j];
-            uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
             float *res = NULL, *xj = xg + (size_t)j * S * D;
             if (fds[j] >= 0) {
-                LmbMsg m = {0};
-                if (lmb_recv(fds[j], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
-                    res = (float *)m.pay;
-                    m.pay = NULL;
-                    lmb_msg_free(&m);
-                    lumi_put_sock(ps[j], fds[j]);
+                LumiPeer *winner = NULL;
+                res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
+                                       fds[j], ps[j], &tried[j], &winner);
+                if (res) {
                     if (L.verify_pct) {
                         vseed = vseed * 1664525u + 1013904223u;
                         if ((int)(vseed % 100u) < L.verify_pct)
-                            lumi_spot_check(layer, eid, xj, D, nr, NULL, res, ps[j], tried[j]);
+                            lumi_spot_check(layer, eid, xj, D, nr, NULL, res, winner, tried[j]);
                     }
                 } else {
-                    close(fds[j]);
-                    ps[j]->dead = 1;
-                    lmb_msg_free(&m);
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
             }
             if (!res) res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, tried[j]);
+            if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             int *rj = rows + (size_t)j * S;
             float *wj = rw + (size_t)j * S;
             for (int r = 0; r < nr; r++) {
@@ -799,29 +935,24 @@ static void lumi_moe_apply_union(int layer, int nu, const int *uid,
         }
         for (int j = 0; j < nb; j++) {
             int eid = uid[base + j], nr = pcnt[base + j], f = pfirst[base + j];
-            uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
             float *res = NULL, *xj = xg + (size_t)j * maxrows * D;
             if (fds[j] >= 0) {
-                LmbMsg m = {0};
-                if (lmb_recv(fds[j], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
-                    res = (float *)m.pay;
-                    m.pay = NULL;
-                    lmb_msg_free(&m);
-                    lumi_put_sock(ps[j], fds[j]);
+                LumiPeer *winner = NULL;
+                res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
+                                       fds[j], ps[j], &tried[j], &winner);
+                if (res) {
                     if (L.verify_pct) {
                         vseed = vseed * 1664525u + 1013904223u;
                         if ((int)(vseed % 100u) < L.verify_pct)
-                            lumi_spot_check(layer, eid, xj, D, nr, NULL, res, ps[j], tried[j]);
+                            lumi_spot_check(layer, eid, xj, D, nr, NULL, res, winner, tried[j]);
                     }
                 } else {
-                    close(fds[j]);
-                    ps[j]->dead = 1;
-                    lmb_msg_free(&m);
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
             }
             if (!res) res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, tried[j]);
+            if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             for (int r = 0; r < nr; r++) {
                 float *us = U + (int64_t)poslist[f + r] * D, w = wlist[f + r];
                 const float *hr = res + (size_t)r * D;
@@ -912,31 +1043,26 @@ static void lumi_moe_apply_v4(int layer, const int *indices, const float *weight
         }
         for (int j = 0; j < nb; j++) {
             int eid = uid[base + j], nr = nrs[j];
-            uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
             float *res = NULL, *xj = xg + (size_t)j * batch * D;
             float *wj = rw + (size_t)j * batch;
             int *rj = rows + (size_t)j * batch;
             if (fds[j] >= 0) {
-                LmbMsg m = {0};
-                if (lmb_recv(fds[j], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
-                    res = (float *)m.pay;
-                    m.pay = NULL;
-                    lmb_msg_free(&m);
-                    lumi_put_sock(ps[j], fds[j]);
+                LumiPeer *winner = NULL;
+                res = lumi_finish_exec(layer, eid, xj, D, nr, wj,
+                                       fds[j], ps[j], &tried[j], &winner);
+                if (res) {
                     if (L.verify_pct) {
                         vseed = vseed * 1664525u + 1013904223u;
                         if ((int)(vseed % 100u) < L.verify_pct)
-                            lumi_spot_check(layer, eid, xj, D, nr, wj, res, ps[j], tried[j]);
+                            lumi_spot_check(layer, eid, xj, D, nr, wj, res, winner, tried[j]);
                     }
                 } else {
-                    close(fds[j]);
-                    ps[j]->dead = 1;
-                    lmb_msg_free(&m);
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
             }
             if (!res) res = lumi_exec_retry(layer, eid, xj, D, nr, wj, tried[j]);
+            if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             for (int r = 0; r < nr; r++) {       /* already weighted by the peer */
                 float *os = out + (size_t)rj[r] * D;
                 const float *hr = res + (size_t)r * D;
@@ -955,10 +1081,13 @@ static void lumi_report(void) {
     if (!L.on) return;
     fprintf(stderr, "[lumabri] %llu remote expert calls in %llu layer rounds · "
                     "%.2fs waiting on peers (%.2f ms per layer round) · "
-                    "%llu failover(s) · %llu spot-check(s), all agreed\n",
+                    "%llu batched call(s)/%llu rows · %llu hedge(s), %llu won · "
+                    "%llu failover(s) · %llu tracker relay call(s) · "
+                    "%llu spot-check(s), all agreed\n",
             L.calls, L.layers_done, L.wait_s,
             L.layers_done ? 1000.0 * L.wait_s / (double)L.layers_done : 0.0,
-            L.failovers, L.verified);
+            L.batch_calls, L.batch_rows, L.hedges, L.hedge_wins,
+            L.failovers, L.relays, L.verified);
 }
 
 #endif /* LUMABRI_CLIENT_H */

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -142,6 +142,18 @@ enum {
      * and the tracker only carries it. Expert nodes include the same record
      * in EMANIFEST, so a chatter cannot accidentally mix checkpoints. */
     LMB_MODEL_ID = 30, LMB_MODEL_ID_R = 31,
+    /* NAT relay for compute. REXEC is {str model,u32 n_experts,EXEC body}
+     * plus the activation payload. The tracker chooses a registered holder,
+     * forwards {u32 id,EXEC body}+pay over its outbound EREG connection, and
+     * returns the output. Direct EXEC remains preferred; this is the floor
+     * for symmetric NATs and networks where no inbound port can be opened. */
+    LMB_REXEC = 32, LMB_REXEC_FWD = 33, LMB_REXEC_R = 34,
+    /* Relay coverage is separate from EPEERS because an unreachable/NATed
+     * node has no direct EMANIFEST to query. Expert heartbeats append their
+     * engine/build/shape metadata; ECOVER returns the OR of compatible live
+     * holders' bitmaps, allowing the chatter to enable remote execution only
+     * when every routed expert has either a direct or relayed path. */
+    LMB_ECOVER = 35, LMB_ECOVER_R = 36,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -221,10 +233,13 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
     case LMB_RREAD_R:
     case LMB_HASHES_R:
     case LMB_EXEC_R:
+    case LMB_REXEC_R:
         *pay_cap = LMB_MAX_PAY;
         break;
     case LMB_RREAD_FWD:
     case LMB_EXEC:
+    case LMB_REXEC:
+    case LMB_REXEC_FWD:
         *body_cap = LMB_MAX_CONTROL_BODY;
         *pay_cap = LMB_MAX_PAY;
         break;
@@ -620,15 +635,21 @@ static int lmb_auth(int fd) {
 /* One-shot request/response on a fresh connection (tracker traffic; bulk
  * reads use pooled persistent connections instead). Returns 0 and fills
  * `resp` (caller frees), or -1. */
-static int lmb_request(const char *addr, uint32_t op,
-                       const void *body, uint32_t body_len, LmbMsg *resp) {
+static int lmb_request_pay(const char *addr, uint32_t op,
+                           const void *body, uint32_t body_len,
+                           const void *pay, uint32_t pay_len, LmbMsg *resp) {
     int fd = lmb_connect(addr);
     if (fd < 0) return -1;
     int rc = lmb_auth(fd);
-    if (rc == 0) rc = lmb_send(fd, op, body, body_len, NULL, 0);
+    if (rc == 0) rc = lmb_send(fd, op, body, body_len, pay, pay_len);
     if (rc == 0) rc = lmb_recv(fd, resp);
     close(fd);
     return rc;
+}
+
+static int lmb_request(const char *addr, uint32_t op,
+                       const void *body, uint32_t body_len, LmbMsg *resp) {
+    return lmb_request_pay(addr, op, body, body_len, NULL, 0, resp);
 }
 
 /* Fetch the operator-bound identity of a complete model. Signature checking

--- a/lumabri_sign.h
+++ b/lumabri_sign.h
@@ -17,6 +17,7 @@
 #define LUMABRI_SIGN_H
 
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -496,6 +497,91 @@ static int lmb_unhex(uint8_t *dst, const char *src, size_t n) {
         else if (b >= 'A' && b <= 'F') lo = b - 'A' + 10;
         if (hi < 0 || lo < 0) return -1;
         dst[i] = (uint8_t)((hi << 4) | lo);
+    }
+    return 0;
+}
+
+/* ---- trust sets / manual key rotation ---------------------------------
+ *
+ * A signed swarm may trust more than one operator key during a planned
+ * rotation.  The wire format deliberately stays unchanged: each object is
+ * signed by one key, while verifiers accept it if ANY key in this small,
+ * out-of-band trust set validates it.  Rollout is therefore:
+ *
+ *   publish old+new keys -> start signing with new -> remove old key
+ *
+ * KMS/HSM policy, automatic revocation and audit belong above this primitive;
+ * this is the dependency-free public floor needed to rotate safely by hand.
+ */
+#define LMB_MAX_TRUST_KEYS 16
+typedef struct {
+    uint8_t key[LMB_MAX_TRUST_KEYS][32];
+    size_t n;
+} LmbTrustKeys;
+
+static int lmb_trust_add_hex(LmbTrustKeys *t, const char *hex) {
+    if (!t || !hex || strlen(hex) != 64) return -1;
+    uint8_t key[32];
+    if (lmb_unhex(key, hex, sizeof key)) return -1;
+    for (size_t i = 0; i < t->n; i++)
+        if (!memcmp(t->key[i], key, sizeof key)) return 0;
+    if (t->n >= LMB_MAX_TRUST_KEYS) return -1;
+    memcpy(t->key[t->n++], key, sizeof key);
+    return 0;
+}
+
+static int lmb_trust_match(const LmbTrustKeys *t, const uint8_t sig[64],
+                           const uint8_t *msg, size_t n) {
+    if (!t) return -1;
+    for (size_t i = 0; i < t->n; i++)
+        if (lmb_sign_verify(sig, msg, n, t->key[i]) == 0) return (int)i;
+    return -1;
+}
+
+static int lmb_trust_verify(const LmbTrustKeys *t, const uint8_t sig[64],
+                            const uint8_t *msg, size_t n) {
+    return lmb_trust_match(t, sig, msg, n) >= 0 ? 0 : -1;
+}
+
+/* A keyring file contains one 64-hex public key per whitespace-separated
+ * field.  A literal spec may contain the same keys separated by commas.
+ * Calls append, so command-line programs may also repeat --pubkey. */
+static int lmb_trust_load_stream(LmbTrustKeys *t, FILE *fp) {
+    char word[256];
+    LmbTrustKeys add = {0};
+    while (t && fp && fscanf(fp, "%255s", word) == 1) {
+        if (word[0] == '#') { int ch; while ((ch = fgetc(fp)) != '\n' && ch != EOF) {} continue; }
+        if (lmb_trust_add_hex(&add, word)) return -1;
+    }
+    if (!t || !add.n) return -1;
+    size_t before = t->n;
+    for (size_t i = 0; i < add.n; i++) {
+        char hex[65]; lmb_hex(hex, add.key[i], 32);
+        if (lmb_trust_add_hex(t, hex)) { t->n = before; return -1; }
+    }
+    return 0;
+}
+
+static int lmb_trust_load_spec(LmbTrustKeys *t, const char *spec) {
+    if (!t || !spec || !*spec) return -1;
+    FILE *fp = fopen(spec, "r");
+    if (fp) {
+        int rc = lmb_trust_load_stream(t, fp);
+        fclose(fp);
+        return rc;
+    }
+    char *copy = strdup(spec);
+    if (!copy) return -1;
+    LmbTrustKeys add = {0};
+    size_t before = t->n;
+    char *save = NULL;
+    for (char *p = strtok_r(copy, ",", &save); p; p = strtok_r(NULL, ",", &save))
+        if (lmb_trust_add_hex(&add, p)) { free(copy); return -1; }
+    free(copy);
+    if (!add.n) return -1;
+    for (size_t i = 0; i < add.n; i++) {
+        char hex[65]; lmb_hex(hex, add.key[i], 32);
+        if (lmb_trust_add_hex(t, hex)) { t->n = before; return -1; }
     }
     return 0;
 }

--- a/lumashim.c
+++ b/lumashim.c
@@ -132,15 +132,15 @@ typedef struct {
 static struct {
     int ok;                       /* full init succeeded */
     char vroot[LMB_PATH_MAX]; size_t vroot_len;
-    char data_dir[LMB_PATH_MAX], maps_dir[LMB_PATH_MAX];
+    char data_dir[LMB_PATH_MAX], maps_dir[LMB_PATH_MAX], cas_dir[LMB_PATH_MAX];
     int cache_lock_fd;              /* shared for process lifetime; exclusive on reset */
     int reset_lock_fd;              /* elects one resetter without queuing behind its chat */
     uint32_t block;
     RFile *files; int nfiles;
     RPeer peers[MAX_RPEERS]; int npeers;
-    uint8_t pubkey[32]; int have_pubkey;   /* LUMABRI_PUBKEY, out of band */
+    LmbTrustKeys trust;                    /* old+new keys during rotation */
     RFile *_Atomic fdmap[FD_LIMIT];
-    _Atomic uint64_t net_bytes, net_blocks, warm_reads;
+    _Atomic uint64_t net_bytes, net_blocks, warm_reads, cas_hits, cas_bytes;
     pthread_once_t once;
 } g = { .cache_lock_fd = -1, .reset_lock_fd = -1, .once = PTHREAD_ONCE_INIT };
 
@@ -504,11 +504,11 @@ static int cache_identity_save(const LmbModelIdentity *id) {
 }
 
 static int model_identity_signature_ok(const LmbModelIdentity *id) {
-    if (!g.have_pubkey) return 1;
+    if (!g.trust.n) return 1;
     if (!id->has_sig) return 0;
     size_t n = 0;
     uint8_t *msg = lmb_model_id_msg(id->model, id->root, &n);
-    int ok = msg && lmb_sign_verify(id->sig, msg, n, g.pubkey) == 0;
+    int ok = msg && lmb_trust_verify(&g.trust, id->sig, msg, n) == 0;
     free(msg);
     return ok;
 }
@@ -694,17 +694,20 @@ static void prefetch_after(RFile *f, uint64_t off, uint64_t len) {
 
 static void *stats_thread(void *arg) {
     int period = (int)(intptr_t)arg;
-    uint64_t last_bytes = 0;
+    uint64_t last_bytes = 0, last_cas = 0;
     for (;;) {
         sleep((unsigned)period);
         uint64_t nb = atomic_load(&g.net_bytes);
         uint64_t blk = atomic_load(&g.net_blocks);
         uint64_t warm = atomic_load(&g.warm_reads);
-        if (nb == last_bytes && !warm) continue;
-        fprintf(stderr, "[lumabri] net %.1f MB in %llu blocks (%.1f MB/s) · warm preads %llu\n",
+        uint64_t cb = atomic_load(&g.cas_bytes), ch = atomic_load(&g.cas_hits);
+        if (nb == last_bytes && cb == last_cas && !warm) continue;
+        fprintf(stderr, "[lumabri] net %.1f MB in %llu blocks (%.1f MB/s) · "
+                "CAS %.1f MB in %llu hits · warm preads %llu\n",
                 (double)nb / 1e6, (unsigned long long)blk,
-                (double)(nb - last_bytes) / 1e6 / period, (unsigned long long)warm);
-        last_bytes = nb;
+                (double)(nb - last_bytes) / 1e6 / period, (double)cb / 1e6,
+                (unsigned long long)ch, (unsigned long long)warm);
+        last_bytes = nb; last_cas = cb;
     }
     return NULL;
 }
@@ -720,20 +723,36 @@ static void shim_init_impl(void) {
     }
     snprintf(g.data_dir, sizeof g.data_dir, "%s/data", cache);
     snprintf(g.maps_dir, sizeof g.maps_dir, "%s/maps", cache);
+    const char *cas = getenv("LUMABRI_CAS");
+    snprintf(g.cas_dir, sizeof g.cas_dir, "%s", cas && cas[0] ? cas : "");
+    if (!g.cas_dir[0]) snprintf(g.cas_dir, sizeof g.cas_dir, "%s/cas", cache);
     mkdir_p(g.data_dir);
     mkdir_p(g.maps_dir);
+    mkdir_p(g.cas_dir);
 
-    /* the operator's public key: 32 hex bytes, or a file holding them.
+    /* The operator trust set: one key, a comma list, or a keyring file.
      * This is the only thing a chatter must obtain out of band — with it,
      * nothing else in the swarm needs to be trusted. */
     const char *pkspec = getenv("LUMABRI_PUBKEY");
     if (pkspec && pkspec[0]) {
-        char hex[80] = "";
         FILE *pf = real_fopen(pkspec, "r");
-        if (pf) { if (fscanf(pf, "%78s", hex) != 1) hex[0] = 0; fclose(pf); }
-        else snprintf(hex, sizeof hex, "%s", pkspec);
-        if (strlen(hex) == 64 && !lmb_unhex(g.pubkey, hex, 32)) g.have_pubkey = 1;
-        else fprintf(stderr, "[lumabri] LUMABRI_PUBKEY is not 32 hex bytes — ignored\n");
+        int bad = 0;
+        size_t trust_before = g.trust.n;
+        if (pf) { bad = lmb_trust_load_stream(&g.trust, pf); fclose(pf); }
+        else {
+            char copy[2048];
+            if (strlen(pkspec) >= sizeof copy) bad = -1;
+            else {
+                snprintf(copy, sizeof copy, "%s", pkspec);
+                char *save = NULL;
+                for (char *p = strtok_r(copy, ",", &save); p;
+                     p = strtok_r(NULL, ",", &save))
+                    if (lmb_trust_add_hex(&g.trust, p)) { bad = -1; break; }
+            }
+        }
+        if (bad) g.trust.n = trust_before;
+        if (bad || !g.trust.n)
+            fprintf(stderr, "[lumabri] LUMABRI_PUBKEY is not a valid key/keyring — ignored\n");
     }
 
     long mib = 8;
@@ -792,13 +811,13 @@ static void shim_init_impl(void) {
         cache_lock_release();
         return;
     }
-    if (online_placement && g.have_pubkey && !have_current_id) {
+    if (online_placement && g.trust.n && !have_current_id) {
         fprintf(stderr, "[lumabri] signed swarm has no complete model identity — disabled\n");
         cache_lock_release();
         return;
     }
     int have_saved_id = cache_identity_get(&saved_rec, &saved_id) == 0;
-    if (!online_placement && g.have_pubkey && !have_saved_id) {
+    if (!online_placement && g.trust.n && !have_saved_id) {
         fprintf(stderr, "[lumabri] offline mirror has no verified model identity — disabled\n");
         cache_lock_release();
         return;
@@ -1015,7 +1034,7 @@ static void shim_init_impl(void) {
             g.nfiles, (double)total / 1e9,
             total ? 100.0 * (double)have / (double)total : 0.0,
             g.npeers, g.block >> 20, pf_depth,
-            g.have_pubkey ? " · verifying against the operator key" : "");
+            g.trust.n ? " · verifying against the operator trust set" : "");
     g.ok = 1;
 }
 
@@ -1138,12 +1157,12 @@ static void hashes_ensure(RFile *f) {
                  * rebuild the signed message ourselves and check it against
                  * a key obtained out of band, so a compromised tracker can
                  * withhold the truth but never rewrite it. */
-                if (g.have_pubkey) {
+                if (g.trust.n) {
                     size_t mlen = 0;
                     uint8_t *sm = has_sig
                         ? lmb_truth_msg(tmodel, f->rel, chunk, tsize, m.pay, n, &mlen)
                         : NULL;
-                    if (sm && lmb_sign_verify(sig, sm, mlen, g.pubkey) == 0)
+                    if (sm && lmb_trust_verify(&g.trust, sig, sm, mlen) == 0)
                         signed_ok = 1;
                     free(sm);
                     if (!signed_ok)
@@ -1152,7 +1171,7 @@ static void hashes_ensure(RFile *f) {
                                 has_sig ? "carries a BAD SIGNATURE"
                                         : "is not signed by the operator key");
                 }
-                if (!g.have_pubkey || signed_ok) {
+                if (!g.trust.n || signed_ok) {
                     hash = m.pay; nh = n; m.pay = NULL;
                 }
             }
@@ -1185,6 +1204,83 @@ static int block_verify(RFile *f, uint64_t off, const uint8_t *data, uint32_t le
         if (memcmp(h, f->hash + (size_t)ci * 32, 32)) return -1;
     }
     return 0;
+}
+
+/* ---- local content-addressed store ------------------------------------
+ *
+ * Verified 1 MiB truth chunks are also published under sha256 names.  A
+ * second checkpoint/mirror using the same bytes can assemble its sparse file
+ * locally without downloading them again.  The hash is checked again on
+ * every CAS read: a filename is a hint, never authority.  `lumabri chat`
+ * points LUMABRI_CAS at ~/.lumabri/cas; direct shim users may choose another
+ * local directory, including a fast shared volume.
+ */
+static void cas_path(char *dst, size_t cap, const uint8_t hash[32]) {
+    char hex[65]; lmb_hex(hex, hash, 32);
+    snprintf(dst, cap, "%s/%.2s/%s", g.cas_dir, hex, hex);
+}
+
+static int cas_read_full(int fd, uint8_t *p, uint32_t n) {
+    uint32_t got = 0;
+    while (got < n) {
+        ssize_t r = real_pread(fd, p + got, n - got, (off_t)got);
+        if (r < 0) { if (errno == EINTR) continue; return -1; }
+        if (!r) return -1;
+        got += (uint32_t)r;
+    }
+    return 0;
+}
+
+static uint8_t *cas_load(RFile *f, uint64_t off, uint32_t len) {
+    if (!g.cas_dir[0] || f->hstate != 1 || off % LMB_HASH_CHUNK) return NULL;
+    uint8_t *data = (uint8_t *)malloc(len ? len : 1);
+    if (!data) return NULL;
+    for (uint32_t o = 0; o < len; o += LMB_HASH_CHUNK) {
+        uint32_t ci = (uint32_t)((off + o) / LMB_HASH_CHUNK);
+        uint32_t n = len - o < LMB_HASH_CHUNK ? len - o : LMB_HASH_CHUNK;
+        char path[LMB_PATH_MAX * 2];
+        if (ci >= f->nh) { free(data); return NULL; }
+        cas_path(path, sizeof path, f->hash + (size_t)ci * 32);
+        int fd = real_open(path, O_RDONLY | O_NOFOLLOW);
+        struct stat st;
+        uint8_t got[32];
+        int bad = fd < 0 || fstat(fd, &st) || !S_ISREG(st.st_mode) ||
+                  st.st_size != (off_t)n || cas_read_full(fd, data + o, n);
+        if (fd >= 0) close(fd);
+        if (!bad) { lmb_sha256(data + o, n, got); bad = memcmp(got, f->hash + (size_t)ci * 32, 32); }
+        if (bad) { free(data); return NULL; }
+    }
+    atomic_fetch_add(&g.cas_hits, 1);
+    atomic_fetch_add(&g.cas_bytes, len);
+    return data;
+}
+
+static void cas_publish(RFile *f, uint64_t off, const uint8_t *data, uint32_t len) {
+    if (!g.cas_dir[0] || f->hstate != 1 || off % LMB_HASH_CHUNK) return;
+    for (uint32_t o = 0; o < len; o += LMB_HASH_CHUNK) {
+        uint32_t ci = (uint32_t)((off + o) / LMB_HASH_CHUNK);
+        uint32_t n = len - o < LMB_HASH_CHUNK ? len - o : LMB_HASH_CHUNK;
+        if (ci >= f->nh) return;
+        char path[LMB_PATH_MAX * 2], tmp[LMB_PATH_MAX * 2 + 96];
+        cas_path(path, sizeof path, f->hash + (size_t)ci * 32);
+        if (!access(path, R_OK)) continue;
+        mkdir_parent(path);
+        snprintf(tmp, sizeof tmp, "%s.tmp.%ld.%lu", path, (long)getpid(),
+                 (unsigned long)pthread_self());
+        int fd = real_open(tmp, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        if (fd < 0) continue;
+        uint32_t put = 0;
+        while (put < n) {
+            ssize_t w = write(fd, data + o + put, n - put);
+            if (w < 0) { if (errno == EINTR) continue; break; }
+            put += (uint32_t)w;
+        }
+        int ok = put == n && fsync(fd) == 0;
+        if (ok) fchmod(fd, 0444);
+        close(fd);
+        if (ok && !rename(tmp, path)) fsync_parent_dir(path);
+        else unlink(tmp);
+    }
 }
 
 /* Make one block present in the mirror. 0 on success. */
@@ -1220,11 +1316,14 @@ static int ensure_block(RFile *f, uint32_t blk) {
     uint64_t off = (uint64_t)blk * g.block;
     uint32_t len = (uint32_t)(off + g.block <= f->size ? g.block : f->size - off);
     uint8_t *data = NULL;
+    int from_cas = 0;
     hashes_ensure(f);
     /* a configured public key implies strict mode: the whole point of
      * carrying one is refusing to run on bytes nobody signed */
-    int require = getenv("LUMABRI_REQUIRE_HASH") != NULL || g.have_pubkey;
-    if (require && f->hstate != 1) {
+    int require = getenv("LUMABRI_REQUIRE_HASH") != NULL || g.trust.n;
+    if (f->hstate == 1 && (data = cas_load(f, off, len)) != NULL) {
+        from_cas = 1;
+    } else if (require && f->hstate != 1) {
         fprintf(stderr, "[lumabri] block %u of %s: integrity required but "
                         "unavailable — refusing the fetch\n", blk, f->rel);
     } else if (f->npeers > 0) {
@@ -1268,6 +1367,7 @@ static int ensure_block(RFile *f, uint32_t blk) {
             data = NULL;
         }
     }
+    if (data && !from_cas) cas_publish(f, off, data, len);
     int ok = 0, werr = 0;
     if (data && wfd >= 0) {
         uint32_t put = 0;
@@ -1280,8 +1380,10 @@ static int ensure_block(RFile *f, uint32_t blk) {
          * bit on disk.  Until then the bit exists only in memory, so a crash
          * causes a safe refetch rather than exposing sparse zeros. */
         if (put == len && !werr) ok = 1;
-        atomic_fetch_add(&g.net_bytes, len);
-        atomic_fetch_add(&g.net_blocks, 1);
+        if (!from_cas) {
+            atomic_fetch_add(&g.net_bytes, len);
+            atomic_fetch_add(&g.net_blocks, 1);
+        }
     }
     free(data);
     /* A peer that had the bytes and a disk that could not keep them are two

--- a/maintainer.c
+++ b/maintainer.c
@@ -41,7 +41,7 @@ static struct {
     char root[LMB_PATH_MAX];
     char name[64], advertise[64], tracker[64], model[64], token[128];
     uint8_t sk[64]; int have_key;   /* --key: this peer is the origin */
-    uint8_t pk[32]; int have_pub;   /* --pubkey: a donor that checks the origin */
+    LmbTrustKeys trust;             /* --pubkey: old+new during manual rotation */
     LmbModelIdentity identity; int have_identity;
     MFile files[MAX_FILES]; int nfiles;
     const char *includes[MAX_INCLUDES]; int nincl;
@@ -372,11 +372,11 @@ static void sign_truth(MFile *f) {
 
 static int model_identity_valid(const LmbModelIdentity *id) {
     if (strcmp(id->model, g.model)) return 0;
-    if (!g.have_pub) return 1;
+    if (!g.trust.n) return 1;
     if (!id->has_sig) return 0;
     size_t n = 0;
     uint8_t *msg = lmb_model_id_msg(id->model, id->root, &n);
-    int ok = msg && lmb_sign_verify(id->sig, msg, n, g.pk) == 0;
+    int ok = msg && lmb_trust_verify(&g.trust, id->sig, msg, n) == 0;
     free(msg);
     return ok;
 }
@@ -478,7 +478,7 @@ static int model_identity_prepare(int disk_donor) {
         else if (have_saved && !memcmp(local.root, saved.root, 32)) local = saved;
         g.identity = local; g.have_identity = 1;
     }
-    if (g.have_pub && (!g.have_identity || !model_identity_valid(&g.identity))) {
+    if (g.trust.n && (!g.have_identity || !model_identity_valid(&g.identity))) {
         fprintf(stderr, "[maintainer %s] no operator-signed identity for model %s\n",
                 g.name, g.model);
         return -1;
@@ -616,7 +616,7 @@ static int fetch_truth(const char *rel, Truth *t) {
      * tracker that invents hashes to match corrupt bytes is caught here and
      * not three hops later. Without the key we can still carry a signature
      * we cannot read: the chatter checks it against its own copy. */
-    if (g.have_pub) {
+    if (g.trust.n) {
         if (!t->has_sig) {
             fprintf(stderr, "[maintainer %s] %s is not signed by the operator — "
                             "refusing to hold it\n", g.name, rel);
@@ -626,7 +626,7 @@ static int fetch_truth(const char *rel, Truth *t) {
         size_t ml = 0;
         uint8_t *msg = lmb_truth_msg(t->model, rel, LMB_HASH_CHUNK, t->size,
                                      t->hash, t->nh, &ml);
-        int ok = msg && lmb_sign_verify(t->sig, msg, ml, g.pk) == 0;
+        int ok = msg && lmb_trust_verify(&g.trust, t->sig, msg, ml) == 0;
         free(msg);
         if (!ok) {
             fprintf(stderr, "[maintainer %s] the signature on %s does not match "
@@ -683,7 +683,7 @@ static int pull_file(const char *rel, uint64_t size, Truth *tr) {
      * already decided we would not be allowed to serve */
     memset(tr, 0, sizeof *tr);
     int have_truth = fetch_truth(rel, tr) == 0;
-    if (!have_truth && g.have_pub) return -1;      /* said why, in fetch_truth */
+    if (!have_truth && g.trust.n) return -1;       /* said why, in fetch_truth */
     if (!have_truth)
         fprintf(stderr, "[maintainer %s] no integrity data for %s — "
                         "pulling unverified\n", g.name, rel);
@@ -956,19 +956,15 @@ int main(int argc, char **argv) {
             fclose(kf);
             g.have_key = 1;
         }
-        /* the public half: a donor holds no key but can still refuse bytes
-         * whose truth the operator did not sign — accepts a file or the hex */
+        /* The public half may be one key or an old+new keyring during a
+         * manual rotation. Repeating --pubkey appends to the trust set. */
         else if (!strcmp(argv[i], "--pubkey") && i + 1 < argc) {
-            char hex[200] = "";
-            FILE *pf = fopen(argv[++i], "r");
-            if (pf) { if (fscanf(pf, "%198s", hex) != 1) hex[0] = 0; fclose(pf); }
-            else snprintf(hex, sizeof hex, "%s", argv[i]);
-            if (strlen(hex) != 64 || lmb_unhex(g.pk, hex, 32)) {
-                fprintf(stderr, "[maintainer] cannot read a 32-byte public key "
-                                "from %s\n", argv[i]);
+            const char *spec = argv[++i];
+            if (lmb_trust_load_spec(&g.trust, spec)) {
+                fprintf(stderr, "[maintainer] cannot read public key/keyring "
+                                "from %s\n", spec);
                 return 2;
             }
-            g.have_pub = 1;
         }
         else {
             fprintf(stderr, "usage: %s --root DIR [--port N] [--tracker H:P]"

--- a/relay_exec_test.sh
+++ b/relay_exec_test.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s tracker expert_node test_relay_exec fixture
+T=$(mktemp -d /tmp/lumabri-relay-exec.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+
+./tracker --port 7560 >"$T/tracker.log" 2>&1 & PIDS+=($!)
+OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 ./expert_node \
+    --model tiny_olmoe --port 7561 --name nat-expert \
+    --tracker 127.0.0.1:7560 --advertise 127.0.0.1:1 \
+    >"$T/node.log" 2>&1 & PIDS+=($!)
+
+for _ in $(seq 1 200); do
+    grep -q "expert nat-expert" "$T/tracker.log" && break
+    sleep .1
+done
+grep -q "expert nat-expert" "$T/tracker.log" || {
+    cat "$T/tracker.log" "$T/node.log"; exit 1;
+}
+
+./test_relay_exec 127.0.0.1:7560 127.0.0.1:7561 tiny_olmoe 8 1024 0

--- a/test_hedge.c
+++ b/test_hedge.c
@@ -1,0 +1,58 @@
+#define LMBE_ENGINE_ID "hedge-test"
+#define LMBE_SOURCE_ID "test"
+#define LMBE_EXPECT_BITS 0
+#include <pthread.h>
+#include "lumabri_client.h"
+
+typedef struct { int port, delay_ms; } Echo;
+
+static void *echo_server(void *arg) {
+    Echo *e = (Echo *)arg;
+    int lfd = lmb_listen(e->port);
+    if (lfd < 0) return (void *)1;
+    int fd = accept(lfd, NULL, NULL);
+    LmbMsg m = {0};
+    int bad = fd < 0 || lmb_recv(fd, &m) || m.op != LMB_EXEC || m.body_len < 16;
+    if (!bad) {
+        if (e->delay_ms) usleep((useconds_t)e->delay_ms * 1000u);
+        bad = lmb_send(fd, LMB_EXEC_R, NULL, 0, m.pay, m.pay_len);
+    }
+    lmb_msg_free(&m);
+    if (fd >= 0) close(fd);
+    close(lfd);
+    return (void *)(intptr_t)(bad != 0);
+}
+
+int main(void) {
+    Echo slow = {7564, 150}, fast = {7565, 0};
+    pthread_t a, b;
+    pthread_create(&a, NULL, echo_server, &slow);
+    pthread_create(&b, NULL, echo_server, &fast);
+    usleep(100000);
+
+    L.n_layers = 1; L.n_experts = 1; L.hidden = 4; L.npeers = 2;
+    L.hedge_ms = 20;
+    L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));
+    for (int i = 0; i < LUMI_MAX_REP; i++) L.own[i] = -1;
+    L.own[0] = 0; L.own[1] = 1;
+    snprintf(L.peers[0].addr, sizeof L.peers[0].addr, "127.0.0.1:%d", slow.port);
+    snprintf(L.peers[1].addr, sizeof L.peers[1].addr, "127.0.0.1:%d", fast.port);
+    L.peers[0].rtt_us = 100; L.peers[1].rtt_us = 200;
+
+    float x[12]; for (int i = 0; i < 12; i++) x[i] = (float)i / 7.0f;
+    int fd = lumi_take_sock(&L.peers[0]);
+    uint32_t tried = 1;
+    int bad = fd < 0 || lumi_send_exec(fd, 0, 0, x, 4, 3, NULL);
+    LumiPeer *from = NULL;
+    float *out = bad ? NULL : lumi_finish_exec(0, 0, x, 4, 3, NULL, fd,
+                                                &L.peers[0], &tried, &from);
+    bad |= !out || memcmp(out, x, sizeof x) || from != &L.peers[1] ||
+           L.hedges != 1 || L.hedge_wins != 1;
+    free(out); free(L.own);
+    void *ra = NULL, *rb = NULL;
+    pthread_join(a, &ra); pthread_join(b, &rb);
+    bad |= (intptr_t)ra || (intptr_t)rb;
+    if (bad) { fputs("hedged request test failed\n", stderr); return 1; }
+    puts("HEDGED EXEC: PASS (3-row batch, fast replica won after 20 ms)");
+    return 0;
+}

--- a/test_key_rotation.c
+++ b/test_key_rotation.c
@@ -1,0 +1,34 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include "lumabri_sign.h"
+
+int main(void) {
+    uint8_t s1[32], s2[32], pk1[32], pk2[32], sk1[64], sk2[64];
+    for (int i = 0; i < 32; i++) { s1[i] = (uint8_t)i; s2[i] = (uint8_t)(i + 73); }
+    lmb_sign_keypair(pk1, sk1, s1); lmb_sign_keypair(pk2, sk2, s2);
+    char h1[65], h2[65]; lmb_hex(h1, pk1, 32); lmb_hex(h2, pk2, 32);
+
+    char path[] = "/tmp/lumabri-keyring.XXXXXX";
+    int fd = mkstemp(path);
+    FILE *fp = fd >= 0 ? fdopen(fd, "w") : NULL;
+    if (!fp) return 2;
+    fprintf(fp, "# overlap window: old then new\n%s\n%s\n", h1, h2);
+    if (fclose(fp)) return 2;
+
+    LmbTrustKeys overlap = {0}, new_only = {0};
+    int bad = lmb_trust_load_spec(&overlap, path) ||
+              lmb_trust_add_hex(&new_only, h2);
+    unlink(path);
+    const uint8_t msg[] = "manual-rotation-test";
+    uint8_t a[64], b[64];
+    lmb_sign(a, msg, sizeof msg, sk1); lmb_sign(b, msg, sizeof msg, sk2);
+    bad |= overlap.n != 2 || lmb_trust_verify(&overlap, a, msg, sizeof msg) ||
+           lmb_trust_verify(&overlap, b, msg, sizeof msg) ||
+           lmb_trust_match(&overlap, a, msg, sizeof msg) != 0 ||
+           lmb_trust_match(&overlap, b, msg, sizeof msg) != 1 ||
+           lmb_trust_verify(&new_only, b, msg, sizeof msg) ||
+           lmb_trust_verify(&new_only, a, msg, sizeof msg) == 0;
+    if (bad) { fputs("key rotation trust-set failure\n", stderr); return 1; }
+    puts("KEY ROTATION: PASS (old+new overlap, then old revoked manually)");
+    return 0;
+}

--- a/test_relay_exec.c
+++ b/test_relay_exec.c
@@ -1,0 +1,39 @@
+/* One real expert call, direct and through the tracker's NAT tunnel. */
+#include "lumabri_proto.h"
+
+int main(int argc, char **argv) {
+    if (argc != 7) {
+        fprintf(stderr, "usage: %s TRACKER NODE MODEL NEXPERTS DIM EID\n", argv[0]);
+        return 2;
+    }
+    const char *tracker = argv[1], *node = argv[2], *model = argv[3];
+    uint32_t nexp = (uint32_t)atoi(argv[4]), dim = (uint32_t)atoi(argv[5]);
+    uint32_t eid = (uint32_t)atoi(argv[6]), layer = 0, rows = 3;
+    float *x = (float *)malloc((size_t)rows * dim * sizeof(float));
+    if (!x) return 2;
+    for (size_t i = 0; i < (size_t)rows * dim; i++)
+        x[i] = (float)((int)(i % 31) - 15) / 31.0f;
+
+    LmbBuf exec = {0};
+    lmb_buf_u32(&exec, layer); lmb_buf_u32(&exec, eid);
+    lmb_buf_u32(&exec, dim); lmb_buf_u32(&exec, rows);
+    uint32_t pay_len = rows * dim * (uint32_t)sizeof(float);
+    LmbMsg direct = {0}, relayed = {0};
+    int bad = lmb_request_pay(node, LMB_EXEC, exec.p, (uint32_t)exec.len,
+                              x, pay_len, &direct) ||
+              direct.op != LMB_EXEC_R || direct.pay_len != pay_len;
+    if (!bad) {
+        LmbBuf b = {0};
+        lmb_buf_str(&b, model); lmb_buf_u32(&b, nexp);
+        lmb_buf_bytes(&b, exec.p, exec.len);
+        bad = lmb_request_pay(tracker, LMB_REXEC, b.p, (uint32_t)b.len,
+                              x, pay_len, &relayed) ||
+              relayed.op != LMB_REXEC_R || relayed.pay_len != pay_len ||
+              memcmp(direct.pay, relayed.pay, pay_len);
+        free(b.p);
+    }
+    free(exec.p); free(x); lmb_msg_free(&direct); lmb_msg_free(&relayed);
+    if (bad) { fprintf(stderr, "relayed EXEC differs from direct EXEC\n"); return 1; }
+    puts("EXEC RELAY: PASS (3-row batch, byte-identical to direct)");
+    return 0;
+}

--- a/tracker.c
+++ b/tracker.c
@@ -34,6 +34,8 @@ typedef struct { char path[LMB_PATH_MAX]; uint64_t size; } PFile;
 
 typedef struct {
     char name[64], addr[64], model[64];
+    char engine[64], profile[LMB_BUILD_PROFILE_MAX];
+    uint32_t bits, hidden, slots, total_experts;
     uint64_t held_bytes, served_bytes, served_reads;
     PFile *files; uint32_t nfiles;
     double ts;
@@ -55,9 +57,11 @@ typedef struct {
     pthread_mutex_t rq_lk;
     pthread_cond_t rq_cv;
     int rq_busy, rq_sent, rq_done, rq_ok;
-    uint32_t rq_id, rq_next;
+    uint32_t rq_id, rq_next, rq_op;
     char rq_path[LMB_PATH_MAX];
     uint64_t rq_off; uint32_t rq_len;
+    uint8_t *rq_body; uint32_t rq_body_len;
+    uint8_t *rq_pay; uint32_t rq_pay_len;
     uint8_t *rq_resp; uint32_t rq_resp_len;
 } Peer;
 
@@ -77,15 +81,15 @@ typedef struct {
     uint32_t nh;
     uint64_t size;
     uint8_t *hash;
-    uint8_t sig[64]; int has_sig;
+    uint8_t sig[64]; int has_sig, sig_rank;
 } GTruth;
 static GTruth g_truth[MAX_FILES];
 static int g_ntruth;
-static uint8_t g_pubkey[32];
-static int g_have_pubkey;    /* --pubkey: only signed truth is accepted */
+static LmbTrustKeys g_trust; /* --pubkey: one key or an overlap keyring */
+#define g_have_pubkey (g_trust.n != 0)
 
 #define MAX_MODELS 128
-typedef struct { LmbModelIdentity id; int used; } GModel;
+typedef struct { LmbModelIdentity id; int used, sig_rank; } GModel;
 static GModel g_models[MAX_MODELS];
 
 /* under g_lk. A first identity must describe exactly the hash inventory in
@@ -95,11 +99,13 @@ static int model_identity_check(const char *model, const LmbModelIdentity *id,
                                 const PFile *files, uint32_t n,
                                 uint8_t *const *hashes, const uint32_t *nh) {
     if (strcmp(model, id->model)) return 0;
+    int sig_rank = -1;
     if (g_have_pubkey) {
         if (!id->has_sig) return 0;
         size_t ml = 0;
         uint8_t *msg = lmb_model_id_msg(model, id->root, &ml);
-        int ok = msg && lmb_sign_verify(id->sig, msg, ml, g_pubkey) == 0;
+        if (msg) sig_rank = lmb_trust_match(&g_trust, id->sig, msg, ml);
+        int ok = sig_rank >= 0;
         free(msg);
         if (!ok) return 0;
     }
@@ -107,7 +113,10 @@ static int model_identity_check(const char *model, const LmbModelIdentity *id,
         if (g_models[i].used && !strcmp(g_models[i].id.model, model)) {
             if (memcmp(g_models[i].id.root, id->root, 32)) return 0;
             if (g_models[i].id.has_sig && !id->has_sig) return 0;
-            if (!g_models[i].id.has_sig && id->has_sig) g_models[i].id = *id;
+            if ((!g_models[i].id.has_sig && id->has_sig) ||
+                (id->has_sig && sig_rank > g_models[i].sig_rank)) {
+                g_models[i].id = *id; g_models[i].sig_rank = sig_rank;
+            }
             return 1;
         }
     LmbModelItem *items = (LmbModelItem *)calloc(n ? n : 1, sizeof *items);
@@ -126,6 +135,7 @@ static int model_identity_check(const char *model, const LmbModelIdentity *id,
     for (int i = 0; i < MAX_MODELS; i++)
         if (!g_models[i].used) {
             g_models[i].used = 1; g_models[i].id = *id;
+            g_models[i].sig_rank = sig_rank;
             return 1;
         }
     return 0;
@@ -142,13 +152,15 @@ static int model_identity_check(const char *model, const LmbModelIdentity *id,
 static int truth_check(const char *model, const char *path, uint64_t size,
                        uint32_t nh, uint8_t **hash,
                        const uint8_t *sig, int has_sig) {
+    int sig_rank = -1;
     if (g_have_pubkey) {
         if (!has_sig) return 0;
         size_t mlen = 0;
         uint8_t *msg = lmb_truth_msg(model, path, LMB_HASH_CHUNK, size,
                                      *hash, nh, &mlen);
         if (!msg) return 0;
-        int ok = lmb_sign_verify(sig, msg, mlen, g_pubkey) == 0;
+        sig_rank = lmb_trust_match(&g_trust, sig, msg, mlen);
+        int ok = sig_rank >= 0;
         free(msg);
         if (!ok) return 0;
     }
@@ -156,9 +168,11 @@ static int truth_check(const char *model, const char *path, uint64_t size,
         if (!strcmp(g_truth[i].model, model) && !strcmp(g_truth[i].path, path)) {
             if (g_truth[i].nh != nh || g_truth[i].size != size ||
                 memcmp(g_truth[i].hash, *hash, (size_t)nh * 32)) return 0;
-            if (!g_truth[i].has_sig && has_sig) {    /* upgrade to signed */
+            if ((!g_truth[i].has_sig && has_sig) ||
+                (has_sig && sig_rank > g_truth[i].sig_rank)) {
                 memcpy(g_truth[i].sig, sig, 64);
                 g_truth[i].has_sig = 1;
+                g_truth[i].sig_rank = sig_rank;
             }
             return 1;
         }
@@ -170,6 +184,7 @@ static int truth_check(const char *model, const char *path, uint64_t size,
     t->size = size;
     t->hash = *hash;
     t->has_sig = has_sig;
+    t->sig_rank = sig_rank;
     if (has_sig) memcpy(t->sig, sig, 64);
     *hash = NULL;
     return 1;
@@ -187,6 +202,7 @@ static double now_s(void) {
  * connection from losing its mutex/storage underneath it.  Called with
  * g_lk held. */
 static Peer *peer_slot_new(int is_expert, int *idx) {
+    (void)is_expert; /* both maintainer and expert control links now relay */
     int pick = -1;
     for (int i = 0; i < MAX_PEERS; i++)
         if (!g_peers[i].used) { pick = i; break; }
@@ -202,14 +218,15 @@ static Peer *peer_slot_new(int is_expert, int *idx) {
     if (pick < 0) return NULL;
     Peer *p = &g_peers[pick];
     if (p->used) {
-        free(p->files); free(p->ebits); free(p->rq_resp);
+        free(p->files); free(p->ebits); free(p->rq_body); free(p->rq_pay);
+        free(p->rq_resp);
         if (p->evfd >= 0) close(p->evfd);
         pthread_mutex_destroy(&p->rq_lk);
         pthread_cond_destroy(&p->rq_cv);
     }
     memset(p, 0, sizeof *p);
     p->ctrl_fd = -1;
-    p->evfd = is_expert ? -1 : eventfd(0, EFD_NONBLOCK);
+    p->evfd = eventfd(0, EFD_NONBLOCK);
     pthread_mutex_init(&p->rq_lk, NULL);
     pthread_cond_init(&p->rq_cv, NULL);
     g_known_logged[pick] = 0;
@@ -379,19 +396,31 @@ static Peer *handle_register(int fd, LmbMsg *m) {
  * Expert peers never enter placements (they hold no files); EPEERS is how a
  * chatter learns who can EXECUTE for a model, server included. */
 
-static int handle_ereg(int fd, LmbMsg *m) {
+static Peer *handle_ereg(int fd, LmbMsg *m) {
     LmbCur c = { m->body, m->body_len, 0 };
     char name[64], addr[64], model[64];
     uint32_t nexperts;
     if (lmb_cur_str(&c, name, sizeof name) || lmb_cur_str(&c, addr, sizeof addr) ||
         lmb_cur_str(&c, model, sizeof model) || lmb_cur_u32(&c, &nexperts)) {
-        send_err(fd, "bad ereg"); return -1;
+        send_err(fd, "bad ereg"); return NULL;
     }
     /* optional, appended by newer nodes: the bitmap of what it holds */
     uint32_t bl = 0; const uint8_t *bits = NULL;
     if (!lmb_cur_u32(&c, &bl) && bl && bl <= (1u << 20) && c.off + bl <= c.len) {
         bits = c.p + c.off; c.off += bl;
     } else bl = 0;
+    uint32_t meta = 0, qbits = 0, hidden = 0, slots = 0, total_experts = 0;
+    char engine[64] = "", profile[LMB_BUILD_PROFILE_MAX] = "";
+    if (c.off < c.len) {
+        if (lmb_cur_u32(&c, &meta) || meta != LMB_EXPERT_MANIFEST_MAGIC ||
+            lmb_cur_str(&c, engine, sizeof engine) ||
+            lmb_cur_str(&c, profile, sizeof profile) ||
+            lmb_cur_u32(&c, &qbits) || lmb_cur_u32(&c, &hidden) ||
+            lmb_cur_u32(&c, &slots) || lmb_cur_u32(&c, &total_experts) ||
+            c.off != c.len) {
+            send_err(fd, "bad ereg metadata"); return NULL;
+        }
+    }
     Peer *slot = NULL;
     int fresh = 0;
     pthread_mutex_lock(&g_lk);
@@ -417,9 +446,14 @@ static int handle_ereg(int fd, LmbMsg *m) {
     if (slot) {
         slot->used = 1; slot->is_expert = 1;
         slot->nexperts = nexperts; slot->ts = now_s();
+        slot->ctrl_fd = fd;
         snprintf(slot->name, sizeof slot->name, "%s", name);
         snprintf(slot->addr, sizeof slot->addr, "%s", use_addr);
         snprintf(slot->model, sizeof slot->model, "%s", model);
+        snprintf(slot->engine, sizeof slot->engine, "%s", engine);
+        snprintf(slot->profile, sizeof slot->profile, "%s", profile);
+        slot->bits = qbits; slot->hidden = hidden;
+        slot->slots = slots; slot->total_experts = total_experts;
         if (bl) {
             uint8_t *nb = (uint8_t *)realloc(slot->ebits, bl);
             if (nb) { slot->ebits = nb; memcpy(slot->ebits, bits, bl);
@@ -427,13 +461,19 @@ static int handle_ereg(int fd, LmbMsg *m) {
         }
     }
     pthread_mutex_unlock(&g_lk);
-    if (!slot) { send_err(fd, "peer table full"); return -1; }
+    if (!slot) { send_err(fd, "peer table full"); return NULL; }
     if (fresh) {
         printf("[tracker] + expert %s @ %s (%s, %u experts)\n",
                name, use_addr, model, nexperts);
         fflush(stdout);
     }
-    return lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
+    if (lmb_send(fd, LMB_OK, NULL, 0, NULL, 0)) {
+        pthread_mutex_lock(&g_lk);
+        if (slot->ctrl_fd == fd) slot->ctrl_fd = -1;
+        pthread_mutex_unlock(&g_lk);
+        return NULL;
+    }
+    return slot;
 }
 
 static int handle_epeers(int fd, LmbMsg *m) {
@@ -458,6 +498,44 @@ static int handle_epeers(int fd, LmbMsg *m) {
             lmb_buf_str(&b, g_peers[i].addr);
     pthread_mutex_unlock(&g_lk);
     int rc = lmb_send(fd, LMB_EPEERS_R, b.p, (uint32_t)b.len, NULL, 0);
+    free(b.p);
+    return rc;
+}
+
+static int handle_ecover(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    char model[64], engine[64], profile[LMB_BUILD_PROFILE_MAX];
+    uint32_t bits, hidden, slots, nexp;
+    if (lmb_cur_str(&c, model, sizeof model) ||
+        lmb_cur_str(&c, engine, sizeof engine) ||
+        lmb_cur_str(&c, profile, sizeof profile) ||
+        lmb_cur_u32(&c, &bits) || lmb_cur_u32(&c, &hidden) ||
+        lmb_cur_u32(&c, &slots) || lmb_cur_u32(&c, &nexp) || c.off != c.len ||
+        !slots || !nexp || (uint64_t)slots * nexp > (1u << 23)) {
+        send_err(fd, "bad ecover"); return -1;
+    }
+    size_t cells = (size_t)slots * nexp, nb = (cells + 7) / 8;
+    uint8_t *cover = (uint8_t *)calloc(nb ? nb : 1, 1);
+    if (!cover) { send_err(fd, "oom"); return -1; }
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *q = &g_peers[i];
+        if (!q->used || !q->is_expert || q->ctrl_fd < 0 || q->evfd < 0 ||
+            now - q->ts > g_stale_s || strcmp(q->model, model) ||
+            strcmp(q->engine, engine) || strcmp(q->profile, profile) ||
+            q->bits != bits || q->hidden != hidden || q->slots != slots ||
+            q->total_experts != nexp) continue;
+        size_t take = (q->enbits + 7) / 8;
+        if (take > nb) take = nb;
+        for (size_t j = 0; j < take; j++) cover[j] |= q->ebits[j];
+    }
+    pthread_mutex_unlock(&g_lk);
+    LmbBuf b = {0};
+    lmb_buf_u32(&b, slots); lmb_buf_u32(&b, nexp);
+    lmb_buf_u32(&b, (uint32_t)nb); lmb_buf_bytes(&b, cover, nb);
+    free(cover);
+    int rc = lmb_send(fd, LMB_ECOVER_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
 }
@@ -711,7 +789,7 @@ static int handle_rread(int fd, LmbMsg *m) {
     pthread_mutex_lock(&g_lk);
     for (int i = 0; i < MAX_PEERS && !p; i++) {
         Peer *q = &g_peers[i];
-        if (!q->used || now - q->ts > g_stale_s || q->ctrl_fd < 0) continue;
+        if (!q->used || now - q->ts > g_stale_s || q->ctrl_fd < 0 || q->evfd < 0) continue;
         if (model[0] && strcmp(q->model, model)) continue;
         for (uint32_t j = 0; j < q->nfiles; j++)
             if (!strcmp(q->files[j].path, path)) { p = q; p->refs++; break; }
@@ -722,9 +800,11 @@ static int handle_rread(int fd, LmbMsg *m) {
     pthread_mutex_lock(&p->rq_lk);
     while (p->rq_busy) pthread_cond_wait(&p->rq_cv, &p->rq_lk);
     p->rq_busy = 1; p->rq_sent = 0; p->rq_done = 0; p->rq_ok = 0;
-    p->rq_id = ++p->rq_next;
+    p->rq_id = ++p->rq_next; p->rq_op = LMB_RREAD_FWD;
     snprintf(p->rq_path, sizeof p->rq_path, "%s", path);
     p->rq_off = off; p->rq_len = len;
+    free(p->rq_body); p->rq_body = NULL; p->rq_body_len = 0;
+    free(p->rq_pay); p->rq_pay = NULL; p->rq_pay_len = 0;
     free(p->rq_resp); p->rq_resp = NULL; p->rq_resp_len = 0;
     pthread_mutex_unlock(&p->rq_lk);
 
@@ -756,6 +836,100 @@ static int handle_rread(int fd, LmbMsg *m) {
     pthread_mutex_lock(&g_lk);
     if (p->refs) p->refs--;
     pthread_mutex_unlock(&g_lk);
+    return rc;
+}
+
+/* EXEC relay: same one-request mailbox as byte relay, but the expert node's
+ * EREG connection is the outbound tunnel.  The tracker validates enough of
+ * the shape to select a real holder and bound memory; the expert validates
+ * the complete engine-specific request before executing it. */
+static int handle_rexec(int fd, LmbMsg *m) {
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[tracker] rexec request body=%u pay=%u\n",
+                m->body_len, m->pay_len);
+    LmbCur c = { m->body, m->body_len, 0 };
+    char model[64];
+    uint32_t nexp = 0, layer = 0, eid = 0, dim = 0, nrows = 0;
+    if (lmb_cur_str(&c, model, sizeof model) || lmb_cur_u32(&c, &nexp) ||
+        lmb_cur_u32(&c, &layer) || lmb_cur_u32(&c, &eid) ||
+        lmb_cur_u32(&c, &dim) || lmb_cur_u32(&c, &nrows)) {
+        send_err(fd, "malformed rexec header"); return -1;
+    }
+    if (nexp < 1 || eid >= nexp ||
+        !dim || nrows < 1 || nrows > LMB_MAX_EXEC_ROWS ||
+        (m->body_len - c.off != 0 && m->body_len - c.off != (uint64_t)nrows * 4) ||
+        (uint64_t)nrows * dim * 4 != m->pay_len) {
+        char why[160];
+        snprintf(why, sizeof why, "bad rexec shape (nexp=%u layer=%u eid=%u "
+                 "dim=%u rows=%u body_tail=%zu pay=%u)", nexp, layer, eid,
+                 dim, nrows, m->body_len - c.off, m->pay_len);
+        send_err(fd, why); return -1;
+    }
+    size_t exec_at = c.off - 16;             /* layer starts 16 bytes earlier */
+    uint64_t gid64 = (uint64_t)layer * nexp + eid;
+    if (gid64 > UINT32_MAX) { send_err(fd, "bad rexec expert id"); return -1; }
+
+    Peer *p = NULL;
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+    for (int i = 0; i < MAX_PEERS && !p; i++) {
+        Peer *q = &g_peers[i];
+        uint32_t gid = (uint32_t)gid64;
+        if (!q->used || !q->is_expert || now - q->ts > g_stale_s ||
+            q->ctrl_fd < 0 || q->evfd < 0 || strcmp(q->model, model) || gid >= q->enbits ||
+            !(q->ebits[gid >> 3] & (uint8_t)(1u << (gid & 7)))) continue;
+        p = q; p->refs++;
+    }
+    pthread_mutex_unlock(&g_lk);
+    if (!p) { send_err(fd, "no relay-capable expert holds it"); return 0; }
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[tracker] rexec selected %s ctrl=%d gid=%llu\n",
+                p->name, p->ctrl_fd, (unsigned long long)gid64);
+
+    uint32_t body_len = m->body_len - (uint32_t)exec_at;
+    uint8_t *body = (uint8_t *)malloc(body_len ? body_len : 1);
+    uint8_t *pay = (uint8_t *)malloc(m->pay_len ? m->pay_len : 1);
+    if (!body || !pay) {
+        free(body); free(pay);
+        pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
+        send_err(fd, "oom"); return -1;
+    }
+    memcpy(body, m->body + exec_at, body_len);
+    memcpy(pay, m->pay, m->pay_len);
+
+    pthread_mutex_lock(&p->rq_lk);
+    while (p->rq_busy) pthread_cond_wait(&p->rq_cv, &p->rq_lk);
+    p->rq_busy = 1; p->rq_sent = 0; p->rq_done = 0; p->rq_ok = 0;
+    p->rq_id = ++p->rq_next; p->rq_op = LMB_REXEC_FWD;
+    free(p->rq_body); p->rq_body = body; p->rq_body_len = body_len;
+    free(p->rq_pay); p->rq_pay = pay; p->rq_pay_len = m->pay_len;
+    free(p->rq_resp); p->rq_resp = NULL; p->rq_resp_len = 0;
+    pthread_mutex_unlock(&p->rq_lk);
+    uint64_t one = 1; if (write(p->evfd, &one, 8) != 8) {}
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[tracker] rexec queued id=%u evfd=%d\n", p->rq_id, p->evfd);
+
+    struct timespec dl;
+    clock_gettime(CLOCK_REALTIME, &dl); dl.tv_sec += RELAY_WAIT_S;
+    pthread_mutex_lock(&p->rq_lk);
+    while (!p->rq_done)
+        if (pthread_cond_timedwait(&p->rq_cv, &p->rq_lk, &dl) != 0) break;
+    int ok = p->rq_done && p->rq_ok;
+    uint8_t *resp = p->rq_resp; uint32_t resp_len = p->rq_resp_len;
+    p->rq_resp = NULL; p->rq_resp_len = 0;
+    free(p->rq_body); p->rq_body = NULL; p->rq_body_len = 0;
+    free(p->rq_pay); p->rq_pay = NULL; p->rq_pay_len = 0;
+    p->rq_busy = 0; pthread_cond_broadcast(&p->rq_cv);
+    pthread_mutex_unlock(&p->rq_lk);
+
+    int rc;
+    if (!ok) { free(resp); send_err(fd, "exec relay timeout or peer failure"); rc = 0; }
+    else {
+        LmbBuf b = {0}; lmb_buf_u32(&b, 1);
+        rc = lmb_send(fd, LMB_REXEC_R, b.p, (uint32_t)b.len, resp, resp_len);
+        free(b.p); free(resp);
+    }
+    pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
     return rc;
 }
 
@@ -840,12 +1014,17 @@ static int handle_assign(int fd, LmbMsg *m) {
 }
 
 /* the peer's control thread completes the pending request */
-static void rread_complete(Peer *p, LmbMsg *m) {
+static void relay_complete(Peer *p, LmbMsg *m) {
     LmbCur c = { m->body, m->body_len, 0 };
     uint32_t id = 0, ok = 0;
     if (lmb_cur_u32(&c, &id) || lmb_cur_u32(&c, &ok)) return;
+    if (getenv("LUMABRI_RELAY_TRACE"))
+        fprintf(stderr, "[tracker] relay complete op=%u id=%u ok=%u pay=%u\n",
+                m->op, id, ok, m->pay_len);
     pthread_mutex_lock(&p->rq_lk);
-    if (p->rq_busy && p->rq_sent && id == p->rq_id && !p->rq_done) {
+    uint32_t expect = p->rq_op == LMB_RREAD_FWD ? LMB_RREAD_R : LMB_REXEC_R;
+    if (p->rq_busy && p->rq_sent && id == p->rq_id && m->op == expect &&
+        !p->rq_done) {
         p->rq_ok = ok && m->pay_len > 0;
         p->rq_resp = m->pay; p->rq_resp_len = m->pay_len;
         m->pay = NULL;                        /* stolen */
@@ -882,21 +1061,39 @@ static void *conn_thread(void *arg) {
                 uint64_t junk;
                 while (read(ctrl->evfd, &junk, 8) == 8) { }
                 LmbBuf b = {0};
+                uint8_t *pay = NULL; uint32_t pay_len = 0, op = 0;
                 int have = 0;
                 pthread_mutex_lock(&ctrl->rq_lk);
                 if (ctrl->rq_busy && !ctrl->rq_sent && !ctrl->rq_done) {
                     ctrl->rq_sent = 1; have = 1;
+                    op = ctrl->rq_op;
                     lmb_buf_u32(&b, ctrl->rq_id);
-                    lmb_buf_str(&b, ctrl->rq_path);
-                    lmb_buf_u64(&b, ctrl->rq_off);
-                    lmb_buf_u32(&b, ctrl->rq_len);
+                    if (op == LMB_RREAD_FWD) {
+                        lmb_buf_str(&b, ctrl->rq_path);
+                        lmb_buf_u64(&b, ctrl->rq_off);
+                        lmb_buf_u32(&b, ctrl->rq_len);
+                    } else if (op == LMB_REXEC_FWD) {
+                        lmb_buf_bytes(&b, ctrl->rq_body, ctrl->rq_body_len);
+                        pay_len = ctrl->rq_pay_len;
+                        if (pay_len) {
+                            pay = (uint8_t *)malloc(pay_len);
+                            if (pay) memcpy(pay, ctrl->rq_pay, pay_len);
+                            else {
+                                have = 0; ctrl->rq_done = 1; ctrl->rq_ok = 0;
+                                pthread_cond_broadcast(&ctrl->rq_cv);
+                            }
+                        }
+                    } else have = 0;
                 }
                 pthread_mutex_unlock(&ctrl->rq_lk);
                 if (have) {
-                    int rc = lmb_send(fd, LMB_RREAD_FWD, b.p, (uint32_t)b.len, NULL, 0);
-                    free(b.p);
+                    if (getenv("LUMABRI_RELAY_TRACE"))
+                        fprintf(stderr, "[tracker] relay forward op=%u id=%u "
+                                "body=%zu pay=%u\n", op, ctrl->rq_id, b.len, pay_len);
+                    int rc = lmb_send(fd, op, b.p, (uint32_t)b.len, pay, pay_len);
+                    free(b.p); free(pay);
                     if (rc) break;
-                } else free(b.p);
+                } else { free(b.p); free(pay); }
             }
             if (!(pf[0].revents & POLLIN)) continue;
         }
@@ -938,15 +1135,33 @@ static void *conn_thread(void *arg) {
             } else rc = -1;
             break;
         }
-        case LMB_RREAD_R:   if (ctrl) rread_complete(ctrl, &m); break;
-        case LMB_EREG:      rc = handle_ereg(fd, &m); break;
+        case LMB_RREAD_R:
+        case LMB_REXEC_R:   if (ctrl) relay_complete(ctrl, &m); break;
+        case LMB_EREG: {
+            Peer *p = handle_ereg(fd, &m);
+            if (p) {
+                if (!ctrl) {
+                    pthread_mutex_lock(&g_lk); p->refs++; pthread_mutex_unlock(&g_lk);
+                    ctrl = p;
+                } else if (ctrl != p) {
+                    pthread_mutex_lock(&g_lk);
+                    if (p->ctrl_fd == fd) p->ctrl_fd = -1;
+                    pthread_mutex_unlock(&g_lk);
+                    send_err(fd, "one expert identity per control connection");
+                    rc = -1;
+                }
+            } else rc = -1;
+            break;
+        }
         case LMB_EASSIGN:   rc = handle_eassign(fd, &m); break;
         case LMB_EPEERS:    rc = handle_epeers(fd, &m); break;
+        case LMB_ECOVER:    rc = handle_ecover(fd, &m); break;
         case LMB_HASHES:    rc = handle_hashes(fd, &m); break;
         case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;
         case LMB_SWARM:     rc = handle_swarm(fd); break;
         case LMB_RREAD:     rc = handle_rread(fd, &m); break;
+        case LMB_REXEC:     rc = handle_rexec(fd, &m); break;
         case LMB_ASSIGN:    rc = handle_assign(fd, &m); break;
         default:            send_err(fd, "unknown op"); rc = -1; break;
         }
@@ -966,16 +1181,11 @@ int main(int argc, char **argv) {
         else if (!strcmp(argv[i], "--token") && i + 1 < argc)
             snprintf(g_token, sizeof g_token, "%s", argv[++i]);
         else if (!strcmp(argv[i], "--pubkey") && i + 1 < argc) {
-            char hex[80] = "";
-            FILE *pf = fopen(argv[++i], "r");
-            if (pf && fscanf(pf, "%78s", hex) == 1 && strlen(hex) == 64 &&
-                !lmb_unhex(g_pubkey, hex, 32)) g_have_pubkey = 1;
-            else if (strlen(argv[i]) == 64 && !lmb_unhex(g_pubkey, argv[i], 32))
-                g_have_pubkey = 1;
-            if (pf) fclose(pf);
-            if (!g_have_pubkey) {
-                fprintf(stderr, "[tracker] --pubkey wants 32 hex bytes "
-                                "(a file or the value itself)\n");
+            const char *spec = argv[++i];
+            if (lmb_trust_load_spec(&g_trust, spec)) {
+                fprintf(stderr, "[tracker] --pubkey wants a 32-byte hex key, "
+                                "a comma list, or a keyring file (max %d)\n",
+                        LMB_MAX_TRUST_KEYS);
                 return 2;
             }
         }
@@ -988,11 +1198,9 @@ int main(int argc, char **argv) {
     int lfd = lmb_listen(port);
     if (lfd < 0) { perror("[tracker] listen"); return 1; }
     printf("[tracker] listening on :%d\n", port);
-    if (g_have_pubkey) {
-        char pub[70];
-        lmb_hex(pub, g_pubkey, 32);
-        printf("[tracker] signed swarm: only truth signed by %s is accepted\n", pub);
-    }
+    if (g_have_pubkey)
+        printf("[tracker] signed swarm: truth accepted from %zu trusted "
+               "operator key%s\n", g_trust.n, g_trust.n == 1 ? "" : "s");
     fflush(stdout);
     for (;;) {
         int fd = accept(lfd, NULL, NULL);


### PR DESCRIPTION
Five features that make a real wide-area, long-lived swarm practical. **Additive:** every new message is a new op (32-36); no existing frame or magic changed, so a v0.6.0 peer still interoperates and just doesn't offer the new paths. No forced upgrade.

- **Speculative verification, batched** — the draft path proposes several tokens, the target verifies them in one layer round instead of one per token, with public counters. Tokens unchanged (per-engine byte-identity tests still pass).
- **Hedged requests** — `LUMABRI_HEDGE_MS` issues the identical deterministic call to the next-nearest replica after a timeout and takes the first valid response. Cuts tail latency without touching output.
- **Local content-addressed store** — blocks cached under `LUMABRI_CAS` by sha256, reused across checkpoints and models, served with the origin offline. **Every load re-hashes against the signed truth** (`O_NOFOLLOW`, atomic read-only publish); only active where integrity truth exists.
- **Manual key rotation** — `--pubkey` accepts a keyring; a signature valid under any key is accepted, so an operator runs old+new overlap then drops the old. No wire change.
- **NAT relay for EXEC** — `REXEC` relays activations over a NAT'd compute peer's control connection, the way `RREAD` already relays bytes. The tracker forwards, never computes; determinism and the second-replica spot-check are unaffected.

## Tests

`cas_test.sh` and `relay_exec_test.sh` join `make test`; `test_hedge` and `test_key_rotation` are unit tests. Full regression green (18 suites + 2 unit tests). Compiled test binaries are gitignored, not committed.

## Not in this batch

The two open items from private review (peer-registration authentication, transport encryption) are unchanged and still pending coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)