### PR TITLE
fix: apply chatter hooks by anchor at build time (survives colibri drift)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,10 +261,9 @@ patches-check:
 #
 # -DLUMIBRI_P2P: the patches predate the rename and test that macro; both
 # spellings are defined so either vintage compiles.
-build/%_p2p.c: $(ENGINE)/%.c engine_patches/%-p2p.diff Makefile
+build/%_p2p.c: $(ENGINE)/%.c engine_patches/make_patches.py engine_patches/%-p2p.diff Makefile
 	@mkdir -p build
-	@if grep -q LUMIBRI_P2P $<; then cp $< $@; \
-	 else patch -s --read-only=ignore -p2 -o $@ $< engine_patches/$*-p2p.diff; fi
+	python3 engine_patches/make_patches.py --engine-dir $(ENGINE) --apply-one $*.c --out $@
 	@sed -i 's/if (L\.on) {/if (lumi_layer_on(layer)) {/' $@
 
 ENGINE_P2P_DEPS = lumabri_client.h lumibri_client.h lumabri_proto.h lumabri_sign.h \

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ is also what makes spot-check verification of untrusted peers possible at all.
 
 ## Requirements
 
-Linux, gcc, GNU make. Python 3 with numpy only for the test fixtures. A
+Linux, gcc, GNU make, and Python 3 (it applies the chatter hooks to the engine
+by anchor at build time, so a patch survives colibri moving the code around it;
+numpy is only needed for the synthetic test fixtures). A
 [colibri](https://github.com/JustVugg/colibri) build provides the engine
 binaries.
 

--- a/engine_patches/make_patches.py
+++ b/engine_patches/make_patches.py
@@ -345,7 +345,30 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--engine-dir", default=os.environ.get("ENGINE", "../moe-stream/c"))
     ap.add_argument("--check", action="store_true")
+    ap.add_argument("--apply-one", metavar="ENGINE.c",
+                    help="apply this engine's hooks and write the patched source to --out")
+    ap.add_argument("--out", help="output path for --apply-one")
     a = ap.parse_args()
+    if a.apply_one:
+        # Build the patched chatter source by anchor, not by a shipped unified
+        # diff: colibri moves the code around each of the engine's lines, and a
+        # line-numbered diff's context drifts out from under `patch` (it can drop
+        # a hunk — e.g. the client include — and leave the rest, which compiles
+        # with implicit-declaration errors). Anchoring on one distinctive line
+        # each survives that, and if an anchor genuinely moved apply_hooks exits
+        # loudly naming it, instead of a silent half-patch.
+        fname = a.apply_one
+        if fname not in ENGINES:
+            sys.exit("make_patches: no hooks defined for %s" % fname)
+        if not a.out:
+            sys.exit("make_patches: --apply-one needs --out")
+        src = pristine(a.engine_dir, fname)
+        if src is None:
+            sys.exit("make_patches: %s not found in %s" % (fname, a.engine_dir))
+        out = src if "LUMIBRI_P2P" in src else apply_hooks(src, ENGINES[fname], fname)
+        with open(a.out, "w", encoding="utf-8", errors="surrogateescape") as f:
+            f.write(out)
+        return
     if a.check:
         tmp = tempfile.mkdtemp()
         try:


### PR DESCRIPTION
A user (@ building `colibri_p2p` against a **newer colibri** than the one the shipped diff was generated from) got:

```
build/colibri_p2p.c:2386: error: implicit declaration of function ‘lumi_init_ex’
build/colibri_p2p.c:4798: error: implicit declaration of function ‘lumi_layer_on’
build/colibri_p2p.c:4804: error: implicit declaration of function ‘lumi_moe_apply_batch’
```

The hooks were inserted but `#include "lumibri_client.h"` was not. **Cause:** colibri moved the includes around the client hook, so that hunk’s *context* no longer matched and `patch` dropped it — while `patch -o` still wrote the rest of the file, which then compiled with the hooks calling undeclared functions. Reproduced exactly: a context-line change near the include anchor makes `patch` reject that one hunk (`include=0, hooks=2`). A line-numbered unified diff is only as stable as the six lines around every hunk, and colibri edits those constantly.

**Fix:** build the patched chatter source the way the DeepSeek chatter already does — **by anchor**. `make_patches.py` gains an `--apply-one` mode that inserts each engine’s hooks on one distinctive line apiece and writes the source directly; the `build/%_p2p.c` rule calls it instead of `patch`. One anchor line survives colibri shuffling code around it far better than six context lines, and if an anchor genuinely moved `apply_hooks` exits **loudly naming it** — a clear failure instead of a silent half-patch.

## Verified
- On an unchanged colibri the anchor-generated source is **byte-identical** to what `patch` produced — nothing changes on the happy path.
- All 12 binaries build; fixture tests (olmoe/inkling/kimi) stay `IDENTICI`; qwen36 byte-identical; `patches-check` green (the `.diff` files are still generated and checked — they just are no longer what the build consumes).
- On a drifted colibri where `patch` dropped the include hunk (`include=0`), the anchor build lands it correctly (`include=1`).

Python 3 was already required at build time for the DeepSeek chatter and the fixtures; it is now required for every chatter — noted in the README requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)