### PR TITLE
fix: reject overlong swarm tokens

### DIFF
--- a/expert_node.c
+++ b/expert_node.c
@@ -118,7 +118,8 @@ static struct {
     pthread_mutex_t c_lk;       /* cache table */
     pthread_cond_t c_cv;
     pthread_mutex_t load_lk;    /* the engine loader is used one call at a time */
-    char name[64], model[64], advertise[64], tracker[64], token[128];
+    char name[64], model[64], advertise[64], tracker[64];
+    char token[LMB_TOKEN_MAX + 1];
     char profile[LMB_BUILD_PROFILE_MAX];
     uint8_t peer_sk[64], peer_pk[32];   /* identity to the tracker */
     int bits;
@@ -413,10 +414,10 @@ static void *conn_thread(void *arg) {
         case LMB_PING:      lmb_emu_delay();   /* probes must see the distance */
                             rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0); break;
         case LMB_AUTH: {
-            char tok[128] = "";
+            char tok[LMB_TOKEN_MAX + 1] = "";
             LmbCur c = { m.body, m.body_len, 0 };
-            lmb_cur_str(&c, tok, sizeof tok);
-            if (!g.token[0] || !strcmp(tok, g.token)) {
+            int bad = lmb_cur_str(&c, tok, sizeof tok) || c.off != c.len;
+            if (!bad && (!g.token[0] || !strcmp(tok, g.token))) {
                 authed = 1;
                 rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
             } else { send_err(fd, "bad token"); rc = -1; }
@@ -669,6 +670,11 @@ int main(int argc, char **argv) {
     if (cache < 0) cache = 0;
     signal(SIGPIPE, SIG_IGN);
     const char *tok = getenv("LUMABRI_TOKEN");
+    if (tok && strlen(tok) > LMB_TOKEN_MAX) {
+        fprintf(stderr, "LUMABRI_TOKEN must be at most %u bytes\n",
+                (unsigned)LMB_TOKEN_MAX);
+        return 2;
+    }
     if (tok) snprintf(g.token, sizeof g.token, "%s", tok);
     if (!g.model[0]) {                /* default model name: the dir basename */
         char tmp[LMB_PATH_MAX];

--- a/lumabri.c
+++ b/lumabri.c
@@ -1750,9 +1750,15 @@ static int cmd_key(int argc, char **argv) {
 
 int main(int argc, char **argv) {
     g_tty = isatty(1);
+    if (argc >= 2 && !strcmp(argv[1], "key")) return cmd_key(argc - 2, argv + 2);
+    const char *tok = getenv("LUMABRI_TOKEN");
+    if (tok && strlen(tok) > LMB_TOKEN_MAX) {
+        fprintf(stderr, "LUMABRI_TOKEN must be at most %u bytes\n",
+                (unsigned)LMB_TOKEN_MAX);
+        return 2;
+    }
     if (argc >= 2 && !strcmp(argv[1], "serve")) return cmd_serve(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "chat"))  return cmd_chat(argc - 2, argv + 2);
-    if (argc >= 2 && !strcmp(argv[1], "key"))   return cmd_key(argc - 2, argv + 2);
     /* No arguments and a terminal: this is a person, not a script. Chat is
      * the only thing a person wants by default, and everything it needs is
      * either remembered or asked for in the panel. */

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -64,6 +64,7 @@
  * the size arithmetic on a model with a large hidden dimension. */
 #define LMB_MAX_EXEC_ROWS 4096u
 #define LMB_PATH_MAX  512
+#define LMB_TOKEN_MAX 127u
 #define LMB_HASH_CHUNK (1u << 20)   /* integrity granularity: sha256 per MiB */
 #define LMB_HASH_MAGIC 0x48414853u  /* "SHAH": optional hash section marker */
 #define LMB_PEER_AUTH_MAGIC 0x52554150u /* "PAUR": trailing peer-identity block */
@@ -657,8 +658,9 @@ static int lmb_listen(int port) {
 static int lmb_auth(int fd) {
     const char *tok = getenv("LUMABRI_TOKEN");
     if (!tok || !tok[0]) return 0;
+    if (strlen(tok) > LMB_TOKEN_MAX) { errno = EMSGSIZE; return -1; }
     LmbBuf b = {0};
-    lmb_buf_str(&b, tok);
+    if (lmb_buf_str(&b, tok)) { free(b.p); return -1; }
     int rc = lmb_send(fd, LMB_AUTH, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     if (rc) return rc;

--- a/maintainer.c
+++ b/maintainer.c
@@ -41,7 +41,8 @@ typedef struct {
 
 static struct {
     char root[LMB_PATH_MAX];
-    char name[64], advertise[64], tracker[64], model[64], token[128];
+    char name[64], advertise[64], tracker[64], model[64];
+    char token[LMB_TOKEN_MAX + 1];
     uint8_t sk[64]; int have_key;   /* --key: this peer is the origin */
     uint8_t peer_sk[64], peer_pk[32];  /* this machine's identity to the tracker */
     LmbTrustKeys trust;             /* --pubkey: old+new during manual rotation */
@@ -546,10 +547,10 @@ static void *conn_thread(void *arg) {
         switch (m.op) {
         case LMB_PING:     rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0); break;
         case LMB_AUTH: {
-            char tok[128] = "";
+            char tok[LMB_TOKEN_MAX + 1] = "";
             LmbCur c = { m.body, m.body_len, 0 };
-            lmb_cur_str(&c, tok, sizeof tok);
-            if (!g.token[0] || !strcmp(tok, g.token)) {
+            int bad = lmb_cur_str(&c, tok, sizeof tok) || c.off != c.len;
+            if (!bad && (!g.token[0] || !strcmp(tok, g.token))) {
                 authed = 1;
                 rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
             } else { send_err(fd, "bad token"); rc = -1; }
@@ -1029,6 +1030,11 @@ int main(int argc, char **argv) {
     }
     if (!g.root[0]) { fprintf(stderr, "[maintainer] --root is required\n"); return 2; }
     const char *tok = getenv("LUMABRI_TOKEN");
+    if (tok && strlen(tok) > LMB_TOKEN_MAX) {
+        fprintf(stderr, "[maintainer] LUMABRI_TOKEN must be at most %u bytes\n",
+                (unsigned)LMB_TOKEN_MAX);
+        return 2;
+    }
     if (tok) snprintf(g.token, sizeof g.token, "%s", tok);
     signal(SIGPIPE, SIG_IGN);   /* a vanished chatter must not kill the peer */
     lmb_conn_gate_init(&g_conn_gate);

--- a/tracker.c
+++ b/tracker.c
@@ -70,7 +70,7 @@ typedef struct {
 static Peer g_peers[MAX_PEERS];
 static pthread_mutex_t g_lk = PTHREAD_MUTEX_INITIALIZER;
 static int g_known_logged[MAX_PEERS];
-static char g_token[128];        /* --token: private swarm, invite required */
+static char g_token[LMB_TOKEN_MAX + 1]; /* --token: private swarm, invite required */
 static LmbConnGate g_conn_gate = LMB_CONN_GATE_INIT;
 static double g_stale_s = STALE_S;
 
@@ -1225,10 +1225,10 @@ static void *conn_thread(void *arg) {
         }
         switch (m.op) {
         case LMB_AUTH: {
-            char tok[128] = "";
+            char tok[LMB_TOKEN_MAX + 1] = "";
             LmbCur c = { m.body, m.body_len, 0 };
-            lmb_cur_str(&c, tok, sizeof tok);
-            if (!g_token[0] || !strcmp(tok, g_token)) {
+            int bad = lmb_cur_str(&c, tok, sizeof tok) || c.off != c.len;
+            if (!bad && (!g_token[0] || !strcmp(tok, g_token))) {
                 authed = 1;
                 rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
             } else { send_err(fd, "bad token"); rc = -1; }
@@ -1301,8 +1301,15 @@ int main(int argc, char **argv) {
     int port = 7300;
     for (int i = 1; i < argc; i++)
         if (!strcmp(argv[i], "--port") && i + 1 < argc) port = atoi(argv[++i]);
-        else if (!strcmp(argv[i], "--token") && i + 1 < argc)
-            snprintf(g_token, sizeof g_token, "%s", argv[++i]);
+        else if (!strcmp(argv[i], "--token") && i + 1 < argc) {
+            const char *tok = argv[++i];
+            if (strlen(tok) > LMB_TOKEN_MAX) {
+                fprintf(stderr, "[tracker] --token must be at most %u bytes\n",
+                        (unsigned)LMB_TOKEN_MAX);
+                return 2;
+            }
+            snprintf(g_token, sizeof g_token, "%s", tok);
+        }
         else if (!strcmp(argv[i], "--pubkey") && i + 1 < argc) {
             const char *spec = argv[++i];
             if (lmb_trust_load_spec(&g_trust, spec)) {


### PR DESCRIPTION
## Summary

- Define a shared 127-byte maximum for private swarm tokens.
- Reject overlong `LUMABRI_TOKEN` and `--token` values instead of silently truncating server-side copies.
- Make clients reject overlong tokens before sending an `AUTH` frame.
- Reject malformed `AUTH` bodies and trailing data consistently in tracker, maintainer, and expert node.

## Validation

Validated in Debian 12:

- `make all`
- `make expert_node ENGINE=/engine`
- `./security_test.sh`
- `./selftest.sh`
- Temporary boundary fixture: 127-byte token accepted end to end, 128-byte token rejected by every entry point with a clear error.
- Temporary malformed-frame fixture: trailing data after the token is rejected.