### PR TITLE
encrypt the transport (X25519 + ChaCha20-Poly1305), opt-in via LUMABRI_ENCRYPT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ test: all test_key_rotation test_hedge
 	./peer_identity_test.sh
 	./crypto_test.sh
 	./secure_test.sh
+	./encrypted_transport_test.sh
 	./test_key_rotation
 	./test_hedge
 

--- a/encrypted_transport_test.sh
+++ b/encrypted_transport_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# lumabri — the transport carries model bytes, encrypted, end to end.
+#
+# With LUMABRI_ENCRYPT set on every process, a tracker, a maintainer and a
+# chatter handshake (X25519 + Ed25519 identity) and every frame after that is
+# ChaCha20-Poly1305. This proves:
+#
+#   1) an encrypted swarm serves a model byte-for-byte over the AEAD channel;
+#   2) a plaintext chatter against an encrypted maintainer gets nothing, not
+#      the bytes in the clear — encryption is not silently skippable;
+#   3) the model bytes never appear on the wire in the clear.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s tracker maintainer liblumabri.so test_shim
+
+T=$(mktemp -d /tmp/lumabri-enc.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+
+wait_port() {
+    for _ in $(seq 1 100); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
+
+mkdir -p "$T/src"
+# a recognisable marker in the file, to grep for on the wire
+MARKER="PLAINTEXT_MODEL_SECRET_$RANDOM$RANDOM"
+printf '%s' "$MARKER" > "$T/src/w.bin"
+head -c $((256 * 1024)) /dev/urandom >> "$T/src/w.bin"
+printf '{"model_type":"olmoe"}\n' > "$T/src/config.json"
+export HOME="$T"          # peer keys land under $T/.lumabri, isolated
+
+echo "· 1) an encrypted swarm serves the model byte-for-byte"
+env LUMABRI_ENCRYPT=1 ./tracker --port 7640 > "$T/tracker.log" 2>&1 & PIDS+=($!)
+wait_port 7640
+env LUMABRI_ENCRYPT=1 ./maintainer --root "$T/src" --port 7641 \
+    --tracker 127.0.0.1:7640 --name origin --model-name fx > "$T/origin.log" 2>&1 & PIDS+=($!)
+wait_port 7641
+sleep 1
+env LUMABRI_ENCRYPT=1 LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v" \
+    LUMABRI_CACHE="$T/c" LUMABRI_TRACKER=127.0.0.1:7640 LUMABRI_MODEL=fx \
+    LUMABRI_BLOCK_MIB=1 LUMABRI_HS_TIMEOUT_MS=2000 \
+    timeout 30 ./test_shim "$T/v" "$T/src" > "$T/shim.log" 2>&1
+grep -q "byte-identical" "$T/shim.log" || { echo "   encrypted fetch failed"; cat "$T/shim.log"; exit 1; }
+grep -q "encryption on" "$T/origin.log" || { echo "   maintainer did not enable encryption"; exit 1; }
+echo "   ✓ served byte-for-byte over X25519 + ChaCha20-Poly1305"
+
+echo "· 2) a plaintext chatter against the encrypted swarm gets nothing"
+set +e
+env LMB_TIMEOUT= LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v2" \
+    LUMABRI_CACHE="$T/c2" LUMABRI_TRACKER=127.0.0.1:7640 LUMABRI_MODEL=fx \
+    LUMABRI_BLOCK_MIB=1 LUMABRI_IO_TIMEOUT_MS=2000 \
+    timeout 20 ./test_shim "$T/v2" "$T/src" > "$T/plain.log" 2>&1
+RC=$?
+set -e
+if [ "$RC" -eq 0 ] && grep -q "byte-identical" "$T/plain.log"; then
+    echo "   a plaintext chatter was served by an encrypted maintainer"; cat "$T/plain.log"; exit 1
+fi
+echo "   ✓ refused: encryption cannot be silently skipped"
+
+echo "· 3) the model bytes never crossed the wire in the clear"
+# capture the maintainer's traffic on a fresh encrypted fetch and grep the marker
+if command -v tcpdump >/dev/null 2>&1 && tcpdump -D >/dev/null 2>&1; then
+    tcpdump -i lo -w "$T/cap.pcap" "tcp port 7641" > /dev/null 2>&1 & TD=$!
+    sleep 0.5
+    env LUMABRI_ENCRYPT=1 LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v3" \
+        LUMABRI_CACHE="$T/c3" LUMABRI_TRACKER=127.0.0.1:7640 LUMABRI_MODEL=fx \
+        LUMABRI_BLOCK_MIB=1 LUMABRI_HS_TIMEOUT_MS=2000 timeout 30 ./test_shim "$T/v3" "$T/src" > /dev/null 2>&1
+    sleep 0.5; kill "$TD" 2>/dev/null || true; wait "$TD" 2>/dev/null || true
+    if grep -a -q "$MARKER" "$T/cap.pcap"; then
+        echo "   the model marker appeared on the wire in the clear"; exit 1; fi
+    echo "   ✓ the marker is not in the captured ciphertext"
+else
+    echo "   (skipped wire capture: tcpdump unavailable in this environment)"
+fi
+
+echo "LUMABRI ENCRYPTED TRANSPORT TEST: PASS"

--- a/expert_node.c
+++ b/expert_node.c
@@ -69,6 +69,7 @@
 
 #include "lumabri_proto.h"
 #include "lumabri_sign.h"
+#include "lumabri_secure.h"
 
 #include <omp.h>
 #include <pthread.h>
@@ -400,6 +401,7 @@ static int handle_emanifest(int fd) {
 
 static void *conn_thread(void *arg) {
     int fd = (int)(intptr_t)arg;
+    if (lmb_secure_server(fd)) { close(fd); lmb_conn_gate_leave(&g_conn_gate); return NULL; }
     int authed = g.token[0] ? 0 : 1;
     LmbMsg m;
     while (lmb_recv(fd, &m) == 0) {
@@ -850,6 +852,7 @@ int main(int argc, char **argv) {
     }
     pthread_t t;
     lmb_conn_gate_init(&g_conn_gate);
+    lmb_secure_init();
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }
     pthread_create(&t, NULL, stats_thread, NULL); pthread_detach(t);
 

--- a/lumabri.c
+++ b/lumabri.c
@@ -37,6 +37,7 @@
 
 #include "lumabri_proto.h"
 #include "lumabri_sign.h"
+#include "lumabri_secure.h"
 
 /* ---- terminal ----------------------------------------------------------- */
 
@@ -1750,6 +1751,8 @@ static int cmd_key(int argc, char **argv) {
 
 int main(int argc, char **argv) {
     g_tty = isatty(1);
+    lmb_secure_init();      /* honours LUMABRI_ENCRYPT for this process's own
+                               tracker queries; children inherit the env */
     if (argc >= 2 && !strcmp(argv[1], "serve")) return cmd_serve(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "chat"))  return cmd_chat(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "key"))   return cmd_key(argc - 2, argv + 2);

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -31,6 +31,7 @@
 
 #include "lumabri_proto.h"
 #include "lumabri_sign.h"
+#include "lumabri_secure.h"
 
 #define LUMI_MAX_PEERS 64
 #define LUMI_MAX_K     64
@@ -383,6 +384,7 @@ static void lumi_maybe_discover(void) {
  * every model that has one. */
 static void lumi_init_ex(int n_layers, int n_experts, int hidden,
                          const unsigned char *routed) {
+    lmb_secure_init();
     const char *spec = getenv("LUMABRI_EXPERTS");
     if (getenv("LUMABRI_NO_EXEC")) return;
     const char *tracker = getenv("LUMABRI_TRACKER");

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -270,8 +270,18 @@ static int lmb_frame_shape_ok(uint32_t op, uint32_t body_len, uint32_t pay_len) 
     return body_len <= bc && pay_len <= pc;
 }
 
+/* Optional encrypted transport. lumabri_secure.h, when a component enables
+ * it, points these at its AEAD channel: a fd that has been handshaked routes
+ * through them, an ordinary fd falls through to plaintext (the hook returns
+ * -2). Static per translation unit, so only a .c that opts in is affected. */
+static int (*lmb_enc_send)(int, uint32_t, const void *, uint32_t, const void *, uint32_t);
+static int (*lmb_enc_recv)(int, LmbMsg *);
+static int (*lmb_enc_wrap)(int fd, int is_client);   /* handshake+register; 0 ok */
+
 static int lmb_send(int fd, uint32_t op, const void *body, uint32_t body_len,
                     const void *pay, uint32_t pay_len) {
+    if (lmb_enc_send) { int r = lmb_enc_send(fd, op, body, body_len, pay, pay_len);
+                        if (r != -2) return r; }
     if (!lmb_frame_shape_ok(op, body_len, pay_len)) { errno = EMSGSIZE; return -1; }
     uint8_t pre[16];
     lmb_put32(pre, LMB_MAGIC); lmb_put32(pre + 4, op);
@@ -284,6 +294,7 @@ static int lmb_send(int fd, uint32_t op, const void *body, uint32_t body_len,
 
 /* Receives one frame; mallocs body/pay. Returns 0, or -1 on error/EOF. */
 static int lmb_recv(int fd, LmbMsg *m) {
+    if (lmb_enc_recv) { int r = lmb_enc_recv(fd, m); if (r != -2) return r; }
     uint8_t pre[16];
     memset(m, 0, sizeof *m);
     if (lmb_read_full(fd, pre, 16)) return -1;
@@ -579,6 +590,9 @@ static int lmb_connect_ms(const char *addr, int timeout_ms) {
         setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
         lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
                                            LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
+        /* when this component has enabled encryption, every outbound
+         * connection handshakes here, before any frame is sent */
+        if (lmb_enc_wrap && lmb_enc_wrap(fd, 1)) { close(fd); fd = -1; }
     }
     return fd;
 }

--- a/lumabri_secure.h
+++ b/lumabri_secure.h
@@ -44,10 +44,22 @@ static void lmb_sec_nonce(uint8_t out[12], uint64_t ctr) {
 
 /* One handshake. `id_sk`/`id_pk` are this peer's Ed25519 identity (v0.7).
  * Returns 0 and fills `s`, or -1. */
+/* seconds a handshake may block, so a plaintext or hostile connection cannot
+ * pin a worker for the bulk io timeout; LUMABRI_HS_TIMEOUT_MS overrides */
+static void lmb_hs_deadline(int fd, int on) {
+    int ms = on ? lmb_env_int("LUMABRI_HS_TIMEOUT_MS", 8000, 100, 60000)
+                : lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
+                              LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000);
+    struct timeval tv = { ms / 1000, (ms % 1000) * 1000 };
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof tv);
+}
+
 static int lmb_secure_handshake(int fd, int is_client,
                                 const uint8_t id_sk[64], const uint8_t id_pk[32],
                                 LmbSecure *s) {
     memset(s, 0, sizeof *s);
+    lmb_hs_deadline(fd, 1);
     uint8_t eph_sk[32], eph_pk[32], peer_eph[32];
     lmb_random(eph_sk, 32);
     lc_x25519_base(eph_pk, eph_sk);
@@ -98,6 +110,7 @@ static int lmb_secure_handshake(int fd, int is_client,
     else           { memcpy(s->tx_key, keys + 32, 32); memcpy(s->rx_key, keys, 32); }
     s->tx_ctr = s->rx_ctr = 0;
     s->active = 1;
+    lmb_hs_deadline(fd, 0);            /* back to the normal io timeout */
     return 0;
 }
 
@@ -152,6 +165,74 @@ static int lmb_secure_recv(LmbSecure *s, int fd, LmbMsg *m) {
     if (m->pay_len)  { m->pay  = (uint8_t *)malloc(m->pay_len);  memcpy(m->pay, pt + m->body_len, m->pay_len); }
     free(pt);
     return 0;
+}
+
+/* ---- opt-in transport integration -------------------------------------
+ * A component calls lmb_secure_init() once at startup. When LUMABRI_ENCRYPT
+ * is set it loads this machine's peer key and installs the proto.h hooks, so
+ * every lmb_connect handshakes outbound and every lmb_secure_server() wraps an
+ * accepted fd, and lmb_send/lmb_recv transparently use the AEAD channel for
+ * any handshaked fd. Off by default: nothing changes unless asked.
+ */
+#include <pthread.h>
+
+#define LMB_SEC_MAXFD 65536
+static LmbSecure *g_sec_reg[LMB_SEC_MAXFD];
+static pthread_mutex_t g_sec_lk = PTHREAD_MUTEX_INITIALIZER;
+static uint8_t g_sec_sk[64], g_sec_pk[32];
+
+static LmbSecure *lmb_sec_get(int fd) {
+    if (fd < 0 || fd >= LMB_SEC_MAXFD) return NULL;
+    pthread_mutex_lock(&g_sec_lk);
+    LmbSecure *s = g_sec_reg[fd];
+    pthread_mutex_unlock(&g_sec_lk);
+    return s;
+}
+
+static int lmb_sec_send_hook(int fd, uint32_t op, const void *b, uint32_t bl,
+                             const void *p, uint32_t pl) {
+    LmbSecure *s = lmb_sec_get(fd);
+    if (!s) return -2;                     /* not an encrypted fd: plaintext */
+    return lmb_secure_send(s, fd, op, b, bl, p, pl);
+}
+static int lmb_sec_recv_hook(int fd, LmbMsg *m) {
+    LmbSecure *s = lmb_sec_get(fd);
+    if (!s) return -2;
+    return lmb_secure_recv(s, fd, m);
+}
+static int lmb_sec_wrap_hook(int fd, int is_client) {
+    if (fd < 0 || fd >= LMB_SEC_MAXFD) return -1;
+    LmbSecure *s = (LmbSecure *)calloc(1, sizeof *s);
+    if (!s) return -1;
+    if (lmb_secure_handshake(fd, is_client, g_sec_sk, g_sec_pk, s)) { free(s); return -1; }
+    pthread_mutex_lock(&g_sec_lk);
+    free(g_sec_reg[fd]);                    /* a reused fd drops the old session */
+    g_sec_reg[fd] = s;
+    pthread_mutex_unlock(&g_sec_lk);
+    return 0;
+}
+
+/* handshake an accepted (inbound) fd; 0 when encryption is off or the wrap
+ * succeeds, -1 when an enabled handshake fails and the caller must drop it */
+static int lmb_secure_server(int fd) {
+    if (!lmb_enc_wrap) return 0;
+    return lmb_enc_wrap(fd, 0);
+}
+
+static void lmb_secure_init(void) {
+    const char *e = getenv("LUMABRI_ENCRYPT");
+    if (!e || !e[0] || e[0] == '0') return;
+    char kp[512];
+    if (lmb_peer_identity(lmb_peer_key_path(kp, sizeof kp), g_sec_sk, g_sec_pk)) {
+        fprintf(stderr, "[lumabri] LUMABRI_ENCRYPT set but no peer key at %s — "
+                        "staying plaintext\n", kp);
+        return;
+    }
+    lmb_enc_send = lmb_sec_send_hook;
+    lmb_enc_recv = lmb_sec_recv_hook;
+    lmb_enc_wrap = lmb_sec_wrap_hook;
+    fprintf(stderr, "[lumabri] transport encryption on "
+                    "(X25519 + ChaCha20-Poly1305, identity-authenticated)\n");
 }
 
 #endif /* LUMABRI_SECURE_H */

--- a/lumashim.c
+++ b/lumashim.c
@@ -49,6 +49,7 @@
 #include <time.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_secure.h"
 #include "lumabri_sha.h"
 #include "lumabri_sign.h"
 
@@ -849,6 +850,7 @@ static void *stats_thread(void *arg) {
 
 static void shim_init_impl(void) {
     shim_resolve();
+    lmb_secure_init();
     const char *cache = getenv("LUMABRI_CACHE");
     if (!cache || !cache[0]) {
         fprintf(stderr, "[lumabri] LUMABRI_VROOT is set but LUMABRI_CACHE is not — disabled\n");

--- a/maintainer.c
+++ b/maintainer.c
@@ -25,6 +25,7 @@
 #include "lumabri_proto.h"
 #include "lumabri_sha.h"
 #include "lumabri_sign.h"
+#include "lumabri_secure.h"
 
 #define MAX_FILES          4096
 #define MAX_INCLUDES       64
@@ -533,6 +534,7 @@ static int handle_read(int fd, LmbMsg *m) {
  * only the index while the bytes stayed public. */
 static void *conn_thread(void *arg) {
     int fd = (int)(intptr_t)arg;
+    if (lmb_secure_server(fd)) { close(fd); lmb_conn_gate_leave(&g_conn_gate); return NULL; }
     int authed = g.token[0] ? 0 : 1;
     LmbMsg m;
     while (lmb_recv(fd, &m) == 0) {
@@ -1032,6 +1034,7 @@ int main(int argc, char **argv) {
     if (tok) snprintf(g.token, sizeof g.token, "%s", tok);
     signal(SIGPIPE, SIG_IGN);   /* a vanished chatter must not kill the peer */
     lmb_conn_gate_init(&g_conn_gate);
+    lmb_secure_init();
     size_t rl = strlen(g.root);
     while (rl > 1 && g.root[rl - 1] == '/') g.root[--rl] = 0;
     if (!g.name[0]) snprintf(g.name, sizeof g.name, "peer-%d", port);

--- a/tracker.c
+++ b/tracker.c
@@ -24,6 +24,7 @@
 #include "lumabri_proto.h"
 #include "lumabri_sha.h"
 #include "lumabri_sign.h"
+#include "lumabri_secure.h"
 
 #define MAX_PEERS  64
 #define MAX_FILES  4096
@@ -1167,6 +1168,7 @@ static void ctrl_teardown(Peer *p, int fd) {
 
 static void *conn_thread(void *arg) {
     int fd = (int)(intptr_t)arg;
+    if (lmb_secure_server(fd)) { close(fd); lmb_conn_gate_leave(&g_conn_gate); return NULL; }
     Peer *ctrl = NULL;    /* set once this connection REGISTERs */
     int authed = g_token[0] ? 0 : 1;
     uint8_t nonce[32]; int have_nonce = 0;   /* per-connection identity challenge */
@@ -1318,6 +1320,7 @@ int main(int argc, char **argv) {
     g_stale_s = (double)lmb_env_int("LUMABRI_STALE_MS", (int)(STALE_S * 1000),
                                     100, 3600000) / 1000.0;
     lmb_conn_gate_init(&g_conn_gate);
+    lmb_secure_init();
     int lfd = lmb_listen(port);
     if (lfd < 0) { perror("[tracker] listen"); return 1; }
     printf("[tracker] listening on :%d\n", port);


### PR DESCRIPTION
Closes the last open network finding: plaintext transport. Tokens and activations no longer cross the wire in the clear.

## How

With `LUMABRI_ENCRYPT` set, every component loads this machine's Ed25519 identity and installs a transport hook: `lmb_connect` handshakes outbound, an accepted fd is wrapped at the top of each `conn_thread`, and `lmb_send`/`lmb_recv` route that fd through the AEAD channel. An un-handshaked fd falls through to plaintext, so **nothing changes unless it is turned on**.

The handshake exchanges ephemeral X25519 keys and each side signs the transcript with its v0.7 identity (bound to identity, not anonymous), then derives per-direction keys with HKDF-SHA512. Every frame is ChaCha20-Poly1305 with a counter nonce. The handshake has a short deadline (`LUMABRI_HS_TIMEOUT_MS`, default 8s) so a plaintext or hostile connection cannot pin a worker.

## Verified

- `crypto_test` — RFC 8439 / 7748 vectors.
- `secure_test` — handshake + AEAD + tamper.
- `encrypted_transport_test` — a full swarm serves a model byte-for-byte over the channel; a plaintext chatter is refused; the model bytes never appear on the wire (where tcpdump exists).
- Plaintext suite green (hooks are no-ops when off); `selftest` and `phase2` also pass end-to-end with `LUMABRI_ENCRYPT=1`.

## Status

Opt-in, so a swarm turns it on together and measures it. The honest limit without a pinned peer key is trust-on-first-use (SSH first-connect). Making it mandatory is a later step once it has run on a real swarm — good candidate for a look through the security advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)