### PR TITLE
fix: a --local chat keeps colibri's AUTOPIN (don't stream every expert)

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -933,12 +933,17 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
             setenv("LUMABRI_STATS", "2", 1);       /* boot progress, not a log */
             setenv("SNAP", vroot, 1);
         }
-        /* Pinning is for an engine that owns its experts. A chatter never
+        /* Pinning is for an engine that owns its experts. A SWARM chatter never
          * does: either they run on peers (pinning is pointless) or they come
          * over the network (pinning is catastrophic — colibri's AUTOPIN reads
          * a shipped .coli_usage and preloads GBs of them before the first
-         * token). overwrite=0, so an explicit PIN still wins. */
-        setenv("PIN", "0", 0);
+         * token). But a --local run owns its experts on disk, and there pinning
+         * the hot ones in RAM is the whole difference between decode from RAM
+         * and streaming every expert off disk each token (measured: GLM at
+         * TIERS 0 resident → ~0.1 tok/s). So only force it off for the swarm;
+         * a local run keeps colibri's own AUTOPIN. overwrite=0 either way, so
+         * an explicit PIN still wins. */
+        if (!local_dir) setenv("PIN", "0", 0);
         setenv("CHAT", "1", 1);                    /* olmoe's dialect */
         setenv("SERVE", "1", 1);                   /* everyone else's */
         setenv("KV_SLOTS", "1", 1);


### PR DESCRIPTION
Reported by a user running GLM locally through `lumabri chat --local`: ~0.1 tok/s, CPU half-idle, and the engine printing `TIERS 0 0 19456 0.00 0.00` — **zero experts resident in RAM**, every one streamed off disk each token.

## Cause
`engine_spawn` force-set `PIN=0` for every chat, to stop colibri’s AUTOPIN from preloading experts. That is correct for a **swarm** chatter — the experts live on peers or arrive over the network, so pinning them locally is pointless or (AUTOPIN reading a shipped `.coli_usage` and pulling GBs over the wire) catastrophic. But it was applied **unconditionally**, including `--local` runs, where the model sits on local disk and the chatter *owns* its experts. There, AUTOPIN caching the hot ones in RAM is the whole difference between decode-from-RAM and streaming every expert off disk. So `--local` through lumabri was actually **slower than running colibri directly**, which AUTOPINs by default.

## Fix
Gate the override on `!local_dir`:
```c
if (!local_dir) setenv("PIN", "0", 0);
```
- **Swarm chatters** (`local_dir == NULL`): unchanged — still `PIN=0`, no local pinning of remote experts.
- **`--local` runs**: keep colibri’s own AUTOPIN, which learns from `.coli_usage` and warms up over a few turns.
- `overwrite=0` is unchanged in both modes, so an explicit `PIN=…` still wins.

One line; no effect on the distributed path. Users on the swarm see no change; a `--local` GLM run stops streaming every expert once its usage history warms up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)