### PR TITLE
fix: a --local chat grows its expert cache to fit RAM (CAP_RAISE)

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -944,6 +944,17 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
          * a local run keeps colibri's own AUTOPIN. overwrite=0 either way, so
          * an explicit PIN still wins. */
         if (!local_dir) setenv("PIN", "0", 0);
+        /* Same split for the expert cache. A swarm chatter caches almost nothing
+         * (experts run on peers), so its cap stays at the small default. But a
+         * --local run holds its own experts, and there the cap IS the resident
+         * set: cap_experts is a swarm-shaped default (64), and colibri only
+         * auto-grows the cache to fit RAM when CAP_RAISE is on — which it turns
+         * OFF by default on a fast SSD. Left alone, a --local GLM cached 64 of
+         * 19456 experts and streamed the rest (TIERS 0…, ~0.1 tok/s) with the
+         * box's RAM sitting idle. Turn the RAM auto-raise on for local runs so
+         * the cache grows to whatever RAM_GB (or the auto 88%) allows; overwrite=0
+         * keeps an explicit CAP_RAISE=… authoritative. */
+        if (local_dir) setenv("CAP_RAISE", "1", 0);
         setenv("CHAT", "1", 1);                    /* olmoe's dialect */
         setenv("SERVE", "1", 1);                   /* everyone else's */
         setenv("KV_SLOTS", "1", 1);


### PR DESCRIPTION
Companion to #40. Same class of bug: a swarm-shaped default applied to `--local`, where it is wrong.

A user running GLM (429 GB, 19456 experts) locally saw `TIERS 0 0 19456`, ~0.1 tok/s, and the box’s RAM idle. Cause: `cap_experts` defaults to **64** — correct for a swarm chatter, whose experts run on peers so it caches almost nothing. But a `--local` run holds its own experts: there the expert-cache cap **is** the resident set. colibri only auto-grows that cache to fit RAM when `CAP_RAISE` is on, and `CAP_RAISE` defaults **off on a fast SSD**. So a local GLM cached 64 of 19456 experts and streamed the rest off disk every token, with RAM unused.

Fix: set `CAP_RAISE=1` for local runs only, so the cache grows to whatever `RAM_GB` (or colibri’s auto 88%-of-free) allows. Swarm chatters are untouched — their tiny cap is correct. `overwrite=0`, so an explicit `CAP_RAISE=…` still wins.

Honest scope: this does **not** make a model larger than RAM fast — experts that do not fit still stream, and 429 GB on 64 GB is disk-bound by arithmetic. It stops a local run from leaving RAM idle while it streams. For a model that exceeds one box, the swarm (experts resident across peers) remains the only fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)