### PR TITLE
fix: validate persisted manifest entries

### DIFF
--- a/lumashim.c
+++ b/lumashim.c
@@ -443,21 +443,32 @@ static int manifest_load(void) {
     snprintf(path, sizeof path, "%s/manifest.txt", g.maps_dir);
     FILE *fp = real_fopen(path, "r");
     if (!fp) return -1;
+    int first = g.nfiles, bad = 0;
     char line[LMB_PATH_MAX + 64];
     while (fgets(line, sizeof line, fp)) {
-        unsigned long long size;
-        char rel[LMB_PATH_MAX];
+        size_t len = strlen(line);
+        if (!len || line[len - 1] != '\n') { bad = 1; break; }
+        line[--len] = 0;
         char *tab = strchr(line, '\t');
-        if (!tab) continue;
-        *tab = 0;
-        size = strtoull(line, NULL, 10);
-        snprintf(rel, sizeof rel, "%s", tab + 1);
-        size_t l = strlen(rel);
-        if (l && rel[l - 1] == '\n') rel[l - 1] = 0;
-        if (rel[0]) file_add(rel, size);
+        if (!tab || tab == line || strchr(tab + 1, '\t')) { bad = 1; break; }
+        *tab++ = 0;
+        char *end = NULL;
+        errno = 0;
+        unsigned long long size = strtoull(line, &end, 10);
+        if (line[0] < '0' || line[0] > '9' || errno == ERANGE || !end || *end ||
+            !lmb_rel_ok(tab) || !file_add(tab, (uint64_t)size)) {
+            bad = 1;
+            break;
+        }
     }
+    if (ferror(fp)) bad = 1;
     fclose(fp);
-    return g.nfiles ? 0 : -1;
+    if (bad) {
+        g.nfiles = first;
+        fprintf(stderr, "[lumabri] saved manifest contains an invalid entry - refusing it\n");
+        return -1;
+    }
+    return g.nfiles > first ? 0 : -1;
 }
 
 typedef struct {


### PR DESCRIPTION
## Summary

- Validate every entry loaded from the persisted offline manifest.
- Reuse `lmb_rel_ok()` for the same path checks applied to network manifests.
- Reject malformed sizes, incomplete lines, extra fields, parse errors, and file-table failures.
- Roll back entries added by the manifest when any row is invalid.

## Why

Network placement and peer manifests validate model-relative paths before using them, but `manifest_load()` previously trusted the cached text file. A corrupted or modified cache manifest could therefore reintroduce names such as `../../outside`, which are later joined to cache directories and opened during sparse-mirror initialization.

The parser also accepted partial numeric values and skipped malformed lines, allowing an offline cache to start from a partially parsed inventory. The offline manifest is now accepted as a complete unit or refused.

## Testing

- Built and tested in a Debian 12 container.
- `selftest.sh`: passed, including the normal offline warm-mirror path.
- Injected `1\t../../canary` into `maps/manifest.txt`.
- Confirmed the manifest was refused before cache initialization.
- Confirmed the outside canary file remained unchanged.
- `git diff --check`: passed.