### PR TITLE
fix: build + byte-identity against current colibri (kimi, deepseek) and name the manifest mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ DS_MULTI  := $(wildcard $(ENGINE)/deepseek_v4.c)
 HAVE_ENGINES := $(notdir $(basename $(wildcard $(ENGINE)/olmoe.c $(ENGINE)/colibri.c \
                  $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c)))
 HAVE_ENGINES += $(if $(DS_MULTI)$(DS_SINGLE),deepseek)
+
+# Current colibri's kimi expert_apply grew two i8-activation params (zq,zsc);
+# older trees took eight. The donor glue passes NULL,NULL (the float fallback,
+# byte-identical) only when the source has them. Probe the exact signature tail
+# so a stray zq elsewhere can't flip it. Empty on missing file or old layout.
+K3_ZQ := $(shell grep -c 'const int8_t \*zq, const float \*zsc' $(ENGINE)/kimi_k3.c 2>/dev/null)
+K3_ZQ_FLAG := $(if $(filter-out 0,$(K3_ZQ)),-DLMBE_K3_EXPERT_APPLY_ZQ,)
 NODE_olmoe    = expert_node
 NODE_colibri  = expert_node_glm
 NODE_inkling  = expert_node_inkling
@@ -113,7 +120,7 @@ expert_node_inkling: $(EXPERT_DEPS) expert_engines/inkling.h $(ENGINE)/inkling.c
 
 expert_node_kimi: $(EXPERT_DEPS) expert_engines/kimi_k3.h $(ENGINE)/kimi_k3.c \
                   engine_patches/kimi_k3-p2p.diff $(ENGINE_PROFILE_DEPS)
-	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) -DLMBE_ENGINE_HEADER='"expert_engines/kimi_k3.h"' \
+	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) $(K3_ZQ_FLAG) -DLMBE_ENGINE_HEADER='"expert_engines/kimi_k3.h"' \
 	      expert_node.c -o $@ -lm -lpthread
 
 # DeepSeek V4 needs two extra things at build time.
@@ -144,6 +151,25 @@ DS_OBJS  := $(patsubst %,build/ds_%.o,$(DS_UNITS))
 DS_UNIT_CFLAGS = -O2 -fopenmp -pthread -D_GNU_SOURCE -include pthread.h -I$(ENGINE) $(DS_CFLAGS)
 DS_HDRS := $(wildcard $(ENGINE)/deepseek_v4*.h $(ENGINE)/deepseek_v4*.inc)
 
+# Current colibri split the pluggable expert-store backend out of deepseek_v4.c
+# into a standalone sibling TU that every V4 link now folds in
+# (Makefile.deepseek-v4: V4_OBJS = target units + REGISTRY_OBJ). It is not a
+# COLI_V4_UNIT_*, so deepseek_v4.c references it (coli_expert_store_backend_*)
+# but our unit objects do not define it — link fails without it. Discover the
+# source from colibri's own REGISTRY_OBJ so a rename follows us, and gate on the
+# file existing so trees that predate the split link exactly as before. The one
+# object is identical for node and chatter (no P2P, no ext header), so it is
+# shared by both links.
+DS_REGISTRY_OBJNAME := $(shell awk -F= '/^REGISTRY_OBJ[ \t]*=/{gsub(/[ \t]/,"",$$2);print $$2}' \
+                         $(ENGINE)/Makefile.deepseek-v4 2>/dev/null)
+DS_SIBLING_SRCS := $(foreach o,$(DS_REGISTRY_OBJNAME),$(wildcard $(ENGINE)/$(o:.o=.c)))
+DS_SIBLING_HDRS := $(wildcard $(ENGINE)/expert_store*.h)
+DS_SIBLING_OBJS := $(patsubst $(ENGINE)/%.c,build/dssib_%.o,$(DS_SIBLING_SRCS))
+
+build/dssib_%.o: $(ENGINE)/%.c $(DS_HDRS) $(DS_SIBLING_HDRS)
+	@mkdir -p build
+	$(CC) $(DS_UNIT_CFLAGS) -c $< -o $@
+
 build/deepseek_v4_noentry.c: $(ENGINE)/deepseek_v4.c
 	@mkdir -p build
 	@awk '/^int main\(int argc, char \*\*argv\) \{/{c++; sub(/^int main/,"int coli_v4_cli_unused_main_"c)} {print}' \
