### PR TITLE
docs: README lists qwen36 in the engines table

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ fails loudly instead of applying in the wrong place.
 | `inkling` | Inkling | yes | `expert_node_inkling`, proven by `phase2_inkling_test.sh` |
 | `kimi_k3` | Kimi K3 | yes | `expert_node_kimi`, proven by `phase2_kimi_test.sh` |
 | `deepseek` | DeepSeek V4 | yes | `expert_node_deepseek`, proven by `phase2_deepseek_test.sh` |
+| `qwen36` | Qwen3.6 | yes | `expert_node_qwen36`, proven by `phase2_qwen36_test.sh` |
 
 "Proven" means the experiment, not the claim: the same engine and the same
 prompt, generated twice, once with the experts local and once with every one of


### PR DESCRIPTION
Follow-up to #46. Adds the `qwen36` row to the engines table so the README matches the six engines the build supports (node + chatter, byte-identity proven by `phase2_qwen36_test.sh`). Docs only.