### PR TITLE
docs: DEPLOY.md still says the DeepSeek chatter isn't ported — #36 shipped it

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -85,10 +85,14 @@ DeepSeek is built from whichever layout your colibri checkout ships. Current
 colibri has the unit-amalgamated `deepseek_v4.c`; `make expert_node_deepseek`
 compiles its `COLI_V4_UNIT_*` objects and links them, no extra step. Older
 colibri trees had a single generated `deepseek.c`, which still works. On the
-current multi-file layout the **expert node** (the donor side) builds; the
-DeepSeek **chatter** patch is written against the old single file and is not
-yet ported, so `make chatters` skips it and says so — a DeepSeek swarm can
-serve and execute experts, and the chat-side delegation patch is a follow-up.
+current multi-file layout **both** sides build: the **expert node** (the donor)
+and the **chatter** (chat-side expert delegation). The chatter is the newer
+half — `deepseek_v4.c` is unit-amalgamated, so instead of the old line patch it
+is hooked by an anchored script and a single client bridge object. `make
+chatters` includes DeepSeek and prints no "skipped" line, so a DeepSeek swarm
+both serves/executes experts and delegates them from the chat side. Verified
+byte-identical against a real V4 model: 3087 remote expert calls over 215 layer
+rounds, PREFILL 10/10 and GREEDY 4/4 against the local oracle.
 
 Skip this whole section if you only want phase 1: a server that serves the
 model's bytes works for every engine, DeepSeek included, and `lumabri chat`


### PR DESCRIPTION
Follow-up to #33 / #35 / #36.

@alangiu-gif confirmed #35 on an independent checkout and flagged that `DEPLOY.md` on `main` still carries the #35-era caveat: it says the DeepSeek **chatter** patch is written against the old single file, that `make chatters` skips DeepSeek "and says so", and that chat-side delegation is a follow-up. #36 ported the chatter to the unit-amalgamated `deepseek_v4.c` but did not touch that paragraph, so the file now contradicts the Makefile.

Checked, not assumed (matching the reporter): with `deepseek_p2p` removed, `make -n chatters ENGINE=...` schedules `-o deepseek_p2p`, `make chatters` prints no "skipped" line, and `CHATTER_ENGINES := $(HAVE_ENGINES)` has deepseek in it.

This rewrites the paragraph to say both sides build on the current layout — the expert node **and** the chatter — notes how the chatter is wired (anchored script + single client bridge object, since the old line patch and header-only client dont survive per-unit amalgamation), and records the byte-identity result against a real V4 model: 3087 remote expert calls over 215 layer rounds, PREFILL 10/10 and GREEDY 4/4 against the local oracle.

Docs only — no code or Makefile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)