### PR TITLE
fix: default engine path to sibling Colibri checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC      ?= cc
 CFLAGS  ?= -O2 -Wall -Wextra
-ENGINE  ?= ../moe-stream/c
+ENGINE  ?= ../colibri/c
 
 all: tracker maintainer liblumabri.so test_shim lumabri
 


### PR DESCRIPTION
## Summary

- Point the default `ENGINE` path at a sibling Colibri checkout.
- Remove the stale reference to the previous `moe-stream` repository name.

## Why

Lumabri is built against Colibri and the documentation consistently refers to a Colibri checkout. With the current default, phase 2 and relay test targets fail unless every invocation overrides `ENGINE` explicitly:

```text
No rule to make target '../moe-stream/c/olmoe.c', needed by 'expert_node'
```

Using `../colibri/c` matches the normal layout where the Lumabri and Colibri repositories are cloned next to each other.

## Testing

- `make test-relay-exec` with no `ENGINE` override
- Debian 12 container with Colibri available at `../colibri/c`
- Result: `EXEC RELAY: PASS (3-row batch, byte-identical to direct)`