### PR TITLE
fix: refuse unsafe operator key overwrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,7 @@ test: all test_key_rotation test_hedge test_verify_failover
 	./cas_test.sh
 	./relay_exec_test.sh
 	./peer_identity_test.sh
+	./key_test.sh
 	./sign_test.sh
 	./crypto_test.sh
 	./secure_test.sh

--- a/key_test.sh
+++ b/key_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Operator keys are irreplaceable local authority. Generation must never
+# rotate an existing key or follow an output symlink implicitly.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s lumabri
+T=$(mktemp -d /tmp/lumabri-key.XXXXXX)
+cleanup() { rm -rf "$T"; }
+trap cleanup EXIT
+
+echo "· a fresh operator keypair has the promised shape and permissions"
+umask 000
+./lumabri key --out "$T/fresh" >"$T/fresh.out"
+MODE=$(stat -c %a "$T/fresh.key" 2>/dev/null || stat -f %Lp "$T/fresh.key")
+[ "$MODE" = 600 ] || {
+    echo "   secret key is not mode 0600"; exit 1; }
+[ "$(wc -c < "$T/fresh.key")" -eq 129 ] || {
+    echo "   secret key is not 128 hex bytes plus newline"; exit 1; }
+[ "$(wc -c < "$T/fresh.pub")" -eq 65 ] || {
+    echo "   public key is not 64 hex bytes plus newline"; exit 1; }
+grep -Eq '^[0-9a-f]{128}$' "$T/fresh.key" || {
+    echo "   secret key is not hexadecimal"; exit 1; }
+grep -Eq '^[0-9a-f]{64}$' "$T/fresh.pub" || {
+    echo "   public key is not hexadecimal"; exit 1; }
+[ "$(tail -c 65 "$T/fresh.key")" = "$(cat "$T/fresh.pub")" ] || {
+    echo "   public file is not the public half of the secret key"; exit 1; }
+grep -Fq "$(cat "$T/fresh.pub")" "$T/fresh.out" || {
+    echo "   command did not print the generated public key"; exit 1; }
+grep -Fqx "    LUMABRI_PUBKEY=$(cat "$T/fresh.pub") lumabri chat --tracker HOST:7300" \
+    "$T/fresh.out" || {
+    echo "   generated verifier command contains the wrong public key"; exit 1; }
+if grep -Fq "$(cat "$T/fresh.key")" "$T/fresh.out"; then
+    echo "   command printed the secret key"; exit 1
+fi
+if grep -Fq "$(cut -c1-64 "$T/fresh.key")" "$T/fresh.out"; then
+    echo "   command printed the private seed"; exit 1
+fi
+echo "   ✓ complete pair created; secret mode is exactly 0600"
+
+echo "· an existing keypair is never rotated implicitly"
+cp "$T/fresh.key" "$T/original.key"
+cp "$T/fresh.pub" "$T/original.pub"
+if ./lumabri key --out "$T/fresh" >"$T/existing.out" 2>"$T/existing.err"; then
+    echo "   existing operator keys were overwritten"; exit 1
+fi
+cmp "$T/original.key" "$T/fresh.key" && cmp "$T/original.pub" "$T/fresh.pub" || {
+    echo "   failed generation changed an existing keypair"; exit 1; }
+echo "   ✓ rerunning the command refuses and preserves both files"
+
+echo "· an existing public destination is preserved without an orphan secret"
+printf 'public destination canary\n' > "$T/public-only.pub"
+if ./lumabri key --out "$T/public-only" >"$T/public-only.out" 2>"$T/public-only.err"; then
+    echo "   existing public destination was overwritten"; exit 1
+fi
+[ "$(cat "$T/public-only.pub")" = "public destination canary" ] || {
+    echo "   existing public destination was modified"; exit 1; }
+[ ! -e "$T/public-only.key" ] || {
+    echo "   orphan secret remained after public destination refusal"; exit 1; }
+echo "   ✓ public destination stayed intact and temporary secret was removed"
+
+echo "· key output paths never follow symlinks"
+printf 'secret canary\n' > "$T/secret-canary"
+ln -s "$T/secret-canary" "$T/linked.key"
+if ./lumabri key --out "$T/linked" >"$T/link.out" 2>"$T/link.err"; then
+    echo "   secret-key symlink was followed"; exit 1
+fi
+[ "$(cat "$T/secret-canary")" = "secret canary" ] || {
+    echo "   secret-key symlink target was modified"; exit 1; }
+[ "$(readlink "$T/linked.key")" = "$T/secret-canary" ] || {
+    echo "   secret-key symlink itself was replaced"; exit 1; }
+[ ! -e "$T/linked.pub" ] || {
+    echo "   public half was left after secret-path refusal"; exit 1; }
+
+printf 'public canary\n' > "$T/public-canary"
+ln -s "$T/public-canary" "$T/public-link.pub"
+if ./lumabri key --out "$T/public-link" >"$T/public-link.out" 2>"$T/public-link.err"; then
+    echo "   public-key symlink was followed"; exit 1
+fi
+[ "$(cat "$T/public-canary")" = "public canary" ] || {
+    echo "   public-key symlink target was modified"; exit 1; }
+[ "$(readlink "$T/public-link.pub")" = "$T/public-canary" ] || {
+    echo "   public-key symlink itself was replaced"; exit 1; }
+[ ! -e "$T/public-link.key" ] || {
+    echo "   orphan secret remained after public-path refusal"; exit 1; }
+echo "   ✓ both symlink targets stayed intact and no orphan secret remained"
+
+echo "LUMABRI KEY TEST: PASS"

