### PR TITLE
transport pinning and hardening: fail-closed encryption with MITM protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+This file follows the commits contained by each Git tag. Changes merged after
+a tag stay under Unreleased until a new tag is created.
+
+## Unreleased
+
+- Persistent endpoint TOFU and strict `LUMABRI_PEER_PINS` verification.
+- Fail-closed encrypted startup, X25519 low-order rejection, bounded aggregate
+  receive memory, one-buffer AEAD frames and encrypted-fd lifecycle cleanup.
+- Durable tracker name-to-key bindings, channel/registration identity binding,
+  per-key and per-source admission quotas.
+- Constant-time invite-token comparison and hardened peer-key/sidecar files.
+- Expanded RFC vectors, tamper, replay, pinning, restart, quota, memory and
+  fail-closed tests.
+- PR #21 token-length validation, PR #22 per-process sidecar staging and PR #24
+  encrypted wire-capture test fixes were merged after v0.8.0 and therefore
+  belong here, not in the v0.8.0 tag.
+
+## v0.8.0
+
+- Opt-in authenticated encrypted transport using ephemeral X25519, Ed25519
+  handshake identities, HKDF-SHA512 and ChaCha20-Poly1305.
+- Self-contained transport primitives and RFC 8439/RFC 7748 tests.
+
+## v0.7.0
+
+- Signed REGISTER/EREG challenge flow and per-machine Ed25519 peer identity.
+- First-use name ownership, Ed25519 undefined-behaviour fixes, per-key live-name
+  cap, signal-handler hardening, warm-cache integrity fixes and telemetry fix.
+
+## v0.6.0
+
+- Protocol v2 build/checkpoint identity, crash-safe multi-process mirror,
+  accept-path bounds, continuous discovery and dense/expert prefetch boundary.
+- Multi-row speculative EXEC, fixed-delay hedging, local content-addressed
+  storage, manual signing-key rotation and READ/EXEC NAT relay.
+- Path, manifest, SIGPIPE, build and test hardening merged in this tag range.
+
+## v0.5.0
+
+- P2P byte serving and remote expert execution for OLMoE, GLM, Inkling, Kimi K3
+  and DeepSeek V4, with per-engine byte-identity tests.
+- TUI, live swarm view, model switching, rarest-first assignments, invite
+  tokens and the generated-patch engine integration model.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -159,6 +159,34 @@ it, put it in the README of your swarm, read it over the phone:
 cat swarm.pub
 ```
 
+This signing key authenticates model contents. Transport endpoints use a
+separate per-machine identity. Print the server's public endpoint key as the
+service user:
+
+```sh
+su - lumabri -c 'lumabri peer-key'
+```
+
+Clients can preseed a strict pin file with that value for the three server
+addresses:
+
+```text
+YOUR_SERVER_IP:7300 64_HEX_ENDPOINT_KEY
+YOUR_SERVER_IP:7301 64_HEX_ENDPOINT_KEY
+YOUR_SERVER_IP:7302 64_HEX_ENDPOINT_KEY
+```
+
+Without a strict file, encrypted clients persist first contact in
+`~/.lumabri/known_hosts` and refuse later key changes. That is convenient but
+does not protect the very first connection from an active MITM. A strict pin
+file does. New direct donor endpoints must be added to the file; unlisted NAT
+donors remain reachable through the pinned tracker's relay.
+
+Endpoint-key rotation uses an overlap just like host-key rotation: add a second
+row for the same address with the new endpoint key, switch the server, then
+remove the old row. A TOFU `known_hosts` file deliberately accepts one key per
+address and must be edited only after the new key is verified out of band.
+
 ### Manual key rotation
 
 Create the replacement key, then distribute a trust file containing the old
@@ -227,6 +255,7 @@ ExecStart=/usr/local/bin/lumabri serve \
     --exec-cache 256
 Restart=always
 RestartSec=5
+Environment=LUMABRI_ENCRYPT=1
 # a private swarm: uncomment and set the same value on every client
 # Environment=LUMABRI_TOKEN=choose-a-long-random-string
 
@@ -298,6 +327,8 @@ the question for scripts and services.
 **Chat** — this is the whole point:
 
 ```sh
+LUMABRI_ENCRYPT=1 \
+LUMABRI_PEER_PINS=/path/to/peer-pins \
 LUMABRI_PUBKEY=<contents of swarm.pub> \
 lumabri chat --tracker YOUR_SERVER_IP:7300 --engines-dir ~/colibri/c
 ```
@@ -387,8 +418,10 @@ systemctl restart lumabri
 
 Two things worth knowing:
 
-- **A tracker restart is free.** State is in RAM and every peer
-  re-registers within one heartbeat (10 s).
+- **A tracker restart rebuilds placements automatically.** Liveness is in RAM
+  and every peer re-registers within one heartbeat (10 s). Name-to-peer-key
+  ownership is persisted under `~/.lumabri/tracker_peer_bindings`, so restart
+  does not reopen names for takeover.
 - **A client with a warm mirror keeps working with the server off.** That
   is the design, and `selftest.sh` pass 3 tests exactly it.
 
@@ -398,7 +431,10 @@ Two things worth knowing:
 
 - SSH keys only: `PasswordAuthentication no` in `/etc/ssh/sshd_config`.
 - Private swarm: set `LUMABRI_TOKEN` in the unit **and** on every client.
-  It is checked by the tracker, every maintainer and every expert node.
+  It is checked by the tracker, every maintainer and every expert node. Keep
+  `LUMABRI_ENCRYPT=1`; a bearer token over plaintext is not private.
+- For production, distribute `LUMABRI_PEER_PINS`. Persistent TOFU detects
+  later key replacement, while pins also authenticate first contact.
 - Keep the operator secret key off the server if you can (see §3).
 - The peers you accept are still untrusted-but-verified: they cannot change
   bytes (signatures) and cannot fake results undetected if clients run

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,7 @@
 # lumabri — design
 
-Data: 2026-08-04. Fase 1 (distribuzione P2P dei byte) funzionante in locale.
+Aggiornato: 2026-08-12. Distribuzione P2P dei byte, esecuzione remota degli
+esperti, relay NAT, integrità firmata e trasporto cifrato sono implementati.
 
 ## Il problema e la scelta
 
@@ -14,16 +15,16 @@ Due varianti studiate:
   *sotto* l'SSD del chatter: banda-limitata da freddo (100 Mbps–1 Gbps casa),
   velocità locale piena da caldo. Nessun problema di latenza per token,
   nessun leak di conversazione, integrità verificabile con hash.
-- **B — i peer eseguono gli esperti** (fase 2). Attivazioni da ~4-8 KB per
+- **B — i peer eseguono gli esperti** (implementata dalla fase 2). Attivazioni da ~4-8 KB per
   esperto: banda irrilevante, ma i layer sono sequenziali → il RTT domina
   (43 layer × 30 ms ≈ 1.3 s/forward). Si amortizza col draft speculativo
   (batch-union: un round trip per layer per l'intero draft da 5 token →
-  ~2 tok/s stimati su RTT 30 ms). Problemi aperti: straggler (il layer
-  aspetta il più lento dei k peer), churn, verifica di output non fidati,
-  privacy delle attivazioni.
+  ~2 tok/s stimati su RTT 30 ms). Batch-union, hedging fisso, failover,
+  verifica su replica e cifratura delle attivazioni sono ora nel core.
 
-Scelta MVP: A, perché ogni pezzo (indice, protocollo, failover, cache) serve
-identico anche a B, e A è utile da sola (il problema "862 GB di download").
+La prima release scelse A perché ogni pezzo (indice, protocollo, failover,
+cache) serviva anche a B. Il sistema attuale le usa entrambe: il chatter
+scarica la parte densa su richiesta ed esegue gli esperti sui peer.
 
 ## Perché LD_PRELOAD e non FUSE
 
@@ -53,9 +54,10 @@ Frame: `{u32 magic "LMB1", u32 op, u32 body_len, u32 pay_len}` + body + pay,
 little-endian, stringhe con prefisso u16. Il pay bulk ha cap 64 MiB;
 REGISTER può portare fino a 64 MiB di hash, i controlli normali 4 MiB e i
 messaggi piccoli 64 KiB. Forma e limiti sono verificati dai soli 16 byte di
-header, prima di allocare o attendere il body. Timeout I/O e numero massimo
-di connessioni sono configurabili e hanno limiti di default. Op sconosciuta
-→ `ERR` esplicito (mai indovinare).
+header, prima di allocare o attendere il body. `LUMABRI_RX_BUDGET_MIB` limita
+anche la memoria aggregata riservata dalle connessioni, non solo il singolo
+frame. Timeout I/O e numero massimo di connessioni sono configurabili e hanno
+limiti di default. Op sconosciuta → `ERR` esplicito (mai indovinare).
 
 | op | flusso | uso |
 |---|---|---|
@@ -65,9 +67,18 @@ di connessioni sono configurabili e hanno limiti di default. Op sconosciuta
 | `REGISTER{name,addr,files}` → `OK` | maintainer→tracker | heartbeat 10 s |
 | `PLACEMENT` → `PLACEMENT_R` | chatter→tracker | file → {size, peer…} |
 
-Il tracker è **solo indice** (Napster docet): mai un byte di modello, stato
-in RAM, restart gratis (tutti si ri-registrano entro un heartbeat). Peer
-silenzioso da >30 s → escluso dai placement.
+Il tracker è **solo indice** (Napster docet): mai un byte di modello. Placement
+e liveness sono in RAM e si ricostruiscono dagli heartbeat; il binding
+nome→chiave Ed25519 è persistito prima dell'ammissione, così un restart non
+riapre i nomi. Peer silenzioso da >30 s → escluso dai placement.
+
+Con `LUMABRI_ENCRYPT=1`, prima del primo frame ogni socket fa un handshake
+X25519 effimero autenticato dall'identità Ed25519 della macchina. HKDF-SHA512
+separa le chiavi per direzione; header, body e payload sono protetti da
+ChaCha20-Poly1305 con contatori anti-replay. Il fallimento nel caricamento
+della chiave blocca la rete, senza downgrade a plaintext. Gli endpoint in
+uscita usano TOFU persistente in `known_hosts`, oppure pin stretti distribuiti
+dall'operatore con `LUMABRI_PEER_PINS`.
 
 ## Lato chatter (lumishim.c)
 
@@ -120,6 +131,11 @@ silenzioso da >30 s → escluso dai placement.
   usano sugli shard; LD_PRELOAD sopravvive comunque all'exec).
 - fd ≥ 65536 su file del modello → EMFILE (limite tabella).
 - Un solo vroot per processo.
+- Il pinning stretto richiede che l'operatore distribuisca tutti gli endpoint.
+  Il default `known_hosts` è TOFU persistente: rileva cambi successivi ma non
+  autentica il primo contatto contro un MITM attivo.
+- Quote per chiave e indirizzo sorgente frenano l'esaurimento della tabella,
+  ma nessun tracker centrale può eliminare un Sybil distribuito su molti IP.
 
 ## Fase 3 — la guerra all'RTT (2026-08-05)
 
@@ -287,13 +303,13 @@ repliche (fase 5) e non da una firma — un peer non può firmare un calcolo
 che dipende dall'input, servirebbe attestazione o prova, ed è un problema
 aperto in tutta la letteratura.
 
-## Fase 2 (esperti remoti) — appunti
+## Fase 2 (esperti remoti) — implementazione
 
-Il punto d'aggancio nel motore è il path `expert_load`/`ColiExpertStore`:
-già oggi è una sorgente di byte intercambiabile (disco, mirror dual-SSD).
-Un backend "peer" che spedisce l'attivazione invece di chiedere i byte
-riusa: l'indice del tracker, il pool/failover dello shim, il batch-union
-(un round per layer per l'unione degli esperti del draft) e la LRU separata
-del drafter (DSpark) perché il drafting non deve pagare rete. La verifica
-resta quella di colibrì: il draft si verifica sempre, la rete non tocca la
-semantica.
+Il punto d'aggancio è il blocco MoE di ogni motore. La patch viene applicata a
+una copia della sorgente e invia l'attivazione invece di leggere i pesi routed
+sul chatter. OLMoE, GLM, Inkling, Kimi K3 e DeepSeek V4 hanno adattatori
+separati perché forma, quantizzazione e ordine delle operazioni differiscono.
+Il tracker, il pool/failover, il batch-union e il relay EXEC sono condivisi;
+il profilo numerico impedisce di mescolare build che potrebbero produrre float
+diversi. Le suite per motore confrontano il risultato remoto e locale byte per
+byte.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ ENGINE  ?= ../colibri/c
 
 all: tracker maintainer liblumabri.so test_shim lumabri
 
-lumabri: lumabri.c lumabri_proto.h lumabri_sign.h
+SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
+
+lumabri: lumabri.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread lumabri.c -o $@
 
 # ---- phase 2: peers execute experts ------------------------------------
@@ -39,7 +41,8 @@ MISSING_ENGINES = $(filter-out $(HAVE_ENGINES),olmoe colibri inkling kimi_k3 dee
 # into the chatter and expert-node build for that family. Compiler/ISA/OpenMP
 # details are appended at runtime by lmb_build_profile().
 ENGINE_PROFILE_DEPS := $(sort $(wildcard $(ENGINE)/*.h)) \
-                       lumabri_client.h lumabri_proto.h lumabri_sign.h lumabri_sha.h
+                       lumabri_client.h lumabri_proto.h lumabri_sign.h lumabri_sha.h \
+                       $(SECURE_DEPS)
 define engine_source_id
 $(shell sha256sum $(ENGINE)/$(1).c $(ENGINE_PROFILE_DEPS) \
         expert_engines/$(2).h engine_patches/$(1)-p2p.diff 2>/dev/null | \
@@ -68,7 +71,7 @@ phase2-all: engines chatters
 # One expert-node binary per engine. The body is the same file; everything
 # engine-shaped lives in expert_engines/<name>.h, which pulls in the engine's
 # own source so remote and local run the same kernels on the same weights.
-EXPERT_DEPS = expert_node.c lumabri_proto.h lumabri_sign.h
+EXPERT_DEPS = expert_node.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 
 expert_node: $(EXPERT_DEPS) expert_engines/olmoe.h $(ENGINE)/olmoe.c \
              engine_patches/olmoe-p2p.diff $(ENGINE_PROFILE_DEPS)
@@ -145,7 +148,8 @@ build/%_p2p.c: $(ENGINE)/%.c engine_patches/%-p2p.diff Makefile
 	 else patch -s -p2 -o $@ $< engine_patches/$*-p2p.diff; fi
 	@sed -i 's/if (L\.on) {/if (lumi_layer_on(layer)) {/' $@
 
-ENGINE_P2P_DEPS = lumabri_client.h lumibri_client.h lumabri_proto.h lumabri_sign.h
+ENGINE_P2P_DEPS = lumabri_client.h lumibri_client.h lumabri_proto.h lumabri_sign.h \
+                  $(SECURE_DEPS)
 
 olmoe_p2p: build/olmoe_p2p.c $(ENGINE_P2P_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_olmoe) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
@@ -199,15 +203,15 @@ test-engines: test-phase2 test-phase2-glm test-phase2-inkling test-phase2-kimi
 	    echo "   it has no synthetic fixture — MODEL=<dir> make test-engines"; \
 	fi
 
-tracker: tracker.c lumabri_proto.h lumabri_sha.h lumabri_sign.h
+tracker: tracker.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread tracker.c -o $@
 
-maintainer: maintainer.c lumabri_proto.h lumabri_sha.h lumabri_sign.h
+maintainer: maintainer.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread maintainer.c -o $@
 
 # The shim interposes libc symbols, so it must not itself be interposable
 # state: -fPIC shared object, resolved via RTLD_NEXT at load time.
-liblumabri.so: lumashim.c lumabri_proto.h lumabri_sha.h lumabri_sign.h
+liblumabri.so: lumashim.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -shared -fPIC -pthread lumashim.c -o $@ -ldl
 
 test_shim: test_shim.c
@@ -219,7 +223,7 @@ test_relay_exec: test_relay_exec.c lumabri_proto.h
 test_key_rotation: test_key_rotation.c lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread test_key_rotation.c -o $@
 
-test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h
+test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_hedge.c -o $@
 
 test-relay-exec: tracker expert_node test_relay_exec fixture
@@ -246,6 +250,7 @@ test: all test_key_rotation test_hedge
 	./cas_test.sh
 	./relay_exec_test.sh
 	./peer_identity_test.sh
+	./sign_test.sh
 	./crypto_test.sh
 	./secure_test.sh
 	./encrypted_transport_test.sh

--- a/README.md
+++ b/README.md
@@ -173,6 +173,40 @@ maintainer commands also accept repeated `--pubkey`.
 There is still one signature per object; the overlap belongs to the verifier,
 so the wire format does not change during rotation.
 
+### Encrypted transport and peer identity
+
+Set `LUMABRI_ENCRYPT=1` on every tracker, maintainer, expert node and chatter
+to encrypt tokens, model blocks and activations with an authenticated
+X25519/Ed25519 handshake and ChaCha20-Poly1305 frames. If a peer key cannot be
+loaded or created, networking fails closed instead of falling back to
+plaintext.
+
+Each machine keeps its private endpoint identity in `~/.lumabri/peer.key` and
+prints the public half with `lumabri peer-key`. Outbound endpoints are recorded
+in `~/.lumabri/known_hosts`; a changed key is refused on later connections.
+For first-contact MITM protection, distribute an operator-managed file before
+connecting:
+
+```text
+SERVER:7300 64_HEX_PEER_KEY
+SERVER:7301 64_HEX_PEER_KEY
+SERVER:7302 64_HEX_PEER_KEY
+```
+
+Then set `LUMABRI_PEER_PINS=/path/to/peer-pins`. Strict pin files must list
+every endpoint the process may contact. `LUMABRI_REQUIRE_PIN=1` applies the
+same no-learning rule to a preseeded `known_hosts`. The endpoint key is not
+the model-signing key: `LUMABRI_PUBKEY` authenticates model contents, while
+peer pins authenticate network endpoints. For endpoint-key rotation, publish
+two rows for the same address containing old and new keys, switch the server,
+then remove the old row. Persistent TOFU instead requires an explicit
+`known_hosts` update after verifying the replacement key out of band.
+
+The tracker also persists the first key that owns each maintainer/executor
+name. A restart rebuilds placements from heartbeats but does not reopen names
+for takeover. Per-key and per-source live-name quotas limit table exhaustion;
+they are admission controls, not a claim to solve distributed Sybil attacks.
+
 The server also runs an expert node on the whole model, so a fresh swarm works
 on day zero with the server executing everything, and donors that join later win
 the calls they are nearest for. The nearest replica sets the speed: an expert
@@ -186,14 +220,18 @@ make test
 ```
 
 runs the core suites: byte identity, donor integrity, role parsing, security