@@ -155,10 +181,10 @@ build/ds_%.o: build/deepseek_v4_noentry.c $(DS_HDRS)
 	@mkdir -p build
 	$(CC) $(DS_UNIT_CFLAGS) -D$* -c $< -o $@
 
-expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h $(DS_OBJS) $(ENGINE_PROFILE_DEPS)
+expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h $(DS_OBJS) $(DS_SIBLING_OBJS) $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -DLMBE_DS_MULTIFILE -I$(ENGINE) \
 	      -DLMBE_ENGINE_HEADER='"expert_engines/deepseek.h"' \
-	      expert_node.c $(DS_OBJS) -o $@ -lm -lpthread
+	      expert_node.c $(DS_OBJS) $(DS_SIBLING_OBJS) -o $@ -lm -lpthread
 
 # The chatter: the same units WITH main (it is the CLI), patched at the three
 # expert-apply sites to delegate routed experts to peers. The lumabri client
@@ -178,8 +204,8 @@ build/dsp2p_%.o: build/deepseek_v4_p2p.c $(DS_HDRS) lumi_v4_ext.h
 	@mkdir -p build
 	$(CC) $(DS_UNIT_CFLAGS) -I. -include lumi_v4_ext.h -DLUMABRI_P2P -DLUMIBRI_P2P -D$* -c $< -o $@
 
-deepseek_p2p: $(DS_P2P_OBJS) build/lumi_v4_bridge.o
-	$(CC) -O2 -fopenmp $(DS_P2P_OBJS) build/lumi_v4_bridge.o -o $@ -lm -lpthread
+deepseek_p2p: $(DS_P2P_OBJS) build/lumi_v4_bridge.o $(DS_SIBLING_OBJS)
+	$(CC) -O2 -fopenmp $(DS_P2P_OBJS) build/lumi_v4_bridge.o $(DS_SIBLING_OBJS) -o $@ -lm -lpthread
 else
 # ---- older colibri: single generated deepseek.c -------------------------
 # It undefines `main` halfway through, so the CLI entry is renamed textually

--- a/engine_patches/deepseek_v4_p2p.py
+++ b/engine_patches/deepseek_v4_p2p.py
@@ -35,11 +35,18 @@ def main():
          '    }\n'
          '#endif\n'
          '    for (int expert_id = 0; !result && expert_id < n; expert_id++) {'),