--- a/lumabri.c
+++ b/lumabri.c
@@ -1777,6 +1777,16 @@ static int cmd_chat(int argc, char **argv) {
  * signatures are computed once. The public half is what everyone else
  * needs, and it is the ONLY thing a chatter must get out of band: with it,
  * neither the tracker nor any peer has to be trusted. */
+static int key_write_full(int fd, const char *data, size_t len) {
+    while (len) {
+        ssize_t n = write(fd, data, len);
+        if (n < 0) { if (errno == EINTR) continue; return -1; }
+        if (n == 0) { errno = EIO; return -1; }
+        data += n; len -= (size_t)n;
+    }
+    return 0;
+}
+
 static int cmd_key(int argc, char **argv) {
     const char *out = "lumabri";
     for (int i = 0; i < argc; i++) {
@@ -1793,28 +1803,52 @@ static int cmd_key(int argc, char **argv) {
     fclose(ur);
     lmb_sign_keypair(pk, sk, seed);
 
-    char skpath[1100], pkpath[1100], hex[200];
-    snprintf(skpath, sizeof skpath, "%s.key", out);
-    snprintf(pkpath, sizeof pkpath, "%s.pub", out);
-    int fd = open(skpath, O_WRONLY | O_CREAT | O_TRUNC, 0600);   /* secret: 0600 */
-    if (fd < 0) { perror(skpath); return 1; }
-    lmb_hex(hex, sk, 64);
-    if (write(fd, hex, strlen(hex)) < 0 || write(fd, "\n", 1) < 0) { perror(skpath); close(fd); return 1; }
-    close(fd);
-    FILE *pf = fopen(pkpath, "w");
-    if (!pf) { perror(pkpath); return 1; }
-    lmb_hex(hex, pk, 32);
-    fprintf(pf, "%s\n", hex);
-    fclose(pf);
+    char skpath[1100], pkpath[1100], skhex[130], pkhex[66];
+    int sn = snprintf(skpath, sizeof skpath, "%s.key", out);
+    int pn = snprintf(pkpath, sizeof pkpath, "%s.pub", out);
+    if (sn < 0 || (size_t)sn >= sizeof skpath ||
+        pn < 0 || (size_t)pn >= sizeof pkpath) {
+        fprintf(stderr, "key output path is too long\n");
+        return 1;
+    }
+
+    int flags = O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    int skfd = open(skpath, flags, 0600);
+    if (skfd < 0) { perror(skpath); return 1; }
+    int pkfd = open(pkpath, flags, 0644);
+    if (pkfd < 0) {
+        int saved = errno;
+        close(skfd); unlink(skpath); errno = saved;
+        perror(pkpath);
+        return 1;
+    }
+
+    lmb_hex(skhex, sk, 64); skhex[128] = '\n'; skhex[129] = 0;
+    lmb_hex(pkhex, pk, 32); pkhex[64] = '\n'; pkhex[65] = 0;
+    int ok = fchmod(skfd, 0600) == 0 &&
+             key_write_full(skfd, skhex, 129) == 0 && fsync(skfd) == 0 &&
+             key_write_full(pkfd, pkhex, 65) == 0 && fsync(pkfd) == 0;
+    int saved = errno;
+    if (close(skfd) && ok) { ok = 0; saved = errno; }
+    if (close(pkfd) && ok) { ok = 0; saved = errno; }
+    if (!ok) {
+        unlink(skpath); unlink(pkpath); errno = saved;
+        perror("cannot write operator keypair");
+        return 1;
+    }
+    pkhex[64] = 0;
 
     printf("\n  %ssecret%s %s  %s(0600 — keep it off the swarm)%s\n",
            C_BOLD, C_R, skpath, C_DIM, C_R);
-    printf("  %spublic%s %s  %s%s%s\n\n", C_BOLD, C_R, pkpath, C_DIM, hex, C_R);
+    printf("  %spublic%s %s  %s%s%s\n\n", C_BOLD, C_R, pkpath, C_DIM, pkhex, C_R);
     printf("  serve the model as its origin:\n");
     printf("    %slumabri serve --model DIR --key %s%s\n", C_DIM, skpath, C_R);
     printf("  let everyone verify (give them the public value, not the file):\n");
     printf("    %sLUMABRI_PUBKEY=%s lumabri chat --tracker HOST:7300%s\n\n",
-           C_DIM, hex, C_R);
+           C_DIM, pkhex, C_R);
     return 0;
 }
 


### PR DESCRIPTION
## Summary

- create operator key outputs with `O_EXCL` and `O_NOFOLLOW` instead of truncating existing paths
- force the secret file to mode `0600`, handle short writes, sync both files, and reject truncated output paths
- print the actual public key after separating the secret/public output buffers
- add a focused key-generation test to `make test`

## Why

`lumabri key --out NAME` previously opened `NAME.key` with `O_TRUNC` and `NAME.pub` through `fopen(..., "w")`. Rerunning the command silently rotated an existing operator identity, a pre-existing permissive secret file kept its old mode, and either destination could be a symlink to another file.

The new behavior refuses any existing destination, including symlinks. If the public destination cannot be created, the just-created secret file is removed instead of leaving an orphan.

## Tests

`key_test.sh` covers:

- fresh key shape, public/secret relationship, exact secret mode under `umask 000`, and stdout not leaking the seed
- refusal and preservation of an existing keypair
- preservation of an existing public-only destination without an orphan secret
- refusal of secret and public symlink destinations without modifying their targets

## Verification

- `./key_test.sh`
- `bash -n key_test.sh`
- `git diff --check`
- built `lumabri` on the available Darwin host with `EKEYREJECTED` mapped for platform compatibility

The repository-wide Linux warning gate cannot run on this Darwin host because `tracker.c` requires `sys/eventfd.h`.