### PR TITLE
feat: qwen36 (Qwen3.6) — sixth engine, node + chatter, byte-identical

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ phase2-glm: expert_node_glm
 DS_SINGLE := $(wildcard $(ENGINE)/deepseek.c)
 DS_MULTI  := $(wildcard $(ENGINE)/deepseek_v4.c)
 HAVE_ENGINES := $(notdir $(basename $(wildcard $(ENGINE)/olmoe.c $(ENGINE)/colibri.c \
-                 $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c)))
+                 $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c $(ENGINE)/qwen36.c)))
 HAVE_ENGINES += $(if $(DS_MULTI)$(DS_SINGLE),deepseek)
 
 # Current colibri's kimi expert_apply grew two i8-activation params (zq,zsc);
@@ -54,13 +54,14 @@ NODE_colibri  = expert_node_glm
 NODE_inkling  = expert_node_inkling
 NODE_kimi_k3  = expert_node_kimi
 NODE_deepseek = expert_node_deepseek
+NODE_qwen36   = expert_node_qwen36
 
 ENGINE_NODES    = $(foreach e,$(HAVE_ENGINES),$(NODE_$(e)))
 # Both the expert node and the chatter build for either DeepSeek layout: the
 # single file with a line patch, the multi-file source with an anchored one.
 CHATTER_ENGINES := $(HAVE_ENGINES)
 ENGINE_CHATTERS = $(foreach e,$(CHATTER_ENGINES),$(e)_p2p)
-MISSING_ENGINES = $(filter-out $(HAVE_ENGINES),olmoe colibri inkling kimi_k3 deepseek)
+MISSING_ENGINES = $(filter-out $(HAVE_ENGINES),olmoe colibri inkling kimi_k3 deepseek qwen36)
 MISSING_CHATTERS = $(filter-out $(CHATTER_ENGINES),$(HAVE_ENGINES))
 
 # A strict distributed run must not mix engine sources or numeric build
@@ -79,6 +80,7 @@ SRCID_olmoe   := $(call engine_source_id,olmoe,olmoe)
 SRCID_colibri := $(call engine_source_id,colibri,colibri)
 SRCID_inkling := $(call engine_source_id,inkling,inkling)
 SRCID_kimi_k3 := $(call engine_source_id,kimi_k3,kimi_k3)
+SRCID_qwen36  := $(call engine_source_id,qwen36,qwen36)
 ifneq ($(DS_MULTI),)
 SRCID_deepseek := $(call engine_source_id,deepseek_v4,deepseek)
 else
@@ -89,6 +91,7 @@ PROFILE_olmoe   = -DLMBE_ENGINE_ID='"olmoe"'      -DLMBE_SOURCE_ID='"$(SRCID_olm
 PROFILE_colibri = -DLMBE_ENGINE_ID='"colibri"'    -DLMBE_SOURCE_ID='"$(SRCID_colibri)"' -DLMBE_EXPECT_BITS=8
 PROFILE_inkling = -DLMBE_ENGINE_ID='"inkling"'    -DLMBE_SOURCE_ID='"$(SRCID_inkling)"' -DLMBE_EXPECT_BITS=8
 PROFILE_kimi_k3 = -DLMBE_ENGINE_ID='"kimi_k3"'    -DLMBE_SOURCE_ID='"$(SRCID_kimi_k3)"' -DLMBE_EXPECT_BITS=0
+PROFILE_qwen36  = -DLMBE_ENGINE_ID='"qwen36"'     -DLMBE_SOURCE_ID='"$(SRCID_qwen36)"'  -DLMBE_EXPECT_BITS=0
 PROFILE_deepseek= -DLMBE_ENGINE_ID='"deepseek_v4"' -DLMBE_SOURCE_ID='"$(SRCID_deepseek)"' -DLMBE_EXPECT_BITS=0
 
 # every engine's peer in one go — the ones this checkout has
@@ -121,6 +124,14 @@ expert_node_inkling: $(EXPERT_DEPS) expert_engines/inkling.h $(ENGINE)/inkling.c
 expert_node_kimi: $(EXPERT_DEPS) expert_engines/kimi_k3.h $(ENGINE)/kimi_k3.c \
                   engine_patches/kimi_k3-p2p.diff $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) $(K3_ZQ_FLAG) -DLMBE_ENGINE_HEADER='"expert_engines/kimi_k3.h"' \
