### PR TITLE
fix: wire the line editor into the chat loop (it still used raw fgets)

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -1873,11 +1873,10 @@ static int cmd_chat(int argc, char **argv) {
         } else
             printf("\n> ");
         fflush(stdout);
-        int got = fgets(line, sizeof line, stdin) != NULL;
+        int got = prompt_line(line, sizeof line) == 0;   /* line editor when a tty */
         if (g_tty) hline("\xe2\x95\xb0", "\xe2\x95\xaf", w);
         if (!got) break;
-        size_t L = strlen(line);
-        while (L && (line[L-1] == '\n' || line[L-1] == '\r')) line[--L] = 0;
+        size_t L = strlen(line);   /* prompt_line already stripped the newline */
         if (!L) continue;
         if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) break;
         if (!strcmp(line, "/swarm")) { render_swarm(tracker); continue; }


### PR DESCRIPTION
Follow-up to #43. The editor was added to `prompt_line`, but the interactive chat REPL read its input with a separate `fgets(line, sizeof line, stdin)` — so the box prompt (`│ ›`) still ran canonical and the arrow keys still landed as `^[[D` in the text. The editor only reached the setup panels, not where people type.

Point the chat loop at `prompt_line` (editor on a tty, `fgets` fallback off one). `prompt_line` already strips the newline, so the local strip loop is dropped.

Verified on the real binary via a pty: `hello` + Left + Left + `X` emits cursor-move escapes and yields `helXlo` — the arrows edit, they no longer insert `[D`. Piped input unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)