### PR TITLE
fix: stage hash sidecars under a per-process name

### DIFF
--- a/maintainer.c
+++ b/maintainer.c
@@ -167,10 +167,18 @@ static int sidecar_path(const MFile *f, const char *ext, char *out, size_t cap) 
                        g.root, f->rel, ext);
 }
 
+/* Stage under a name unique to this process. Two maintainers may share one
+ * --root (phase5_test does, and so does any machine donating from the tree it
+ * already serves): with a single fixed .tmp they collide on the same staging
+ * file, one truncating the other mid-write, and the loser's rename then fails
+ * on a file that is no longer its own. The rename is what makes the sidecar
+ * appear atomically, so per-process staging removes the race entirely rather
+ * than tolerating it — every other staging site in the tree already
+ * uniquifies by pid this way. */
 static int sidecar_write(const char *path, const void *a, size_t na,
                          const void *b, size_t nb) {
-    char tmp[LMB_LOCAL_PATH_MAX], dir[LMB_LOCAL_PATH_MAX];
-    if (path_printf(tmp, sizeof tmp, "%s.tmp", path) ||
+    char tmp[LMB_LOCAL_PATH_MAX + 32], dir[LMB_LOCAL_PATH_MAX];
+    if (path_printf(tmp, sizeof tmp, "%s.tmp.%ld", path, (long)getpid()) ||
         path_printf(dir, sizeof dir, "%s", path)) return -1;
     char *slash = strrchr(dir, '/');
     if (slash) { *slash = 0;


### PR DESCRIPTION
## Summary
- `sidecar_write` staged every hash sidecar as `<target>.tmp` — one fixed name — so two maintainers sharing one `--root` collided on the same staging file: one truncated the other's mid-write, and the loser's `rename` then failed on a file that was no longer its own
- stage as `<target>.tmp.<pid>` instead, so each writer owns its staging file and `rename` stays the atomic publish it was meant to be: both succeed, last writer wins
- the `.tmp` buffer grows by the width of the suffix, so #15's truncation check is unchanged and an otherwise-fitting path does not start failing

## Why this and not the workaround
c5c0341 was right that a failed sidecar write must not be fatal — the hashes are already in memory, and the sidecar is only a cache. But tolerating the failure leaves the loser dropping its sidecar and **re-hashing that file on every start**, for as long as the two share the root. This removes the collision instead, so the non-fatal path stops being reached for this reason at all.

Every other staging site in the tree — all four in `lumashim.c` — already uniquifies by pid. This was the one that did not.

## Reproduction
Two maintainers, one `--root`, six 4 MiB files, instrumented `sidecar_write` on `main`:

```
DBG rename .../f5.bin.sha.tmp -> .../f5.bin.sha: No such file or directory
[maintainer b] could not cache integrity data for f5.bin (will re-hash next start)
```

Five runs each, counting lost sidecars: **7 before, 0 after**, with no leftover staging files in either case.

## Verification
Full suite from a fresh clone of this branch (Debian x86_64, WSL2): selftest, donate, signed_donor, hot_cache_integrity, role, security, expert_input, prefetch_policy and cas all pass; `relay_exec_test.sh` needs the sibling engine checkout as usual.

No regression test is included on purpose: reproducing this needs two processes racing on one root, and a test that depends on losing that race would be flaky in CI. The mechanism is deterministic enough to reason about — one fixed staging name, two writers — and the reproduction above is easy to run by hand.