+	      expert_node.c -o $@ -lm -lpthread
+
+# qwen36 (Qwen3.6): olmoe dialect, experts group-scaled and int4/int8, one row
+# at a time. The CUDA VRAM tier is compiled out on CPU (qwen36_tier.h supplies
+# inline stubs), so nothing beside qwen36.c needs linking.
+expert_node_qwen36: $(EXPERT_DEPS) expert_engines/qwen36.h $(ENGINE)/qwen36.c \
+                    engine_patches/qwen36-p2p.diff $(ENGINE_PROFILE_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_qwen36) -DLMBE_ENGINE_HEADER='"expert_engines/qwen36.h"' \
 	      expert_node.c -o $@ -lm -lpthread
 
 # DeepSeek V4 needs two extra things at build time.
@@ -268,6 +279,9 @@ colibri_p2p: build/colibri_p2p.c $(ENGINE_P2P_DEPS)
 inkling_p2p: build/inkling_p2p.c $(ENGINE_P2P_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_inkling) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
+qwen36_p2p: build/qwen36_p2p.c $(ENGINE_P2P_DEPS)
+	$(CC) $(P2P_CFLAGS) $(PROFILE_qwen36) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
+
 kimi_k3_p2p: build/kimi_k3_p2p.c $(ENGINE_P2P_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) -DLUMABRI_P2P -DLUMIBRI_P2P $< -o $@ -lm -lpthread
 
@@ -302,6 +316,9 @@ test-phase2-kimi: expert_node_kimi
 # script's header for why)
 test-phase2-deepseek: expert_node_deepseek
 	./phase2_deepseek_test.sh
+
+test-phase2-qwen36: expert_node_qwen36
+	./phase2_qwen36_test.sh
 
 # Every engine's byte-identity proof, one after the other. DeepSeek V4 has no
 # synthetic fixture (see phase2_deepseek_test.sh), so it runs only when a real

--- a/engine_patches/colibri-p2p.diff
+++ b/engine_patches/colibri-p2p.diff
@@ -1,7 +1,7 @@
 diff --git a/c/colibri.c b/c/colibri.c
 --- a/c/colibri.c
 +++ b/c/colibri.c
-@@ -63,6 +63,13 @@
+@@ -68,6 +68,13 @@
  #include "schema_gbnf.h"                          /* SCHEMA=: JSON-Schema -> GBNF for method F */
  #include "decode_batch.h"
  #include "route_trace.h"                           /* ROUTE_TRACE + .coli_usage, engine-agnostic (#700) */
@@ -12,10 +12,10 @@ diff --git a/c/colibri.c b/c/colibri.c
 + * at runtime unless the swarm can cover every expert. */
 +#include "lumibri_client.h"
 +#endif
+ #include "kv_fp8.h"                               /* KV8=1: cache latente in fp8 e4m3 + scala per-riga */
+ #include "kv_tq.h"                                /* KV_TQ=3|4: cache latente PolarQuant (rot+polare) */
  #ifdef _OPENMP
- #include <omp.h>                                  /* scratch per-thread nell'attention */
- #else
-@@ -1918,6 +1925,19 @@
+@@ -2417,6 +2424,19 @@
      for(int i=0;i<c->n_layers;i++) if(!m->L[i].sparse) rt_drop_row(i);
      if(!m->has_mtp) rt_drop_row(c->n_layers);
      m->resident_bytes=rb;
@@ -35,7 +35,7 @@ diff --git a/c/colibri.c b/c/colibri.c
  }
  
  /* embed: dequantizza la riga del token (scala per-riga) in x[hidden] */
-@@ -4015,6 +4035,17 @@
+@@ -5089,6 +5109,17 @@
          int e=idxs[(int64_t)s*K+kk];
          if(!seen[e]){ seen[e]=1; uniq[nu++]=e; }
      }

--- a/engine_patches/inkling-p2p.diff
+++ b/engine_patches/inkling-p2p.diff
@@ -1,7 +1,7 @@
 diff --git a/c/inkling.c b/c/inkling.c
 --- a/c/inkling.c
 +++ b/c/inkling.c
