### PR TITLE
harden: Ed25519 UB, per-identity name cap, signal-handler race

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -127,18 +127,34 @@ static int g_nchildren = 0;
 static char **g_cargv[8];
 static const char *g_cwhat[8];
 
+/* on_sigint reads g_children/g_nchildren; the main thread writes them. Block
+ * the two signals around every write so the handler never sees the array
+ * half-updated (a torn read would kill a stale pid or miss a live child). */
+static void children_lock(sigset_t *saved) {
+    sigset_t s; sigemptyset(&s);
+    sigaddset(&s, SIGINT); sigaddset(&s, SIGTERM);
+    sigprocmask(SIG_BLOCK, &s, saved);
+}
+static void children_unlock(const sigset_t *saved) {
+    sigprocmask(SIG_SETMASK, saved, NULL);
+}
+
 static void spawn_tracked(char *const argv[], const char *what) {
     int n = 0;
     while (argv[n]) n++;
     char **copy = (char **)calloc((size_t)n + 1, sizeof *copy);
     for (int i = 0; i < n; i++) copy[i] = strdup(argv[i]);
+    pid_t pid = spawn_argv(argv);          /* the slow part, outside the mask */
+    sigset_t saved; children_lock(&saved);
     int idx = g_nchildren;
     g_cargv[idx] = copy;
     g_cwhat[idx] = what;
-    g_children[g_nchildren++] = spawn_argv(argv);
+    g_children[idx] = pid;
+    g_nchildren++;
+    children_unlock(&saved);
 }
 
-static volatile int g_stopping = 0;
+static volatile sig_atomic_t g_stopping = 0;
 
 static void on_sigint(int sig) {
     (void)sig;
@@ -390,12 +406,19 @@ static int cmd_serve(int argc, char **argv) {
                    "scaricano gli esperti invece di farli eseguire%s\n", C_DIM, C_R);
             fflush(stdout);
             sleep(5);
-            g_children[idx] = spawn_argv(g_cargv[idx]);
+            pid_t np = spawn_argv(g_cargv[idx]);
+            sigset_t saved; children_lock(&saved);
+            g_children[idx] = np;
+            children_unlock(&saved);
             printf("  %s%s riavviato%s\n", C_DIM, g_cwhat[idx], C_R);
             fflush(stdout);
             continue;
         }
-        if (idx >= 0) g_children[idx] = g_children[--g_nchildren];
+        if (idx >= 0) {
+            sigset_t saved; children_lock(&saved);
+            g_children[idx] = g_children[--g_nchildren];
+            children_unlock(&saved);
+        }
     }
     return 0;
 }
@@ -1256,7 +1279,8 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             const char *pub = getenv("LUMABRI_PUBKEY");
             if (pub && pub[0]) { argv[a++] = "--pubkey"; argv[a++] = (char *)pub; }
             argv[a] = NULL;
-            g_children[g_nchildren++] = spawn_argv(argv);
+            { pid_t np = spawn_argv(argv); sigset_t sv; children_lock(&sv);
+              g_children[g_nchildren++] = np; children_unlock(&sv); }
             printf("  %s\xe2\x9c\xa6 dono %.0f GB di %s%s%s%s: il tracker mi assegna "
                    "i file piu\xcc\x80 rari%s\n",
                    C_GRN, r->gb, C_R, C_BOLD, model, C_DIM, C_R);
@@ -1285,7 +1309,8 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             argv[a++] = "--model-name"; argv[a++] = (char *)model;
             argv[a++] = "--cache";      argv[a++] = "64";
             argv[a] = NULL;
-            g_children[g_nchildren++] = spawn_argv(argv);
+            { pid_t np = spawn_argv(argv); sigset_t sv; children_lock(&sv);
+              g_children[g_nchildren++] = np; children_unlock(&sv); }
             printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s)%s\n",
                    C_GRN, C_R, C_DIM, node, C_R);
         }

--- a/lumabri_sign.h
+++ b/lumabri_sign.h
@@ -149,7 +149,7 @@ static void lmb_car(lmb_gf o) {
         o[i] += (1LL << 16);
         int64_t c = o[i] >> 16;
         o[(i + 1) * (i < 15)] += c - 1 + 37 * (c - 1) * (i == 15);
-        o[i] -= c << 16;
+        o[i] -= c * 65536;          /* not c<<16: c may be negative (UB) */
     }
 }
 
@@ -303,7 +303,8 @@ static void lmb_modL(uint8_t *r, int64_t x[64]) {
         for (j = i - 32; j < i - 12; ++j) {
             x[j] += carry - 16 * x[i] * (int64_t)lmb_L[j - (i - 32)];
             carry = (x[j] + 128) >> 8;
-            x[j] -= carry << 8;
+            x[j] -= carry * 256;     /* not carry<<8: carry may be negative,
+                                        and left-shifting a negative is UB */
         }
         x[j] += carry;
         x[i] = 0;

--- a/security_test.sh
+++ b/security_test.sh
@@ -250,4 +250,16 @@ sleep 0.2                                  # let the 64 go stale
     echo "   a fresh peer could not reclaim a stale slot"; exit 1; }
 echo "   ✓ stale slot recycled; the cap applies to live peers, not history"
 
