### PR TITLE
build the DeepSeek chatter for current colibri's multi-file V4 (verified identical)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,16 +49,9 @@ NODE_kimi_k3  = expert_node_kimi
 NODE_deepseek = expert_node_deepseek
 
 ENGINE_NODES    = $(foreach e,$(HAVE_ENGINES),$(NODE_$(e)))
-# The expert-node (donor) side builds for either DeepSeek layout. The chatter
-# patch is written against the single-file deepseek.c, so on current multi-file
-# colibri the DeepSeek chatter is not yet ported — skip it rather than fail the
-# build; the peer node is what makes DeepSeek experts available to a swarm.
+# Both the expert node and the chatter build for either DeepSeek layout: the
+# single file with a line patch, the multi-file source with an anchored one.
 CHATTER_ENGINES := $(HAVE_ENGINES)
-ifneq ($(DS_MULTI),)
-ifeq ($(DS_SINGLE),)
-CHATTER_ENGINES := $(filter-out deepseek,$(CHATTER_ENGINES))
-endif
-endif
 ENGINE_CHATTERS = $(foreach e,$(CHATTER_ENGINES),$(e)_p2p)
 MISSING_ENGINES = $(filter-out $(HAVE_ENGINES),olmoe colibri inkling kimi_k3 deepseek)
 MISSING_CHATTERS = $(filter-out $(CHATTER_ENGINES),$(HAVE_ENGINES))
