### PR TITLE
authenticate peer registration: a name is bound to a key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,7 @@ test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h
 
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh
+	./peer_identity_test.sh
 
 test-cas: tracker maintainer liblumabri.so test_shim
 	./cas_test.sh

--- a/expert_node.c
+++ b/expert_node.c
@@ -68,6 +68,7 @@
 #endif
 
 #include "lumabri_proto.h"
+#include "lumabri_sign.h"
 
 #include <omp.h>
 #include <pthread.h>
@@ -119,6 +120,7 @@ static struct {
     pthread_mutex_t load_lk;    /* the engine loader is used one call at a time */
     char name[64], model[64], advertise[64], tracker[64], token[128];
     char profile[LMB_BUILD_PROFILE_MAX];
+    uint8_t peer_sk[64], peer_pk[32];   /* identity to the tracker */
     int bits;
     LmbModelIdentity identity; int have_identity;
     pthread_mutex_t identity_lk;
@@ -438,7 +440,7 @@ static void *conn_thread(void *arg) {
 
 /* ---- tracker heartbeat: this is how chatters find us --------------------- */
 
-static int send_ereg(int fd) {
+static int send_ereg(int fd, const uint8_t nonce[32]) {
     LmbBuf b = {0};
     lmb_buf_str(&b, g.name);
     lmb_buf_str(&b, g.advertise);
@@ -462,6 +464,11 @@ static int send_ereg(int fd) {
     lmb_buf_u32(&b, (uint32_t)g.hidden);
     lmb_buf_u32(&b, (uint32_t)g.n_slots);
     lmb_buf_u32(&b, (uint32_t)g.n_experts);
+    /* identity: sign the connection nonce with this machine's peer key */
+    uint8_t msg[512], sig[64];
+    size_t ml = lmb_peer_auth_msg(nonce, g.name, g.model, g.advertise, msg, sizeof msg);
+    lmb_sign(sig, msg, ml, g.peer_sk);
+    lmb_buf_peer_auth(&b, g.peer_pk, sig);
     int rc = lmb_send(fd, LMB_EREG, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
@@ -482,14 +489,16 @@ static void *control_thread(void *arg) {
             continue;
         }
         warned = 0;
+        uint8_t nonce[32];
+        if (lmb_request_challenge(fd, nonce)) { close(fd); sleep(1); continue; }
         struct timeval tv = { HEARTBEAT_S, 0 };
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
-        if (send_ereg(fd)) { close(fd); sleep(1); continue; }
+        if (send_ereg(fd, nonce)) { close(fd); sleep(1); continue; }
         for (;;) {
             LmbMsg m;
             if (lmb_recv(fd, &m) != 0) {
                 if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                    if (send_ereg(fd)) break;
+                    if (send_ereg(fd, nonce)) break;
                     continue;
                 }
                 break;
@@ -832,6 +841,13 @@ int main(int argc, char **argv) {
                "(--parallel N to say otherwise)\n", g.name);
     fflush(stdout);
 
+    if (g.tracker[0]) {
+        char kp[512];
+        if (lmb_peer_identity(lmb_peer_key_path(kp, sizeof kp), g.peer_sk, g.peer_pk)) {
+            fprintf(stderr, "[%s] cannot load or create a peer key at %s\n", g.name, kp);
+            return 1;
+        }
+    }
     pthread_t t;
     lmb_conn_gate_init(&g_conn_gate);
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -61,6 +61,7 @@
 #define LMB_PATH_MAX  512
 #define LMB_HASH_CHUNK (1u << 20)   /* integrity granularity: sha256 per MiB */
 #define LMB_HASH_MAGIC 0x48414853u  /* "SHAH": optional hash section marker */
+#define LMB_PEER_AUTH_MAGIC 0x52554150u /* "PAUR": trailing peer-identity block */
 
 enum {
     LMB_PING = 1, LMB_OK = 2, LMB_ERR = 3,
@@ -154,6 +155,11 @@ enum {
      * holders' bitmaps, allowing the chatter to enable remote execution only
      * when every routed expert has either a direct or relayed path. */
     LMB_ECOVER = 35, LMB_ECOVER_R = 36,
+    /* Peer identity. A control connection asks CHALLENGE and gets a 32-byte
+     * random nonce; its REGISTER/EREG then carries {pubkey, sig} over that
+     * nonce, so the tracker binds each name to the key that first claimed it
+     * and refuses a different key under the same name. */
+    LMB_CHALLENGE = 37, LMB_CHALLENGE_R = 38,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -341,6 +347,27 @@ static int lmb_buf_str(LmbBuf *b, const char *s) {  /* u16 len + bytes */
     if (lmb_buf_reserve(b, n)) return -1;
     memcpy(b->p + b->len, s, n); b->len += n;
     return 0;
+}
+
+/* Append the 100-byte peer-identity block a REGISTER/EREG ends with. The
+ * caller signs {nonce,name,model,addr} with lmb_peer_auth_msg + lmb_sign;
+ * this only lays the bytes down, so lumabri_proto.h stays crypto-free. */
+static int lmb_buf_peer_auth(LmbBuf *b, const uint8_t pk[32], const uint8_t sig[64]) {
+    if (lmb_buf_u32(b, LMB_PEER_AUTH_MAGIC)) return -1;
+    if (lmb_buf_bytes(b, pk, 32)) return -1;
+    return lmb_buf_bytes(b, sig, 64);
+}
+
+/* Ask the tracker for this connection's identity nonce. 0 and fills nonce, or
+ * -1. Sent once per control connection, right after connect (and AUTH). */
+static int lmb_request_challenge(int fd, uint8_t nonce[32]) {
+    if (lmb_send(fd, LMB_CHALLENGE, NULL, 0, NULL, 0)) return -1;
+    LmbMsg m;
+    if (lmb_recv(fd, &m)) return -1;
+    int ok = m.op == LMB_CHALLENGE_R && m.body_len == 32;
+    if (ok) memcpy(nonce, m.body, 32);
+    lmb_msg_free(&m);
+    return ok ? 0 : -1;
 }
 
 typedef struct { const uint8_t *p; size_t len, off; } LmbCur;

--- a/lumabri_sign.h
+++ b/lumabri_sign.h
@@ -20,6 +20,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
 
 /* ---- SHA-512 (FIPS 180-4) ---------------------------------------------- */
 
@@ -584,6 +588,107 @@ static int lmb_trust_load_spec(LmbTrustKeys *t, const char *spec) {
         if (lmb_trust_add_hex(t, hex)) { t->n = before; return -1; }
     }
     return 0;
+}
+
+/* ---- peer identity ------------------------------------------------------
+ * A peer authenticates its own name to the tracker with an Ed25519 key that
+ * is NOT the operator key: the operator key signs the model, this key only
+ * says "this name is mine". The tracker binds a name to the first key that
+ * claims it and refuses any later claim under a different key, so a stranger
+ * can no longer register under an honest peer's name and evict it.
+ */
+
+/* 32 random bytes, or abort: a weak nonce or seed is worse than none. */
+static void lmb_random(void *buf, size_t n) {
+    FILE *ur = fopen("/dev/urandom", "rb");
+    if (!ur || fread(buf, 1, n, ur) != n) {
+        fprintf(stderr, "[lumabri] cannot read %zu random bytes from "
+                        "/dev/urandom\n", n);
+        if (ur) fclose(ur);
+        abort();
+    }
+    fclose(ur);
+}
+
+/* Load this machine's peer key from `path`, or create it on first use (0600).
+ * One key per machine: every role it runs shares the identity, and each of
+ * their names is bound to it. Returns 0, or -1 if the file is unreadable and
+ * cannot be created. */
+static int lmb_peer_identity(const char *path, uint8_t sk[64], uint8_t pk[32]) {
+    /* Two roles on one machine (a serve's maintainer and expert node) start
+     * together and both may find no key. Exclusive-create on the real path so
+     * exactly one writes it; the loser re-reads the winner's file instead of
+     * writing a second, different key that would fail its own name after a
+     * restart. A brief spin covers the window where the file exists but the
+     * winner has not finished writing it. */
+    for (int attempt = 0; attempt < 200; attempt++) {
+        char hex[200] = "";
+        FILE *f = fopen(path, "r");
+        if (f) {
+            int got = fscanf(f, "%198s", hex) == 1;
+            fclose(f);
+            if (got && strlen(hex) == 128 && !lmb_unhex(sk, hex, 64)) {
+                memcpy(pk, sk + 32, 32);
+                return 0;
+            }
+            usleep(3000);        /* created but not yet written: wait and retry */
+            continue;
+        }
+        int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+        if (fd < 0) {
+            if (errno == EEXIST) { usleep(3000); continue; }
+            return -1;
+        }
+        uint8_t seed[32];
+        lmb_random(seed, sizeof seed);
+        lmb_sign_keypair(pk, sk, seed);
+        char out[130];
+        lmb_hex(out, sk, 64);
+        out[128] = '\n'; out[129] = 0;
+        int wrote = (int)write(fd, out, 129) == 129;
+        if (fsync(fd)) wrote = 0;
+        close(fd);
+        if (!wrote) { unlink(path); return -1; }
+        return 0;
+    }
+    return -1;
+}
+
+/* This machine's default peer-key path: $LUMABRI_PEER_KEY, else
+ * $HOME/.lumabri/peer.key, else ./.lumabri_peer.key. */
+static const char *lmb_peer_key_path(char *buf, size_t cap) {
+    const char *e = getenv("LUMABRI_PEER_KEY");
+    if (e && e[0]) { snprintf(buf, cap, "%s", e); return buf; }
+    const char *home = getenv("HOME");
+    if (home && home[0]) {
+        char dir[400];
+        snprintf(dir, sizeof dir, "%s/.lumabri", home);
+        mkdir(dir, 0700);
+        snprintf(buf, cap, "%s/peer.key", dir);
+    } else snprintf(buf, cap, "./.lumabri_peer.key");
+    return buf;
+}
+
+/* The exact bytes both sides sign for a registration: a domain tag so this
+ * signature can never be replayed as any other, the tracker's per-connection
+ * nonce so it cannot be replayed on another connection, then the identity
+ * this REGISTER claims. Built in one place so the tracker and the peer cannot
+ * disagree by a byte. Returns the length, or 0 if it would not fit. */
+#define LMB_PEER_AUTH_TAG "lumabri-peer-auth-v1"
+static size_t lmb_peer_auth_msg(const uint8_t nonce[32], const char *name,
+                                const char *model, const char *addr,
+                                uint8_t *out, size_t cap) {
+    size_t nl = strlen(name), ml = strlen(model), al = strlen(addr);
+    size_t need = sizeof(LMB_PEER_AUTH_TAG) + 32 + nl + 1 + ml + 1 + al + 1;
+    if (need > cap) return 0;
+    size_t o = 0;
+    memcpy(out + o, LMB_PEER_AUTH_TAG, sizeof(LMB_PEER_AUTH_TAG));
+    o += sizeof(LMB_PEER_AUTH_TAG);
+    memcpy(out + o, nonce, 32); o += 32;
+    memcpy(out + o, name, nl);  o += nl; out[o++] = 0;
+    memcpy(out + o, model, ml); o += ml; out[o++] = 0;
+    memcpy(out + o, addr, al);  o += al; out[o++] = 0;
+    return o;
 }
 
 #endif /* LUMABRI_SIGN_H */

--- a/maintainer.c
+++ b/maintainer.c
@@ -41,6 +41,7 @@ static struct {
     char root[LMB_PATH_MAX];
     char name[64], advertise[64], tracker[64], model[64], token[128];
     uint8_t sk[64]; int have_key;   /* --key: this peer is the origin */
+    uint8_t peer_sk[64], peer_pk[32];  /* this machine's identity to the tracker */
     LmbTrustKeys trust;             /* --pubkey: old+new during manual rotation */
     LmbModelIdentity identity; int have_identity;
     MFile files[MAX_FILES]; int nfiles;
@@ -832,7 +833,7 @@ static void pull_slice(uint64_t budget) {
  * from behind any NAT with zero router configuration. The tracker uses the
  * same connection to push RREAD_FWD when a chatter could not reach us
  * directly: we answer with the bytes and the tracker relays them back. */
-static int register_body_send(int fd, uint64_t held) {
+static int register_body_send(int fd, uint64_t held, const uint8_t nonce[32]) {
     LmbBuf b = {0};
     lmb_buf_str(&b, g.name);
     lmb_buf_str(&b, g.advertise);
@@ -842,6 +843,12 @@ static int register_body_send(int fd, uint64_t held) {
     lmb_buf_u64(&b, atomic_load(&g.served_reads));
     manifest_body(&b);
     hash_section(&b);
+    /* prove the name is ours: sign the tracker's nonce (bound to this
+     * connection) together with the identity this REGISTER claims */
+    uint8_t msg[512], sig[64];
+    size_t ml = lmb_peer_auth_msg(nonce, g.name, g.model, g.advertise, msg, sizeof msg);
+    lmb_sign(sig, msg, ml, g.peer_sk);
+    lmb_buf_peer_auth(&b, g.peer_pk, sig);
     int rc = lmb_send(fd, LMB_REGISTER, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
@@ -864,14 +871,17 @@ static void *control_thread(void *arg) {
             continue;
         }
         warned = 0;
+        /* one identity nonce for this connection, reused by every heartbeat */
+        uint8_t nonce[32];
+        if (lmb_request_challenge(fd, nonce)) { close(fd); sleep(HEARTBEAT_S); continue; }
         struct timeval tv = { HEARTBEAT_S, 0 };   /* recv timeout = beat cadence */
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
-        if (register_body_send(fd, held)) { close(fd); sleep(HEARTBEAT_S); continue; }
+        if (register_body_send(fd, held, nonce)) { close(fd); sleep(HEARTBEAT_S); continue; }
         for (;;) {
             LmbMsg m;
             if (lmb_recv(fd, &m) != 0) {
                 if (errno == EAGAIN || errno == EWOULDBLOCK) {   /* quiet: beat */
-                    if (register_body_send(fd, held)) break;
+                    if (register_body_send(fd, held, nonce)) break;
                     continue;
                 }
                 break;                                            /* dead socket */
@@ -1050,6 +1060,14 @@ int main(int argc, char **argv) {
                g.name, lmb_emu_rtt_us, lmb_emu_jitter_us, lmb_emu_loss_ppm);
     fflush(stdout);
 
+    if (g.tracker[0]) {
+        char kp[512];
+        if (lmb_peer_identity(lmb_peer_key_path(kp, sizeof kp), g.peer_sk, g.peer_pk)) {
+            fprintf(stderr, "[maintainer %s] cannot load or create a peer key at %s\n",
+                    g.name, kp);
+            return 1;
+        }
+    }
     int lfd = lmb_listen(port);
     if (lfd < 0) { perror("[maintainer] listen"); return 1; }
     pthread_t t;

--- a/peer_identity_test.sh
+++ b/peer_identity_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# lumabri — a name belongs to the key that first claimed it.
+#
+# The tracker used to locate a peer's slot by name alone, so anyone who could
+# reach it could register under an honest peer's name and take over its slot,
+# redirecting or evicting it. Each peer now signs a per-connection nonce with
+# its own Ed25519 key; the tracker binds the name to that key on first use and
+# refuses a different key under the same name.
+#
+#   1) an honest maintainer registers and is reachable at its address;
+#   2) an impostor with the SAME name but a different key is rejected, and the
+#      honest peer's address is untouched;
+#   3) the honest peer, restarted with the same key, reclaims its own name;
+#   4) a REGISTER with no signature at all is refused.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s tracker maintainer
+
+T=$(mktemp -d /tmp/lumabri-peerid.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+
+wait_port() {
+    for _ in $(seq 1 100); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
+
+mkdir -p "$T/src"
+head -c $((1024 * 1024)) /dev/urandom > "$T/src/w.bin"
+printf '{"model_type":"olmoe"}\n' > "$T/src/config.json"
+
+# is address ADDR listed among the holders of MODEL at the tracker?
+cat > "$T/probe.c" <<'EOF'
+#include "lumabri_proto.h"
+int main(int argc, char **argv) {
+    LmbBuf b = {0}; LmbMsg m = {0};
+    lmb_buf_str(&b, argv[2]);
+    if (lmb_request(argv[1], LMB_PLACEMENT, b.p, (uint32_t)b.len, &m) ||
+        m.op != LMB_PLACEMENT_R) return 2;
+    LmbCur c = { m.body, m.body_len, 0 }; uint32_t n = 0;
+    if (lmb_cur_u32(&c, &n)) return 2;
+    for (uint32_t i = 0; i < n; i++) {
+        char path[LMB_PATH_MAX], peer[64]; uint64_t size; uint16_t np;
+        if (lmb_cur_str(&c, path, sizeof path) || lmb_cur_u64(&c, &size) ||
+            lmb_cur_u16(&c, &np)) return 2;
+        for (uint16_t p = 0; p < np; p++) {
+            if (lmb_cur_str(&c, peer, sizeof peer)) return 2;
+            if (!strcmp(peer, argv[3])) return 0;   /* present */
+        }
+    }
+    return 1;                                       /* absent */
+}
+EOF
+cc -O2 -w -I. "$T/probe.c" -o "$T/probe" -lpthread
+
+# a REGISTER with no identity block, to prove the signature is mandatory
+cat > "$T/noauth.c" <<'EOF'
+#include "lumabri_proto.h"
+int main(int argc, char **argv) {
+    int fd = lmb_connect(argv[1]);
+    if (fd < 0) return 2;
+    LmbBuf b = {0};
+    lmb_buf_str(&b, "origin"); lmb_buf_str(&b, "127.0.0.1:1");
+    lmb_buf_str(&b, "fx"); lmb_buf_u64(&b, 0);
+    lmb_buf_u64(&b, 0); lmb_buf_u64(&b, 0); lmb_buf_u32(&b, 0);
+    LmbMsg m = {0};
+    int rc = lmb_send(fd, LMB_REGISTER, b.p, (uint32_t)b.len, NULL, 0) ||
+             lmb_recv(fd, &m);
+    int refused = !rc && m.op == LMB_ERR;
+    lmb_msg_free(&m); close(fd);
+    return refused ? 0 : 1;
+}
+EOF
+cc -O2 -w -I. "$T/noauth.c" -o "$T/noauth" -lpthread
+
+./tracker --port 7640 > "$T/tracker.log" 2>&1 & PIDS+=($!)
+wait_port 7640
+
+run_origin() {   # run_origin PORT KEYFILE  -> background pid in $LASTPID
+    env LUMABRI_PEER_KEY="$2" ./maintainer --root "$T/src" --port "$1" \
+        --tracker 127.0.0.1:7640 --name origin --model-name fx \
+        --advertise "127.0.0.1:$1" > "$T/origin-$1.log" 2>&1 &
+    LASTPID=$!
+}
+
+wait_placed() {  # wait until ADDR is a holder of fx
+    for _ in $(seq 1 100); do
+        "$T/probe" 127.0.0.1:7640 fx "$1" && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+echo "· 1) an honest maintainer registers under its name"
+run_origin 7641 "$T/keyA"; PIDS+=($LASTPID); HONEST=$LASTPID
+wait_port 7641
+wait_placed 127.0.0.1:7641 || { echo "   honest origin never appeared"; cat "$T/origin-7641.log"; exit 1; }
+echo "   ✓ origin @ 127.0.0.1:7641"
+
+echo "· 2) an impostor with the same name but a different key is refused"
+run_origin 7642 "$T/keyB"; PIDS+=($LASTPID)
+wait_port 7642
+sleep 2                                   # give it heartbeats to try
+for _ in $(seq 1 50); do
+    grep -q "already held by another key" "$T/tracker.log" && break
+    sleep 0.1
+done
+grep -q "already held by another key" "$T/tracker.log" || {
+    echo "   the tracker did not reject the impostor"; cat "$T/tracker.log"; exit 1; }
+if "$T/probe" 127.0.0.1:7640 fx 127.0.0.1:7642; then
+    echo "   the impostor's address took over the name"; exit 1; fi
+"$T/probe" 127.0.0.1:7640 fx 127.0.0.1:7641 || {
+    echo "   the honest peer's address was displaced"; exit 1; }
+echo "   ✓ rejected; origin still @ 127.0.0.1:7641"
+
+echo "· 3) the honest peer restarts with the same key and reclaims its name"
+kill "$HONEST" 2>/dev/null || true
+wait "$HONEST" 2>/dev/null || true
+run_origin 7643 "$T/keyA"; PIDS+=($LASTPID)   # same keyA, new port
+wait_port 7643
+wait_placed 127.0.0.1:7643 || {
+    echo "   the honest peer could not reclaim its own name"; cat "$T/origin-7643.log"; exit 1; }
+echo "   ✓ reclaimed with the same key"
+
+echo "· 4) a REGISTER with no signature is refused"
+"$T/noauth" 127.0.0.1:7640 || { echo "   an unsigned REGISTER was accepted"; exit 1; }
+echo "   ✓ unauthenticated registration refused"
+
+echo "LUMABRI PEER IDENTITY TEST: PASS"

--- a/security_test.sh
+++ b/security_test.sh
@@ -208,34 +208,46 @@ wait "$HOLDER_PID" 2>/dev/null || true
 echo "   ✓ configured connection cap rejects excess idle clients"
 
 echo "· 6) stale peer names do not exhaust the tracker's lifetime capacity"
+# Registrations are now signed, so each junk peer authenticates under its own
+# name and key. Mandatory auth alone means anonymous junk cannot take a slot
+# at all; this still exercises the reclaim path, with authenticated peers that
+# then go stale.
+cat > "$T/authreg.c" <<'EOF'
+#include "lumabri_proto.h"
+#include "lumabri_sign.h"
+int main(int argc, char **argv) {         /* addr name keyfile */
+    uint8_t sk[64], pk[32];
+    if (lmb_peer_identity(argv[3], sk, pk)) return 2;
+    int fd = lmb_connect(argv[1]);
+    if (fd < 0) return 2;
+    uint8_t nonce[32];
+    if (lmb_request_challenge(fd, nonce)) { close(fd); return 2; }
+    LmbBuf b = {0};
+    lmb_buf_str(&b, argv[2]); lmb_buf_str(&b, "127.0.0.1:9");
+    lmb_buf_str(&b, "model"); lmb_buf_u64(&b, 0);
+    lmb_buf_u64(&b, 0); lmb_buf_u64(&b, 0); lmb_buf_u32(&b, 0);
+    uint8_t msg[512], sig[64];
+    size_t ml = lmb_peer_auth_msg(nonce, argv[2], "model", "127.0.0.1:9", msg, sizeof msg);
+    lmb_sign(sig, msg, ml, sk);
+    lmb_buf_peer_auth(&b, pk, sig);
+    LmbMsg m = {0};
+    int rc = lmb_send(fd, LMB_REGISTER, b.p, (uint32_t)b.len, NULL, 0) || lmb_recv(fd, &m);
+    int accepted = !rc && m.op != LMB_ERR;
+    lmb_msg_free(&m); free(b.p); close(fd);
+    return accepted ? 0 : 1;
+}
+EOF
+cc -O2 -w -I. "$T/authreg.c" -o "$T/authreg" -lpthread
+
 env LUMABRI_STALE_MS=100 ./tracker --port 7555 > "$T/reuse.log" 2>&1 & PIDS+=($!)
 sleep 0.3
-python3 - 7555 <<'PY'
-import socket, struct, sys, time
-port = int(sys.argv[1])
-def string(s):
-    b = s.encode()
-    return struct.pack("<H", len(b)) + b
-def register(i):
-    body = string(f"gone-{i}") + string("127.0.0.1:9") + string("model")
-    body += struct.pack("<I", 0)
-    s = socket.create_connection(("127.0.0.1", port))
-    s.sendall(struct.pack("<IIII", 0x31424D4C, 23, len(body), 0) + body)
-    pre = b""
-    while len(pre) < 16:
-        part = s.recv(16 - len(pre))
-        if not part:
-            raise SystemExit(f"peer {i}: tracker closed without a reply")
-        pre += part
-    op = struct.unpack("<IIII", pre)[1]
-    s.close()
-    if op != 2:
-        raise SystemExit(f"peer {i}: tracker table was not reusable")
-for i in range(64):
-    register(i)
-time.sleep(0.2)
-register(64)
-PY
+for i in $(seq 0 63); do
+    "$T/authreg" 127.0.0.1:7555 "gone-$i" "$T/jk-$i" || {
+        echo "   authenticated peer $i was refused a slot in an empty table"; exit 1; }
+done
+sleep 0.2                                  # let the 64 go stale
+"$T/authreg" 127.0.0.1:7555 "gone-64" "$T/jk-64" || {
+    echo "   a fresh peer could not reclaim a stale slot"; exit 1; }
 echo "   ✓ stale slot recycled; the cap applies to live peers, not history"
 
 echo "LUMABRI SECURITY TEST: PASS"

--- a/tracker.c
+++ b/tracker.c
@@ -42,6 +42,8 @@ typedef struct {
     int used;
     unsigned refs;              /* control/relay users holding this slot */
     int is_expert;              /* EREG peer: executes experts, holds no files */
+    uint8_t pubkey[32];         /* this name's identity, bound on first claim */
+    int has_key;
     uint32_t nexperts;
     /* WHICH experts, not just how many: one bit per (slot, expert). Without
      * it the tracker can count executors but cannot tell whether they
@@ -243,8 +245,40 @@ static void send_err(int fd, const char *msg) {
 
 /* ---- REGISTER ----------------------------------------------------------- */
 
-static Peer *handle_register(int fd, LmbMsg *m) {
-    LmbCur c = { m->body, m->body_len, 0 };
+/* Peer identity travels as a fixed 100-byte block at the very end of REGISTER
+ * and EREG: {u32 magic, pubkey[32], sig[64]}. Strip it before the rest of the
+ * body is parsed, so every existing field parses against the shortened length
+ * exactly as before. Returns that shortened length; sets *present and fills
+ * pk/sig when the block is there. The signature itself is checked later,
+ * once name/model/addr are known, against the connection's nonce. */
+static size_t peer_auth_strip(const LmbMsg *m, uint8_t pk[32], uint8_t sig[64],
+                              int *present) {
+    *present = 0;
+    size_t blen = m->body_len;
+    if (blen < 100 || lmb_get32(m->body + blen - 100) != LMB_PEER_AUTH_MAGIC)
+        return blen;
+    const uint8_t *tail = m->body + blen - 100;
+    memcpy(pk, tail + 4, 32);
+    memcpy(sig, tail + 36, 64);
+    *present = 1;
+    return blen - 100;
+}
+
+/* 0 if this name may be held by this key: unclaimed, or already this key.
+ * -1 if the name is owned by a different key (the takeover this closes). */
+static int name_key_ok(const char *name, int is_expert, const uint8_t pk[32]) {
+    for (int i = 0; i < MAX_PEERS; i++)
+        if (g_peers[i].used && g_peers[i].is_expert == is_expert &&
+            g_peers[i].has_key && !strcmp(g_peers[i].name, name))
+            return memcmp(g_peers[i].pubkey, pk, 32) ? -1 : 0;
+    return 0;
+}
+
+static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
+    uint8_t peer_pk[32], peer_sig[64];
+    int have_auth = 0;
+    size_t blen = peer_auth_strip(m, peer_pk, peer_sig, &have_auth);
+    LmbCur c = { m->body, blen, 0 };
     char name[64], addr[64], model[64];
     uint64_t held, sbytes, sreads;
     uint32_t n;
@@ -252,6 +286,22 @@ static Peer *handle_register(int fd, LmbMsg *m) {
         lmb_cur_str(&c, model, sizeof model) || lmb_cur_u64(&c, &held) ||
         lmb_cur_u64(&c, &sbytes) || lmb_cur_u64(&c, &sreads) ||
         lmb_cur_u32(&c, &n) || n > MAX_FILES) { send_err(fd, "bad register"); return NULL; }
+    /* Prove the name belongs to this key before anything is bound to it. The
+     * signature is over the connection's nonce, so it cannot be replayed onto
+     * another connection, and over name+model+addr, so it cannot be lifted
+     * onto a different claim. */
+    if (!have_auth || !nonce) {
+        printf("[tracker] REJECTED: %s did not authenticate its identity\n", name);
+        fflush(stdout); send_err(fd, "registration must be signed (CHALLENGE first)");
+        return NULL;
+    }
+    uint8_t authmsg[512];
+    size_t aml = lmb_peer_auth_msg(nonce, name, model, addr, authmsg, sizeof authmsg);
+    if (!aml || lmb_sign_verify(peer_sig, authmsg, aml, peer_pk)) {
+        printf("[tracker] REJECTED: %s has a bad identity signature\n", name);
+        fflush(stdout); send_err(fd, "bad identity signature");
+        return NULL;
+    }
     PFile *files = (PFile *)calloc(n ? n : 1, sizeof *files);
     if (!files) { send_err(fd, "oom"); return NULL; }
     /* The index is what every chatter builds its local mirror from, so a
@@ -347,6 +397,17 @@ static Peer *handle_register(int fd, LmbMsg *m) {
         fflush(stdout);
         n = 0;
     }
+    /* trust on first use: the name belongs to the key that first claimed it,
+     * and a different key under that name is the takeover this refuses */
+    if (name_key_ok(name, 0, peer_pk) < 0) {
+        pthread_mutex_unlock(&g_lk);
+        printf("[tracker] REJECTED: %s is already held by another key\n", name);
+        fflush(stdout);
+        for (uint32_t i = 0; i < n; i++) free(fh[i]);
+        free(fh); free(fnh); free(fsig); free(fhas); free(files);
+        send_err(fd, "name held by another key");
+        return NULL;
+    }
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && !g_peers[i].is_expert &&
             !strcmp(g_peers[i].name, name)) { slot = &g_peers[i]; idx = i; break; }
@@ -354,6 +415,7 @@ static Peer *handle_register(int fd, LmbMsg *m) {
         slot = peer_slot_new(0, &idx);
         fresh = slot != NULL;
     }
+    if (slot) { memcpy(slot->pubkey, peer_pk, 32); slot->has_key = 1; }
     /* observed address: a maintainer that advertises localhost from another
      * machine gets its host part corrected to what this connection shows —
      * the --advertise footgun dies here, ports stay as declared */
@@ -396,14 +458,29 @@ static Peer *handle_register(int fd, LmbMsg *m) {
  * Expert peers never enter placements (they hold no files); EPEERS is how a
  * chatter learns who can EXECUTE for a model, server included. */
 
-static Peer *handle_ereg(int fd, LmbMsg *m) {
-    LmbCur c = { m->body, m->body_len, 0 };
+static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
+    uint8_t peer_pk[32], peer_sig[64];
+    int have_auth = 0;
+    size_t blen = peer_auth_strip(m, peer_pk, peer_sig, &have_auth);
+    LmbCur c = { m->body, blen, 0 };
     char name[64], addr[64], model[64];
     uint32_t nexperts;
     if (lmb_cur_str(&c, name, sizeof name) || lmb_cur_str(&c, addr, sizeof addr) ||
         lmb_cur_str(&c, model, sizeof model) || lmb_cur_u32(&c, &nexperts)) {
         send_err(fd, "bad ereg"); return NULL;
     }
+    if (!have_auth || !nonce) {
+        printf("[tracker] REJECTED: %s (expert) did not authenticate\n", name);
+        fflush(stdout); send_err(fd, "ereg must be signed (CHALLENGE first)");
+        return NULL;
+    }
+    { uint8_t authmsg[512];
+      size_t aml = lmb_peer_auth_msg(nonce, name, model, addr, authmsg, sizeof authmsg);
+      if (!aml || lmb_sign_verify(peer_sig, authmsg, aml, peer_pk)) {
+          printf("[tracker] REJECTED: %s (expert) bad identity signature\n", name);
+          fflush(stdout); send_err(fd, "bad identity signature");
+          return NULL;
+      } }
     /* optional, appended by newer nodes: the bitmap of what it holds */
     uint32_t bl = 0; const uint8_t *bits = NULL;
     if (!lmb_cur_u32(&c, &bl) && bl && bl <= (1u << 20) && c.off + bl <= c.len) {
@@ -424,6 +501,12 @@ static Peer *handle_ereg(int fd, LmbMsg *m) {
     Peer *slot = NULL;
     int fresh = 0;
     pthread_mutex_lock(&g_lk);
+    if (name_key_ok(name, 1, peer_pk) < 0) {
+        pthread_mutex_unlock(&g_lk);
+        printf("[tracker] REJECTED: expert %s is already held by another key\n", name);
+        fflush(stdout); send_err(fd, "name held by another key");
+        return NULL;
+    }
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert &&
             !strcmp(g_peers[i].name, name)) { slot = &g_peers[i]; break; }
@@ -431,6 +514,7 @@ static Peer *handle_ereg(int fd, LmbMsg *m) {
         slot = peer_slot_new(1, NULL);
         fresh = slot != NULL;
     }
+    if (slot) { memcpy(slot->pubkey, peer_pk, 32); slot->has_key = 1; }
     const char *use_addr = addr;
     char fixed[64];
     struct sockaddr_in sin;
@@ -1052,6 +1136,7 @@ static void *conn_thread(void *arg) {
     int fd = (int)(intptr_t)arg;
     Peer *ctrl = NULL;    /* set once this connection REGISTERs */
     int authed = g_token[0] ? 0 : 1;
+    uint8_t nonce[32]; int have_nonce = 0;   /* per-connection identity challenge */
     for (;;) {
         if (ctrl) {
             struct pollfd pf[2] = { { fd, POLLIN, 0 }, { ctrl->evfd, POLLIN, 0 } };
@@ -1117,8 +1202,13 @@ static void *conn_thread(void *arg) {
             break;
         }
         case LMB_PING:      rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0); break;
+        case LMB_CHALLENGE:
+            lmb_random(nonce, sizeof nonce);
+            have_nonce = 1;
+            rc = lmb_send(fd, LMB_CHALLENGE_R, nonce, sizeof nonce, NULL, 0);
+            break;
         case LMB_REGISTER: {
-            Peer *p = handle_register(fd, &m);
+            Peer *p = handle_register(fd, &m, have_nonce ? nonce : NULL);
             if (p) {
                 if (!ctrl) {
                     pthread_mutex_lock(&g_lk);
@@ -1138,7 +1228,7 @@ static void *conn_thread(void *arg) {
         case LMB_RREAD_R:
         case LMB_REXEC_R:   if (ctrl) relay_complete(ctrl, &m); break;
         case LMB_EREG: {
-            Peer *p = handle_ereg(fd, &m);
+            Peer *p = handle_ereg(fd, &m, have_nonce ? nonce : NULL);
             if (p) {
                 if (!ctrl) {
                     pthread_mutex_lock(&g_lk); p->refs++; pthread_mutex_unlock(&g_lk);


### PR DESCRIPTION
Closes the peer-name-takeover finding. The tracker located a peer's slot by name alone, so any reachable client could REGISTER/EREG under an honest peer's name and evict or redirect it (availability; no model bytes).

## How

- Each peer gets its own Ed25519 identity, distinct from the operator key, generated once per machine at `~/.lumabri/peer.key` (`LUMABRI_PEER_KEY` overrides).
- A control connection asks `CHALLENGE`, gets a 32-byte random nonce, and its `REGISTER`/`EREG` carries a trailing `{pubkey, sig}` over `{nonce, name, model, addr}`. Per-connection nonce ⇒ no replay onto another connection; signed fields ⇒ no lifting onto a different claim.
- The tracker binds a name to the first key that presents it (**trust on first use**) and refuses a later registration under that name with a different key. Signature is **mandatory**.

## Protocol break → v0.7.0

Every peer must present the identity block, so a pre-0.7 maintainer/expert-node is refused by a 0.7 tracker. **A swarm upgrades together.** The chatter path is untouched (it reads from the tracker, never registers).

## Tests

`peer_identity_test.sh`: honest registration; impostor refused with the honest address intact; restart reclaim with the same key; unsigned REGISTER refused. `security_test` stale-reclaim now authenticates its junk peers. Full regression green (19 suites + 2 unit tests).

## Not this

The plaintext-transport finding is unchanged and still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)