### PR TITLE
feat: field-aware profile gate — omp never refuses, cc/isa opt-in (#38)

### DIFF
--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -61,6 +61,7 @@ static struct {
     LmbTrustKeys trust;
     double next_discover, discover_period_s;
     int verify_pct;             /* LUMABRI_VERIFY: % of calls double-checked */
+    int allow_codegen_skew;     /* LUMABRI_ALLOW_CODEGEN_SKEW: cc/isa -> warn, not refuse */
     int hedge_ms;               /* 0 disables; base policy, fixed delay */
     unsigned long long calls, layers_done, failovers, verified, relays;
     unsigned long long hedges, hedge_wins, batch_calls, batch_rows;
@@ -213,9 +214,22 @@ static int lumi_add_peer(const char *addr) {
             snprintf(why, sizeof why, "engine: peer='%s' vs local='%s'",
                      engine, LMBE_ENGINE_ID);
         else if (strcmp(profile, L.profile)) {
+            /* Field-aware: identity/ABI (abi/engine/src/math/f32) always gates;
+             * cc/isa gate unless LUMABRI_ALLOW_CODEGEN_SKEW (then a warning, with
+             * the spot-check as the net); omp never gates (version alone changes
+             * no bits). A blanket strcmp used to refuse two boxes for a libgomp
+             * version or a gcc point release with identical output. */
             char d[192];
-            lmb_profile_diff(profile, L.profile, d, sizeof d);
-            snprintf(why, sizeof why, "build %s", d);
+            int r = lmb_profile_compat(profile, L.profile,
+                                       L.allow_codegen_skew, d, sizeof d);
+            if (r == 1)
+                snprintf(why, sizeof why, "build %s", d);
+            else if (r == 2)
+                fprintf(stderr, "[lumabri] peer %s: build %s — admitted "
+                        "(LUMABRI_ALLOW_CODEGEN_SKEW; spot-check %s)\n",
+                        p->addr, d,
+                        L.verify_pct ? "on" : "OFF — set LUMABRI_VERIFY=<pct>");
+            /* r == 0: differ only in omp — compatible, admit silently */
         } else if (bits != (uint32_t)L.expected_bits)
             snprintf(why, sizeof why, "bits: peer=%u vs local=%d",
                      bits, L.expected_bits);
@@ -444,6 +458,14 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
         L.verify_pct = atoi(v);
         if (L.verify_pct < 0) L.verify_pct = 0;
         if (L.verify_pct > 100) L.verify_pct = 100;
+    }
+    if (getenv("LUMABRI_ALLOW_CODEGEN_SKEW")) {
+        L.allow_codegen_skew = 1;
+        /* A peer with a different cc/isa may round the low bits differently; the
+         * spot-check (rerun on another replica, demand agreement) is what turns
+         * that from an unchecked risk into a caught one. Default a small rate on
+         * unless the operator set LUMABRI_VERIFY themselves. */
+        if (!v && L.verify_pct == 0) L.verify_pct = 5;
     }
     L.hedge_ms = lmb_env_int("LUMABRI_HEDGE_MS", 0, 0, 60000);
     L.initialized = 1;

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -611,6 +611,70 @@ static LMB_MAYBE_UNUSED void lmb_profile_diff(const char *peer, const char *loca
         snprintf(out, cap, "identical");
 }
 
+/* Value of one `key=` segment of a build profile, "" if absent. */
+static LMB_MAYBE_UNUSED int lmb_prof_field(const char *p, const char *key,
+                                           char *out, size_t cap) {
+    size_t klen = strlen(key);
+    for (const char *s = p; *s; ) {
+        if (!strncmp(s, key, klen) && s[klen] == '=') {
+            const char *v = s + klen + 1, *e = v;
+            while (*e && *e != ';') e++;
+            size_t n = (size_t)(e - v);
+            if (n >= cap) n = cap - 1;
+            memcpy(out, v, n); out[n] = 0;
+            return 0;
+        }
+        while (*s && *s != ';') s++;
+        if (*s == ';') s++;
+    }
+    if (cap) out[0] = 0;
+    return -1;
+}
+
+/* Compare two build profiles field by field, three tiers:
+ *  - identity/ABI (abi, engine, src, math, f32): a mismatch means the peer runs
+ *    different code or a different model — always incompatible.
+ *  - codegen (cc, isa): the peer may round the low bits differently. Incompatible
+ *    by default — byte-identity is the guarantee — but with allow_codegen it is
+ *    downgraded to a warning so a heterogeneous swarm is possible for callers
+ *    that accept approximate results and pair it with spot-check verification.
+ *  - omp: the OpenMP *version* does not change results on its own — the thread
+ *    count and reduction order do, and neither is in the profile — so it never
+ *    gates (two libgomp versions no longer refuse each other).
+ * Returns 0 compatible, 1 incompatible (why = the differing field), 2 compatible
+ * with a codegen warning (why = the field that may round differently). */
+static LMB_MAYBE_UNUSED int lmb_profile_compat(const char *peer, const char *local,
+                                               int allow_codegen,
+                                               char *why, size_t cap) {
+    static const char *const hard[] = { "abi", "engine", "src", "math", "f32" };
+    static const char *const codegen[] = { "cc", "isa" };
+    char a[72], b[72];   /* a profile value; longest in practice is cc= (~40) */
+    for (size_t i = 0; i < sizeof hard / sizeof *hard; i++) {
+        lmb_prof_field(peer, hard[i], a, sizeof a);
+        lmb_prof_field(local, hard[i], b, sizeof b);
+        if (strcmp(a, b)) {
+            snprintf(why, cap, "%s: peer='%s' vs local='%s'", hard[i], a, b);
+            return 1;
+        }
+    }
+    int warned = 0;
+    for (size_t i = 0; i < sizeof codegen / sizeof *codegen; i++) {
+        lmb_prof_field(peer, codegen[i], a, sizeof a);
+        lmb_prof_field(local, codegen[i], b, sizeof b);
+        if (strcmp(a, b)) {
+            if (!allow_codegen) {
+                snprintf(why, cap, "%s: peer='%s' vs local='%s'", codegen[i], a, b);
+                return 1;
+            }
+            if (!warned) {
+                snprintf(why, cap, "%s: peer='%s' vs local='%s'", codegen[i], a, b);
+                warned = 1;
+            }
+        }
+    }
+    return warned ? 2 : 0;   /* 0: differ only in omp (ignored) */
+}
+
 static int lmb_cur_u32(LmbCur *c, uint32_t *v) {
     if (c->off > c->len || 4 > c->len - c->off) return -1;
     *v = lmb_get32(c->p + c->off); c->off += 4;


### PR DESCRIPTION
Closes #38.

@alangiu-gif measured (twice, cross-OS, byte-identical model) that the peer gate is an exact `strcmp` of the whole build profile, so a swarm must be homogeneous in **compiler and ISA** — two Linux boxes on different gcc point releases, or a macOS/Linux pair, refuse each other even with a matching `src` hash.

**The strictness is deliberate** and stays the default: `cc`/`isa` change float codegen (FMA contraction, vector width → reduction order), which can flip the low bits — and byte-identity is the guarantee that makes a distributed run equal to local. But the fields do not all mean the same thing, so split them:

| tier | fields | on mismatch |
|---|---|---|
| identity / ABI | `abi` `engine` `src` `math` `f32` | always incompatible (different code or model; `math` = fast-vs-strict is a real numeric change) |
| codegen | `cc` `isa` | incompatible **by default**; with `LUMABRI_ALLOW_CODEGEN_SKEW=1` → a **warning**, peer admitted |
| ignored | `omp` | never gates — the OpenMP *version* changes no bits on its own (thread count and reduction order do, and neither is in the profile) |

`LUMABRI_ALLOW_CODEGEN_SKEW=1` also defaults the spot-check on (`LUMABRI_VERIFY=5` if unset): the existing rerun-on-another-replica check turns codegen skew from an unchecked risk into a caught one, so a heterogeneous swarm degrades to "verified, occasionally re-checked" rather than "assumed identical."

`lmb_profile_compat()` does the field-aware comparison and names the specific field either way (building on #39’s diagnostic, which already replaced the blanket `(model/build/engine/bits/shape)`).

**Scope:** wire format unchanged — the profile string still carries every field; only the comparison changed, and only on the chatter running this build. Homogeneous swarms are unaffected. Section C of `phase2_test.sh` (incompatible build refused) still passes — it differs in `src`, a hard field. Unit-tested across mac/linux, omp-only, src, math, and identical inputs.

**What this is not:** it does not make heterogeneous output byte-identical — it makes the divergence *visible and checked* instead of silently refused. Operators who need bit-exactness keep the default and a homogeneous swarm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)