@@ -166,6 +159,27 @@ expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h $(DS_OBJS) $(ENGI
 	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -DLMBE_DS_MULTIFILE -I$(ENGINE) \
 	      -DLMBE_ENGINE_HEADER='"expert_engines/deepseek.h"' \
 	      expert_node.c $(DS_OBJS) -o $@ -lm -lpthread
+
+# The chatter: the same units WITH main (it is the CLI), patched at the three
+# expert-apply sites to delegate routed experts to peers. The lumabri client
+# state lives in one object (lumi_v4_bridge.o) so it is not duplicated per unit.
+DS_P2P_OBJS := $(patsubst %,build/dsp2p_%.o,$(DS_UNITS))
+
+build/deepseek_v4_p2p.c: $(ENGINE)/deepseek_v4.c engine_patches/deepseek_v4_p2p.py
+	@mkdir -p build
+	@python3 engine_patches/deepseek_v4_p2p.py $< $@
+
+build/lumi_v4_bridge.o: lumi_v4_bridge.c $(ENGINE_P2P_DEPS)
+	@mkdir -p build
+	$(CC) -O2 -fopenmp -pthread -I. -Wno-unused-function $(PROFILE_deepseek) $(DS_CFLAGS) \
+	      -c lumi_v4_bridge.c -o $@
+
+build/dsp2p_%.o: build/deepseek_v4_p2p.c $(DS_HDRS) lumi_v4_ext.h
+	@mkdir -p build
+	$(CC) $(DS_UNIT_CFLAGS) -I. -include lumi_v4_ext.h -DLUMABRI_P2P -DLUMIBRI_P2P -D$* -c $< -o $@
+
+deepseek_p2p: $(DS_P2P_OBJS) build/lumi_v4_bridge.o
+	$(CC) -O2 -fopenmp $(DS_P2P_OBJS) build/lumi_v4_bridge.o -o $@ -lm -lpthread
 else
 # ---- older colibri: single generated deepseek.c -------------------------
 # It undefines `main` halfway through, so the CLI entry is renamed textually
@@ -231,8 +245,12 @@ inkling_p2p: build/inkling_p2p.c $(ENGINE_P2P_DEPS)
 kimi_k3_p2p: build/kimi_k3_p2p.c $(ENGINE_P2P_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
+# The single-file chatter rule; the multi-file one is defined near the node,
+# above, so only one deepseek_p2p recipe exists for a given colibri layout.
+ifeq ($(DS_MULTI),)
 deepseek_p2p: build/deepseek_p2p.c $(ENGINE_P2P_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+endif
 
 # what a CHATTER needs; `engines` is what a compute DONOR needs
 chatters: $(ENGINE_CHATTERS)

--- a/engine_patches/deepseek_v4_p2p.py
+++ b/engine_patches/deepseek_v4_p2p.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Patch colibri's multi-file deepseek_v4.c for the lumabri chatter.
+#
+# The single-file deepseek.c had a hand-written .diff; deepseek_v4.c is the new
+# unit-amalgamated source, compiled once per COLI_V4_UNIT_*, so a line diff is
+# brittle and the lumabri client cannot be #included directly (its static state
+# would be duplicated per unit). Instead we anchor on the three expert-apply
+# sites, call thin extern bridge functions (defined once in lumi_v4_bridge.c),
+# and route every routed expert to peers when a swarm covers them.
+#
+# Anchors mirror the old patch exactly: before each expert loop, skip it and
+# apply the whole layer remotely. Idempotent and self-checking: it counts the
+# insertions and fails loudly if the source layout moved.
+import sys, re
+
+def main():
+    src, dst = sys.argv[1], sys.argv[2]
+    s = open(src).read()
+    n = 0
+    # The bridge externs are forced in with -include lumi_v4_ext.h, so they sit
+    # at file scope for every COLI_V4_UNIT_* section; this script only inserts
+    # the call hooks.
+
+    # apply hooks: (anchor, hook, expected count)
+    hooks = [
+        # site 1 — moe_token: single loader, reset n
+        ('    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
+         '    for (int expert_id = 0; !result && expert_id < n; expert_id++) {',
+         '    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
+         '#ifdef LUMABRI_P2P\n'
+         '    if (!result && lumi_v4_bridge_on(weights->plan.layer)) {\n'
+         '        lumi_v4_bridge_apply(weights->plan.layer, indices, route_weights,\n'
+         '                             topk, input, 1, d, output);\n'
+         '        n = 0;\n'
+         '    }\n'
+         '#endif\n'
+         '    for (int expert_id = 0; !result && expert_id < n; expert_id++) {'),
+        # site 2 — moe_token_pipeline: dual loader, reset selected
+        ('    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
+         '\n'
+         '#ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER\n'
+         '    for (int current = 0; !result && current < selected; current++) {',
+         '    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
+         '#ifdef LUMABRI_P2P\n'
+         '    if (!result && lumi_v4_bridge_on(weights->plan.layer)) {\n'
+         '        lumi_v4_bridge_apply(weights->plan.layer, indices, route_weights,\n'
+         '                             topk, input, 1, d, output);\n'
+         '        selected = 0;\n'
+         '    }\n'
+         '#endif\n'
+         '\n'
+         '#ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER\n'
+         '    for (int current = 0; !result && current < selected; current++) {'),
+        # site 3 — v4_moe_batch_union: batch, reset n
+        ('    if (!result)\n'
+         '        memset(outputs, 0, (size_t)batch * d * sizeof(*outputs));\n'
+         '\n'
+         '    int key_count = 0;',
+         '    if (!result)\n'
+         '        memset(outputs, 0, (size_t)batch * d * sizeof(*outputs));\n'
+         '#ifdef LUMABRI_P2P\n'
+         '    if (!result && lumi_v4_bridge_on(weights->plan.layer)) {\n'
+         '        lumi_v4_bridge_apply(weights->plan.layer, indices, route_weights,\n'
+         '                             topk, inputs, batch, d, outputs);\n'
+         '        n = 0;\n'
+         '    }\n'
+         '#endif\n'
+         '\n'
+         '    int key_count = 0;'),
+    ]
+    for anchor, repl in hooks:
+        if s.count(anchor) != 1:
+            sys.exit("deepseek_v4.c: expert-apply anchor found %d times (want 1) — "
+                     "layout changed" % s.count(anchor))
+        s = s.replace(anchor, repl, 1); n += 1
+
+    # init hook — the always-run tail of coli_v4_engine_open (4-space indent,
+    # not the conditional 8-space one), so it fires on every successful open.
+    init_anchor = "\n    engine->summary.head_resident = engine->head_cache.data != NULL;\n"
+    inits = s.count(init_anchor)
+    if inits < 1:
+        sys.exit("deepseek_v4.c: engine-init anchor not found — layout changed")
+    init_hook = (init_anchor +
+        "#ifdef LUMABRI_P2P\n"
+        "    lumi_v4_bridge_init(engine->config.num_hidden_layers,\n"
+        "                        engine->config.n_routed_experts,\n"
+        "                        engine->config.hidden_size);\n"
+        "    atexit(lumi_v4_bridge_report);\n"
+        "#endif\n")
+    s = s.replace(init_anchor, init_hook); n += inits
+
+    open(dst, "w").write(s)
+    if n < 4:
+        sys.exit("expected at least 4 insertions, made %d" % n)
+    print("deepseek_v4 p2p: %d hooks inserted (%d engine-open tail)" % (n, inits))
+
+if __name__ == "__main__":
+    main()

--- a/lumi_v4_bridge.c
+++ b/lumi_v4_bridge.c
@@ -1,0 +1,20 @@
+/* One home for the lumabri client state, so the multi-file deepseek_v4 chatter
+ * links a single L instead of one per compilation unit. deepseek_v4_p2p.py
+ * gives the units extern declarations of these four; here are the definitions.
+ * Generated/placed by the Makefile; safe to regenerate. */
+#define LUMABRI_P2P
+#define LUMIBRI_P2P
+#include "lumabri_client.h"
+
+void lumi_v4_bridge_init(int n_layers, int n_experts, int hidden) {
+    static int done = 0;                 /* several engine-open paths may call */
+    if (done) return;
+    done = 1;
+    lumi_init_ex(n_layers, n_experts, hidden, NULL);   /* every V4 layer routes */
+}
+int lumi_v4_bridge_on(int layer) { return lumi_layer_on(layer); }
+void lumi_v4_bridge_apply(int layer, const int *indices, const float *weights,
+                          int topk, const float *x, int batch, int D, float *out) {
+    lumi_moe_apply_v4(layer, indices, weights, topk, x, batch, D, out);
+}
+void lumi_v4_bridge_report(void) { lumi_report(); }

--- a/lumi_v4_ext.h
+++ b/lumi_v4_ext.h
@@ -1,0 +1,15 @@
+/* Extern declarations of the lumabri bridge, forced into every deepseek_v4
+ * unit with -include so they sit at true file scope regardless of which
+ * COLI_V4_UNIT_* section is active. The definitions live once in
+ * lumi_v4_bridge.c; the hooks inserted by deepseek_v4_p2p.py call these. */
+#ifndef LUMI_V4_EXT_H
+#define LUMI_V4_EXT_H
+#ifdef LUMABRI_P2P
+extern void lumi_v4_bridge_init(int n_layers, int n_experts, int hidden);
+extern int  lumi_v4_bridge_on(int layer);
+extern void lumi_v4_bridge_apply(int layer, const int *indices,
+        const float *weights, int topk, const float *x, int batch,
+        int D, float *out);
+extern void lumi_v4_bridge_report(void);
+#endif
+#endif


### PR DESCRIPTION
Finishes the DeepSeek port started in #35 (expert node): the chatter (`deepseek_p2p`) now builds against current colibri's unit-amalgamated `deepseek_v4.c`, so a DeepSeek chatter can delegate routed experts to peers instead of streaming them from its own disk.

## How
- **Anchored patcher** (`engine_patches/deepseek_v4_p2p.py`), not a line diff: finds the three expert-apply sites (`moe_token`, the dual loader in `moe_token_pipeline`, `v4_moe_batch_union`) and the tail of `coli_v4_engine_open`, inserts the same hooks the old patch used, fails loudly if any anchor moves. Keeps the engine's `main()` — the chatter is the CLI.
- **One client home** (`lumi_v4_bridge.c` + `lumi_v4_ext.h`): the header-only client would give each of the ~26 units its own `L` state, so the unit running `lumi_init` and the unit applying experts would see different peer tables. The bridge defines the client once and exposes four extern entry points; the ext header is forced into every unit with `-include` so the declarations sit at file scope for whichever `COLI_V4_UNIT_` is active.
- **Makefile**: builds the patched units with `-DLUMABRI_P2P`, compiles the bridge with the DeepSeek profile so chatter and expert node share one build identity, links them. Single-file chatter rule kept for older colibri, guarded so one recipe exists per layout.

## Verified
Against the real 156 GB DeepSeek V4 model on **current colibri**: phase 2 active, **3087 remote expert calls / 215 layer rounds**, **PREFILL 10/10 positions, GREEDY 4/4 tokens** identical to the local oracle. Single-file path, `make all`, and the other four engines unchanged; `selftest` and `phase2_test` green.

Closes the DeepSeek half of the multi-file colibri support (peer node was #35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)