### PR TITLE
fix: spot-check the failover answer too, not only the fast-path one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,9 @@ test_key_rotation: test_key_rotation.c lumabri_sign.h
 test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread test_hedge.c -o $@
 
+test_verify_failover: test_verify_failover.c lumabri_client.h lumabri_proto.h lumabri_sign.h
+	$(CC) $(CFLAGS) -pthread test_verify_failover.c -o $@
+
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh
 
@@ -234,7 +237,7 @@ test-key-rotation: test_key_rotation
 test-hedge: test_hedge
 	./test_hedge
 
-test: all test_key_rotation test_hedge
+test: all test_key_rotation test_hedge test_verify_failover
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -249,6 +252,7 @@ test: all test_key_rotation test_hedge
 	./crypto_test.sh
 	./secure_test.sh
 	./encrypted_transport_test.sh
+	./verify_failover_test.sh
 	./test_key_rotation
 	./test_hedge
 

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -614,17 +614,25 @@ static float *lumi_exec_relay(int layer, int eid, const float *x, int D, int nr,
 
 /* the failover path: run one expert synchronously on the next replicas.
  * Costs a full extra round trip — it is the price of a peer dying, paid
- * once, instead of the generation dying with it. */
+ * once, instead of the generation dying with it.
+ *
+ * `tried` is in/out and `from` reports which replica actually answered, so
+ * the caller can spot-check this answer exactly as it does a fast-path one:
+ * a failover answer is still an answer, and an unverified answer is the
+ * thing this client exists not to emit. `from` stays NULL for a relayed
+ * result, which has no replica to attribute it to. */
 static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
-                              const float *w, uint32_t tried) {
+                              const float *w, uint32_t *tried_io, LumiPeer **from) {
     int gid = layer * L.n_experts + eid;
     uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
+    uint32_t tried = tried_io ? *tried_io : 0;
     int waited = 0;
+    if (from) *from = NULL;
     for (;;) {
         int r = lumi_pick(gid, tried);
         if (r < 0) {
             float *relayed = lumi_exec_relay(layer, eid, x, D, nr, w);
-            if (relayed) return relayed;
+            if (relayed) { if (tried_io) *tried_io = tried; return relayed; }
             /* Every known replica is gone. Giving up here is correct in the
              * sense that inventing a result is never allowed — but it threw
              * away a whole generation for a peer that was rebooting, or a
@@ -673,6 +681,8 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
         lmb_msg_free(&m);
         lumi_put_sock(p, fd);
         L.failovers++;
+        if (tried_io) *tried_io = tried;
+        if (from) *from = p;
         return res;
     }
 }
@@ -707,9 +717,26 @@ static void lumi_spot_check(int layer, int eid, const float *x, int D, int nr,
         fprintf(stderr, "[lumabri] INTEGRITY FAILURE on layer %d expert %d: "
                 "%s and %s returned different bytes for the same activation. "
                 "One of them is lying or broken; refusing to continue.\n",
-                layer, eid, from->addr, p->addr);
+                layer, eid, from ? from->addr : "the tracker relay", p->addr);
         exit(1);
     }
+}
+
+/* The sampling gate in front of it. Every answer this client is willing to
+ * use goes through here — fast path, failover and relay alike — so the
+ * percentage an operator asks for is the percentage of USED answers that get
+ * checked, not the percentage of one favoured path. A relayed answer has no
+ * replica of its own (`from` is NULL); it is still worth offering to the
+ * check, which compares it against any replica that is reachable and is a
+ * no-op when none is. */
+static unsigned lumi_vseed = 0x9e3779b9u;
+static void lumi_maybe_spot_check(int layer, int eid, const float *x, int D,
+                                  int nr, const float *w, const float *got,
+                                  LumiPeer *from, uint32_t tried) {
+    if (!L.verify_pct || !got) return;
+    lumi_vseed = lumi_vseed * 1664525u + 1013904223u;
+    if ((int)(lumi_vseed % 100u) < L.verify_pct)
+        lumi_spot_check(layer, eid, x, D, nr, w, got, from, tried);
 }
 
 /* Run the K selected experts of one layer on their peers and accumulate into
@@ -745,24 +772,22 @@ static void lumi_moe_apply(int layer, const int *idx, const float *val, int K,
         }
     }
     /* then collect, in order; a failed reply falls over to the next replica */
-    static unsigned vseed = 0x9e3779b9u;
     for (int k = 0; k < K; k++) {
         if (fds[k] >= 0) {
             LumiPeer *winner = NULL;
             res[k] = lumi_finish_exec(layer, idx[k], x, D, 1, NULL,
                                       fds[k], ps[k], &tried[k], &winner);
             if (res[k]) {
-                if (L.verify_pct) {
-                    vseed = vseed * 1664525u + 1013904223u;
-                    if ((int)(vseed % 100u) < L.verify_pct)
-                        lumi_spot_check(layer, idx[k], x, D, 1, NULL, res[k], winner, tried[k]);
-                }
+                lumi_maybe_spot_check(layer, idx[k], x, D, 1, NULL, res[k],
+                                      winner, tried[k]);
                 continue;
             }
             fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                             "trying next replica\n", ps[k]->addr, layer, idx[k]);
         }
-        res[k] = lumi_exec_retry(layer, idx[k], x, D, 1, NULL, tried[k]);
+        LumiPeer *rf = NULL;
+        res[k] = lumi_exec_retry(layer, idx[k], x, D, 1, NULL, &tried[k], &rf);
+        lumi_maybe_spot_check(layer, idx[k], x, D, 1, NULL, res[k], rf, tried[k]);
     }
     /* accumulate in the router's order, exactly as the local path does */
     for (int k = 0; k < K; k++) {
@@ -817,7 +842,6 @@ static void lumi_moe_apply_batch(int layer, const int *idxs, const float *ws,
     uint32_t tried[LUMI_BLOCK];
     LumiPeer *ps[LUMI_BLOCK];
     int nrs[LUMI_BLOCK];
-    static unsigned vseed = 0x9e3779b9u;
 
     for (int base = 0; base < nu; base += LUMI_BLOCK) {
         int nb = nu - base < LUMI_BLOCK ? nu - base : LUMI_BLOCK;
@@ -861,17 +885,18 @@ static void lumi_moe_apply_batch(int layer, const int *idxs, const float *ws,
                 res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
                                        fds[j], ps[j], &tried[j], &winner);
                 if (res) {
-                    if (L.verify_pct) {
-                        vseed = vseed * 1664525u + 1013904223u;
-                        if ((int)(vseed % 100u) < L.verify_pct)
-                            lumi_spot_check(layer, eid, xj, D, nr, NULL, res, winner, tried[j]);
-                    }
+                    lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res,
+                                          winner, tried[j]);
                 } else {
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
             }
-            if (!res) res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, tried[j]);
+            if (!res) {
+                LumiPeer *rf = NULL;
+                res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, &tried[j], &rf);
+                lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res, rf, tried[j]);
+            }
             if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             int *rj = rows + (size_t)j * S;
             float *wj = rw + (size_t)j * S;
@@ -909,7 +934,6 @@ static void lumi_moe_apply_union(int layer, int nu, const int *uid,
     int fds[LUMI_BLOCK];
     uint32_t tried[LUMI_BLOCK];
     LumiPeer *ps[LUMI_BLOCK];
-    static unsigned vseed = 0x85ebca6bu;
 
     for (int base = 0; base < nu; base += LUMI_BLOCK) {
         int nb = nu - base < LUMI_BLOCK ? nu - base : LUMI_BLOCK;
@@ -943,17 +967,18 @@ static void lumi_moe_apply_union(int layer, int nu, const int *uid,
                 res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
                                        fds[j], ps[j], &tried[j], &winner);
                 if (res) {
-                    if (L.verify_pct) {
-                        vseed = vseed * 1664525u + 1013904223u;
-                        if ((int)(vseed % 100u) < L.verify_pct)
-                            lumi_spot_check(layer, eid, xj, D, nr, NULL, res, winner, tried[j]);
-                    }
+                    lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res,
+                                          winner, tried[j]);
                 } else {
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
             }
-            if (!res) res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, tried[j]);
+            if (!res) {
+                LumiPeer *rf = NULL;
+                res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, &tried[j], &rf);
+                lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res, rf, tried[j]);
+            }
             if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             for (int r = 0; r < nr; r++) {
                 float *us = U + (int64_t)poslist[f + r] * D, w = wlist[f + r];
@@ -1005,7 +1030,6 @@ static void lumi_moe_apply_v4(int layer, const int *indices, const float *weight
     uint32_t tried[LUMI_BLOCK];
     LumiPeer *ps[LUMI_BLOCK];
     int nrs[LUMI_BLOCK];
-    static unsigned vseed = 0xc2b2ae35u;
 
     for (int base = 0; base < nu; base += LUMI_BLOCK) {
         int nb = nu - base < LUMI_BLOCK ? nu - base : LUMI_BLOCK;
@@ -1053,17 +1077,18 @@ static void lumi_moe_apply_v4(int layer, const int *indices, const float *weight
                 res = lumi_finish_exec(layer, eid, xj, D, nr, wj,
                                        fds[j], ps[j], &tried[j], &winner);
                 if (res) {
-                    if (L.verify_pct) {
-                        vseed = vseed * 1664525u + 1013904223u;
-                        if ((int)(vseed % 100u) < L.verify_pct)
-                            lumi_spot_check(layer, eid, xj, D, nr, wj, res, winner, tried[j]);
-                    }
+                    lumi_maybe_spot_check(layer, eid, xj, D, nr, wj, res,
+                                          winner, tried[j]);
                 } else {
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
             }
-            if (!res) res = lumi_exec_retry(layer, eid, xj, D, nr, wj, tried[j]);
+            if (!res) {
+                LumiPeer *rf = NULL;
+                res = lumi_exec_retry(layer, eid, xj, D, nr, wj, &tried[j], &rf);
+                lumi_maybe_spot_check(layer, eid, xj, D, nr, wj, res, rf, tried[j]);
+            }
             if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             for (int r = 0; r < nr; r++) {       /* already weighted by the peer */
                 float *os = out + (size_t)rj[r] * D;

--- a/test_verify_failover.c
+++ b/test_verify_failover.c
@@ -1,0 +1,112 @@
+/* Does the spot-check cover the FAILOVER answer, not only the fast-path one?
+ *
+ * Three replicas hold one expert, in this replica order:
+ *
+ *   1. refuses every call, so the client fails over
+ *   2. answers — honestly or with one byte flipped, per argv[1]
+ *   3. answers honestly, and is the checker the spot-check can reach
+ *
+ * With LUMABRI_VERIFY=100 every answer the client is willing to USE must be
+ * double-checked, whichever path produced it. So:
+ *
+ *   liar    the failover answer disagrees with replica 3 → the client must
+ *           print INTEGRITY FAILURE and exit 1, never return the bytes
+ *   honest  the failover answer agrees → the run completes, and the check
+ *           must have actually run (L.verified > 0), so a spot-check that
+ *           silently did nothing cannot pass as a success
+ *
+ * The honest case is the one that keeps the fix safe: verifying the failover
+ * path must not make an ordinary peer failure look like an attack.
+ */
+#define LMBE_ENGINE_ID "verify-failover-test"
+#define LMBE_SOURCE_ID "test"
+#define LMBE_EXPECT_BITS 0
+#include <pthread.h>
+#include "lumabri_client.h"
+
+typedef struct {
+    int port;
+    int refuse;          /* drop every call: forces the caller to fail over */
+    int lie;             /* flip one byte of the answer */
+    int served;
+} Node;
+
+/* An honest expert here echoes the activation back unchanged: deterministic,
+ * so two honest nodes always agree and any disagreement is the lie. */
+static void *node_thread(void *arg) {
+    Node *n = (Node *)arg;
+    int lfd = lmb_listen(n->port);
+    if (lfd < 0) return (void *)1;
+    for (;;) {
+        int fd = accept(lfd, NULL, NULL);
+        if (fd < 0) break;
+        if (n->refuse) { close(fd); continue; }
+        for (;;) {
+            LmbMsg m = {0};
+            if (lmb_recv(fd, &m) || m.op != LMB_EXEC) { lmb_msg_free(&m); break; }
+            uint32_t len = m.pay_len;
+            uint8_t *out = (uint8_t *)malloc(len ? len : 1);
+            memcpy(out, m.pay, len);
+            if (n->lie && len) out[0] ^= 0xFF;
+            n->served++;
+            int rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, out, len);
+            free(out);
+            lmb_msg_free(&m);
+            if (rc) break;
+        }
+        close(fd);
+    }
+    close(lfd);
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    int lie = argc > 1 && !strcmp(argv[1], "liar");
+    int base = lie ? 7571 : 7581;
+    Node refuse = { base, 1, 0, 0 };
+    Node second = { base + 1, 0, lie, 0 };
+    Node third  = { base + 2, 0, 0, 0 };
+    pthread_t t[3];
+    pthread_create(&t[0], NULL, node_thread, &refuse);
+    pthread_create(&t[1], NULL, node_thread, &second);
+    pthread_create(&t[2], NULL, node_thread, &third);
+    usleep(200000);
+
+    L.n_layers = 1; L.n_experts = 1; L.hidden = 4;
+    L.npeers = 3;
+    L.verify_pct = 100;
+    L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));
+    for (int i = 0; i < LUMI_MAX_REP; i++) L.own[i] = -1;
+    L.own[0] = 0; L.own[1] = 1; L.own[2] = 2;
+    snprintf(L.peers[0].addr, sizeof L.peers[0].addr, "127.0.0.1:%d", refuse.port);
+    snprintf(L.peers[1].addr, sizeof L.peers[1].addr, "127.0.0.1:%d", second.port);
+    snprintf(L.peers[2].addr, sizeof L.peers[2].addr, "127.0.0.1:%d", third.port);
+    L.peers[0].rtt_us = 100; L.peers[1].rtt_us = 200; L.peers[2].rtt_us = 300;
+
+    float x[4]; for (int i = 0; i < 4; i++) x[i] = (float)(i + 1) / 3.0f;
+    float out[4] = {0};
+    int idx[1] = { 0 };
+    float val[1] = { 1.0f };
+
+    /* In the liar case the client detects the disagreement inside this call
+     * and exits(1); nothing below runs. */
+    lumi_moe_apply(0, idx, val, 1, x, 4, out);
+
+    if (lie) {
+        printf("FAIL: the corrupted failover answer was accepted "
+               "(checker served %d call(s))\n", third.served);
+        return 1;
+    }
+    if (!L.verified) {
+        printf("FAIL: the honest failover answer was never checked "
+               "(verified=%llu)\n", L.verified);
+        return 1;
+    }
+    if (memcmp(out, x, sizeof x) != 0) {
+        printf("FAIL: honest run returned the wrong bytes\n");
+        return 1;
+    }
+    printf("VERIFIED FAILOVER: PASS (honest failover checked %llu time(s) "
+           "against replica 3, no false alarm)\n", L.verified);
+    return 0;
+}

--- a/verify_failover_test.sh
+++ b/verify_failover_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# A spot-check must cover every answer the chatter is willing to use, not just
+# the one the fast path produced. The failover path returns an answer too, and
+# on a NAT'd swarm the relay behind it can be the only way an expert is
+# reachable at all — an answer nobody can check is exactly what this client
+# exists not to emit.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s test_verify_failover
+
+echo "· a lying replica reached through failover is caught"
+set +e
+OUT=$(./test_verify_failover liar 2>&1)
+RC=$?
+set -e
+if [ "$RC" -eq 0 ]; then
+    echo "   the corrupted failover answer was accepted"
+    echo "$OUT"
+    exit 1
+fi
+grep -q "INTEGRITY FAILURE" <<<"$OUT" || {
+    echo "   the run stopped, but not with the integrity error"
+    echo "$OUT"
+    exit 1
+}
+echo "   ✓ INTEGRITY FAILURE, and the bytes never reached the model"
+
+echo "· an honest failover is checked and not mistaken for an attack"
+./test_verify_failover honest
+
+echo "LUMABRI VERIFY FAILOVER TEST: PASS"


### PR DESCRIPTION
## Summary
`LUMABRI_VERIFY` reruns a sampled expert call on a second replica and stops the run when the two disagree — the one defence against a peer returning wrong *activations*, since an expert's output cannot be checked against a signed hash the way its weights can.

All four apply paths sampled the fast-path answer. **None sampled the failover answer.** Every call site did:

```c
if (!res) res = lumi_exec_retry(...);   /* used, never checked */
```

so an answer produced after a peer failure went into the model unverified — at any verify percentage, **including 100**. And `lumi_exec_relay` sits behind that same path, so on a NAT'd swarm an expert reachable only through the tracker tunnel was never checked at all: a permanent blind spot rather than a sampling gap.

## The change
- `lumi_exec_retry` reports which replica answered and the updated `tried` mask, mirroring what `lumi_finish_exec` already does
- every call site offers that answer to the same sampling gate
- the gate moves into `lumi_maybe_spot_check`, so the four copies of the sampling arithmetic become one and every path producing a usable answer goes through it
- a relayed answer has no replica to attribute it to: it is offered with a NULL origin, checked against any replica that is reachable, and — exactly as before — the check is a no-op when none is

Net effect: the percentage an operator asks for now applies to *answers*, not to one favoured path.

## Demonstration
`verify_failover_test` drives three replicas — one refuses (forcing the failover), one answers, one is the checker:

| | stock `main` | with this change |
|---|---|---|
| lying replica via failover | `checker served 0 calls`, corrupted bytes **accepted**, exit 0 | `INTEGRITY FAILURE`, exit 1, bytes never reach the model |
| honest failover | — | completes, check confirmed to have run (`verified > 0`), no false alarm |

The honest case is the one that matters for safety: verifying the failover path must not turn an ordinary peer failure into a false integrity alarm. The test asserts the check actually ran, so a spot-check that silently did nothing cannot pass as success.

## Verification
Fresh clone of this branch (Debian x86_64, WSL2): the whole suite passes — selftest, donate, signed_donor, hot_cache_integrity, role, security, expert_input, prefetch_policy, cas, peer_identity, crypto, secure, encrypted_transport, **verify_failover**, key_rotation and hedge. `relay_exec_test.sh` needs the sibling engine checkout as usual. No new compiler warnings; `test_hedge` confirms the fast path and hedging are unchanged.