-(path escape, hostile frame lengths, idle connections), protocol input
-validation and prefetch policy. Per-engine expert identity runs with fixtures
+(path escape, hostile frame lengths, aggregate receive memory, idle
+connections, durable identities and admission quotas), protocol input
+validation, cryptographic vectors, encrypted transport and prefetch policy.
+Per-engine expert identity runs with fixtures
 (`make test-engines`), and DeepSeek V4 against a real model
 (`make test-phase2-deepseek MODEL=<dir>`). Assignment, concurrency and signing
 have their own scripts (`assign_test.sh`, `concurrency_test.sh`,
 `sign_test.sh`). The newer mechanisms have focused targets:
-`make test-cas test-key-rotation test-hedge test-relay-exec`. Every claim in
-this README has a script behind it.
+`make test-cas test-key-rotation test-hedge test-relay-exec`. Relay EXEC needs
+an OLMoE engine source under `ENGINE`; its script reports `SKIP` explicitly
+when that external checkout is absent. Every claim in this README has a script
+behind it.
 
 ## How it compares
 
@@ -217,7 +255,9 @@ binaries.
 Working prototype, deployable. Open swarms verify bytes (sha256 per MiB and a
 signed complete-model root, checked by the chatter against its own trust set)
 and results (spot-check on a second replica). Private swarms add an invite token
-everywhere with `LUMABRI_TOKEN`. Multi-row speculative verification, fixed-delay
+everywhere with `LUMABRI_TOKEN`; `LUMABRI_ENCRYPT=1` protects that token and
+activations in transit, using persistent TOFU or strict endpoint pins.
+Multi-row speculative verification, fixed-delay
 hedging, a local cross-checkpoint CAS, manual old+new key rotation and NAT relay
 for both READ and EXEC are implemented. Automatic SLA tuning, distributed/S3
 CAS, KMS/HSM integration and automatic revocation are intentionally not part of