-@@ -153,6 +153,13 @@
+@@ -162,6 +162,13 @@
  static double rss_gb(void) { struct rusage r; getrusage(RUSAGE_SELF, &r); return r.ru_maxrss / (1024.0*1024.0); }
  #endif
  static float *falloc(int64_t n) { float *p = malloc(n*sizeof(float)); if(!p){fprintf(stderr,"OOM %ld\n",(long)n);exit(1);} return p; }
@@ -15,7 +15,7 @@ diff --git a/c/inkling.c b/c/inkling.c
  static float sigmoidf(float x) { return 1.f / (1.f + expf(-x)); }
  static float siluf(float x) { return x / (1.f + expf(-x)); }
  /* TOPP=p (0..1): top-p adattivo sui routed — tieni gli esperti fino al peso
-@@ -867,6 +874,16 @@
+@@ -952,6 +959,16 @@
      for (int i = 0; i < c->n_layers; i++) if (!c->sparse[i]) rt_drop_row(i);
      rt_drop_row(c->n_layers);                     /* inkling has no MTP row */
      m->eusage = rt_counts_all();                  /* alias: the bump sites stay as they are */
@@ -32,7 +32,7 @@ diff --git a/c/inkling.c b/c/inkling.c
      m->dense_load_s = now_s() - t0;
  }
  
-@@ -1185,6 +1202,16 @@
+@@ -1318,6 +1335,16 @@
          }
          m->euse += keff[s];
      }
@@ -49,9 +49,9 @@ diff --git a/c/inkling.c b/c/inkling.c
      /* Il ciclo sotto ACQUISISCE uno slot per ogni coppia (token, esperto) e ne tiene
       * il puntatore fino al calcolo. slot_acquire evince l'LRU quando la cache e'
       * piena — anche uno slot gia' consegnato in QUESTA chiamata: il puntatore resta
-@@ -1202,6 +1229,9 @@
-     float *g = falloc(2*I), *u = g + I, *hh = falloc(D);
+@@ -1336,6 +1363,9 @@
      int q4 = m->xq && m->rb13*2 == D;   /* packed int4 vs int8 container */
+     int shared_done = 0;                /* set when overlapped with the last GPU round */
      int64_t npair = (int64_t)S*K;
 +#ifdef LUMIBRI_P2P
 +    if (lumi_remote) npair = 0;       /* nothing left to acquire, fill or compute */

--- a/engine_patches/kimi_k3-p2p.diff
+++ b/engine_patches/kimi_k3-p2p.diff
@@ -1,10 +1,10 @@
 diff --git a/c/kimi_k3.c b/c/kimi_k3.c
 --- a/c/kimi_k3.c
 +++ b/c/kimi_k3.c
-@@ -173,6 +173,13 @@
+@@ -265,6 +265,13 @@
+     return fcalloc(n);
+ #endif
  }
- static float *falloc(int64_t n){ float *p=malloc((size_t)n*sizeof(float)); if(!p){fprintf(stderr,"OOM %lld floats\n",(long long)n);exit(1);} return p; }
- static float *fcalloc(int64_t n){ float *p=calloc((size_t)n,sizeof(float)); if(!p){fprintf(stderr,"OOM %lld floats\n",(long long)n);exit(1);} return p; }
 +
 +#ifdef LUMIBRI_P2P
 +/* lumabri: with a tracker (or LUMABRI_EXPERTS) the routed experts run on
@@ -15,7 +15,7 @@ diff --git a/c/kimi_k3.c b/c/kimi_k3.c
  static inline float sigmoidf_(float x){ return 1.f/(1.f+expf(-x)); }
  static inline float siluf_(float x){ return x/(1.f+expf(-x)); }
  static void softmax_(float *x, int n){ float m=x[0]; for(int i=1;i<n;i++) if(x[i]>m)m=x[i];
-@@ -632,6 +639,16 @@
+@@ -1030,6 +1037,16 @@
      }
      fprintf(stderr,"[K3] init done in %.1fs | %d layers | expert cache %d/layer (%.1f MB/slot) | RSS %.1f GB\n",
              now_s()-t0,c->n_layers,cap,m->e_slot/1e6,rss_gb());
@@ -29,10 +29,10 @@ diff --git a/c/kimi_k3.c b/c/kimi_k3.c
 +        atexit(lumi_report);
 +    }
 +#endif
-     #undef NM
- }
- 
-@@ -1146,6 +1163,15 @@
+     /* Phase 9: layer validation init */
+     { const char *vl=getenv("K3_VALIDATE_LAYER");
+       const char *vt=getenv("K3_VALIDATE_TOKEN");
+@@ -1873,6 +1890,15 @@
              nu=keep;
          }
  #endif