+echo "· 7) one key cannot monopolise the table with many names"
+env LUMABRI_STALE_MS=600000 ./tracker --port 7556 > "$T/cap.log" 2>&1 & PIDS+=($!)
+sleep 0.3
+ok=0
+for i in $(seq 1 8); do
+    "$T/authreg" 127.0.0.1:7556 "mine-$i" "$T/onekey" && ok=$((ok+1))
+done
+[ "$ok" -eq 8 ] || { echo "   the first 8 names for one key were not all accepted ($ok)"; exit 1; }
+if "$T/authreg" 127.0.0.1:7556 "mine-9" "$T/onekey"; then
+    echo "   a 9th name under the same key was accepted"; exit 1; fi
+echo "   ✓ 8 names held, the 9th refused; anonymous junk cannot exhaust the table"
+
 echo "LUMABRI SECURITY TEST: PASS"

--- a/tracker.c
+++ b/tracker.c
@@ -274,6 +274,24 @@ static int name_key_ok(const char *name, int is_expert, const uint8_t pk[32]) {
     return 0;
 }
 
+/* Authentication stops anonymous junk from taking a slot, but one attacker
+ * can still mint many keys. Cap how many distinct names a single identity may
+ * hold, so no key can monopolise the 64-slot table: a real machine uses a
+ * handful (serve = origin + executor, a donor one or two). Counts live slots
+ * only, so a restart that reclaims the same names is unaffected. */
+#define MAX_NAMES_PER_KEY 8
+static int identity_has_room(const uint8_t pk[32], const char *name, int is_expert) {
+    int held = 0;
+    for (int i = 0; i < MAX_PEERS; i++) {
+        if (!g_peers[i].used || !g_peers[i].has_key) continue;
+        if (memcmp(g_peers[i].pubkey, pk, 32)) continue;
+        if (g_peers[i].is_expert == is_expert && !strcmp(g_peers[i].name, name))
+            return 1;                      /* reclaiming a name it already holds */
+        held++;
+    }
+    return held < MAX_NAMES_PER_KEY;
+}
+
 static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
     uint8_t peer_pk[32], peer_sig[64];
     int have_auth = 0;
@@ -408,6 +426,15 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
         send_err(fd, "name held by another key");
         return NULL;
     }
+    if (!identity_has_room(peer_pk, name, 0)) {
+        pthread_mutex_unlock(&g_lk);
+        printf("[tracker] REJECTED: one key already holds %d names\n", MAX_NAMES_PER_KEY);
+        fflush(stdout);
+        for (uint32_t i = 0; i < n; i++) free(fh[i]);
+        free(fh); free(fnh); free(fsig); free(fhas); free(files);
+        send_err(fd, "too many names for one key");
+        return NULL;
+    }
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && !g_peers[i].is_expert &&
             !strcmp(g_peers[i].name, name)) { slot = &g_peers[i]; idx = i; break; }
@@ -505,6 +532,12 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
         pthread_mutex_unlock(&g_lk);
         printf("[tracker] REJECTED: expert %s is already held by another key\n", name);
         fflush(stdout); send_err(fd, "name held by another key");
+        return NULL;
+    }
+    if (!identity_has_room(peer_pk, name, 1)) {
+        pthread_mutex_unlock(&g_lk);
+        printf("[tracker] REJECTED: one key already holds %d names\n", MAX_NAMES_PER_KEY);
+        fflush(stdout); send_err(fd, "too many names for one key");
         return NULL;
     }
     for (int i = 0; i < MAX_PEERS; i++)


### PR DESCRIPTION
Three items from private review, all verified.

- **Two Ed25519 signed-shift UBs.** `c << 16` and `carry << 8` in the Curve25519 reduction shift a possibly-negative `int64` (undefined behaviour). UBSan flagged both on a sign/verify round-trip; replaced with `* 65536` / `* 256`, defined for negatives. Output bit-identical: `sign_test` still matches RFC 8032 and OpenSSL both ways, and the round-trip is UBSan-clean.
- **Peer-table exhaustion residual.** Authentication (v0.7) already stops anonymous slot-grabbing; one attacker can still mint keys. The tracker now caps distinct names per identity at 8 (a machine uses one or two), so no key can monopolise the 64-slot table. `security_test` case 7 proves the 9th name is refused.
- **Signal-handler race.** `on_sigint` read `g_children`/`g_nchildren` while the main thread mutated them; every write now runs with SIGINT/SIGTERM blocked, and `g_stopping` is `volatile sig_atomic_t`.

Regression green (11 suites + 2 unit tests).

Any remaining ThreadSanitizer chat-frontend races should come through the security advisory with their traces, so the exact sites are fixed rather than guessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)