--- a/assign_test.sh
+++ b/assign_test.sh
@@ -25,6 +25,7 @@ make -s tracker expert_node ENGINE="$ENGINE"
 [ -f "$MODEL/config.json" ] || make -s fixture
 
 T=$(mktemp -d /tmp/lumabri-assign.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/cas_test.sh
+++ b/cas_test.sh
@@ -4,6 +4,7 @@ cd "$(dirname "$0")"
 
 make -s tracker maintainer liblumabri.so test_shim
 T=$(mktemp -d /tmp/lumabri-cas.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/crypto_test.sh
+++ b/crypto_test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # lumabri — the transport primitives against their published test vectors.
 #
-# ChaCha20, Poly1305 and the AEAD from RFC 8439, and X25519 from RFC 7748.
+# ChaCha20, Poly1305 and the AEAD from RFC 8439, X25519 from RFC 7748,
+# HMAC-SHA512 from RFC 4231, and an independently generated HKDF-SHA512
+# vector using RFC 5869's first test-case inputs.
 # A cipher that merely round-trips proves nothing; a cipher that reproduces
 # the RFC's own bytes is the real check, the same standard sign_test holds
 # Ed25519 to. Also a tamper case: one flipped byte must fail the tag.
@@ -93,6 +95,32 @@ int main(void) {
         lc_x25519(sa, a, B); lc_x25519(sb, b, A);
         if (memcmp(sa, sb, 32)) { printf("  FAIL X25519 DH disagreement\n"); fail = 1; }
         else printf("  ok   X25519 DH agreement\n");
+    }
+    /* RFC 4231 test case 1 — HMAC-SHA512 */
+    {
+        uint8_t key[20], out[64]; memset(key, 0x0b, sizeof key);
+        lc_hmac_sha512(key, sizeof key, (const uint8_t *)"Hi There", 8, out);
+        hx("HMAC-SHA512 (RFC 4231 case 1)", out,
+           "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cded"
+           "aa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854", 64);
+    }
+    /* HKDF-SHA512 with RFC 5869 case-1 IKM/salt/info.  Expected bytes were
+     * generated independently with Python's hashlib+hmac, not this code. */
+    {
+        uint8_t ikm[22], salt[13], info[10], out[64];
+        memset(ikm, 0x0b, sizeof ikm);
+        for (int i = 0; i < 13; i++) salt[i] = (uint8_t)i;
+        for (int i = 0; i < 10; i++) info[i] = (uint8_t)(0xf0 + i);
+        if (lc_hkdf(salt, sizeof salt, ikm, sizeof ikm,
+                    info, sizeof info, out, sizeof out)) {
+            printf("  FAIL HKDF-SHA512 returned an error\n"); fail = 1;
+        } else hx("HKDF-SHA512 expand", out,
+           "832390086cda71fb47625bb5ceb168e4c8e26a1a16ed34d9fc7fe92c148157933"
+           "8da362cb8d9f925d7cbcce0dff7098769cf15959867d571c1715450cb530137", 64);
+        if (lc_hkdf(salt, sizeof salt, ikm, sizeof ikm,
+                    info, sizeof info, out, 65) == 0) {
+            printf("  FAIL HKDF accepted an oversized output\n"); fail = 1;
+        } else printf("  ok   HKDF rejects oversized output\n");
     }
     puts(fail ? "LUMABRI CRYPTO TEST: FAIL" : "LUMABRI CRYPTO TEST: PASS");
     return fail;

--- a/donate_test.sh
+++ b/donate_test.sh
@@ -9,6 +9,7 @@ cd "$(dirname "$0")"
 make -s all
 
 T=$(mktemp -d /tmp/lumabri-donate.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() {
     if [ "${#PIDS[@]}" -gt 0 ]; then

--- a/encrypted_transport_test.sh
+++ b/encrypted_transport_test.sh
@@ -8,7 +8,8 @@
 #   1) an encrypted swarm serves a model byte-for-byte over the AEAD channel;
 #   2) a plaintext chatter against an encrypted maintainer gets nothing, not
 #      the bytes in the clear — encryption is not silently skippable;
-#   3) the model bytes never appear on the wire in the clear.
+#   3) the model bytes never appear on the wire in the clear;
+#   4) a wrong endpoint pin is rejected before any application frame.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -95,13 +96,55 @@ echo "   ✓ the marker is not in the tapped ciphertext ($(wc -c < "$T/wire.log"
 if command -v tcpdump >/dev/null 2>&1 && tcpdump -D >/dev/null 2>&1; then
     tcpdump -i lo -w "$T/cap.pcap" "tcp port 7641" > /dev/null 2>&1 & TD=$!
     sleep 0.5
-    env LUMABRI_ENCRYPT=1 LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v4" \
-        LUMABRI_CACHE="$T/c4" LUMABRI_TRACKER=127.0.0.1:7640 LUMABRI_MODEL=fx \
-        LUMABRI_BLOCK_MIB=1 LUMABRI_HS_TIMEOUT_MS=2000 timeout 30 ./test_shim "$T/v4" "$T/src" > /dev/null 2>&1
-    sleep 0.5; kill "$TD" 2>/dev/null || true; wait "$TD" 2>/dev/null || true
-    if grep -a -q "$MARKER" "$T/cap.pcap"; then
-        echo "   the model marker appeared on the raw wire in the clear"; exit 1; fi
-    echo "   ✓ confirmed at the kernel wire too (tcpdump)"
+    if kill -0 "$TD" 2>/dev/null; then
+        env LUMABRI_ENCRYPT=1 LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v4" \
+            LUMABRI_CACHE="$T/c4" LUMABRI_TRACKER=127.0.0.1:7640 LUMABRI_MODEL=fx \
+            LUMABRI_BLOCK_MIB=1 LUMABRI_HS_TIMEOUT_MS=2000 timeout 30 ./test_shim "$T/v4" "$T/src" > /dev/null 2>&1
+        sleep 0.5; kill "$TD" 2>/dev/null || true; wait "$TD" 2>/dev/null || true
+        if [ ! -s "$T/cap.pcap" ] || ! tcpdump -r "$T/cap.pcap" -c 1 >/dev/null 2>&1; then
+            echo "   · kernel capture skipped: tcpdump produced no readable packets"
+        elif grep -a -q "$MARKER" "$T/cap.pcap"; then
+            echo "   the model marker appeared on the raw wire in the clear"; exit 1
+        else
+            echo "   ✓ confirmed at the kernel wire too (tcpdump)"
+        fi
+    else
+        wait "$TD" 2>/dev/null || true
+        echo "   · kernel capture skipped: tcpdump could not start"
+    fi
+else
+    echo "   · kernel capture skipped: tcpdump unavailable (user-space tap passed)"
 fi
+
+echo "· 4) a wrong endpoint pin is rejected"
+printf '127.0.0.1:7640 %064d\n' 0 > "$T/wrong.pins"
+set +e
+env LUMABRI_ENCRYPT=1 LUMABRI_PEER_PINS="$T/wrong.pins" \
+    LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_VROOT="$T/v5" LUMABRI_CACHE="$T/c5" \
+    LUMABRI_TRACKER=127.0.0.1:7640 LUMABRI_MODEL=fx LUMABRI_BLOCK_MIB=1 \
+    LUMABRI_HS_TIMEOUT_MS=2000 timeout 20 ./test_shim "$T/v5" "$T/src" \
+    > "$T/wrong-pin.log" 2>&1
+PIN_RC=$?
+set -e
+if [ "$PIN_RC" -eq 0 ] && grep -q "byte-identical" "$T/wrong-pin.log"; then
+    echo "   client accepted the wrong tracker identity pin"; exit 1
+fi
+grep -q '^127\.0\.0\.1:7640 ' "$T/.lumabri/known_hosts" || {
+    echo "   tracker identity was not persisted in known_hosts"; exit 1; }
+echo "   ✓ wrong pin refused; successful TOFU identity persisted"
+
+echo "· 5) encryption cannot downgrade when its identity key is unavailable"
+set +e
+env HOME="$T" LUMABRI_ENCRYPT=1 \
+    LUMABRI_PEER_KEY="$T/missing-parent/peer.key" \
+    ./tracker --port 7649 > "$T/fail-closed.log" 2>&1
+KEY_RC=$?
+set -e
+if [ "$KEY_RC" -eq 0 ]; then
+    echo "   tracker continued after encrypted identity setup failed"; exit 1
+fi
+grep -q "refusing all network traffic" "$T/fail-closed.log" || {
+    echo "   encrypted identity failure was not explicit"; cat "$T/fail-closed.log"; exit 1; }
+echo "   ✓ startup refused; no plaintext listener was opened"
 
 echo "LUMABRI ENCRYPTED TRANSPORT TEST: PASS"

--- a/expert_node.c
+++ b/expert_node.c
@@ -419,7 +419,7 @@ static void *conn_thread(void *arg) {
             char tok[LMB_TOKEN_MAX + 1] = "";
             LmbCur c = { m.body, m.body_len, 0 };
             int bad = lmb_cur_str(&c, tok, sizeof tok) || c.off != c.len;
-            if (!bad && (!g.token[0] || !strcmp(tok, g.token))) {
+            if (!bad && (!g.token[0] || lmb_token_equal(tok, g.token))) {
                 authed = 1;
                 rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
             } else { send_err(fd, "bad token"); rc = -1; }
@@ -858,7 +858,7 @@ int main(int argc, char **argv) {
     }
     pthread_t t;
     lmb_conn_gate_init(&g_conn_gate);
-    lmb_secure_init();
+    if (lmb_secure_init()) return 1;
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }
     pthread_create(&t, NULL, stats_thread, NULL); pthread_detach(t);
 

--- a/hot_cache_integrity_test.sh
+++ b/hot_cache_integrity_test.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")"
 
 make -s all
 T=$(mktemp -d /tmp/lumabri-hot-cache.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() {
     if [ "${#PIDS[@]}" -gt 0 ]; then

--- a/lumabri.c
+++ b/lumabri.c
@@ -123,21 +123,22 @@ static pid_t spawn_argv(char *const argv[]) {
 
 static pid_t g_children[8];
 static int g_nchildren = 0;
+/* The async handler never reads the mutable table/count.  Each fixed slot is
+ * one sig_atomic_t publication, so delivery on any worker thread cannot see a
+ * compacted/torn child table. */
+static volatile sig_atomic_t g_signal_children[8];
 /* what each child was, and how to start it again: a supervisor that cannot
  * name or restart what died is just a process that happens to be the parent */
 static char **g_cargv[8];
 static const char *g_cwhat[8];
 
-/* on_sigint reads g_children/g_nchildren; the main thread writes them. Block
- * the two signals around every write so the handler never sees the array
- * half-updated (a torn read would kill a stale pid or miss a live child). */
-static void children_lock(sigset_t *saved) {
-    sigset_t s; sigemptyset(&s);
-    sigaddset(&s, SIGINT); sigaddset(&s, SIGTERM);
-    sigprocmask(SIG_BLOCK, &s, saved);
+static void child_publish(int idx, pid_t pid) {
+    g_children[idx] = pid;
+    g_signal_children[idx] = (sig_atomic_t)pid;
 }
-static void children_unlock(const sigset_t *saved) {
-    sigprocmask(SIG_SETMASK, saved, NULL);
+static void child_unpublish(int idx) {
+    g_signal_children[idx] = 0;
+    g_children[idx] = 0;
 }
 
 static void spawn_tracked(char *const argv[], const char *what) {
@@ -146,13 +147,11 @@ static void spawn_tracked(char *const argv[], const char *what) {
     char **copy = (char **)calloc((size_t)n + 1, sizeof *copy);
     for (int i = 0; i < n; i++) copy[i] = strdup(argv[i]);
     pid_t pid = spawn_argv(argv);          /* the slow part, outside the mask */
-    sigset_t saved; children_lock(&saved);
     int idx = g_nchildren;
     g_cargv[idx] = copy;
     g_cwhat[idx] = what;
-    g_children[idx] = pid;
+    child_publish(idx, pid);
     g_nchildren++;
-    children_unlock(&saved);
 }
 
 static volatile sig_atomic_t g_stopping = 0;
@@ -160,7 +159,10 @@ static volatile sig_atomic_t g_stopping = 0;
 static void on_sigint(int sig) {
     (void)sig;
     g_stopping = 1;
-    for (int i = 0; i < g_nchildren; i++) kill(g_children[i], SIGTERM);
+    for (int i = 0; i < 8; i++) {
+        sig_atomic_t p = g_signal_children[i];
+        if (p > 0) kill((pid_t)p, SIGTERM);
+    }
 }
 
 /* Which expert-node binary can execute this model's experts, or NULL when
@@ -369,19 +371,17 @@ static int cmd_serve(int argc, char **argv) {
 
     printf("\n%sserving%s %s %s(tracker %s%s)%s\n", C_GRN, C_R, model, C_DIM, taddr,
            with_exec ? " · executing experts for the swarm" : "", C_R);
-    /* Without --advertise every peer here registers as 127.0.0.1, and the
-     * tracker's correction cannot help: it only rewrites the host when the
-     * registration arrives from OFF this machine, and these arrive over
-     * loopback. A remote chatter then gets 127.0.0.1, fails to connect, falls
-     * back to the relay for bytes — and phase 2 never starts at all, because
-     * expert execution has no relay. It looks like a slow swarm instead of a
-     * misconfigured one, so say it plainly. */
+    /* Without --advertise every local peer registers as 127.0.0.1, and the
+     * tracker's correction cannot help because these registrations arrive
+     * over loopback. A remote chatter then uses the READ/EXEC tracker relay.
+     * That works through NAT but adds an extra hop and centralises traffic,
+     * so say plainly that --advertise is required for the direct P2P path. */
     if (!advertise && !join)
-        printf("%s⚠ nessun --advertise: questo sciame è raggiungibile SOLO da "
-               "questa macchina.%s\n"
-               "%s  I peer si annunciano come 127.0.0.1 e un chatter remoto non "
-               "può collegarsi.%s\n"
-               "%s  Per aprirlo:  lumabri serve --model %s --advertise <ip-pubblico>%s\n",
+        printf("%s⚠ nessun --advertise: i chatter remoti useranno il relay del "
+               "tracker per READ ed EXEC.%s\n"
+               "%s  Funziona anche dietro NAT, ma aggiunge un hop e carica il "
+               "tracker; --advertise abilita il P2P diretto.%s\n"
+               "%s  Per il percorso diretto: lumabri serve --model %s --advertise <ip-pubblico>%s\n",
                C_RED, C_R, C_DIM, C_R, C_DIM, model, C_R);
     printf("%schat from this machine:   lumabri chat%s\n", C_DIM, C_R);
     printf("%schat from another one:    lumabri chat --tracker <this-ip>:%d%s\n\n",
@@ -408,17 +408,16 @@ static int cmd_serve(int argc, char **argv) {
             fflush(stdout);
             sleep(5);
             pid_t np = spawn_argv(g_cargv[idx]);
-            sigset_t saved; children_lock(&saved);
-            g_children[idx] = np;
-            children_unlock(&saved);
+            child_publish(idx, np);
             printf("  %s%s riavviato%s\n", C_DIM, g_cwhat[idx], C_R);
             fflush(stdout);
             continue;
         }
         if (idx >= 0) {
-            sigset_t saved; children_lock(&saved);
-            g_children[idx] = g_children[--g_nchildren];
-            children_unlock(&saved);
+            int last = --g_nchildren;
+            pid_t moved = g_children[last];
+            if (idx != last) child_publish(idx, moved); /* duplicate is harmless */
+            child_unpublish(last);
         }
     }
     return 0;
@@ -1280,8 +1279,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             const char *pub = getenv("LUMABRI_PUBKEY");
             if (pub && pub[0]) { argv[a++] = "--pubkey"; argv[a++] = (char *)pub; }
             argv[a] = NULL;
-            { pid_t np = spawn_argv(argv); sigset_t sv; children_lock(&sv);
-              g_children[g_nchildren++] = np; children_unlock(&sv); }
+            { pid_t np = spawn_argv(argv); child_publish(g_nchildren++, np); }
             printf("  %s\xe2\x9c\xa6 dono %.0f GB di %s%s%s%s: il tracker mi assegna "
                    "i file piu\xcc\x80 rari%s\n",
                    C_GRN, r->gb, C_R, C_BOLD, model, C_DIM, C_R);
@@ -1310,8 +1308,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             argv[a++] = "--model-name"; argv[a++] = (char *)model;
             argv[a++] = "--cache";      argv[a++] = "64";
             argv[a] = NULL;
-            { pid_t np = spawn_argv(argv); sigset_t sv; children_lock(&sv);
-              g_children[g_nchildren++] = np; children_unlock(&sv); }
+            { pid_t np = spawn_argv(argv); child_publish(g_nchildren++, np); }
             printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s)%s\n",
                    C_GRN, C_R, C_DIM, node, C_R);
         }
@@ -1692,8 +1689,10 @@ static int cmd_chat(int argc, char **argv) {
      * running as an orphan, still serving, with nobody left who knew it
      * existed. */
     for (int i = 0; i < g_nchildren; i++) {
-        kill(g_children[i], SIGTERM);
-        waitpid(g_children[i], NULL, 0);
+        pid_t p = g_children[i];
+        child_unpublish(i);
+        kill(p, SIGTERM);
+        waitpid(p, NULL, 0);
     }
     if (g_nchildren) printf("  %sdonazione chiusa%s\n", C_DIM, C_R);
     printf("\n");
@@ -1747,13 +1746,28 @@ static int cmd_key(int argc, char **argv) {
     return 0;
 }
 
+/* Print this machine's transport/registration identity.  Operators use this
+ * public value to build LUMABRI_PEER_PINS without exposing peer.key. */
+static int cmd_peer_key(int argc, char **argv) {
+    (void)argv;
+    if (argc) { fprintf(stderr, "usage: lumabri peer-key\n"); return 2; }
+    char path[512], hex[65]; uint8_t sk[64], pk[32];
+    const char *kp = lmb_peer_key_path(path, sizeof path);
+    if (lmb_peer_identity(kp, sk, pk)) { perror(kp); return 1; }
+    lmb_hex(hex, pk, sizeof pk);
+    printf("%s\n", hex);
+    memset(sk, 0, sizeof sk);
+    return 0;
+}
+
 /* ---- main --------------------------------------------------------------- */
 
 int main(int argc, char **argv) {
     g_tty = isatty(1);
-    lmb_secure_init();      /* honours LUMABRI_ENCRYPT for this process's own
-                               tracker queries; children inherit the env */
     if (argc >= 2 && !strcmp(argv[1], "key")) return cmd_key(argc - 2, argv + 2);
+    if (argc >= 2 && !strcmp(argv[1], "peer-key"))
+        return cmd_peer_key(argc - 2, argv + 2);
+    if (lmb_secure_init()) return 1; /* children inherit the same strict mode */
     const char *tok = getenv("LUMABRI_TOKEN");
     if (tok && strlen(tok) > LMB_TOKEN_MAX) {
         fprintf(stderr, "LUMABRI_TOKEN must be at most %u bytes\n",
@@ -1769,6 +1783,7 @@ int main(int argc, char **argv) {
     fprintf(stderr,
         "lumabri: run huge models from a swarm of peers\n\n"
         "  lumabri                                                    chat (asks what it needs)\n"
+        "  lumabri peer-key                                           print this machine's endpoint identity\n"
         "  lumabri serve --model DIR [--port 7300] [--join TRACKER]   share a model\n"
         "  lumabri chat  [--tracker HOST:7300] [--model NAME]         chat with it\n"
         "  lumabri key   [--out NAME]                                 operator keypair\n");

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -384,7 +384,7 @@ static void lumi_maybe_discover(void) {
  * every model that has one. */
 static void lumi_init_ex(int n_layers, int n_experts, int hidden,
                          const unsigned char *routed) {
-    lmb_secure_init();
+    if (lmb_secure_init()) return;
     const char *spec = getenv("LUMABRI_EXPERTS");
     if (getenv("LUMABRI_NO_EXEC")) return;
     const char *tracker = getenv("LUMABRI_TRACKER");
@@ -560,7 +560,7 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
             int i = map[q];
             LmbMsg m = {0};
             if (lmb_recv(fd[i], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
-                float *res = (float *)m.pay; m.pay = NULL; lmb_msg_free(&m);
+                float *res = (float *)lmb_msg_take_pay(&m); lmb_msg_free(&m);
                 lumi_put_sock(p[i], fd[i]); fd[i] = -1;
                 if (i == 1) L.hedge_wins++;
                 for (int j = 0; j < 2; j++) if (fd[j] >= 0) close(fd[j]);
@@ -600,7 +600,7 @@ static float *lumi_exec_relay(int layer, int eid, const float *x, int D, int nr,
     uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
     float *out = NULL;
     if (!rc && m.op == LMB_REXEC_R && m.pay_len == want) {
-        out = (float *)m.pay; m.pay = NULL; L.relays++;
+        out = (float *)lmb_msg_take_pay(&m); L.relays++;
     } else if (!rc && m.op == LMB_ERR) {
         char why[160] = "relay refused the call";
         LmbCur c = { m.body, m.body_len, 0 };
@@ -668,8 +668,7 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
             fprintf(stderr, "[lumabri] peer %s failed — trying next replica\n", p->addr);
             continue;
         }
-        float *res = (float *)m.pay;
-        m.pay = NULL;
+        float *res = (float *)lmb_msg_take_pay(&m);
         lmb_msg_free(&m);
         lumi_put_sock(p, fd);
         L.failovers++;

--- a/lumabri_crypto.h
+++ b/lumabri_crypto.h
@@ -290,19 +290,23 @@ static void lc_hmac_sha512(const uint8_t *key, size_t klen,
     lmb_sha512_update(&s, inner, 64); lmb_sha512_final(&s, out);
 }
 
-/* HKDF-Extract+Expand to `n` bytes (n <= 64: one block is plenty here). */
-static void lc_hkdf(const uint8_t *salt, size_t slen,
-                    const uint8_t *ikm, size_t ilen,
-                    const uint8_t *info, size_t inflen,
-                    uint8_t *out, size_t n) {
+/* HKDF-Extract+Expand to `n` bytes.  This transport only needs one SHA-512
+ * block; reject larger requests and oversized info instead of truncating the
+ * output or overflowing the fixed expand buffer. */
+static int lc_hkdf(const uint8_t *salt, size_t slen,
+                   const uint8_t *ikm, size_t ilen,
+                   const uint8_t *info, size_t inflen,
+                   uint8_t *out, size_t n) {
     uint8_t prk[64], t[64 + 64];
+    if (n > 64 || inflen > sizeof(t) - 1) return -1;
     lc_hmac_sha512(salt, slen, ikm, ilen, prk);      /* extract */
     size_t tl = 0;
     memcpy(t + tl, info, inflen); tl += inflen;
     t[tl++] = 1;
     uint8_t okm[64];
     lc_hmac_sha512(prk, 64, t, tl, okm);             /* expand, block 1 */
-    memcpy(out, okm, n < 64 ? n : 64);
+    memcpy(out, okm, n);
+    return 0;
 }
 
 #endif /* LUMABRI_CRYPTO_H */

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -69,6 +69,17 @@
 #define LMB_HASH_MAGIC 0x48414853u  /* "SHAH": optional hash section marker */
 #define LMB_PEER_AUTH_MAGIC 0x52554150u /* "PAUR": trailing peer-identity block */
 
+/* Both arguments must point at the fixed LMB_TOKEN_MAX+1 authentication
+ * buffers used by the daemons.  Compare the complete buffers so a remote
+ * caller cannot learn a shared invite token one prefix at a time. */
+static int lmb_token_equal(const char a[LMB_TOKEN_MAX + 1],
+                           const char b[LMB_TOKEN_MAX + 1]) {
+    unsigned diff = 0;
+    for (size_t i = 0; i <= LMB_TOKEN_MAX; i++)
+        diff |= (unsigned)(uint8_t)a[i] ^ (unsigned)(uint8_t)b[i];
+    return diff == 0;
+}
+
 enum {
     LMB_PING = 1, LMB_OK = 2, LMB_ERR = 3,
     LMB_MANIFEST = 4, LMB_MANIFEST_R = 5,
@@ -176,6 +187,10 @@ typedef struct {
     uint32_t op;
     uint8_t *body; uint32_t body_len;
     uint8_t *pay;  uint32_t pay_len;
+    /* Encrypted frames are decrypted into one allocation and body/pay point
+     * inside it.  Plain frames keep the legacy two-allocation layout. */
+    uint8_t *storage;
+    uint32_t rx_reserved;
 } LmbMsg;
 
 typedef struct {
@@ -277,7 +292,38 @@ static int lmb_frame_shape_ok(uint32_t op, uint32_t body_len, uint32_t pay_len) 
  * -2). Static per translation unit, so only a .c that opts in is affected. */
 static int (*lmb_enc_send)(int, uint32_t, const void *, uint32_t, const void *, uint32_t);
 static int (*lmb_enc_recv)(int, LmbMsg *);
-static int (*lmb_enc_wrap)(int fd, int is_client);   /* handshake+register; 0 ok */
+static int (*lmb_enc_wrap)(int fd, int is_client, const char *addr);
+static void (*lmb_enc_forget)(int fd);
+static int lmb_env_int(const char *name, int fallback, int lo, int hi);
+
+/* Bound aggregate receive memory, not just each individual frame.  Without
+ * this, the connection gate multiplied by a legal 64 MiB payload is still an
+ * easy multi-gigabyte OOM. */
+static _Atomic uint64_t lmb_rx_inflight;
+
+static int lmb_rx_reserve(LmbMsg *m, uint32_t n) {
+    if (!n) return 0;
+    uint64_t cap = (uint64_t)lmb_env_int("LUMABRI_RX_BUDGET_MIB", 256, 16, 4096)
+                   << 20;
+    uint64_t old = atomic_load(&lmb_rx_inflight);
+    do {
+        if ((uint64_t)n > cap || old > cap - n) { errno = ENOBUFS; return -1; }
+    } while (!atomic_compare_exchange_weak(&lmb_rx_inflight, &old, old + n));
+    m->rx_reserved = n;
+    return 0;
+}
+
+static void lmb_rx_release(LmbMsg *m) {
+    if (m->rx_reserved) {
+        atomic_fetch_sub(&lmb_rx_inflight, m->rx_reserved);
+        m->rx_reserved = 0;
+    }
+}
+
+static int lmb_close(int fd) {
+    if (lmb_enc_forget) lmb_enc_forget(fd);
+    return close(fd);
+}
 
 static int lmb_send(int fd, uint32_t op, const void *body, uint32_t body_len,
                     const void *pay, uint32_t pay_len) {
@@ -307,22 +353,51 @@ static int lmb_recv(int fd, LmbMsg *m) {
         errno = EMSGSIZE;
         return -1;
     }
+    uint64_t total64 = (uint64_t)m->body_len + m->pay_len;
+    if (total64 > UINT32_MAX || lmb_rx_reserve(m, (uint32_t)total64)) return -1;
     if (m->body_len) {
-        if (!(m->body = (uint8_t *)malloc(m->body_len))) return -1;
-        if (lmb_read_full(fd, m->body, m->body_len)) { free(m->body); m->body = NULL; return -1; }
+        if (!(m->body = (uint8_t *)malloc(m->body_len))) { lmb_rx_release(m); return -1; }
+        if (lmb_read_full(fd, m->body, m->body_len)) {
+            free(m->body); m->body = NULL; lmb_rx_release(m); return -1;
+        }
     }
     if (m->pay_len) {
-        if (!(m->pay = (uint8_t *)malloc(m->pay_len))) { free(m->body); m->body = NULL; return -1; }
+        if (!(m->pay = (uint8_t *)malloc(m->pay_len))) {
+            free(m->body); m->body = NULL; lmb_rx_release(m); return -1;
+        }
         if (lmb_read_full(fd, m->pay, m->pay_len)) {
-            free(m->body); free(m->pay); m->body = m->pay = NULL; return -1;
+            free(m->body); free(m->pay); m->body = m->pay = NULL;
+            lmb_rx_release(m); return -1;
         }
     }
     return 0;
 }
 
 static void lmb_msg_free(LmbMsg *m) {
-    free(m->body); free(m->pay);
+    if (m->storage) free(m->storage);
+    else { free(m->body); free(m->pay); }
     m->body = m->pay = NULL;
+    m->storage = NULL;
+    lmb_rx_release(m);
+}
+
+/* Transfer a payload out of a message without relying on body/pay being
+ * separate mallocs.  For a secure combined frame, compact the payload to the
+ * front and transfer the one allocation. */
+static uint8_t *lmb_msg_take_pay(LmbMsg *m) {
+    if (!m || !m->pay) return NULL;
+    uint8_t *out;
+    if (m->storage) {
+        out = m->storage;
+        if (m->pay != out) memmove(out, m->pay, m->pay_len);
+        m->storage = NULL;
+    } else {
+        out = m->pay;
+        free(m->body);
+    }
+    m->body = m->pay = NULL;
+    lmb_rx_release(m);
+    return out;
 }
 
 /* ---- body builder / cursor -------------------------------------------- */
@@ -593,7 +668,7 @@ static int lmb_connect_ms(const char *addr, int timeout_ms) {
                                            LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
         /* when this component has enabled encryption, every outbound
          * connection handshakes here, before any frame is sent */
-        if (lmb_enc_wrap && lmb_enc_wrap(fd, 1)) { close(fd); fd = -1; }
+        if (lmb_enc_wrap && lmb_enc_wrap(fd, 1, addr)) { lmb_close(fd); fd = -1; }
     }
     return fd;
 }
@@ -696,7 +771,7 @@ static int lmb_request_pay(const char *addr, uint32_t op,
     int rc = lmb_auth(fd);
     if (rc == 0) rc = lmb_send(fd, op, body, body_len, pay, pay_len);
     if (rc == 0) rc = lmb_recv(fd, resp);
-    close(fd);
+    lmb_close(fd);
     return rc;
 }
 

--- a/lumabri_secure.h
+++ b/lumabri_secure.h
@@ -16,9 +16,9 @@
  * cannot forge without a key the peer would recognise as wrong.
  *
  * This defeats passive capture of tokens and activations and frame tampering
- * and replay. Full MITM resistance still needs the verifier to pin the peer's
- * identity out of band (LUMABRI_PUBKEY for a signed swarm); without a pin it
- * is trust-on-first-use, the SSH first-connect model.
+ * and replay. LUMABRI_PEER_PINS provides strict out-of-band endpoint pinning;
+ * without it, persistent known_hosts provides the SSH first-connect model.
+ * LUMABRI_PUBKEY is separate: it authenticates model contents, not endpoints.
  */
 #ifndef LUMABRI_SECURE_H
 #define LUMABRI_SECURE_H
@@ -26,6 +26,8 @@
 #include "lumabri_proto.h"
 #include "lumabri_crypto.h"
 #include "lumabri_sign.h"
+#include <ctype.h>
+#include <sys/file.h>
 
 typedef struct {
     int active;
@@ -75,6 +77,14 @@ static int lmb_secure_handshake(int fd, int is_client,
         memcpy(eph_c, peer_eph, 32); memcpy(eph_s, eph_pk, 32);
     }
 
+    /* RFC 7748 permits protocols to reject the all-zero result.  We must:
+     * accepting a low-order public point destroys contributory behaviour and
+     * produces a publicly predictable traffic secret. */
+    uint8_t shared[32], shared_or = 0;
+    lc_x25519(shared, eph_sk, peer_eph);
+    for (size_t i = 0; i < sizeof shared; i++) shared_or |= shared[i];
+    if (!shared_or) { errno = EPROTO; return -1; }
+
     /* transcript both sides sign: tag || client ephemeral || server ephemeral */
     uint8_t tr[sizeof(LMB_HS_TAG) - 1 + 64];
     size_t tl = 0;
@@ -90,27 +100,31 @@ static int lmb_secure_handshake(int fd, int is_client,
         /* the server sends its identity and signature right after its
          * ephemeral; read and verify them, then send ours */
         if (lmb_read_full(fd, peer_id, 32) || lmb_read_full(fd, peer_sig, 64)) return -1;
-        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) return -1;
+        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) { errno = EKEYREJECTED; return -1; }
         if (lmb_write_full(fd, id_pk, 32) || lmb_write_full(fd, my_sig, 64)) return -1;
     } else {
         if (lmb_write_full(fd, id_pk, 32) || lmb_write_full(fd, my_sig, 64)) return -1;
         if (lmb_read_full(fd, peer_id, 32) || lmb_read_full(fd, peer_sig, 64)) return -1;
-        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) return -1;
+        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) { errno = EKEYREJECTED; return -1; }
     }
     memcpy(s->peer_id, peer_id, 32); s->have_peer_id = 1;
 
-    uint8_t shared[32];
-    lc_x25519(shared, eph_sk, peer_eph);
-
     uint8_t info[64], keys[64];
     memcpy(info, eph_c, 32); memcpy(info + 32, eph_s, 32);
-    lc_hkdf((const uint8_t *)"lumabri-secure-v1", 17, shared, 32, info, 64, keys, 64);
+    if (lc_hkdf((const uint8_t *)"lumabri-secure-v1", 17,
+                shared, 32, info, 64, keys, 64)) {
+        errno = EOVERFLOW;
+        return -1;
+    }
     /* client sends with keys[0..31], server sends with keys[32..63] */
     if (is_client) { memcpy(s->tx_key, keys, 32); memcpy(s->rx_key, keys + 32, 32); }
     else           { memcpy(s->tx_key, keys + 32, 32); memcpy(s->rx_key, keys, 32); }
     s->tx_ctr = s->rx_ctr = 0;
     s->active = 1;
     lmb_hs_deadline(fd, 0);            /* back to the normal io timeout */
+    memset(eph_sk, 0, sizeof eph_sk);
+    memset(shared, 0, sizeof shared);
+    memset(keys, 0, sizeof keys);
     return 0;
 }
 
@@ -126,17 +140,18 @@ static int lmb_secure_send(LmbSecure *s, int fd, uint32_t op,
     uint8_t hdr[16];
     lc_st32(hdr, LMB_MAGIC); lc_st32(hdr + 4, op);
     lc_st32(hdr + 8, body_len); lc_st32(hdr + 12, pay_len);
-    uint8_t *pt = (uint8_t *)malloc(total ? total : 1);
     uint8_t *ct = (uint8_t *)malloc(total ? total : 1);
     uint8_t tag[16];
-    if (!pt || !ct) { free(pt); free(ct); return -1; }
-    if (body_len) memcpy(pt, body, body_len);
-    if (pay_len)  memcpy(pt + body_len, pay, pay_len);
+    if (!ct) return -1;
+    if (body_len) memcpy(ct, body, body_len);
+    if (pay_len)  memcpy(ct + body_len, pay, pay_len);
     uint8_t nonce[12]; lmb_sec_nonce(nonce, s->tx_ctr++);
-    lc_aead_seal(s->tx_key, nonce, hdr, 16, pt, total, ct, tag);
+    /* ChaCha20 is safe in place, so an outbound 64 MiB frame also needs only
+     * one frame-sized allocation. */
+    lc_aead_seal(s->tx_key, nonce, hdr, 16, ct, total, ct, tag);
     int rc = lmb_write_full(fd, hdr, 16) || lmb_write_full(fd, ct, total) ||
              lmb_write_full(fd, tag, 16);
-    free(pt); free(ct);
+    free(ct);
     return rc ? -1 : 0;
 }
 
@@ -150,21 +165,117 @@ static int lmb_secure_recv(LmbSecure *s, int fd, LmbMsg *m) {
     m->body_len = lc_ld32(hdr + 8);
     m->pay_len = lc_ld32(hdr + 12);
     if (!lmb_frame_shape_ok(m->op, m->body_len, m->pay_len)) return -1;
-    uint32_t total = m->body_len + m->pay_len;
-    uint8_t *ct = (uint8_t *)malloc(total ? total : 1);
-    uint8_t *pt = (uint8_t *)malloc(total ? total : 1);
+    uint64_t total64 = (uint64_t)m->body_len + m->pay_len;
+    if (total64 > UINT32_MAX) { errno = EMSGSIZE; return -1; }
+    uint32_t total = (uint32_t)total64;
+    if (lmb_rx_reserve(m, total)) return -1;
+    /* AEAD open is safe in-place: authenticate ciphertext first, then XOR the
+     * ChaCha stream over the same bytes.  One legal 64 MiB frame therefore
+     * costs 64 MiB, not two or three copies. */
+    uint8_t *wire = (uint8_t *)malloc(total ? total : 1);
     uint8_t tag[16];
-    if (!ct || !pt) { free(ct); free(pt); return -1; }
-    if (lmb_read_full(fd, ct, total) || lmb_read_full(fd, tag, 16)) { free(ct); free(pt); return -1; }
-    uint8_t nonce[12]; lmb_sec_nonce(nonce, s->rx_ctr++);
-    if (lc_aead_open(s->rx_key, nonce, hdr, 16, ct, total, tag, pt)) {
-        free(ct); free(pt); return -1;             /* tamper, replay, or wrong key */
+    if (!wire) { lmb_rx_release(m); return -1; }
+    if (lmb_read_full(fd, wire, total) || lmb_read_full(fd, tag, 16)) {
+        free(wire); lmb_rx_release(m); return -1;
     }
-    free(ct);
-    if (m->body_len) { m->body = (uint8_t *)malloc(m->body_len); memcpy(m->body, pt, m->body_len); }
-    if (m->pay_len)  { m->pay  = (uint8_t *)malloc(m->pay_len);  memcpy(m->pay, pt + m->body_len, m->pay_len); }
-    free(pt);
+    uint8_t nonce[12]; lmb_sec_nonce(nonce, s->rx_ctr++);
+    if (lc_aead_open(s->rx_key, nonce, hdr, 16, wire, total, tag, wire)) {
+        free(wire); lmb_rx_release(m); return -1;  /* tamper, replay, or wrong key */
+    }
+    m->storage = wire;
+    if (m->body_len) m->body = wire;
+    if (m->pay_len) m->pay = wire + m->body_len;
     return 0;
+}
+
+/* ---- peer pinning and persistent TOFU ----------------------------------
+ *
+ * A self-signed handshake proves possession of *a* key, not that it is the
+ * key belonging to the endpoint the caller intended.  Outbound connections
+ * therefore check "address -> Ed25519 key" here before any application frame
+ * (and thus before an invite token or activation) is sent.
+ *
+ * LUMABRI_PEER_PINS points at a strict, operator-managed file.  Every outbound
+ * address must occur in it.  Otherwise ~/.lumabri/known_hosts is persistent
+ * TOFU: first contact is recorded durably, later changes are refused.
+ * LUMABRI_REQUIRE_PIN=1 disables learning and accepts existing known_hosts
+ * entries only.  File format: one `host:port 64hex` pair per line. */
+
+static int lmb_sec_addr_ok(const char *addr) {
+    if (!addr || !*addr || strlen(addr) >= 256) return 0;
+    for (const unsigned char *p = (const unsigned char *)addr; *p; p++)
+        if (isspace(*p) || *p < 0x21 || *p == 0x7f) return 0;
+    return 1;
+}
+
+static const char *lmb_sec_known_hosts_path(char out[512]) {
+    const char *e = getenv("LUMABRI_KNOWN_HOSTS");
+    if (e && *e) { snprintf(out, 512, "%s", e); return out; }
+    const char *home = getenv("HOME");
+    if (!home || !*home) return NULL;
+    char dir[448];
+    if (snprintf(dir, sizeof dir, "%s/.lumabri", home) >= (int)sizeof dir) return NULL;
+    if (mkdir(dir, 0700) && errno != EEXIST) return NULL;
+    if (snprintf(out, 512, "%s/known_hosts", dir) >= 512) return NULL;
+    return out;
+}
+
+/* Returns 0 match/learned, -1 mismatch/missing/error. */
+static int lmb_sec_pin_file(const char *path, const char *addr,
+                            const uint8_t peer[32], int learn) {
+    int flags = learn ? (O_RDWR | O_CREAT) : O_RDONLY;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    int fd = open(path, flags, 0600);
+    if (fd < 0) return -1;
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode) ||
+        (learn && (st.st_uid != geteuid() || (st.st_mode & 022)))) {
+        close(fd); errno = EACCES; return -1;
+    }
+    if (flock(fd, learn ? LOCK_EX : LOCK_SH)) { close(fd); return -1; }
+    FILE *fp = fdopen(fd, learn ? "r+" : "r");
+    if (!fp) { close(fd); return -1; }
+    char line[768], host[256], hex[65], extra;
+    int found = 0, seen_addr = 0, bad = 0;
+    rewind(fp);
+    while (fgets(line, sizeof line, fp)) {
+        char *p = line;
+        while (isspace((unsigned char)*p)) p++;
+        if (!*p || *p == '#') continue;
+        int n = sscanf(p, "%255s %64s %c", host, hex, &extra);
+        if (n != 2) { bad = 1; break; }
+        if (strcmp(host, addr)) continue;
+        uint8_t key[32];
+        if (lmb_unhex(key, hex, sizeof key)) { bad = 1; break; }
+        if (learn) {
+            /* known_hosts owns exactly one key per endpoint. */
+            if (seen_addr++ || memcmp(key, peer, 32)) { bad = 1; break; }
+            found = 1;
+        } else if (!memcmp(key, peer, 32)) {
+            /* An operator pin set may carry old+new rows during rotation. */
+            found = 1;
+        }
+    }
+    if (!bad && !found && learn) {
+        char ph[65]; lmb_hex(ph, peer, 32);
+        if (fseek(fp, 0, SEEK_END) || fprintf(fp, "%s %s\n", addr, ph) < 0 ||
+            fflush(fp) || fsync(fd)) bad = 1;
+        else found = 1;
+    }
+    fclose(fp); /* also unlocks and closes fd */
+    return !bad && found ? 0 : -1;
+}
+
+static int lmb_sec_check_peer(const char *addr, const uint8_t peer[32]) {
+    if (!lmb_sec_addr_ok(addr)) return -1;
+    const char *pins = getenv("LUMABRI_PEER_PINS");
+    if (pins && *pins) return lmb_sec_pin_file(pins, addr, peer, 0);
+    char path[512];
+    if (!lmb_sec_known_hosts_path(path)) return -1;
+    int require = lmb_env_int("LUMABRI_REQUIRE_PIN", 0, 0, 1);
+    return lmb_sec_pin_file(path, addr, peer, !require);
 }
 
 /* ---- opt-in transport integration -------------------------------------
@@ -177,62 +288,160 @@ static int lmb_secure_recv(LmbSecure *s, int fd, LmbMsg *m) {
 #include <pthread.h>
 
 #define LMB_SEC_MAXFD 65536
-static LmbSecure *g_sec_reg[LMB_SEC_MAXFD];
+typedef struct {
+    LmbSecure sec;
+    unsigned refs;
+    int closing;
+    pthread_mutex_t tx_lk, rx_lk;
+} LmbSecEntry;
+static LmbSecEntry *g_sec_reg[LMB_SEC_MAXFD];
 static pthread_mutex_t g_sec_lk = PTHREAD_MUTEX_INITIALIZER;
 static uint8_t g_sec_sk[64], g_sec_pk[32];
+static int g_sec_enabled, g_sec_failed;
 
-static LmbSecure *lmb_sec_get(int fd) {
+static void lmb_sec_wipe(void *p, size_t n) {
+    volatile uint8_t *v = (volatile uint8_t *)p;
+    while (n--) *v++ = 0;
+}
+
+static void lmb_sec_entry_free(LmbSecEntry *e) {
+    pthread_mutex_destroy(&e->tx_lk);
+    pthread_mutex_destroy(&e->rx_lk);
+    lmb_sec_wipe(&e->sec, sizeof e->sec);
+    free(e);
+}
+
+/* Take a lifetime reference before dropping the registry lock.  close() may
+ * run on another application thread while send/recv is blocked; without this
+ * reference it could free the session under the AEAD operation. */
+static LmbSecEntry *lmb_sec_acquire(int fd) {
     if (fd < 0 || fd >= LMB_SEC_MAXFD) return NULL;
     pthread_mutex_lock(&g_sec_lk);
-    LmbSecure *s = g_sec_reg[fd];
+    LmbSecEntry *e = g_sec_reg[fd];
+    if (e && !e->closing) e->refs++;
+    else e = NULL;
     pthread_mutex_unlock(&g_sec_lk);
-    return s;
+    return e;
+}
+
+static void lmb_sec_release(LmbSecEntry *e) {
+    int reap = 0;
+    pthread_mutex_lock(&g_sec_lk);
+    if (e->refs) e->refs--;
+    if (e->closing && !e->refs) reap = 1;
+    pthread_mutex_unlock(&g_sec_lk);
+    if (reap) lmb_sec_entry_free(e);
 }
 
 static int lmb_sec_send_hook(int fd, uint32_t op, const void *b, uint32_t bl,
                              const void *p, uint32_t pl) {
-    LmbSecure *s = lmb_sec_get(fd);
-    if (!s) return -2;                     /* not an encrypted fd: plaintext */
-    return lmb_secure_send(s, fd, op, b, bl, p, pl);
+    LmbSecEntry *e = lmb_sec_acquire(fd);
+    if (!e) return -2;                     /* not an encrypted fd: plaintext */
+    pthread_mutex_lock(&e->tx_lk);         /* counters and frames stay ordered */
+    int rc = lmb_secure_send(&e->sec, fd, op, b, bl, p, pl);
+    pthread_mutex_unlock(&e->tx_lk);
+    lmb_sec_release(e);
+    return rc;
 }
 static int lmb_sec_recv_hook(int fd, LmbMsg *m) {
-    LmbSecure *s = lmb_sec_get(fd);
-    if (!s) return -2;
-    return lmb_secure_recv(s, fd, m);
+    LmbSecEntry *e = lmb_sec_acquire(fd);
+    if (!e) return -2;
+    pthread_mutex_lock(&e->rx_lk);
+    int rc = lmb_secure_recv(&e->sec, fd, m);
+    pthread_mutex_unlock(&e->rx_lk);
+    lmb_sec_release(e);
+    return rc;
 }
-static int lmb_sec_wrap_hook(int fd, int is_client) {
-    if (fd < 0 || fd >= LMB_SEC_MAXFD) return -1;
-    LmbSecure *s = (LmbSecure *)calloc(1, sizeof *s);
-    if (!s) return -1;
-    if (lmb_secure_handshake(fd, is_client, g_sec_sk, g_sec_pk, s)) { free(s); return -1; }
+static void lmb_sec_forget_hook(int fd) {
+    if (fd < 0 || fd >= LMB_SEC_MAXFD) return;
+    int reap = 0;
     pthread_mutex_lock(&g_sec_lk);
-    free(g_sec_reg[fd]);                    /* a reused fd drops the old session */
-    g_sec_reg[fd] = s;
+    LmbSecEntry *e = g_sec_reg[fd];
+    g_sec_reg[fd] = NULL;
+    if (e) { e->closing = 1; if (!e->refs) reap = 1; }
+    pthread_mutex_unlock(&g_sec_lk);
+    if (reap) lmb_sec_entry_free(e);
+}
+
+static int lmb_sec_wrap_hook(int fd, int is_client, const char *addr) {
+    if (fd < 0 || fd >= LMB_SEC_MAXFD) return -1;
+    LmbSecEntry *e = (LmbSecEntry *)calloc(1, sizeof *e);
+    if (!e) return -1;
+    if (pthread_mutex_init(&e->tx_lk, NULL)) { free(e); return -1; }
+    if (pthread_mutex_init(&e->rx_lk, NULL)) {
+        pthread_mutex_destroy(&e->tx_lk); free(e); return -1;
+    }
+    if (lmb_secure_handshake(fd, is_client, g_sec_sk, g_sec_pk, &e->sec) ||
+        (is_client && lmb_sec_check_peer(addr, e->sec.peer_id))) {
+        lmb_sec_entry_free(e); return -1;
+    }
+    lmb_sec_forget_hook(fd);                 /* fd reuse drops the old keys */
+    pthread_mutex_lock(&g_sec_lk);
+    g_sec_reg[fd] = e;
     pthread_mutex_unlock(&g_sec_lk);
     return 0;
+}
+
+static int lmb_sec_reject_send(int fd, uint32_t op, const void *b, uint32_t bl,
+                               const void *p, uint32_t pl) {
+    (void)fd; (void)op; (void)b; (void)bl; (void)p; (void)pl;
+    errno = EACCES; return -1;
+}
+static int lmb_sec_reject_recv(int fd, LmbMsg *m) {
+    (void)fd; (void)m; errno = EACCES; return -1;
+}
+static int lmb_sec_reject_wrap(int fd, int is_client, const char *addr) {
+    (void)fd; (void)is_client; (void)addr; errno = EACCES; return -1;
 }
 
 /* handshake an accepted (inbound) fd; 0 when encryption is off or the wrap
  * succeeds, -1 when an enabled handshake fails and the caller must drop it */
 static int lmb_secure_server(int fd) {
     if (!lmb_enc_wrap) return 0;
-    return lmb_enc_wrap(fd, 0);
+    return lmb_enc_wrap(fd, 0, NULL);
 }
 
-static void lmb_secure_init(void) {
+/* 1 when fd is encrypted and its handshake identity equals pk; 0 otherwise. */
+static int lmb_secure_peer_matches(int fd, const uint8_t pk[32]) {
+    LmbSecEntry *e = lmb_sec_acquire(fd);
+    if (!e) return 0;
+    int match = e->sec.active && e->sec.have_peer_id &&
+                !memcmp(e->sec.peer_id, pk, 32);
+    lmb_sec_release(e);
+    return match;
+}
+
+static int lmb_secure_enabled(void) { return g_sec_enabled && !g_sec_failed; }
+
+static int lmb_secure_init(void) {
     const char *e = getenv("LUMABRI_ENCRYPT");
-    if (!e || !e[0] || e[0] == '0') return;
+    if (!e || !e[0] || e[0] == '0') return 0;
+    if (g_sec_enabled) return g_sec_failed ? -1 : 0;
+    g_sec_enabled = 1;
     char kp[512];
     if (lmb_peer_identity(lmb_peer_key_path(kp, sizeof kp), g_sec_sk, g_sec_pk)) {
         fprintf(stderr, "[lumabri] LUMABRI_ENCRYPT set but no peer key at %s — "
-                        "staying plaintext\n", kp);
-        return;
+                        "refusing all network traffic\n", kp);
+        g_sec_failed = 1;
+        lmb_enc_send = lmb_sec_reject_send;
+        lmb_enc_recv = lmb_sec_reject_recv;
+        lmb_enc_wrap = lmb_sec_reject_wrap;
+        return -1;
     }
     lmb_enc_send = lmb_sec_send_hook;
     lmb_enc_recv = lmb_sec_recv_hook;
     lmb_enc_wrap = lmb_sec_wrap_hook;
+    lmb_enc_forget = lmb_sec_forget_hook;
     fprintf(stderr, "[lumabri] transport encryption on "
-                    "(X25519 + ChaCha20-Poly1305, identity-authenticated)\n");
+                    "(X25519 + ChaCha20-Poly1305, pinned/persistent-TOFU identity)\n");
+    return 0;
 }
+
+/* Source files including this header get lifecycle-safe closes automatically.
+ * The LD_PRELOAD shim defines its own close interposer and opts out, then calls
+ * lmb_sec_forget_hook itself. */
+#ifndef LMB_SECURE_NO_CLOSE_REDIRECT
+#define close(fd) lmb_close(fd)
+#endif
 
 #endif /* LUMABRI_SECURE_H */

--- a/lumabri_sign.h
+++ b/lumabri_sign.h
@@ -624,8 +624,17 @@ static int lmb_peer_identity(const char *path, uint8_t sk[64], uint8_t pk[32]) {
      * winner has not finished writing it. */
     for (int attempt = 0; attempt < 200; attempt++) {
         char hex[200] = "";
-        FILE *f = fopen(path, "r");
-        if (f) {
+        int rflags = O_RDONLY;
+#ifdef O_NOFOLLOW
+        rflags |= O_NOFOLLOW;
+#endif
+        int rfd = open(path, rflags);
+        if (rfd >= 0) {
+            struct stat st;
+            if (fstat(rfd, &st) || !S_ISREG(st.st_mode) || st.st_uid != geteuid() ||
+                (st.st_mode & 077) != 0) { close(rfd); errno = EACCES; return -1; }
+            FILE *f = fdopen(rfd, "r");
+            if (!f) { close(rfd); return -1; }
             int got = fscanf(f, "%198s", hex) == 1;
             fclose(f);
             if (got && strlen(hex) == 128 && !lmb_unhex(sk, hex, 64)) {
@@ -643,10 +652,18 @@ static int lmb_peer_identity(const char *path, uint8_t sk[64], uint8_t pk[32]) {
         uint8_t seed[32];
         lmb_random(seed, sizeof seed);
         lmb_sign_keypair(pk, sk, seed);
+        memset(seed, 0, sizeof seed);
         char out[130];
         lmb_hex(out, sk, 64);
         out[128] = '\n'; out[129] = 0;
-        int wrote = (int)write(fd, out, 129) == 129;
+        size_t off = 0;
+        while (off < 129) {
+            ssize_t n = write(fd, out + off, 129 - off);
+            if (n < 0 && errno == EINTR) continue;
+            if (n <= 0) break;
+            off += (size_t)n;
+        }
+        int wrote = off == 129;
         if (fsync(fd)) wrote = 0;
         close(fd);
         if (!wrote) { unlink(path); return -1; }

--- a/lumashim.c
+++ b/lumashim.c
@@ -48,6 +48,7 @@
 #include <sys/stat.h>
 #include <time.h>
 
+#define LMB_SECURE_NO_CLOSE_REDIRECT 1
 #include "lumabri_proto.h"
 #include "lumabri_secure.h"
 #include "lumabri_sha.h"
@@ -715,13 +716,13 @@ static void *probe_thread(void *arg) {
     p->rtt_us = LONG_MAX;
     int fd = lmb_connect_ms(p->addr, 2000);
     if (fd < 0) return NULL;
-    if (lmb_auth(fd)) { real_close(fd); return NULL; }
+    if (lmb_auth(fd)) { lmb_close(fd); return NULL; }
     for (int i = 0; i < 2; i++) {
         struct timespec a, b;
         clock_gettime(CLOCK_MONOTONIC, &a);
         LmbMsg m = {0};
         if (lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) || lmb_recv(fd, &m)) {
-            real_close(fd);
+            lmb_close(fd);
             return NULL;
         }
         lmb_msg_free(&m);
@@ -732,7 +733,7 @@ static void *probe_thread(void *arg) {
     pthread_mutex_lock(&p->lk);
     if (p->nidle < POOL_SOCKS) { p->idle[p->nidle++] = fd; fd = -1; }
     pthread_mutex_unlock(&p->lk);
-    if (fd >= 0) real_close(fd);
+    if (fd >= 0) lmb_close(fd);
     return NULL;
 }
 
@@ -850,7 +851,7 @@ static void *stats_thread(void *arg) {
 
 static void shim_init_impl(void) {
     shim_resolve();
-    lmb_secure_init();
+    if (lmb_secure_init()) return; /* fail closed: hooks reject every network fd */
     const char *cache = getenv("LUMABRI_CACHE");
     if (!cache || !cache[0]) {
         fprintf(stderr, "[lumabri] LUMABRI_VROOT is set but LUMABRI_CACHE is not — disabled\n");
@@ -1201,7 +1202,7 @@ static uint8_t *peer_fetch(RPeer *p, const char *rel, uint64_t off, uint32_t len
         if (fd < 0) {
             fd = lmb_connect_ms(p->addr, 2500);
             if (fd < 0) return NULL;             /* unreachable: relay decides */
-            if (lmb_auth(fd)) { real_close(fd); return NULL; }
+            if (lmb_auth(fd)) { lmb_close(fd); return NULL; }
         }
 
         LmbBuf b = {0};
@@ -1210,15 +1211,14 @@ static uint8_t *peer_fetch(RPeer *p, const char *rel, uint64_t off, uint32_t len
         free(b.p);
         LmbMsg m = {0};
         if (rc == 0) rc = lmb_recv(fd, &m);
-        if (rc != 0) { real_close(fd); continue; }   /* dead socket: retry fresh */
+        if (rc != 0) { lmb_close(fd); continue; }   /* dead socket: retry fresh */
 
         if (m.op == LMB_READ_R && m.pay_len == len) {
-            uint8_t *data = m.pay;
-            m.pay = NULL;                       /* steal the payload */
+            uint8_t *data = lmb_msg_take_pay(&m);
             lmb_msg_free(&m);
             pthread_mutex_lock(&p->lk);
             if (p->nidle < POOL_SOCKS) p->idle[p->nidle++] = fd;
-            else { pthread_mutex_unlock(&p->lk); real_close(fd); return data; }
+            else { pthread_mutex_unlock(&p->lk); lmb_close(fd); return data; }
             pthread_mutex_unlock(&p->lk);
             return data;
         }
@@ -1227,7 +1227,7 @@ static uint8_t *peer_fetch(RPeer *p, const char *rel, uint64_t off, uint32_t len
         lmb_msg_free(&m);
         pthread_mutex_lock(&p->lk);
         if (p->nidle < POOL_SOCKS) p->idle[p->nidle++] = fd;
-        else { pthread_mutex_unlock(&p->lk); real_close(fd); return NULL; }
+        else { pthread_mutex_unlock(&p->lk); lmb_close(fd); return NULL; }
         pthread_mutex_unlock(&p->lk);
         return NULL;
     }
@@ -1255,8 +1255,7 @@ static uint8_t *relay_fetch(const char *rel, uint64_t off, uint32_t len) {
         lmb_msg_free(&m);
         return NULL;
     }
-    uint8_t *data = m.pay;
-    m.pay = NULL;
+    uint8_t *data = lmb_msg_take_pay(&m);
     lmb_msg_free(&m);
     return data;
 }
@@ -1328,7 +1327,7 @@ static void hashes_ensure(RFile *f) {
                                         : "is not signed by the operator key");
                 }
                 if (!g.trust.n || signed_ok) {
-                    hash = m.pay; nh = n; m.pay = NULL;
+                    hash = lmb_msg_take_pay(&m); nh = n;
                     has_sig_ok = (int)has_sig;
                     if (has_sig) memcpy(saved_sig, sig, 64);
                     snprintf(saved_model, sizeof saved_model, "%s", tmodel);
@@ -1857,5 +1856,6 @@ void *mmap64(void *addr, size_t len, int prot, int flags, int fd, off_t off) {
 int close(int fd) {
     shim_resolve();
     if (fdmap_get(fd)) fdmap_set(fd, NULL);
+    lmb_sec_forget_hook(fd);
     return real_close(fd);
 }

--- a/maintainer.c
+++ b/maintainer.c
@@ -169,18 +169,14 @@ static int sidecar_path(const MFile *f, const char *ext, char *out, size_t cap) 
                        g.root, f->rel, ext);
 }
 
-/* Stage under a name unique to this process. Two maintainers may share one
- * --root (phase5_test does, and so does any machine donating from the tree it
- * already serves): with a single fixed .tmp they collide on the same staging
- * file, one truncating the other mid-write, and the loser's rename then fails
- * on a file that is no longer its own. The rename is what makes the sidecar
- * appear atomically, so per-process staging removes the race entirely rather
- * than tolerating it — every other staging site in the tree already
- * uniquifies by pid this way. */
+/* Stage in the destination directory under a kernel-created unique name.
+ * mkstemp gives concurrent threads/processes separate files and O_EXCL
+ * prevents a stale predictable name or local symlink from being followed.
+ * rename then publishes the complete, durable sidecar atomically. */
 static int sidecar_write(const char *path, const void *a, size_t na,
                          const void *b, size_t nb) {
-    char tmp[LMB_LOCAL_PATH_MAX + 32], dir[LMB_LOCAL_PATH_MAX];
-    if (path_printf(tmp, sizeof tmp, "%s.tmp.%ld", path, (long)getpid()) ||
+    char tmp[LMB_LOCAL_PATH_MAX + 48], dir[LMB_LOCAL_PATH_MAX];
+    if (path_printf(tmp, sizeof tmp, "%s.tmp.%ld.XXXXXX", path, (long)getpid()) ||
         path_printf(dir, sizeof dir, "%s", path)) return -1;
     char *slash = strrchr(dir, '/');
     if (slash) { *slash = 0;
@@ -188,8 +184,10 @@ static int sidecar_write(const char *path, const void *a, size_t na,
             { *p = 0; mkdir(dir, 0755); *p = '/'; }
         mkdir(dir, 0755);
     }
-    FILE *fp = fopen(tmp, "wb");
-    if (!fp) return -1;
+    int tfd = mkstemp(tmp);
+    if (tfd < 0) return -1;
+    FILE *fp = fdopen(tfd, "wb");
+    if (!fp) { close(tfd); unlink(tmp); return -1; }
     int ok = (!na || fwrite(a, 1, na, fp) == na) &&
              (!nb || fwrite(b, 1, nb, fp) == nb) &&
              fflush(fp) == 0 && fsync(fileno(fp)) == 0;
@@ -560,7 +558,7 @@ static void *conn_thread(void *arg) {
             char tok[LMB_TOKEN_MAX + 1] = "";
             LmbCur c = { m.body, m.body_len, 0 };
             int bad = lmb_cur_str(&c, tok, sizeof tok) || c.off != c.len;
-            if (!bad && (!g.token[0] || !strcmp(tok, g.token))) {
+            if (!bad && (!g.token[0] || lmb_token_equal(tok, g.token))) {
                 authed = 1;
                 rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
             } else { send_err(fd, "bad token"); rc = -1; }
@@ -646,7 +644,7 @@ static int fetch_truth(const char *rel, Truth *t) {
         return -1;
     }
     t->has_sig = has_sig != 0;
-    t->hash = m.pay; m.pay = NULL;
+    t->hash = lmb_msg_take_pay(&m);
     lmb_msg_free(&m);
 
     /* With the operator's public key we check the signature ourselves, so a
@@ -771,7 +769,7 @@ static int pull_file(const char *rel, uint64_t size, Truth *tr) {
             free(rb.p);
             if (rc == 0 && rm.op == LMB_READ_R && rm.pay_len == want) {
                 if (chunks_ok(truth, truth_n, rm.pay, off, want)) {
-                    data = rm.pay; got = rm.pay_len; rm.pay = NULL;
+                    data = lmb_msg_take_pay(&rm); got = rm.pay_len;
                 } else {
                     fprintf(stderr, "[maintainer %s] %s served corrupt bytes of "
                             "%s — rejected\n", g.name, addrs[ai], rel);
@@ -788,7 +786,7 @@ static int pull_file(const char *rel, uint64_t size, Truth *tr) {
             if (lmb_request(g.tracker, LMB_RREAD, rb.p, (uint32_t)rb.len, &rm) == 0 &&
                 rm.op == LMB_RREAD_R && rm.pay_len == want &&
                 chunks_ok(truth, truth_n, rm.pay, off, want)) {
-                data = rm.pay; got = rm.pay_len; rm.pay = NULL;
+                data = lmb_msg_take_pay(&rm); got = rm.pay_len;
             }
             free(rb.p); lmb_msg_free(&rm);
         }
@@ -1048,7 +1046,7 @@ int main(int argc, char **argv) {
     if (tok) snprintf(g.token, sizeof g.token, "%s", tok);
     signal(SIGPIPE, SIG_IGN);   /* a vanished chatter must not kill the peer */
     lmb_conn_gate_init(&g_conn_gate);
-    lmb_secure_init();
+    if (lmb_secure_init()) return 1;
     size_t rl = strlen(g.root);
     while (rl > 1 && g.root[rl - 1] == '/') g.root[--rl] = 0;
     if (!g.name[0]) snprintf(g.name, sizeof g.name, "peer-%d", port);

--- a/peer_identity_test.sh
+++ b/peer_identity_test.sh
@@ -18,6 +18,7 @@ cd "$(dirname "$0")"
 make -s tracker maintainer
 
 T=$(mktemp -d /tmp/lumabri-peerid.XXXXXX)
+export HOME="$T"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
@@ -78,7 +79,7 @@ int main(int argc, char **argv) {
 EOF
 cc -O2 -w -I. "$T/noauth.c" -o "$T/noauth" -lpthread
 
-./tracker --port 7640 > "$T/tracker.log" 2>&1 & PIDS+=($!)
+./tracker --port 7640 > "$T/tracker.log" 2>&1 & TRACKER=$!; PIDS+=($TRACKER)
 wait_port 7640
 
 run_origin() {   # run_origin PORT KEYFILE  -> background pid in $LASTPID
@@ -130,5 +131,23 @@ echo "   ✓ reclaimed with the same key"
 echo "· 4) a REGISTER with no signature is refused"
 "$T/noauth" 127.0.0.1:7640 || { echo "   an unsigned REGISTER was accepted"; exit 1; }
 echo "   ✓ unauthenticated registration refused"
+
+echo "· 5) the name binding survives a tracker restart"
+kill "$TRACKER" 2>/dev/null || true
+wait "$TRACKER" 2>/dev/null || true
+./tracker --port 7640 > "$T/tracker-restart.log" 2>&1 & TRACKER2=$!; PIDS+=($TRACKER2)
+wait_port 7640
+# keyB is already retrying in the background; it must remain rejected while
+# the honest keyA control connection reconnects and reclaims the placement.
+for _ in $(seq 1 100); do
+    grep -q "already held by another key" "$T/tracker-restart.log" &&
+    "$T/probe" 127.0.0.1:7640 fx 127.0.0.1:7643 && break
+    sleep 0.1
+done
+grep -q "already held by another key" "$T/tracker-restart.log" || {
+    echo "   restarted tracker forgot the bound key"; cat "$T/tracker-restart.log"; exit 1; }
+"$T/probe" 127.0.0.1:7640 fx 127.0.0.1:7643 || {
+    echo "   honest key could not reclaim after tracker restart"; exit 1; }
+echo "   ✓ persisted binding rejected keyB and admitted keyA after restart"
 
 echo "LUMABRI PEER IDENTITY TEST: PASS"

--- a/phase3_test.sh
+++ b/phase3_test.sh
@@ -18,6 +18,7 @@ cd "$(dirname "$0")"
 make -s all
 
 T=$(mktemp -d /tmp/lumabri-phase3.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/phase4_test.sh
+++ b/phase4_test.sh
@@ -18,6 +18,7 @@ MODEL="$PWD/tiny_olmoe"
 [ -f "$MODEL/config.json" ] || make -s fixture
 
 T=$(mktemp -d /tmp/lumabri-phase4.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/phase5_test.sh
+++ b/phase5_test.sh
@@ -20,6 +20,7 @@ cd "$(dirname "$0")"
 make -s all
 
 T=$(mktemp -d /tmp/lumabri-phase5.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/prefetch_policy_test.sh
+++ b/prefetch_policy_test.sh
@@ -22,6 +22,7 @@ cd "$(dirname "$0")"
 make -s liblumabri.so tracker maintainer
 
 T=$(mktemp -d /tmp/lumabri-prefetch.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/relay_exec_test.sh
+++ b/relay_exec_test.sh
@@ -2,11 +2,17 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-make -s tracker expert_node test_relay_exec fixture
+ENGINE_DIR=${ENGINE:-../colibri/c}
+if [ ! -f "$ENGINE_DIR/olmoe.c" ]; then
+    echo "LUMABRI RELAY EXEC TEST: SKIP (no olmoe.c under ENGINE=$ENGINE_DIR)"
+    exit 0
+fi
+make -s ENGINE="$ENGINE_DIR" tracker expert_node test_relay_exec fixture
 T=$(mktemp -d /tmp/lumabri-relay-exec.XXXXXX)
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 
 ./tracker --port 7560 >"$T/tracker.log" 2>&1 & PIDS+=($!)
 OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 ./expert_node \

--- a/role_test.sh
+++ b/role_test.sh
@@ -16,6 +16,7 @@ cd "$(dirname "$0")"
 make -s lumabri tracker maintainer
 
 T=$(mktemp -d /tmp/lumabri-role.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/secure_test.sh
+++ b/secure_test.sh
@@ -6,13 +6,16 @@
 #
 #   1) both sides derive the same session and traffic decrypts to the input;
 #   2) the header (op and lengths) is authenticated, not just the body;
-#   3) a flipped byte anywhere in a frame fails the tag, never wrong plaintext;
-#   4) each side learns the other's true identity key from the handshake.
+#   3) ciphertext and header tampering both fail authentication;
+#   4) replay and a low-order X25519 point are rejected;
+#   5) persistent TOFU rejects an endpoint key change;
+#   6) closing an encrypted fd removes and wipes its registered session.
 set -euo pipefail
 cd "$(dirname "$0")"
 
 T=$(mktemp -d /tmp/lumabri-secure.XXXXXX)
 trap 'rm -rf "$T"' EXIT
+export HOME="$T"
 
 cat > "$T/t.c" <<'EOF'
 #include <stdio.h>
@@ -28,7 +31,7 @@ static int fail;
 static void *srv_echo(void *arg) {
     int fd = *(int *)arg;
     LmbSecure s;
-    if (lmb_secure_handshake(fd, 0, sk_s, pk_s, &s)) { fail = 1; return NULL; }
+    if (lmb_secure_handshake(fd, 0, sk_s, pk_s, &s)) { perror("  FAIL server handshake"); fail = 1; return NULL; }
     if (memcmp(s.peer_id, pk_c, 32)) { printf("  FAIL server saw wrong client identity\n"); fail = 1; }
     LmbMsg m;
     if (lmb_secure_recv(&s, fd, &m)) { printf("  FAIL server recv\n"); fail = 1; return NULL; }
@@ -45,7 +48,56 @@ static void *srv_hs(void *arg) {
     return NULL;
 }
 
-int main(void) {
+static void *srv_low_order(void *arg) {
+    int fd = *(int *)arg; uint8_t peer[32], zero[32] = {0};
+    if (lmb_read_full(fd, peer, sizeof peer) || lmb_write_full(fd, zero, sizeof zero))
+        fail = 1;
+    return NULL;
+}
+
+static int secure_pair(int sp[2], LmbSecure *client, LmbSecure *server) {
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp)) return -1;
+    pthread_t hs; g_srv_ok = 0;
+    pthread_create(&hs, NULL, srv_hs, &sp[1]);
+    int rc = lmb_secure_handshake(sp[0], 1, sk_c, pk_c, client);
+    pthread_join(hs, NULL);
+    if (rc || !g_srv_ok) return -1;
+    *server = g_srv;
+    return 0;
+}
+
+static int registered(int fd) {
+    if (fd < 0 || fd >= LMB_SEC_MAXFD) return 0;
+    pthread_mutex_lock(&g_sec_lk);
+    int yes = g_sec_reg[fd] && !g_sec_reg[fd]->closing;
+    pthread_mutex_unlock(&g_sec_lk);
+    return yes;
+}
+
+static void raw_frame(const LmbSecure *s, int fd, uint64_t ctr,
+                      uint8_t op, const uint8_t *pt, uint32_t n,
+                      int flip_header, int flip_cipher) {
+    uint8_t hdr[16], tag[16], nonce[12], *ct = malloc(n ? n : 1);
+    lc_st32(hdr, LMB_MAGIC); lc_st32(hdr + 4, op);
+    lc_st32(hdr + 8, n); lc_st32(hdr + 12, 0);
+    lmb_sec_nonce(nonce, ctr);
+    lc_aead_seal(s->tx_key, nonce, hdr, 16, pt, n, ct, tag);
+    if (flip_header) hdr[4] ^= 1;
+    if (flip_cipher && n) ct[n / 2] ^= 0x80;
+    lmb_write_full(fd, hdr, 16); lmb_write_full(fd, ct, n); lmb_write_full(fd, tag, 16);
+    free(ct);
+}
+
+typedef struct { int fd; uint8_t *want; } WrapArg;
+static void *srv_wrap(void *arg) {
+    WrapArg *wa = (WrapArg *)arg;
+    if (lmb_secure_server(wa->fd) ||
+        !lmb_secure_peer_matches(wa->fd, wa->want)) fail = 1;
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) return 2;
     uint8_t seed[32];
     for (int i = 0; i < 32; i++) seed[i] = (uint8_t)(i + 1);
     lmb_sign_keypair(pk_c, sk_c, seed);
@@ -58,7 +110,7 @@ int main(void) {
     pthread_t th; pthread_create(&th, NULL, srv_echo, &sp[1]);
 
     LmbSecure c;
-    if (lmb_secure_handshake(sp[0], 1, sk_c, pk_c, &c)) { printf("  FAIL client handshake\n"); return 1; }
+    if (lmb_secure_handshake(sp[0], 1, sk_c, pk_c, &c)) { perror("  FAIL client handshake"); return 1; }
     if (memcmp(c.peer_id, pk_s, 32)) { printf("  FAIL client saw wrong server identity\n"); fail = 1; }
     else printf("  ok   handshake: each side learns the other's identity\n");
 
@@ -73,30 +125,101 @@ int main(void) {
     pthread_join(th, NULL);
     close(sp[0]); close(sp[1]);
 
-    /* 3: a flipped byte in a frame fails the tag */
+    /* 3a: a flipped ciphertext byte fails the tag */
     int hp[2];
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, hp)) { perror("socketpair"); return 1; }
-    pthread_t hs; pthread_create(&hs, NULL, srv_hs, &hp[1]);
-    LmbSecure a;
-    if (lmb_secure_handshake(hp[0], 1, sk_c, pk_c, &a)) { printf("  FAIL tamper handshake\n"); return 1; }
-    pthread_join(hs, NULL);
-    if (!g_srv_ok) { printf("  FAIL tamper server handshake\n"); return 1; }
-
-    uint8_t hdr[16]; lc_st32(hdr, LMB_MAGIC); lc_st32(hdr + 4, 7);
-    lc_st32(hdr + 8, 5); lc_st32(hdr + 12, 0);
-    uint8_t pt[5] = "hello", ct[5], tag[16], nonce[12];
-    lmb_sec_nonce(nonce, a.tx_ctr);
-    lc_aead_seal(a.tx_key, nonce, hdr, 16, pt, 5, ct, tag);
-    ct[2] ^= 0x80;                                      /* corrupt the wire */
-    lmb_write_full(hp[0], hdr, 16); lmb_write_full(hp[0], ct, 5); lmb_write_full(hp[0], tag, 16);
+    LmbSecure a, z;
+    if (secure_pair(hp, &a, &z)) { printf("  FAIL tamper handshake\n"); return 1; }
+    const uint8_t pt[5] = "hello";
+    raw_frame(&a, hp[0], 0, 7, pt, 5, 0, 1);
     LmbMsg tm;
-    if (lmb_secure_recv(&g_srv, hp[1], &tm) == 0) { printf("  FAIL tampered frame accepted\n"); fail = 1; lmb_msg_free(&tm); }
-    else printf("  ok   a flipped byte fails the tag\n");
+    if (lmb_secure_recv(&z, hp[1], &tm) == 0) { printf("  FAIL tampered ciphertext accepted\n"); fail = 1; lmb_msg_free(&tm); }
+    else printf("  ok   ciphertext tampering fails the tag\n");
     close(hp[0]); close(hp[1]);
+
+    /* 3b: the header is AAD, so changing op also fails the tag. */
+    if (secure_pair(hp, &a, &z)) return 1;
+    raw_frame(&a, hp[0], 0, 7, pt, 5, 1, 0);
+    if (lmb_secure_recv(&z, hp[1], &tm) == 0) { printf("  FAIL tampered header accepted\n"); fail = 1; lmb_msg_free(&tm); }
+    else printf("  ok   header tampering fails the tag\n");
+    close(hp[0]); close(hp[1]);
+
+    /* 4a: a repeated nonce/frame is rejected once rx_ctr advanced. */
+    if (secure_pair(hp, &a, &z)) return 1;
+    raw_frame(&a, hp[0], 0, 7, pt, 5, 0, 0);
+    raw_frame(&a, hp[0], 0, 7, pt, 5, 0, 0);
+    if (lmb_secure_recv(&z, hp[1], &tm)) { printf("  FAIL first replay frame\n"); fail = 1; }
+    else lmb_msg_free(&tm);
+    if (lmb_secure_recv(&z, hp[1], &tm) == 0) { printf("  FAIL replay accepted\n"); fail = 1; lmb_msg_free(&tm); }
+    else printf("  ok   replayed frame rejected\n");
+    close(hp[0]); close(hp[1]);
+
+    /* 4b: the all-zero shared result from a low-order point is forbidden. */
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, hp)) return 1;
+    pthread_t lo; pthread_create(&lo, NULL, srv_low_order, &hp[1]);
+    if (lmb_secure_handshake(hp[0], 1, sk_c, pk_c, &a) == 0) {
+        printf("  FAIL low-order X25519 point accepted\n"); fail = 1;
+    } else printf("  ok   low-order X25519 point rejected\n");
+    pthread_join(lo, NULL); close(hp[0]); close(hp[1]);
+
+    /* 5: first contact is persisted; a different key for the same endpoint
+     * is rejected.  Strict operator pins reject missing endpoints as well. */
+    setenv("LUMABRI_KNOWN_HOSTS", argv[1], 1);
+    if (lmb_sec_check_peer("node:1", pk_s) ||
+        lmb_sec_check_peer("node:1", pk_s) ||
+        lmb_sec_check_peer("node:1", pk_c) == 0) {
+        printf("  FAIL persistent TOFU key-change check\n"); fail = 1;
+    } else printf("  ok   persistent TOFU rejects endpoint key change\n");
+    setenv("LUMABRI_REQUIRE_PIN", "1", 1);
+    if (lmb_sec_check_peer("missing:2", pk_s) == 0) {
+        printf("  FAIL strict pin mode learned a missing endpoint\n"); fail = 1;
+    } else printf("  ok   strict mode refuses an unpinned endpoint\n");
+    unsetenv("LUMABRI_REQUIRE_PIN");
+
+    char pins[512]; snprintf(pins, sizeof pins, "%s.pins", argv[1]);
+    FILE *pf = fopen(pins, "w");
+    char hs[65], hc[65]; lmb_hex(hs, pk_s, 32); lmb_hex(hc, pk_c, 32);
+    int pbad = !pf;
+    if (pf) {
+        if (fprintf(pf, "rotate:4 %s\nrotate:4 %s\n", hs, hc) < 0) pbad = 1;
+        if (fclose(pf)) pbad = 1;
+    }
+    if (pbad || lmb_sec_pin_file(pins, "rotate:4", pk_s, 0) ||
+        lmb_sec_pin_file(pins, "rotate:4", pk_c, 0)) {
+        printf("  FAIL strict pin overlap rotation\n"); fail = 1;
+    } else printf("  ok   strict pins accept old+new rotation overlap\n");
+
+    /* 6: exercise the transparent registry and its close lifecycle. */
+    setenv("LUMABRI_ENCRYPT", "1", 1);
+    if (lmb_secure_init()) { printf("  FAIL secure init\n"); fail = 1; }
+    else {
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, hp)) return 1;
+        WrapArg wa = { hp[1], g_sec_pk };
+        pthread_t wt; pthread_create(&wt, NULL, srv_wrap, &wa);
+        int wr = lmb_sec_wrap_hook(hp[0], 1, "registry:3");
+        pthread_join(wt, NULL);
+        /* Both wrappers use this process's configured identity; the purpose
+         * here is registry lifecycle, while the direct handshake above
+         * independently proved distinct peer identities. */
+        if (wr || !registered(hp[0]) || !registered(hp[1]) ||
+            !lmb_secure_peer_matches(hp[1], g_sec_pk)) {
+            printf("  FAIL encrypted fd registration\n"); fail = 1;
+        } else {
+            lmb_close(hp[0]);
+            if (registered(hp[0])) { printf("  FAIL close retained session\n"); fail = 1; }
+            else printf("  ok   close removes encrypted fd session\n");
+            LmbSecEntry *held = lmb_sec_acquire(hp[1]);
+            lmb_sec_forget_hook(hp[1]);
+            if (!held || registered(hp[1])) {
+                printf("  FAIL concurrent session retirement\n"); fail = 1;
+            } else printf("  ok   active I/O reference defers session destruction\n");
+            if (held) lmb_sec_release(held);
+            lmb_close(hp[1]);
+        }
+    }
 
     puts(fail ? "LUMABRI SECURE TEST: FAIL" : "LUMABRI SECURE TEST: PASS");
     return fail;
 }
 EOF
 cc -O2 -w -I. -pthread "$T/t.c" -o "$T/t"
-"$T/t"
+"$T/t" "$T/known_hosts"

--- a/security_test.sh
+++ b/security_test.sh
@@ -21,6 +21,7 @@ cd "$(dirname "$0")"
 
 make -s all
 T=$(mktemp -d /tmp/lumabri-sec.XXXXXX)
+export HOME="$T"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
@@ -239,7 +240,8 @@ int main(int argc, char **argv) {         /* addr name keyfile */
 EOF
 cc -O2 -w -I. "$T/authreg.c" -o "$T/authreg" -lpthread
 
-env LUMABRI_STALE_MS=100 ./tracker --port 7555 > "$T/reuse.log" 2>&1 & PIDS+=($!)
+env LUMABRI_STALE_MS=100 LUMABRI_MAX_NAMES_PER_SOURCE=64 \
+    ./tracker --port 7555 > "$T/reuse.log" 2>&1 & PIDS+=($!)
 sleep 0.3
 for i in $(seq 0 63); do
     "$T/authreg" 127.0.0.1:7555 "gone-$i" "$T/jk-$i" || {
@@ -261,5 +263,36 @@ done
 if "$T/authreg" 127.0.0.1:7556 "mine-9" "$T/onekey"; then
     echo "   a 9th name under the same key was accepted"; exit 1; fi
 echo "   ✓ 8 names held, the 9th refused; anonymous junk cannot exhaust the table"
+
+echo "· 8) one source address cannot bypass the cap with many identity keys"
+env LUMABRI_STALE_MS=600000 LUMABRI_MAX_NAMES_PER_SOURCE=8 \
+    ./tracker --port 7557 > "$T/source-cap.log" 2>&1 & PIDS+=($!)
+sleep 0.3
+ok=0
+for i in $(seq 1 8); do
+    "$T/authreg" 127.0.0.1:7557 "source-$i" "$T/source-key-$i" && ok=$((ok+1))
+done
+[ "$ok" -eq 8 ] || { echo "   the first 8 identities from one source were not accepted ($ok)"; exit 1; }
+if "$T/authreg" 127.0.0.1:7557 "source-9" "$T/source-key-9"; then
+    echo "   a 9th identity from the same source address was accepted"; exit 1; fi
+echo "   ✓ source quota holds even when every name uses a different key"
+
+echo "· 9) aggregate receive memory is bounded across legal frames"
+cat > "$T/rxbudget.c" <<'EOF'
+#include "lumabri_proto.h"
+int main(void) {
+    LmbMsg a = {0}, b = {0};
+    setenv("LUMABRI_RX_BUDGET_MIB", "16", 1);
+    if (lmb_rx_reserve(&a, 10u << 20)) return 1;
+    if (lmb_rx_reserve(&b, 10u << 20) == 0) return 2;
+    lmb_rx_release(&a);
+    if (lmb_rx_reserve(&b, 10u << 20)) return 3;
+    lmb_rx_release(&b);
+    return atomic_load(&lmb_rx_inflight) != 0;
+}
+EOF
+cc -O2 -w -I. "$T/rxbudget.c" -o "$T/rxbudget" -lpthread
+"$T/rxbudget" || { echo "   aggregate receive budget failed"; exit 1; }
+echo "   ✓ concurrent frame reservations cannot exceed the configured budget"
 
 echo "LUMABRI SECURITY TEST: PASS"

--- a/selftest.sh
+++ b/selftest.sh
@@ -16,6 +16,7 @@ cd "$(dirname "$0")"
 make -s all
 
 T=$(mktemp -d /tmp/lumabri-selftest.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/sign_test.sh
+++ b/sign_test.sh
@@ -14,6 +14,7 @@ cd "$(dirname "$0")"
 
 make -s all
 T=$(mktemp -d /tmp/lumabri-sign.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT

--- a/signed_donor_test.sh
+++ b/signed_donor_test.sh
@@ -28,6 +28,7 @@ cd "$(dirname "$0")"
 make -s all
 
 T=$(mktemp -d /tmp/lumabri-sdonor.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 PIDS=()
 cleanup() {
     if [ "${#PIDS[@]}" -gt 0 ]; then

--- a/tracker.c
+++ b/tracker.c
@@ -10,8 +10,9 @@
  * maintainer behind any home NAT thus serves with zero router configuration;
  * direct peer-to-peer remains the first choice and the relay the fallback.
  *
- * State is in-memory only. A tracker restart costs nothing: every maintainer
- * reconnects within one heartbeat.
+ * Placement/liveness state is in memory and rebuilt from heartbeats after a
+ * restart. Name-to-identity ownership is the exception: it is persisted
+ * before admission, so restarting the tracker cannot reopen an honest name.
  *
  *   ./tracker [--port 7300]
  */
@@ -34,7 +35,7 @@
 typedef struct { char path[LMB_PATH_MAX]; uint64_t size; } PFile;
 
 typedef struct {
-    char name[64], addr[64], model[64];
+    char name[64], addr[64], model[64], source[64];
     char engine[64], profile[LMB_BUILD_PROFILE_MAX];
     uint32_t bits, hidden, slots, total_experts;
     uint64_t held_bytes, served_bytes, served_reads;
@@ -74,6 +75,155 @@ static int g_known_logged[MAX_PEERS];
 static char g_token[LMB_TOKEN_MAX + 1]; /* --token: private swarm, invite required */
 static LmbConnGate g_conn_gate = LMB_CONN_GATE_INIT;
 static double g_stale_s = STALE_S;
+static int g_max_names_per_source = 16;
+
+/* Unlike liveness/placement state, identity ownership must survive a tracker
+ * restart.  Otherwise "TOFU" means only "trust until the process exits" and
+ * an attacker can claim the honest name during the next boot. */
+#define MAX_BINDINGS 4096
+typedef struct { char name[64]; uint8_t pubkey[32]; int is_expert; } Binding;
+static Binding g_bindings[MAX_BINDINGS];
+static int g_nbindings;
+static char g_bindings_path[512];
+
+static int binding_name_ok(const char *s) {
+    if (!s || !*s || strlen(s) >= 64) return 0;
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++)
+        if (*p == '\t' || *p == '\n' || *p == '\r' || *p < 0x20) return 0;
+    return 1;
+}
+
+static int binding_find(const char *name, int is_expert) {
+    for (int i = 0; i < g_nbindings; i++)
+        if (g_bindings[i].is_expert == is_expert &&
+            !strcmp(g_bindings[i].name, name)) return i;
+    return -1;
+}
+
+static int binding_path_default(void) {
+    if (g_bindings_path[0]) return 0;
+    const char *e = getenv("LUMABRI_PEER_BINDINGS");
+    if (e && *e) return snprintf(g_bindings_path, sizeof g_bindings_path, "%s", e)
+                         < (int)sizeof g_bindings_path ? 0 : -1;
+    const char *home = getenv("HOME");
+    if (!home || !*home) return -1;
+    char dir[448];
+    if (snprintf(dir, sizeof dir, "%s/.lumabri", home) >= (int)sizeof dir) return -1;
+    if (mkdir(dir, 0700) && errno != EEXIST) return -1;
+    return snprintf(g_bindings_path, sizeof g_bindings_path,
+                    "%s/tracker_peer_bindings", dir) < (int)sizeof g_bindings_path ? 0 : -1;
+}
+
+static int bindings_load(void) {
+    if (binding_path_default()) return -1;
+    int flags = O_RDONLY;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    int fd = open(g_bindings_path, flags);
+    if (fd < 0) return errno == ENOENT ? 0 : -1;
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode) || st.st_uid != geteuid() ||
+        (st.st_mode & 022)) { close(fd); errno = EACCES; return -1; }
+    FILE *fp = fdopen(fd, "r");
+    if (!fp) { close(fd); return -1; }
+    char line[768]; int rc = 0;
+    while (fgets(line, sizeof line, fp)) {
+        size_t n = strlen(line);
+        if (n && line[n - 1] == '\n') line[--n] = 0;
+        if (!n || line[0] == '#') continue;
+        char *a = strchr(line, '\t'), *b = a ? strchr(a + 1, '\t') : NULL;
+        if (!a || !b || a != line + 1 || (line[0] != 'M' && line[0] != 'E')) { rc = -1; break; }
+        *a++ = 0; *b++ = 0;
+        if (strlen(a) != 64 || !binding_name_ok(b) || g_nbindings >= MAX_BINDINGS) { rc = -1; break; }
+        Binding x = {0}; x.is_expert = line[0] == 'E';
+        snprintf(x.name, sizeof x.name, "%s", b);
+        if (lmb_unhex(x.pubkey, a, 32)) { rc = -1; break; }
+        int old = binding_find(x.name, x.is_expert);
+        if (old >= 0) {
+            if (memcmp(g_bindings[old].pubkey, x.pubkey, 32)) { rc = -1; break; }
+        } else g_bindings[g_nbindings++] = x;
+    }
+    if (ferror(fp)) rc = -1;
+    fclose(fp);
+    return rc;
+}
+
+/* Called under g_lk.  Durable publication precedes admission to the live
+ * table, so a crash can lose liveness but never ownership. */
+static int binding_check_or_add(const char *name, int is_expert,
+                                const uint8_t pk[32]) {
+    int old = binding_find(name, is_expert);
+    if (old >= 0) return memcmp(g_bindings[old].pubkey, pk, 32) ? -1 : 0;
+    if (!binding_name_ok(name) || g_nbindings >= MAX_BINDINGS) return -1;
+    int flags = O_RDWR | O_CREAT;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    int fd = open(g_bindings_path, flags, 0600);
+    if (fd < 0 || flock(fd, LOCK_EX)) { if (fd >= 0) close(fd); return -1; }
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode) || st.st_uid != geteuid() ||
+        (st.st_mode & 022)) {
+        flock(fd, LOCK_UN); close(fd); errno = EACCES; return -1;
+    }
+    /* A second tracker may share the durable state during a rolling restart.
+     * Re-read it while holding the file lock, so two processes cannot append
+     * conflicting owners from stale in-memory snapshots. */
+    int dfd = dup(fd), disk_found = 0, disk_bad = dfd < 0;
+    FILE *rf = dfd >= 0 ? fdopen(dfd, "r") : NULL;
+    if (!rf && dfd >= 0) { close(dfd); disk_bad = 1; }
+    if (rf) {
+        char line[768];
+        while (fgets(line, sizeof line, rf)) {
+            size_t n = strlen(line);
+            if (n && line[n - 1] == '\n') line[--n] = 0;
+            if (!n || line[0] == '#') continue;
+            char kind = line[0], *a = strchr(line, '\t');
+            char *b = a ? strchr(a + 1, '\t') : NULL;
+            if (!a || !b || a != line + 1 || (kind != 'M' && kind != 'E')) {
+                disk_bad = 1; break;
+            }
+            *a++ = 0; *b++ = 0;
+            uint8_t saved[32];
+            if (strlen(a) != 64 || !binding_name_ok(b) ||
+                lmb_unhex(saved, a, sizeof saved)) { disk_bad = 1; break; }
+            if ((kind == 'E') == is_expert && !strcmp(b, name)) {
+                if (memcmp(saved, pk, sizeof saved)) { disk_bad = 1; break; }
+                disk_found = 1;
+            }
+        }
+        if (ferror(rf)) disk_bad = 1;
+        fclose(rf);
+    }
+    if (disk_bad) { flock(fd, LOCK_UN); close(fd); return -1; }
+    if (disk_found) {
+        flock(fd, LOCK_UN); close(fd);
+        Binding *x = &g_bindings[g_nbindings++];
+        memset(x, 0, sizeof *x); x->is_expert = is_expert;
+        snprintf(x->name, sizeof x->name, "%s", name); memcpy(x->pubkey, pk, 32);
+        return 0;
+    }
+    char hex[65], row[768]; lmb_hex(hex, pk, 32);
+    int rn = snprintf(row, sizeof row, "%c\t%s\t%s\n", is_expert ? 'E' : 'M', hex, name);
+    int ok = rn > 0 && rn < (int)sizeof row;
+    off_t end = lseek(fd, 0, SEEK_END);
+    size_t off = 0;
+    if (end < 0) ok = 0;
+    while (ok && off < (size_t)rn) {
+        ssize_t w = write(fd, row + off, (size_t)rn - off);
+        if (w < 0 && errno == EINTR) continue;
+        if (w <= 0) { ok = 0; break; }
+        off += (size_t)w;
+    }
+    if (ok && fsync(fd)) ok = 0;
+    flock(fd, LOCK_UN); close(fd);
+    if (!ok) return -1;
+    Binding *x = &g_bindings[g_nbindings++];
+    memset(x, 0, sizeof *x); x->is_expert = is_expert;
+    snprintf(x->name, sizeof x->name, "%s", name); memcpy(x->pubkey, pk, 32);
+    return 0;
+}
 
 /* Ground truth: sha256 per LMB_HASH_CHUNK of every (model, path), taken
  * from the FIRST registrant — the origin server registers before any donor
@@ -268,6 +418,8 @@ static size_t peer_auth_strip(const LmbMsg *m, uint8_t pk[32], uint8_t sig[64],
 /* 0 if this name may be held by this key: unclaimed, or already this key.
  * -1 if the name is owned by a different key (the takeover this closes). */
 static int name_key_ok(const char *name, int is_expert, const uint8_t pk[32]) {
+    int bi = binding_find(name, is_expert);
+    if (bi >= 0 && memcmp(g_bindings[bi].pubkey, pk, 32)) return -1;
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert == is_expert &&
             g_peers[i].has_key && !strcmp(g_peers[i].name, name))
@@ -281,16 +433,28 @@ static int name_key_ok(const char *name, int is_expert, const uint8_t pk[32]) {
  * handful (serve = origin + executor, a donor one or two). Counts live slots
  * only, so a restart that reclaims the same names is unaffected. */
 #define MAX_NAMES_PER_KEY 8
-static int identity_has_room(const uint8_t pk[32], const char *name, int is_expert) {
-    int held = 0;
+static int identity_has_room(const uint8_t pk[32], const char *name, int is_expert,
+                             const char *source) {
+    int held = 0, from_source = 0;
+    double now = now_s();
     for (int i = 0; i < MAX_PEERS; i++) {
         if (!g_peers[i].used || !g_peers[i].has_key) continue;
-        if (memcmp(g_peers[i].pubkey, pk, 32)) continue;
         if (g_peers[i].is_expert == is_expert && !strcmp(g_peers[i].name, name))
             return 1;                      /* reclaiming a name it already holds */
-        held++;
+        int live = now - g_peers[i].ts <= g_stale_s || g_peers[i].ctrl_fd >= 0;
+        if (!live) continue;
+        if (!memcmp(g_peers[i].pubkey, pk, 32)) held++;
+        if (source && *source && !strcmp(g_peers[i].source, source)) from_source++;
     }
-    return held < MAX_NAMES_PER_KEY;
+    return held < MAX_NAMES_PER_KEY && from_source < g_max_names_per_source;
+}
+
+static void connection_source(int fd, char out[64]) {
+    out[0] = 0;
+    struct sockaddr_storage ss; socklen_t sl = sizeof ss;
+    if (getpeername(fd, (struct sockaddr *)&ss, &sl)) return;
+    if (getnameinfo((struct sockaddr *)&ss, sl, out, 64, NULL, 0,
+                    NI_NUMERICHOST)) out[0] = 0;
 }
 
 static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
@@ -299,6 +463,7 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
     size_t blen = peer_auth_strip(m, peer_pk, peer_sig, &have_auth);
     LmbCur c = { m->body, blen, 0 };
     char name[64], addr[64], model[64];
+    char source[64]; connection_source(fd, source);
     uint64_t held, sbytes, sreads;
     uint32_t n;
     if (lmb_cur_str(&c, name, sizeof name) || lmb_cur_str(&c, addr, sizeof addr) ||
@@ -319,6 +484,12 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
     if (!aml || lmb_sign_verify(peer_sig, authmsg, aml, peer_pk)) {
         printf("[tracker] REJECTED: %s has a bad identity signature\n", name);
         fflush(stdout); send_err(fd, "bad identity signature");
+        return NULL;
+    }
+    if (lmb_secure_enabled() && !lmb_secure_peer_matches(fd, peer_pk)) {
+        printf("[tracker] REJECTED: %s registration key differs from its "
+               "encrypted-channel identity\n", name);
+        fflush(stdout); send_err(fd, "channel/registration identity mismatch");
         return NULL;
     }
     PFile *files = (PFile *)calloc(n ? n : 1, sizeof *files);
@@ -427,13 +598,13 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
         send_err(fd, "name held by another key");
         return NULL;
     }
-    if (!identity_has_room(peer_pk, name, 0)) {
+    if (!identity_has_room(peer_pk, name, 0, source)) {
         pthread_mutex_unlock(&g_lk);
-        printf("[tracker] REJECTED: one key already holds %d names\n", MAX_NAMES_PER_KEY);
+        printf("[tracker] REJECTED: peer identity or source reached its live-name quota\n");
         fflush(stdout);
         for (uint32_t i = 0; i < n; i++) free(fh[i]);
         free(fh); free(fnh); free(fsig); free(fhas); free(files);
-        send_err(fd, "too many names for one key");
+        send_err(fd, "peer identity or source admission quota reached");
         return NULL;
     }
     for (int i = 0; i < MAX_PEERS; i++)
@@ -442,6 +613,13 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
     if (!slot) {
         slot = peer_slot_new(0, &idx);
         fresh = slot != NULL;
+    }
+    if (slot && binding_check_or_add(name, 0, peer_pk)) {
+        pthread_mutex_unlock(&g_lk);
+        for (uint32_t i = 0; i < n; i++) free(fh[i]);
+        free(fh); free(fnh); free(fsig); free(fhas); free(files);
+        send_err(fd, "cannot persist peer identity binding");
+        return NULL;
     }
     if (slot) { memcpy(slot->pubkey, peer_pk, 32); slot->has_key = 1; }
     /* observed address: a maintainer that advertises localhost from another
@@ -467,6 +645,7 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
         snprintf(slot->name, sizeof slot->name, "%s", name);
         snprintf(slot->addr, sizeof slot->addr, "%s", use_addr);
         snprintf(slot->model, sizeof slot->model, "%s", model);
+        snprintf(slot->source, sizeof slot->source, "%s", source);
     }
     pthread_mutex_unlock(&g_lk);
     for (uint32_t i = 0; i < n; i++) free(fh[i]);   /* stolen ones are NULL */
@@ -492,6 +671,7 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
     size_t blen = peer_auth_strip(m, peer_pk, peer_sig, &have_auth);
     LmbCur c = { m->body, blen, 0 };
     char name[64], addr[64], model[64];
+    char source[64]; connection_source(fd, source);
     uint32_t nexperts;
     if (lmb_cur_str(&c, name, sizeof name) || lmb_cur_str(&c, addr, sizeof addr) ||
         lmb_cur_str(&c, model, sizeof model) || lmb_cur_u32(&c, &nexperts)) {
@@ -509,6 +689,12 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
           fflush(stdout); send_err(fd, "bad identity signature");
           return NULL;
       } }
+    if (lmb_secure_enabled() && !lmb_secure_peer_matches(fd, peer_pk)) {
+        printf("[tracker] REJECTED: expert %s key differs from its "
+               "encrypted-channel identity\n", name);
+        fflush(stdout); send_err(fd, "channel/registration identity mismatch");
+        return NULL;
+    }
     /* optional, appended by newer nodes: the bitmap of what it holds */
     uint32_t bl = 0; const uint8_t *bits = NULL;
     if (!lmb_cur_u32(&c, &bl) && bl && bl <= (1u << 20) && c.off + bl <= c.len) {
@@ -535,10 +721,10 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
         fflush(stdout); send_err(fd, "name held by another key");
         return NULL;
     }
-    if (!identity_has_room(peer_pk, name, 1)) {
+    if (!identity_has_room(peer_pk, name, 1, source)) {
         pthread_mutex_unlock(&g_lk);
-        printf("[tracker] REJECTED: one key already holds %d names\n", MAX_NAMES_PER_KEY);
-        fflush(stdout); send_err(fd, "too many names for one key");
+        printf("[tracker] REJECTED: peer identity or source reached its live-name quota\n");
+        fflush(stdout); send_err(fd, "peer identity or source admission quota reached");
         return NULL;
     }
     for (int i = 0; i < MAX_PEERS; i++)
@@ -547,6 +733,11 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
     if (!slot) {
         slot = peer_slot_new(1, NULL);
         fresh = slot != NULL;
+    }
+    if (slot && binding_check_or_add(name, 1, peer_pk)) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "cannot persist expert identity binding");
+        return NULL;
     }
     if (slot) { memcpy(slot->pubkey, peer_pk, 32); slot->has_key = 1; }
     const char *use_addr = addr;
@@ -568,6 +759,7 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
         snprintf(slot->name, sizeof slot->name, "%s", name);
         snprintf(slot->addr, sizeof slot->addr, "%s", use_addr);
         snprintf(slot->model, sizeof slot->model, "%s", model);
+        snprintf(slot->source, sizeof slot->source, "%s", source);
         snprintf(slot->engine, sizeof slot->engine, "%s", engine);
         snprintf(slot->profile, sizeof slot->profile, "%s", profile);
         slot->bits = qbits; slot->hidden = hidden;
@@ -1144,8 +1336,7 @@ static void relay_complete(Peer *p, LmbMsg *m) {
     if (p->rq_busy && p->rq_sent && id == p->rq_id && m->op == expect &&
         !p->rq_done) {
         p->rq_ok = ok && m->pay_len > 0;
-        p->rq_resp = m->pay; p->rq_resp_len = m->pay_len;
-        m->pay = NULL;                        /* stolen */
+        p->rq_resp = lmb_msg_take_pay(m); p->rq_resp_len = m->pay_len;
         p->rq_done = 1;
         pthread_cond_broadcast(&p->rq_cv);
     }
@@ -1230,7 +1421,7 @@ static void *conn_thread(void *arg) {
             char tok[LMB_TOKEN_MAX + 1] = "";
             LmbCur c = { m.body, m.body_len, 0 };
             int bad = lmb_cur_str(&c, tok, sizeof tok) || c.off != c.len;
-            if (!bad && (!g_token[0] || !strcmp(tok, g_token))) {
+            if (!bad && (!g_token[0] || lmb_token_equal(tok, g_token))) {
                 authed = 1;
                 rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
             } else { send_err(fd, "bad token"); rc = -1; }
@@ -1321,13 +1512,27 @@ int main(int argc, char **argv) {
                 return 2;
             }
         }
-        else { fprintf(stderr, "usage: %s [--port N] [--token S] [--pubkey FILE]\n",
+        else if (!strcmp(argv[i], "--peer-bindings") && i + 1 < argc) {
+            if (snprintf(g_bindings_path, sizeof g_bindings_path, "%s", argv[++i]) >=
+                (int)sizeof g_bindings_path) {
+                fprintf(stderr, "[tracker] --peer-bindings path is too long\n");
+                return 2;
+            }
+        }
+        else { fprintf(stderr, "usage: %s [--port N] [--token S] [--pubkey FILE] "
+                               "[--peer-bindings FILE]\n",
                        argv[0]); return 2; }
     signal(SIGPIPE, SIG_IGN);   /* a vanished peer must not kill the tracker */
     g_stale_s = (double)lmb_env_int("LUMABRI_STALE_MS", (int)(STALE_S * 1000),
                                     100, 3600000) / 1000.0;
+    g_max_names_per_source = lmb_env_int("LUMABRI_MAX_NAMES_PER_SOURCE", 16, 1, MAX_PEERS);
+    if (bindings_load()) {
+        fprintf(stderr, "[tracker] cannot load trusted peer bindings from %s\n",
+                g_bindings_path[0] ? g_bindings_path : "the state directory");
+        return 1;
+    }
     lmb_conn_gate_init(&g_conn_gate);
-    lmb_secure_init();
+    if (lmb_secure_init()) return 1;
     int lfd = lmb_listen(port);
     if (lfd < 0) { perror("[tracker] listen"); return 1; }
     printf("[tracker] listening on :%d\n", port);


### PR DESCRIPTION
Turns the opt-in encrypted transport into something that resists an **active** attacker, not only a passive one, and hardens the surrounding code.

## Identity pinning (the MITM close)
- `LUMABRI_PEER_PINS`: strict operator-managed file, every outbound address must be pinned.
- Otherwise `~/.lumabri/known_hosts`: persistent trust-on-first-use, later key change refused. `LUMABRI_REQUIRE_PIN` accepts only known endpoints.
- The pin is checked **client-side against the address after the handshake**, so an active MITM presenting its own identity is rejected, not merely noted. Rotation carries old+new rows.
- Encryption that cannot initialise **fails closed**, never falls through to plaintext.

## Handshake hardening
- X25519 all-zero shared secret rejected (no low-order point → predictable traffic secret).
- Both sides sign the ephemeral transcript with their v0.7 identity; ephemeral/shared/derived keys wiped after use.
- Per-direction counter nonces (replay fails); the 16-byte header is AEAD associated data (op + lengths authenticated).

## Memory & lifetime
- In-flight receive allocation bounded by a global atomic budget.
- AEAD allocates one frame-sized buffer (ChaCha20 in place).
- Sessions removed from the fd registry on close (no stale session on a reused fd); a lifetime reference is taken before the registry lock drops.

## Tracker
- Name→key bindings persisted (a restarted tracker still refuses a name under a different key); channel identity tied to the registration; per-key and per-source quotas; constant-time token compare.

## Tests & docs
`crypto_test` +HMAC-SHA512 (RFC 4231) +HKDF-SHA512 vectors +oversized rejection; `secure_test` +header tamper +replay +low-order rejection; `peer_identity_test` +tracker-restart binding +Sybil quota; a fail-closed case. README/DEPLOY/DESIGN/CHANGELOG updated.

## Verified
`make test`, all five engine builds, byte-identity on OLMoE/GLM/Inkling/Kimi K3 and real DeepSeek V4 (10/10 prefill, 4/4 greedy), phase 5, relay EXEC, encrypted transport end to end. Reviewed independently: X25519 low-order rejection, client-side pin enforcement, fail-closed init, secret wiping, fd-reuse cleanup, global RX bound, constant-time token — all confirmed.

Still trust-on-first-use without a pin; a look through the security advisory before relying on it against the open internet remains the right follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)