--- a/engine_patches/make_patches.py
+++ b/engine_patches/make_patches.py
@@ -236,12 +236,40 @@ fail:
 """),
 ]
 
+# --------------------------------------------------------------------------
+# qwen36 (Qwen3.6): olmoe's dialect and one row at a time, but every layer also
+# has a SHARED expert after the routed loop, plus a CUDA tier branch behind
+# qt_ready() (a stub returning 0 without COLI_CUDA). So the hook must NOT
+# `continue` — it delegates the K routed experts and lets the shared expert and
+# the row's tail run locally. It lands right after `int shared_done = 0;` and
+# ends in `} else`, so it becomes an `else if` in front of the qt_ready() branch:
+# the CPU path delegates, shared_done stays 0, and the shared expert still adds
+# itself to `out`. Without the macro the added lines vanish and qt_ready() is a
+# plain `if` again.
+# --------------------------------------------------------------------------
+QWEN36 = [
+    hook('#include "qwen36_tier.h"   /* optional transparent Vulkan compute backend for MoE experts */\n',
+         INCLUDE),
+    hook("    m->dense_load_s = now_s() - t0;\n", """#ifdef LUMIBRI_P2P
+    lumi_init(c->n_layers, c->n_experts, c->hidden);
+    atexit(lumi_report);
+#endif
+"""),
+    hook("        int shared_done = 0;\n", """#ifdef LUMIBRI_P2P
+        if (lumi_layer_on(layer)) {   /* the K routed experts run on peers; routing, the sum and the shared expert stay here */
+            lumi_moe_apply(layer, idx, val, K, xs, D, out + (int64_t)s*D);
+        } else
+#endif
+"""),
+]
+
 ENGINES = {
     "olmoe.c": OLMOE,
     "colibri.c": COLIBRI,
     "inkling.c": INKLING,
     "kimi_k3.c": KIMI,
     "deepseek.c": DEEPSEEK,
+    "qwen36.c": QWEN36,
 }
 
 

--- a/engine_patches/olmoe-p2p.diff
+++ b/engine_patches/olmoe-p2p.diff
@@ -1,21 +1,21 @@
 diff --git a/c/olmoe.c b/c/olmoe.c
 --- a/c/olmoe.c
 +++ b/c/olmoe.c
-@@ -38,6 +38,13 @@
+@@ -37,6 +37,13 @@
+ #endif
  #include "omp_tune.h"
  #include "route_trace.h"                    /* shared routing telemetry (#700) */
- 
++
 +#ifdef LUMIBRI_P2P
 +/* lumabri: with a tracker (or LUMABRI_EXPERTS) the routed experts run on
 + * peers instead of being read from disk. Inert without the define, and inert
 + * at runtime unless the swarm can cover every expert. */
 +#include "lumibri_client.h"
 +#endif
-+
+ #include "serve_codec.h"
+ 
  #ifdef _WIN32
- #include <windows.h>
- #define sleep_ms(ms) Sleep(ms)
-@@ -347,6 +354,10 @@
+@@ -392,6 +399,10 @@
      if (cl < 0.1f) cl = 0.1f; if (cl > 1.0f) cl = 1.0f;
      m->pilot_conf_limit = cl;
      m->dense_load_s = now_s() - t0;
@@ -26,7 +26,7 @@ diff --git a/c/olmoe.c b/c/olmoe.c
  
      // Persistent Hot Pinning: try to load hot_pinned.bin
      char pinpath[512];
-@@ -666,6 +677,12 @@
+@@ -730,6 +741,12 @@
              if (freq_l) for (int kk = 0; kk < K; kk++) if (idx[kk] >= 0) freq_l[idx[kk]]++;
          }
          const float *xs = x + (int64_t)s*D;
@@ -38,4 +38,4 @@ diff --git a/c/olmoe.c b/c/olmoe.c
 +#endif
          for (int kk = 0; kk < K; kk++) {
              Slot *e; expert_get(m, layer, idx[kk], &e);
-             matmul_q(g, xs, e->g, e->gs, D, I);     /* gate_proj [I,D] */
+ #if defined(__AVX2__)

--- a/engine_patches/qwen36-p2p.diff
+++ b/engine_patches/qwen36-p2p.diff
@@ -1,0 +1,40 @@
+diff --git a/c/qwen36.c b/c/qwen36.c
+--- a/c/qwen36.c
++++ b/c/qwen36.c
+@@ -60,6 +60,13 @@
+ #include "st.h"
+ #include "json.h"   /* tokenizer.json parsing (reuse minimal parser) */
+ #include "qwen36_tier.h"   /* optional transparent Vulkan compute backend for MoE experts */
++
++#ifdef LUMIBRI_P2P
++/* lumabri: with a tracker (or LUMABRI_EXPERTS) the routed experts run on
++ * peers instead of being read from disk. Inert without the define, and inert
++ * at runtime unless the swarm can cover every expert. */
++#include "lumibri_client.h"
++#endif
+ 
+ #ifdef _WIN32
+ #include <windows.h>
+@@ -1180,6 +1187,10 @@
+     if (cl < 0.1f) cl = 0.1f; if (cl > 1.0f) cl = 1.0f;
+     m->pilot_conf_limit = cl;
+     m->dense_load_s = now_s() - t0;
++#ifdef LUMIBRI_P2P
++    lumi_init(c->n_layers, c->n_experts, c->hidden);
++    atexit(lumi_report);
++#endif
+ }
+ 
+ /* scale counts per expert matrix: per-row (gs=0) or grouped along input dim */
+@@ -1619,6 +1630,11 @@
+         }
+         const float *xs = x + (int64_t)s*D;
+         int shared_done = 0;
++#ifdef LUMIBRI_P2P
++        if (lumi_layer_on(layer)) {   /* the K routed experts run on peers; routing, the sum and the shared expert stay here */
++            lumi_moe_apply(layer, idx, val, K, xs, D, out + (int64_t)s*D);
++        } else
++#endif
+         if (qt_ready()) {
+             /* CUDA expert tier: run the resident experts as async groups on
+              * all devices, compute the misses on the CPU (overlapped), then

--- a/expert_engines/qwen36.h
+++ b/expert_engines/qwen36.h
@@ -1,0 +1,103 @@
+/* expert_engines/qwen36.h — the Qwen3.6 (qwen36) glue.
+ *
+ * qwen36 is a hybrid DeltaNet/Gated-Attention model, but every layer carries a
+ * streaming MoE block and that is the only part a peer runs. Written in olmoe's
+ * dialect, so this mirrors olmoe.h — with two qwen36 specifics that must match
+ * or the returned expert diverges in the low bits:
+ *
+ *   - experts are group-scaled: matmul_qe() dispatches to matmul_q_gs when the
+ *     global g_expert_gs (from qwen36_meta.json) is set. We set it at open, and
+ *     apply through matmul_qe, exactly as moe() does.
+ *   - experts ship int4 or int8 in one container; slot_ensure_int8() is what
+ *     rematerialises int8 before the matmuls, so we call it here too.
+ *
+ * The routed expert math below is the body of qwen36.c's moe() inner loop
+ * (the CPU `else` branch; the CUDA tier's qt_ready() is a stub returning 0 in a
+ * build without COLI_CUDA). The routing weight, the shared expert and the
+ * accumulation stay on the chatter — the model's semantics, not the peer's.
+ */
+#ifndef LMBE_QWEN36_H
+#define LMBE_QWEN36_H
+
+#define main qwen36_main_unused
+#include "qwen36.c"
+#undef main
+
+typedef Slot LmbeSlot;
+
+static Model lmbe_M;
+
+static const char *lmbe_engine_name(void) { return "qwen36"; }
+static int lmbe_effective_bits(int bits) { (void)bits; return 0; }
+
+static void lmbe_open(const char *dir, int cap, int bits) {
+    (void)cap; (void)bits;            /* qwen36 reads the container's own format */
+    load_cfg(&lmbe_M.c, dir);
+    int n_layers_from_config = lmbe_M.c.n_layers;
+    load_meta(&lmbe_M.c, dir);
+    validate_cfg(&lmbe_M.c, n_layers_from_config);
+    st_init(&lmbe_M.S, dir);
+    g_expert_gs = lmbe_M.c.expert_gs;   /* the engine sets this after load; match it */
+    /* load_expert_merged() indexes m->active_of[layer]; the full model_init sets
+     * it, which the peer skips, so build the same identity map here (Phase 2
+     * stores every layer under its own index). Without this the resident-mode
+     * preload dereferences a NULL and the node segfaults before serving. */
+    lmbe_M.active_of = (int *)malloc((size_t)lmbe_M.c.n_layers * sizeof(int));
+    for (int i = 0; i < lmbe_M.c.n_layers; i++) lmbe_M.active_of[i] = i;
+}
+
+static int lmbe_n_slots(void)   { return lmbe_M.c.n_layers; }
+static int lmbe_n_experts(void) { return lmbe_M.c.n_experts; }
+static int lmbe_hidden(void)    { return lmbe_M.c.hidden; }   /* experts work in hidden space */
+static int lmbe_inter(void)     { return lmbe_M.c.inter; }
+static int lmbe_routed(int slot) { (void)slot; return 1; }    /* every layer has a MoE block */
+
+static void lmbe_slot_init(LmbeSlot *s) { slot_ensure_allocated(&lmbe_M, s); }
+
+static void lmbe_slot_load(int slot, int eid, LmbeSlot *s) {
+    load_expert_merged(&lmbe_M, slot, eid, s);
+    s->eid = eid;
+}
+
+typedef struct { float *g, *u, *hh; } LmbeScratch;
+
+static void *lmbe_scratch_new(int nrows) {
+    (void)nrows;                      /* qwen36's expert kernel is one row at a time */
+    LmbeScratch *sc = (LmbeScratch *)calloc(1, sizeof *sc);
+    sc->g  = falloc(lmbe_M.c.inter);
+    sc->u  = falloc(lmbe_M.c.inter);
+    sc->hh = falloc(lmbe_M.c.hidden);
+    return sc;
+}
+
+static void lmbe_scratch_free(void *p) {
+    LmbeScratch *sc = (LmbeScratch *)p;
+    free(sc->g); free(sc->u); free(sc->hh); free(sc);
+}
+
+/* Exactly qwen36.c's moe() routed inner loop, per row, unweighted: the down
+ * projection of SwiGLU(gate(x), up(x)). slot_ensure_int8 first (int4 -> int8 if
+ * needed), matmul_qe throughout (group scale via g_expert_gs). The chatter
+ * multiplies by the routing weight and accumulates, and runs the shared expert
+ * itself — identical to how the engine's moe() finishes the row. */
+static void lmbe_apply(const LmbeSlot *e, int slot, const float *x, float *out,
+                       int nrows, const float *w, void *p) {
+    (void)w;                          /* this engine weights on the chatter */
+    (void)slot;
+    LmbeScratch *sc = (LmbeScratch *)p;
+    Slot *es = (Slot *)e;             /* slot_ensure_int8 rematerialises in place */
+    int D = lmbe_M.c.hidden, I = lmbe_M.c.inter;
+    slot_ensure_int8(&lmbe_M, es);
+    for (int r = 0; r < nrows; r++) {
+        const float *xr = x + (int64_t)r * D;
+        matmul_qe(sc->g, xr, es->g, es->gs, D, I);
+        matmul_qe(sc->u, xr, es->u, es->us, D, I);
+        for (int i = 0; i < I; i++) {
+            float gv = sc->g[i];
+            sc->g[i] = (gv / (1.f + expf(-gv))) * sc->u[i];
+        }
+        matmul_qe(out + (int64_t)r * D, sc->g, es->d, es->ds, I, D);
+    }
+}
+
+#endif

--- a/lumabri.c
+++ b/lumabri.c
@@ -207,6 +207,7 @@ static const char *expert_node_for(const char *model_type) {
     if (strstr(model_type, "inkling"))  return "expert_node_inkling";
     if (strstr(model_type, "kimi"))     return "expert_node_kimi";
     if (strstr(model_type, "deepseek")) return "expert_node_deepseek";
+    if (strstr(model_type, "qwen"))     return "expert_node_qwen36";
     return NULL;
 }
 
@@ -887,6 +888,7 @@ static const char *engine_for(const char *model_type) {
     if (strstr(model_type, "deepseek")) return "deepseek";
     if (strstr(model_type, "kimi")) return "kimi_k3";
     if (strstr(model_type, "inkling")) return "inkling";
+    if (strstr(model_type, "qwen")) return "qwen36";
     return "colibri";
 }
 

--- a/phase2_qwen36_test.sh
+++ b/phase2_qwen36_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# lumabri phase 2 on the qwen36 (Qwen3.6) engine — the experiment.
+#
+# The same model, the same prompt, generated twice:
+#   A) LOCAL   — the engine reads expert weights and runs them itself
+#   B) P2P     — the chatter keeps dense+router+KV; every routed expert runs on
+#                a peer process that holds it, reached over TCP
+# The generated tokens must be IDENTICAL. That is the only result that matters.
+#
+# No synthetic fixture ships here: a qwen36 container is built by colibri's own
+# tools (they need torch + transformers), so point MODEL at one. Build a tiny
+# one with, from a colibri checkout:
+#
+#   python tools/make_qwen36_tiny.py --out /tmp/qw_hf --emit-ref /tmp/qw_hf/ref.json
+#   python tools/convert_qwen36.py  --model /tmp/qw_hf --out /tmp/qw --ebits 4   # add --gs 64 for the group-scaled path
+#   cp /tmp/qw_hf/ref.json /tmp/qw/ref.json
+#   MODEL=/tmp/qw ./phase2_qwen36_test.sh
+#
+# qwen36 computes an expert one row at a time (olmoe's dialect), so the per-row
+# EXEC matches the local path exactly. Its two specifics — group-scaled experts
+# (matmul_qe/expert_gs) and int4/int8 in one container (slot_ensure_int8) — are
+# what the donor glue has to reproduce; --gs 64 is the container that exercises
+# the first, and this test is what proves it.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ENGINE="${ENGINE:-../colibri/c}"
+MODEL="${MODEL:-$PWD/qwen36_tiny}"
+NODES="${NODES:-4}"          # how many peers to split the experts across
+PORT0="${PORT0:-7571}"
+CACHE="${CACHE:-16}"         # local-run expert cache slots per layer
+GEN="${GEN:-16}"
+BITS="${BITS:-4}"
+
+[ -f "$MODEL/config.json" ] && [ -f "$MODEL/qwen36_meta.json" ] || {
+    echo "no qwen36 container at $MODEL (need config.json + qwen36_meta.json)"
+    echo "build one with colibri's make_qwen36_tiny.py + convert_qwen36.py — see the header"
+    exit 1; }
+REF="$MODEL/ref.json"; [ -f "$REF" ] || REF="ref.json"
+
+make -s expert_node_qwen36 qwen36_p2p ENGINE="$ENGINE"
+
+T=$(mktemp -d /tmp/lumabri-qwen36.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+
+echo
+echo "══ A) LOCAL — experts read and run by the engine itself"
+SNAP="$MODEL" OMP_NUM_THREADS="${THREADS:-6}" \
+    ./qwen36_p2p "$CACHE" "$BITS" "$REF" > "$T/local.out" 2>"$T/local.err" || true
+A=$(grep "^C engine" "$T/local.out" || true)
+[ -n "$A" ] || { echo "no tokens from the local run"; tail -20 "$T/local.err"; exit 1; }
+echo "  $A"
+
+echo
+echo "══ starting $NODES expert peers (each holds 1/$NODES of the experts)"
+ADDRS=""
+for i in $(seq 0 $((NODES-1))); do
+    p=$((PORT0+i))
+    OMP_NUM_THREADS="${NODE_THREADS:-2}" COLI_NO_OMP_TUNE=1 \
+    ./expert_node_qwen36 --model "$MODEL" --port "$p" --name "qw-$i" \
+                         --stride "$NODES:$i" > "$T/node$i.log" 2>&1 & PIDS+=($!)
+    ADDRS="${ADDRS:+$ADDRS,}127.0.0.1:$p"
+done
+for i in $(seq 0 $((NODES-1))); do
+    p=$((PORT0+i))
+    for _ in $(seq 1 300); do
+        (exec 3<>/dev/tcp/127.0.0.1/$p) 2>/dev/null && { exec 3<&-; break; }
+        sleep 0.2
+    done
+done
+grep -h "holding" "$T/node0.log" | head -1 || { tail -10 "$T/node0.log"; exit 1; }
+
+echo
+echo "══ B) P2P — every routed expert runs on a peer"
+SNAP="$MODEL" OMP_NUM_THREADS="${THREADS:-6}" LUMABRI_EXPERTS="$ADDRS" \
+    ./qwen36_p2p "$CACHE" "$BITS" "$REF" > "$T/p2p.out" 2>"$T/p2p.err" || true
+B=$(grep "^C engine" "$T/p2p.out" || true)
+echo "  $B"
+grep -E "^\[lumabri\]" "$T/p2p.err" | grep -iE "phase 2 active|remote expert|incompatible" | head
+
+echo
+grep -q "phase 2 active" "$T/p2p.err" || { echo "✗ phase 2 never engaged"; exit 1; }
+if [ -n "$A" ] && [ "$A" = "$B" ]; then
+    echo "✓ IDENTICI — la rete non ha cambiato un solo token"
+else
+    echo "✗ DIVERGENZA — il P2P ha cambiato l'output:"
+    echo "  local: $A"
+    echo "  p2p  : $B"
+    exit 1
+fi


### PR DESCRIPTION
colibri added **qwen36** (Qwen3.6-35B-A3B): a hybrid Gated-DeltaNet / Gated-Attention model where every layer carries a streaming MoE block (256 experts, top-8). The MoE is the part a peer runs, so lumabri distributes it like the other five engines.

## What it took
qwen36 is written in olmoe’s dialect and computes an expert **one row at a time**, so the per-row EXEC matches the local path exactly — no batched union. Two specifics the donor glue reproduces or the returned expert diverges:
- **group-scaled experts**: `matmul_qe()` dispatches to `matmul_q_gs` when `g_expert_gs` (from `qwen36_meta.json`) is set. The glue sets it at open and applies through `matmul_qe`, exactly as `moe()` does.
- **int4/int8 in one container**: `slot_ensure_int8()` rematerialises int8 before the matmuls, so the glue calls it too.

The glue also rebuilds `m->active_of` (the identity map the peer’s lighter open skips) — `load_expert_merged` indexes it, and a NULL there segfaulted the resident-mode preload before serving (found with ASan, fixed).

The chatter hook lands as an `else if` in front of `qt_ready()` (the CUDA tier — a stub returning 0 without `COLI_CUDA`) and does **not** `continue`: unlike olmoe, qwen36 has a **shared expert** after the routed loop, so the routed experts delegate while the shared expert and the row’s tail still run locally. `lumi_moe_apply` accumulates the weighted routed sum into `out`; the shared expert then adds itself — identical to how `moe()` finishes the row.

## Verified byte-identical
Against a tiny qwen36 container built with colibri’s own `make_qwen36_tiny.py` + `convert_qwen36.py`, **both** quantization modes:

| mode | result |
|---|---|
| per-row scale (`gs=0`) | `local == p2p`, phase 2 active, 320 remote expert calls, 4 peers |
| group-scaled (`--gs 64`) | `local == p2p` — the path that exercises `matmul_q_gs` |

Same tokens, four peers holding a quarter of the experts each. A `phase2_qwen36_test.sh` (MODEL-based, like DeepSeek) and a `test-phase2-qwen36` target ship with it.

## Also: refreshed the other four p2p diffs
Current colibri moved the anchor line numbers (e.g. `olmoe.c` gained `serve_codec.h`), so the committed diffs no longer applied — `colibri_p2p` failed to patch. Running `make_patches.py` against current colibri refreshes all four and adds qwen36; `patches-check` passes and olmoe / inkling / kimi stay byte-identical.

## No regression
All 12 binaries (6 nodes + 6 chatters) build against current colibri; the fixture tests are IDENTICI; single-file paths untouched. `expert_engines/qwen36.h`, `engine_patches/qwen36-p2p.diff`, the Makefile rules and the `engine_for`/`expert_node_for` mappings are the new surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)