-        # site 2 — moe_token_pipeline: dual loader, reset selected
+        # site 2 — moe_token_pipeline: dual loader, reset selected.
+        # Current colibri allocates a `views` array (and, under COLI_V4_GPU_TIER,
+        # a batch path) before the per-expert loop, so the anchor is the malloc,
+        # not the loop. selected=0 stays correct on the CPU build we compile:
+        # the GPU batch path is #ifdef'd out, so the only tail that runs is
+        # `output = round(output + shared)` — identical to sites 1 and 3, with
+        # the routed partial already written remotely. (views = malloc(0) is a
+        # valid non-NULL pointer on glibc; selected==topk>0 in every local run.)
         ('    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
          '\n'
          '#ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER\n'
-         '    for (int current = 0; !result && current < selected; current++) {',
+         '    ColiExpertView *views = malloc((size_t)selected * sizeof(*views));',
          '    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
          '#ifdef LUMABRI_P2P\n'
          '    if (!result && lumi_v4_bridge_on(weights->plan.layer)) {\n'
@@ -50,7 +57,7 @@ def main():
          '#endif\n'
          '\n'
          '#ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER\n'
-         '    for (int current = 0; !result && current < selected; current++) {'),
+         '    ColiExpertView *views = malloc((size_t)selected * sizeof(*views));'),
         # site 3 — v4_moe_batch_union: batch, reset n
         ('    if (!result)\n'
          '        memset(outputs, 0, (size_t)batch * d * sizeof(*outputs));\n'

--- a/expert_engines/kimi_k3.h
+++ b/expert_engines/kimi_k3.h
@@ -48,7 +48,13 @@ static void lmbe_slot_load(int slot, int eid, LmbeSlot *s) {
     s->eid = eid;
 }
 
-typedef struct { float *gate, *up, *hz; } LmbeScratch;
+typedef struct {
+    float *gate, *up, *hz;
+#ifdef LMBE_K3_EXPERT_APPLY_ZQ
+    int8_t *zq;                       /* one pre-quantized z row, mxfp4_qx form */
+    float  *zsc;                      /* its per-32-block scales */
+#endif
+} LmbeScratch;
 
 static void *lmbe_scratch_new(int nrows) {
     (void)nrows;                      /* K3's kernels are one row at a time */
@@ -56,12 +62,20 @@ static void *lmbe_scratch_new(int nrows) {
     sc->gate = falloc(lmbe_M.c.moe_inter);
     sc->up   = falloc(lmbe_M.c.moe_inter);
     sc->hz   = falloc(lmbe_M.c.latent);
+#ifdef LMBE_K3_EXPERT_APPLY_ZQ
+    sc->zq   = (int8_t *)malloc((size_t)lmbe_M.c.latent);
+    sc->zsc  = falloc(lmbe_M.c.latent / 32 + 1);
+#endif
     return sc;
 }
 
 static void lmbe_scratch_free(void *p) {
     LmbeScratch *sc = (LmbeScratch *)p;
-    free(sc->gate); free(sc->up); free(sc->hz); free(sc);
+    free(sc->gate); free(sc->up); free(sc->hz);
+#ifdef LMBE_K3_EXPERT_APPLY_ZQ
+    free(sc->zq); free(sc->zsc);
+#endif
+    free(sc);
 }
 
 /* The engine's OWN expert_apply, not a transcription of it.
@@ -80,9 +94,29 @@ static void lmbe_apply(const LmbeSlot *ec, int slot, const float *z, float *out,
     int LT = lmbe_M.c.latent;
     (void)slot;
     memset(out, 0, (size_t)nrows * LT * sizeof(float));
-    for (int r = 0; r < nrows; r++)
-        expert_apply(&lmbe_M, s, z + (int64_t)r * LT, 1.0f,
-                     out + (int64_t)r * LT, sc->gate, sc->up, sc->hz);
+#ifdef LMBE_K3_EXPERT_APPLY_ZQ
+    /* Match the engine's batch path exactly. With int8-activation matmuls on
+     * (K3_IDOT, the default) and the latent tiling into 32-wide blocks, the
+     * engine pre-quantizes each z row once with mxfp4_qx and feeds expert_apply
+     * the shared zq/zsc. Passing NULL there is NOT equivalent: expert_apply
+     * then requantizes z in-call, which rounds differently and diverges in the
+     * low bits — a distinct token a few steps later. So the donor quantizes on
+     * exactly the same condition (g_k3_idot && LT%32==0) with the same routine;
+     * otherwise NULL is right, because the engine also feeds NULL then. */
+    int use_zq = g_k3_idot && (LT % 32 == 0) && sc->zq && sc->zsc;
+#endif
+    for (int r = 0; r < nrows; r++) {
+        const float *zr = z + (int64_t)r * LT;
+#ifdef LMBE_K3_EXPERT_APPLY_ZQ
+        if (use_zq) mxfp4_qx(zr, 1, LT, sc->zq, sc->zsc);
+        expert_apply(&lmbe_M, s, zr, 1.0f, out + (int64_t)r * LT,
+                     sc->gate, sc->up, sc->hz,
+                     use_zq ? sc->zq : NULL, use_zq ? sc->zsc : NULL);
+#else
+        expert_apply(&lmbe_M, s, zr, 1.0f, out + (int64_t)r * LT,
+                     sc->gate, sc->up, sc->hz);
+#endif
+    }
 }
 
 #endif

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -188,6 +188,7 @@ static int lumi_add_peer(const char *addr) {
     uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0;
     uint32_t n = 0, peer_hidden = 0;
     char engine[64] = "", profile[LMB_BUILD_PROFILE_MAX] = "", peer_model[64] = "";
+    char why[224] = "";   /* which manifest field made this peer incompatible */
     LmbModelIdentity peer_id = {0};
     int bad = lmb_cur_u32(&c, &magic) || magic != LMB_EXPERT_MANIFEST_MAGIC ||
               lmb_cur_str(&c, engine, sizeof engine) ||
@@ -201,15 +202,33 @@ static int lumi_add_peer(const char *addr) {
               (has_sig && lmb_cur_bytes(&c, peer_id.sig, sizeof peer_id.sig));
         peer_id.has_sig = has_sig != 0;
     }
-    if (!bad) bad = lmb_cur_u32(&c, &n) ||
-                    n > (uint64_t)L.n_layers * (uint64_t)L.n_experts;
-    if (!bad && (strcmp(engine, LMBE_ENGINE_ID) || strcmp(profile, L.profile) ||
-                 bits != (uint32_t)L.expected_bits ||
-                 (L.expected_model[0] && strcmp(peer_model, L.expected_model)) ||
-                 ((L.have_identity || L.trust.n) && !have_id) ||
-                 (have_id && !lumi_identity_valid(peer_model, &peer_id)) ||
-                 (L.have_identity && memcmp(L.identity.root, peer_id.root, 32)))) {
+    if (!bad) bad = lmb_cur_u32(&c, &n);
+    if (!bad && n > (uint64_t)L.n_layers * (uint64_t)L.n_experts) {
+        snprintf(why, sizeof why, "shape: peer lists %u experts, this model has %llu",
+                 n, (unsigned long long)((uint64_t)L.n_layers * L.n_experts));
         bad = 1;
+    }
+    if (!bad && !why[0]) {
+        if (strcmp(engine, LMBE_ENGINE_ID))
+            snprintf(why, sizeof why, "engine: peer='%s' vs local='%s'",
+                     engine, LMBE_ENGINE_ID);
+        else if (strcmp(profile, L.profile)) {
+            char d[192];
+            lmb_profile_diff(profile, L.profile, d, sizeof d);
+            snprintf(why, sizeof why, "build %s", d);
+        } else if (bits != (uint32_t)L.expected_bits)
+            snprintf(why, sizeof why, "bits: peer=%u vs local=%d",
+                     bits, L.expected_bits);
+        else if (L.expected_model[0] && strcmp(peer_model, L.expected_model))
+            snprintf(why, sizeof why, "model: peer='%s' vs local='%s'",
+                     peer_model, L.expected_model);
+        else if ((L.have_identity || L.trust.n) && !have_id)
+            snprintf(why, sizeof why, "peer sent no signed model identity");
+        else if (have_id && !lumi_identity_valid(peer_model, &peer_id))
+            snprintf(why, sizeof why, "peer model identity failed to verify");
+        else if (L.have_identity && memcmp(L.identity.root, peer_id.root, 32))
+            snprintf(why, sizeof why, "model identity differs from the pinned one");
+        if (why[0]) bad = 1;
     }
     size_t gids = (size_t)L.n_layers * L.n_experts;
     uint8_t *seen = reprobe >= 0 ? (uint8_t *)calloc(gids, 1) : NULL;
@@ -234,16 +253,20 @@ static int lumi_add_peer(const char *addr) {
                     bad = 1;
                     break;
                 }
-    if (bad || lmb_cur_u32(&c, &peer_hidden) ||
-        peer_hidden != (uint32_t)L.hidden || c.off != c.len || m.pay_len != 0) {
+    int tail_bad = lmb_cur_u32(&c, &peer_hidden) || c.off != c.len || m.pay_len != 0;
+    if (!bad && !why[0] && !tail_bad && peer_hidden != (uint32_t)L.hidden)
+        snprintf(why, sizeof why, "shape: peer hidden=%u vs local hidden=%d",
+                 peer_hidden, L.hidden);
+    if (bad || tail_bad || peer_hidden != (uint32_t)L.hidden) {
         /* roll the claims back: this peer must not own anything */
         if (reprobe < 0)
             for (size_t i = 0; i < gids * LUMI_MAX_REP; i++)
                 if (L.own[i] == pi) L.own[i] = -1;
         free(seen);
         lmb_msg_free(&m);
-        fprintf(stderr, "[lumabri] peer %s: incompatible manifest "
-                        "(model/build/engine/bits/shape) — skipped\n", p->addr);
+        fprintf(stderr, "[lumabri] peer %s: incompatible manifest — %s — skipped\n",
+                p->addr,
+                why[0] ? why : "malformed or model/build/engine/bits/shape mismatch");
         return -1;
     }
     if (!L.expected_model[0]) snprintf(L.expected_model, sizeof L.expected_model,

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -576,6 +576,41 @@ static LMB_MAYBE_UNUSED void lmb_build_profile(char *out, size_t cap) {
              LMB_PROFILE_OMP, LMB_PROFILE_MATH, sizeof(float));
 }
 
+/* Name the first `key=val` segment of two build profiles that differs, so an
+ * "incompatible manifest" points at the one knob to match — nearly always a
+ * different compiler version (cc=) or -march tier (isa=) between the two
+ * machines, or a src= from a different engine checkout — instead of a blank
+ * "build". Writes "<key>: peer='<a>' vs local='<b>'"; falls back to the whole
+ * strings if they differ only in structure. */
+static LMB_MAYBE_UNUSED void lmb_profile_diff(const char *peer, const char *local,
+                                              char *out, size_t cap) {
+    const char *a = peer, *b = local;
+    while (*a && *b) {
+        const char *ae = a; while (*ae && *ae != ';') ae++;
+        const char *be = b; while (*be && *be != ';') be++;
+        size_t an = (size_t)(ae - a), bn = (size_t)(be - b);
+        if (an != bn || memcmp(a, b, an)) {
+            size_t kn = 0;                          /* key is up to '=' */
+            while (kn < an && a[kn] != '=') kn++;
+            const char *av = kn < an ? a + kn + 1 : a;   /* value after '=' */
+            int avn = kn < an ? (int)(an - kn - 1) : (int)an;
+            size_t lk = 0;
+            while (lk < bn && b[lk] != '=') lk++;
+            const char *bv = lk < bn ? b + lk + 1 : b;
+            int bvn = lk < bn ? (int)(bn - lk - 1) : (int)bn;
+            snprintf(out, cap, "%.*s: peer='%.*s' vs local='%.*s'",
+                     (int)kn, a, avn, av, bvn, bv);
+            return;
+        }
+        a = *ae ? ae + 1 : ae;
+        b = *be ? be + 1 : be;
+    }
+    if (strcmp(peer, local))
+        snprintf(out, cap, "peer='%s' vs local='%s'", peer, local);
+    else
+        snprintf(out, cap, "identical");
+}
+
 static int lmb_cur_u32(LmbCur *c, uint32_t *v) {
     if (c->off > c->len || 4 > c->len - c->off) return -1;
     *v = lmb_get32(c->p + c->off); c->off += 4;

--- a/phase2_kimi_test.sh
+++ b/phase2_kimi_test.sh
@@ -35,7 +35,10 @@ run() { OMP_NUM_THREADS="${THREADS:-2}" "$@" \
 echo
 echo "══ A) LOCAL — experts read and run by the engine itself"
 run env > "$T/local.out" 2>"$T/local.err" || { tail -20 "$T/local.err"; exit 1; }
-A=$(tr -s ' \n' ' ' < "$T/local.out" | sed 's/^ *//;s/ *$//')
+# Current colibri prints a "TUNE decode: N tokens in Xs" timing line on stdout;
+# it varies run to run and is not part of the output. Compare only the token ids
+# before it — the whole point of this test.
+A=$(tr -s ' \n' ' ' < "$T/local.out" | sed 's/TUNE.*//' | sed 's/^ *//;s/ *$//')
 [ -n "$A" ] || { echo "no tokens from the local run"; tail -20 "$T/local.err"; exit 1; }
 echo "  tokens: $A"
 
@@ -61,7 +64,7 @@ grep -h "dense and route nothing\|holding" "$T/node0.log" || true
 echo
 echo "══ B) P2P — every routed expert runs on a peer"
 run env LUMABRI_EXPERTS="$ADDRS" > "$T/p2p.out" 2>"$T/p2p.err" || { tail -20 "$T/p2p.err"; exit 1; }
-B=$(tr -s ' \n' ' ' < "$T/p2p.out" | sed 's/^ *//;s/ *$//')
+B=$(tr -s ' \n' ' ' < "$T/p2p.out" | sed 's/TUNE.*//' | sed 's/^ *//;s/ *$//')
 echo "  tokens: $B"
 grep -E "^\[lumabri\]" "$T/p2p.err" || true
 


### PR DESCRIPTION
Current colibri advanced again after #35/#36. `make phase2-all` broke, and — worse — kimi went byte-**divergent** silently. Four engine-side fixes plus one diagnostic, each verified against the real engine. No regression on the older single-file / 8-arg colibri (moe-stream): it still builds 10/10 and runs byte-identical.

### kimi `expert_apply` gained two params (int8 activation)
`expert_apply(…, const int8_t *zq, const float *zsc)`. Two problems:
1. **Build:** the donor glue called it with 8 args → *too few arguments*. A probe on the exact signature tail sets `-DLMBE_K3_EXPERT_APPLY_ZQ` only when the source has them; the glue adds the two args under it, 8-arg trees unchanged.
2. **Byte-identity:** `K3_IDOT` (int8-activation matmuls) is **on by default**, so the local engine pre-quantizes each `z` row with `mxfp4_qx` and feeds `expert_apply` the shared `zq`/`zsc`. Passing `NULL` is **not** the same path — `expert_apply` then requantizes in-call and rounds differently, so the donor diverged a few tokens in (the test caught it: `✗ DIVERGENZA`). The glue now quantizes on exactly the engine’s condition (`g_k3_idot && latent%32==0`) with the same routine. Back to `✓ IDENTICI`.

### deepseek link: new sibling TU
colibri split the pluggable expert-store backend into a standalone `expert_store_registry.c` that every V4 link now folds in (`V4_OBJS = target units + REGISTRY_OBJ`). Our unit-only build missed it → `undefined reference to coli_expert_store_backend_open_selected`. We discover the source from colibri’s own `REGISTRY_OBJ` (follows a rename; empty on older trees) and link the one shared object into both the node and the chatter.

### deepseek chatter anchor moved
The pipeline expert-apply site now allocates a `views` array before the loop, so site 2’s anchor moved from the for-loop to the malloc. The hook (`selected=0`) is unchanged and still correct: the GPU batch path is `#ifdef`’d out on our CPU build, so the only tail that runs is the shared `round(output + shared)` — identical to sites 1 and 3. Re-verified against a real 156 GB V4 model: **3087 remote expert calls, PREFILL 10/10, GREEDY 4/4** identical.

### manifest diagnostic now names the field
`incompatible manifest (model/build/engine/bits/shape)` named every field and pinpointed none — so an operator whose peers were refused, and whose chatter then mirrored the whole model to local disk until it filled, had no way to see why. It now names the one field that differs, and for the build profile the exact sub-field:

```
[lumabri] peer 1.2.3.4:7302: incompatible manifest — build cc: peer=gcc 12.2 vs local=gcc 14.2 — skipped
[lumabri] peer 1.2.3.4:7302: incompatible manifest — build src: peer=3a94… vs local=9842… — skipped
```

This is usually a **different compiler version or -march tier between two machines** (the profile pins both on purpose — differing codegen would break byte-identity), which no message previously surfaced. Wire format unchanged; the profile string is unaffected, so this does not change interop.

### kimi test
Current colibri prints a `TUNE decode: N tokens in Xs` timing line on stdout; the harness compared whole stdout and failed on timing alone. Compare only the token ids before it.

## Verification (all against current colibri)
- deepseek chatter vs real 156 GB V4: 3087 remote calls, PREFILL 10/10, GREEDY 4/4 — `✓ IDENTICI`
- kimi phase 2: `✓ IDENTICI` on current **and** old colibri
- olmoe, inkling phase 2: `✓ IDENTICI`
- selftest / donate / incompatible-profile-refused: PASS
- `make all` + `make phase2-all`: 10/10 binaries on current colibri, 10/10 on moe-stream
- GLM phase 2 needs a fixture the colibri checkout does not ship (`glm_tiny_i4`); unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)