### PR TITLE
fix: send frames with MSG_NOSIGNAL so a vanished peer cannot kill the engine

### DIFF
--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -37,6 +37,11 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0     /* platforms without it deliver SIGPIPE; the
+                              daemons ignore the signal themselves */
+#endif
+
 #define LMB_MAGIC     0x31424D4Cu           /* "LMB1" read as little-endian */
 #define LMB_MAX_BODY  (64u << 20)   /* a REGISTER carrying block hashes for a
                                        whole huge model must fit: 32 B/MiB */
@@ -175,10 +180,15 @@ typedef struct {
 
 /* ---- full-buffer socket I/O ------------------------------------------- */
 
+/* MSG_NOSIGNAL, not write(): this library also runs inside somebody else's
+ * inference engine — via the LD_PRELOAD shim and the patched-engine client —
+ * where it has no business changing the process's SIGPIPE disposition. A
+ * peer that vanishes mid-frame must surface as EPIPE on this call, never as
+ * a signal that kills the engine before failover can run. */
 static int lmb_write_full(int fd, const void *buf, size_t n) {
     const uint8_t *p = (const uint8_t *)buf;
     while (n) {
-        ssize_t w = write(fd, p, n);
+        ssize_t w = send(fd, p, n, MSG_NOSIGNAL);
         if (w < 0) { if (errno == EINTR) continue; return -1; }
         p += w; n -= (size_t)w;
     }

--- a/test_hedge.c
+++ b/test_hedge.c
@@ -15,7 +15,12 @@ static void *echo_server(void *arg) {
     int bad = fd < 0 || lmb_recv(fd, &m) || m.op != LMB_EXEC || m.body_len < 16;
     if (!bad) {
         if (e->delay_ms) usleep((useconds_t)e->delay_ms * 1000u);
-        bad = lmb_send(fd, LMB_EXEC_R, NULL, 0, m.pay, m.pay_len);
+        /* The slow replica answers into a socket the hedge already closed.
+         * That send failing with EPIPE is the mechanism working — the loser's
+         * late frame must never be mistaken for a reply — so only the fast
+         * replica's send is required to succeed. */
+        int sent = lmb_send(fd, LMB_EXEC_R, NULL, 0, m.pay, m.pay_len);
+        bad = sent != 0 && !e->delay_ms;
     }
     lmb_msg_free(&m);
     if (fd >= 0) close(fd);


### PR DESCRIPTION
## Summary
- write every frame with `send(fd, p, n, MSG_NOSIGNAL)` instead of `write()` in `lmb_write_full`, so a peer that vanishes mid-frame surfaces as an ordinary `EPIPE` from `lmb_send` — which every caller already handles as a failed peer — instead of a SIGPIPE that kills the host engine before failover, hedging or the relay floor can run
- the daemons already ignore SIGPIPE in `main()`; the shim and the patched-engine client run inside somebody else's inference engine, where changing the signal disposition is not an option — the fix belongs in the one place all socket writes pass through
- `#ifndef MSG_NOSIGNAL` guard for platforms without it
- fix `test_hedge`'s expectation: the losing replica's late send failing with `EPIPE` is the mechanism working (the losing socket is closed precisely so its frame can never be mistaken for a reply), so only the fast replica's send is required to succeed

## Verification
On a fresh Linux clone (Debian x86_64, WSL2), `./test_hedge` goes **141 (SIGPIPE) → assertion failure → PASS** across the two changes, with the hedging assertions (`hedges == 1`, `hedge_wins == 1`) intact. Full suite from a fresh clone of this branch: selftest, donate, signed_donor, role, security, expert_input, prefetch_policy, cas and key_rotation all pass (`relay_exec_test.sh` needs the `../moe-stream` sibling checkout, as before; test scripts chmod'ed locally — see the companion mode-only PR).

Closes #10