### PR TITLE
Expose executor telemetry in swarm status

### DIFF
--- a/expert_node.c
+++ b/expert_node.c
@@ -127,6 +127,7 @@ static struct {
     LmbModelIdentity identity; int have_identity;
     pthread_mutex_t identity_lk;
     _Atomic uint64_t calls, cold;
+    _Atomic uint32_t in_flight;
     double busy_s;
     pthread_mutex_t stat_lk;
 } g = { .c_lk = PTHREAD_MUTEX_INITIALIZER, .load_lk = PTHREAD_MUTEX_INITIALIZER,
@@ -298,6 +299,10 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
      * box stops multiplying and starts context-switching. The measured cost
      * of that was a tenfold collapse at four clients. Queueing is the cheaper
      * failure — everyone waits a little instead of everyone thrashing. */
+    /* Count both work waiting at the compute gate and work currently running.
+     * Keep it visible through configured response delays as those calls still
+     * consume end-to-end executor capacity from the chatter's perspective. */
+    atomic_fetch_add(&g.in_flight, 1);
     gate_enter();
 
     /* one scratch per connection thread: the kernels are called concurrently */
@@ -325,6 +330,7 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
       if (slow && atoi(slow) > 0) usleep((useconds_t)atoi(slow) * 1000u); }
     lmb_emu_delay();   /* the reply's flight time, when one is being emulated */
     atomic_fetch_add(&g.calls, 1);
+    atomic_fetch_sub(&g.in_flight, 1);
     pthread_mutex_lock(&g.stat_lk); g.busy_s += dt; pthread_mutex_unlock(&g.stat_lk);
     *outp = out; *out_len = (uint32_t)obytes;
     return 0;
@@ -454,7 +460,7 @@ static void *conn_thread(void *arg) {
 
 /* ---- tracker heartbeat: this is how chatters find us --------------------- */
 
-static int send_ereg(int fd, const uint8_t nonce[32]) {
+static int send_ereg(int fd, const uint8_t nonce[32], int send_stats) {
     LmbBuf b = {0};
     lmb_buf_str(&b, g.name);
     lmb_buf_str(&b, g.advertise);
@@ -478,6 +484,13 @@ static int send_ereg(int fd, const uint8_t nonce[32]) {
     lmb_buf_u32(&b, (uint32_t)g.hidden);
     lmb_buf_u32(&b, (uint32_t)g.n_slots);
     lmb_buf_u32(&b, (uint32_t)g.n_experts);
+    if (send_stats) {
+        lmb_buf_u32(&b, LMB_EREG_STATS_MAGIC);
+        lmb_buf_u32(&b, LMB_EREG_STATS_VERSION);
+        lmb_buf_u32(&b, LMB_EREG_STATS_LENGTH);
+        lmb_buf_u64(&b, atomic_load(&g.calls));
+        lmb_buf_u32(&b, atomic_load(&g.in_flight));
+    }
     /* identity: sign the connection nonce with this machine's peer key */
     uint8_t msg[512], sig[64];
     size_t ml = lmb_peer_auth_msg(nonce, g.name, g.model, g.advertise, msg, sizeof msg);
@@ -534,12 +547,16 @@ static void *control_thread(void *arg) {
         if (lmb_request_challenge(fd, nonce)) { close(fd); sleep(1); continue; }
         struct timeval tv = { HEARTBEAT_S, 0 };
         setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
-        if (send_ereg(fd, nonce)) { close(fd); sleep(1); continue; }
+        /* Capability state belongs to this tracker connection. The first
+         * heartbeat is always legacy, and reconnecting resets negotiation so
+         * a node can safely move from a new tracker to an old one. */
+        int stats_enabled = 0;
+        if (send_ereg(fd, nonce, stats_enabled)) { close(fd); sleep(1); continue; }
         for (;;) {
             LmbMsg m;
             if (lmb_recv(fd, &m) != 0) {
                 if (errno == EAGAIN || errno == EWOULDBLOCK) {
-                    if (send_ereg(fd, nonce)) break;
+                    if (send_ereg(fd, nonce, stats_enabled)) break;
                     continue;
                 }
                 break;
@@ -555,6 +572,11 @@ static void *control_thread(void *arg) {
                     break;              /* reconnect and register the new name */
                 }
             }
+            else if (m.op == LMB_OK && m.body_len == 12 &&
+                     lmb_get32(m.body) == LMB_EREG_CAP_MAGIC &&
+                     lmb_get32(m.body + 4) == LMB_EREG_CAP_VERSION &&
+                     (lmb_get32(m.body + 8) & LMB_EREG_CAP_STATS))
+                stats_enabled = 1;
             lmb_msg_free(&m);
             if (rc) break;
             pthread_mutex_lock(&g.identity_lk);

--- a/lumabri.c
+++ b/lumabri.c
@@ -613,10 +613,10 @@ static int swarm_stats(const char *tracker, SwarmRow *rows, int cap,
     LmbMsg m = {0};
     if (exec_out) *exec_out = 0;
     if (lmb_request(tracker, LMB_SWARM, NULL, 0, &m)) return -1;
-    if (m.op != LMB_SWARM_R) { lmb_msg_free(&m); return -1; }
+    if (m.op != LMB_SWARM_R) { lmb_msg_free(&m); return -2; }
     LmbCur c = { m.body, m.body_len, 0 };
     uint32_t n = 0;
-    if (lmb_cur_u32(&c, &n)) { lmb_msg_free(&m); return -1; }
+    if (lmb_cur_u32(&c, &n)) { lmb_msg_free(&m); return -2; }
     int out = 0;
     /* Consume every legacy row even when the caller's output array is full;
      * the optional executor suffix starts only after the complete prefix. */
@@ -626,17 +626,19 @@ static int swarm_stats(const char *tracker, SwarmRow *rows, int cap,
             lmb_cur_u64(&c, &r.held) || lmb_cur_u64(&c, &r.served_bytes) ||
             lmb_cur_u64(&c, &r.served_reads) || lmb_cur_u32(&c, &r.age_s) ||
             lmb_cur_u32(&c, &r.nfiles)) {
-            lmb_msg_free(&m); return -1;
+            lmb_msg_free(&m); return -2;
         }
         if (out < cap) rows[out++] = r;
     }
-    int eout = 0;
-    if (c.len - c.off >= 12) {
+    int eout = 0, malformed = 0;
+    if (c.off < c.len) {
         uint32_t magic = 0, version = 0, len = 0;
         LmbCur suffix = c;
-        if (!lmb_cur_u32(&suffix, &magic) && magic == LMB_SWARM_EXEC_MAGIC &&
-            !lmb_cur_u32(&suffix, &version) && !lmb_cur_u32(&suffix, &len) &&
-            len <= suffix.len - suffix.off && version == LMB_SWARM_EXEC_VERSION) {
+        if (lmb_cur_u32(&suffix, &magic) || magic != LMB_SWARM_EXEC_MAGIC ||
+            lmb_cur_u32(&suffix, &version) || lmb_cur_u32(&suffix, &len) ||
+            len != suffix.len - suffix.off) {
+            malformed = 1;
+        } else if (version == LMB_SWARM_EXEC_VERSION) {
             LmbCur section = { suffix.p + suffix.off, len, 0 };
             uint32_t en = 0;
             int valid = !lmb_cur_u32(&section, &en) && en <= 4096;
@@ -644,19 +646,20 @@ static int swarm_stats(const char *tracker, SwarmRow *rows, int cap,
                 ExecSwarmRow r = {0};
                 uint32_t have = 0;
                 valid = !lmb_cur_str(&section, r.model, sizeof r.model) &&
-                        !lmb_cur_u32(&section, &have) &&
+                        !lmb_cur_u32(&section, &have) && have <= 1 &&
                         !lmb_cur_u64(&section, &r.calls) &&
                         !lmb_cur_u32(&section, &r.in_flight) &&
                         !lmb_cur_u32(&section, &r.age_s);
                 r.have_stats = have != 0;
                 if (valid && eout < exec_cap) exec_rows[eout++] = r;
             }
-            if (!valid || section.off != section.len) eout = 0;
+            if (!valid || section.off != section.len) malformed = 1;
         }
     }
+    if (malformed) eout = 0;
     if (exec_out) *exec_out = eout;
     lmb_msg_free(&m);
-    return out;
+    return malformed ? -2 : out;
 }
 
 /* /swarm: the network, anonymous. Peers are numbered, never named. */
@@ -665,30 +668,29 @@ static void render_swarm(const char *tracker) {
     ExecSwarmRow exec_rows[64];
     int ne = 0;
     int n = swarm_stats(tracker, rows, 64, exec_rows, 64, &ne);
-    if (n < 0) { printf("  %stracker unreachable%s\n", C_RED, C_R); return; }
-    char lines[132][256];
+    if (n == -1) { printf("  %stracker unreachable%s\n", C_RED, C_R); return; }
+    if (n < 0) { printf("  %smalformed swarm response%s\n", C_RED, C_R); return; }
+    char lines[129][256];
     int nl = 0;
     snprintf(lines[nl++], sizeof lines[0],
-             "%s%sswarm status%s  %s%d storage peers | %d executors%s",
+             "%s%sla rete adesso%s  %s%d peer vivi \xc2\xb7 %d exec%s",
              C_BOLD, C_CORAL, C_R, C_DIM, n, ne, C_R);
-    snprintf(lines[nl++], sizeof lines[0], "%sstorage peers%s", C_BOLD, C_R);
     for (int i = 0; i < n; i++)
         snprintf(lines[nl++], sizeof lines[0],
-                 "%sstorage-%d%s  %-12.12s %5.1f GB  %s%.0f MB out | %llu reads | hb %us%s",
+                 "%speer-%d%s  %-12.12s %5.1f GB  %s%.0f MB out \xc2\xb7 %llu req \xc2\xb7 hb %us%s",
                  C_BOLD, i + 1, C_R, rows[i].model, (double)rows[i].held / 1e9,
                  C_DIM, (double)rows[i].served_bytes / 1e6,
                  (unsigned long long)rows[i].served_reads, rows[i].age_s, C_R);
-    snprintf(lines[nl++], sizeof lines[0], "%sexecutors%s", C_BOLD, C_R);
     for (int i = 0; i < ne; i++) {
         if (exec_rows[i].have_stats)
             snprintf(lines[nl++], sizeof lines[0],
-                     "%sexecutor-%d%s  %-12.12s %s%llu calls | %u in flight | hb %us%s",
+                     "%sexec-%d%s  %-12.12s %s%llu calls \xc2\xb7 %u in flight \xc2\xb7 hb %us%s",
                      C_BOLD, i + 1, C_R, exec_rows[i].model, C_DIM,
                      (unsigned long long)exec_rows[i].calls,
                      exec_rows[i].in_flight, exec_rows[i].age_s, C_R);
         else
             snprintf(lines[nl++], sizeof lines[0],
-                     "%sexecutor-%d%s  %-12.12s %sstats unavailable | hb %us%s",
+                     "%sexec-%d%s  %-12.12s %sstats unavailable \xc2\xb7 hb %us%s",
                      C_BOLD, i + 1, C_R, exec_rows[i].model, C_DIM,
                      exec_rows[i].age_s, C_R);
     }
@@ -711,6 +713,7 @@ static void render_swarm(const char *tracker) {
 static int swarm_models(const char *tracker, char names[][64], int cap) {
     SwarmRow rows[64];
     int n = swarm_stats(tracker, rows, 64, NULL, 0, NULL), out = 0;
+    if (n < 0) return 0;
     for (int i = 0; i < n; i++) {
         int seen = 0;
         for (int j = 0; j < out; j++) if (!strcmp(names[j], rows[i].model)) seen = 1;

--- a/lumabri.c
+++ b/lumabri.c
@@ -601,21 +601,60 @@ typedef struct {
     uint32_t age_s, nfiles;
 } SwarmRow;
 
-static int swarm_stats(const char *tracker, SwarmRow *rows, int cap) {
+typedef struct {
+    char model[64];
+    uint64_t calls;
+    uint32_t in_flight, age_s;
+    int have_stats;
+} ExecSwarmRow;
+
+static int swarm_stats(const char *tracker, SwarmRow *rows, int cap,
+                       ExecSwarmRow *exec_rows, int exec_cap, int *exec_out) {
     LmbMsg m = {0};
-    if (lmb_request(tracker, LMB_SWARM, NULL, 0, &m) || m.op != LMB_SWARM_R) return -1;
+    if (exec_out) *exec_out = 0;
+    if (lmb_request(tracker, LMB_SWARM, NULL, 0, &m)) return -1;
+    if (m.op != LMB_SWARM_R) { lmb_msg_free(&m); return -1; }
     LmbCur c = { m.body, m.body_len, 0 };
     uint32_t n = 0;
     if (lmb_cur_u32(&c, &n)) { lmb_msg_free(&m); return -1; }
     int out = 0;
-    for (uint32_t i = 0; i < n && out < cap; i++) {
-        SwarmRow *r = &rows[out];
-        if (lmb_cur_str(&c, r->model, sizeof r->model) ||
-            lmb_cur_u64(&c, &r->held) || lmb_cur_u64(&c, &r->served_bytes) ||
-            lmb_cur_u64(&c, &r->served_reads) || lmb_cur_u32(&c, &r->age_s) ||
-            lmb_cur_u32(&c, &r->nfiles)) break;
-        out++;
+    /* Consume every legacy row even when the caller's output array is full;
+     * the optional executor suffix starts only after the complete prefix. */
+    for (uint32_t i = 0; i < n; i++) {
+        SwarmRow r = {0};
+        if (lmb_cur_str(&c, r.model, sizeof r.model) ||
+            lmb_cur_u64(&c, &r.held) || lmb_cur_u64(&c, &r.served_bytes) ||
+            lmb_cur_u64(&c, &r.served_reads) || lmb_cur_u32(&c, &r.age_s) ||
+            lmb_cur_u32(&c, &r.nfiles)) {
+            lmb_msg_free(&m); return -1;
+        }
+        if (out < cap) rows[out++] = r;
     }
+    int eout = 0;
+    if (c.len - c.off >= 12) {
+        uint32_t magic = 0, version = 0, len = 0;
+        LmbCur suffix = c;
+        if (!lmb_cur_u32(&suffix, &magic) && magic == LMB_SWARM_EXEC_MAGIC &&
+            !lmb_cur_u32(&suffix, &version) && !lmb_cur_u32(&suffix, &len) &&
+            len <= suffix.len - suffix.off && version == LMB_SWARM_EXEC_VERSION) {
+            LmbCur section = { suffix.p + suffix.off, len, 0 };
+            uint32_t en = 0;
+            int valid = !lmb_cur_u32(&section, &en) && en <= 4096;
+            for (uint32_t i = 0; valid && i < en; i++) {
+                ExecSwarmRow r = {0};
+                uint32_t have = 0;
+                valid = !lmb_cur_str(&section, r.model, sizeof r.model) &&
+                        !lmb_cur_u32(&section, &have) &&
+                        !lmb_cur_u64(&section, &r.calls) &&
+                        !lmb_cur_u32(&section, &r.in_flight) &&
+                        !lmb_cur_u32(&section, &r.age_s);
+                r.have_stats = have != 0;
+                if (valid && eout < exec_cap) exec_rows[eout++] = r;
+            }
+            if (!valid || section.off != section.len) eout = 0;
+        }
+    }
+    if (exec_out) *exec_out = eout;
     lmb_msg_free(&m);
     return out;
 }
@@ -623,25 +662,44 @@ static int swarm_stats(const char *tracker, SwarmRow *rows, int cap) {
 /* /swarm: the network, anonymous. Peers are numbered, never named. */
 static void render_swarm(const char *tracker) {
     SwarmRow rows[64];
-    int n = swarm_stats(tracker, rows, 64);
+    ExecSwarmRow exec_rows[64];
+    int ne = 0;
+    int n = swarm_stats(tracker, rows, 64, exec_rows, 64, &ne);
     if (n < 0) { printf("  %stracker unreachable%s\n", C_RED, C_R); return; }
-    char lines[65][256];
-    snprintf(lines[0], sizeof lines[0], "%s%sla rete adesso%s  %s%d peer vivi%s",
-             C_BOLD, C_CORAL, C_R, C_DIM, n, C_R);
+    char lines[132][256];
+    int nl = 0;
+    snprintf(lines[nl++], sizeof lines[0],
+             "%s%sswarm status%s  %s%d storage peers | %d executors%s",
+             C_BOLD, C_CORAL, C_R, C_DIM, n, ne, C_R);
+    snprintf(lines[nl++], sizeof lines[0], "%sstorage peers%s", C_BOLD, C_R);
     for (int i = 0; i < n; i++)
-        snprintf(lines[i + 1], sizeof lines[0],
-                 "%speer-%d%s  %-12.12s %5.1f GB  %s%.0f MB out · %llu req · hb %us%s",
+        snprintf(lines[nl++], sizeof lines[0],
+                 "%sstorage-%d%s  %-12.12s %5.1f GB  %s%.0f MB out | %llu reads | hb %us%s",
                  C_BOLD, i + 1, C_R, rows[i].model, (double)rows[i].held / 1e9,
                  C_DIM, (double)rows[i].served_bytes / 1e6,
                  (unsigned long long)rows[i].served_reads, rows[i].age_s, C_R);
+    snprintf(lines[nl++], sizeof lines[0], "%sexecutors%s", C_BOLD, C_R);
+    for (int i = 0; i < ne; i++) {
+        if (exec_rows[i].have_stats)
+            snprintf(lines[nl++], sizeof lines[0],
+                     "%sexecutor-%d%s  %-12.12s %s%llu calls | %u in flight | hb %us%s",
+                     C_BOLD, i + 1, C_R, exec_rows[i].model, C_DIM,
+                     (unsigned long long)exec_rows[i].calls,
+                     exec_rows[i].in_flight, exec_rows[i].age_s, C_R);
+        else
+            snprintf(lines[nl++], sizeof lines[0],
+                     "%sexecutor-%d%s  %-12.12s %sstats unavailable | hb %us%s",
+                     C_BOLD, i + 1, C_R, exec_rows[i].model, C_DIM,
+                     exec_rows[i].age_s, C_R);
+    }
     /* the box fits its widest line; the terminal caps it */
     int w = 0;
-    for (int i = 0; i <= n; i++)
+    for (int i = 0; i < nl; i++)
         if (vis_len(lines[i]) + 6 > w) w = vis_len(lines[i]) + 6;
     if (w > term_w() - 2) w = term_w() - 2;
     printf("\n");
     hline("\xe2\x95\xad", "\xe2\x95\xae", w);
-    for (int i = 0; i <= n; i++) {
+    for (int i = 0; i < nl; i++) {
         int pad = w - 4 - vis_len(lines[i]);
         printf("%s\xe2\x94\x82%s  %s%*s%s\xe2\x94\x82%s\n", C_GRAY, C_R, lines[i],
                pad > 0 ? pad : 0, "", C_GRAY, C_R);
@@ -652,7 +710,7 @@ static void render_swarm(const char *tracker) {
 /* distinct model names on the swarm; returns count */
 static int swarm_models(const char *tracker, char names[][64], int cap) {
     SwarmRow rows[64];
-    int n = swarm_stats(tracker, rows, 64), out = 0;
+    int n = swarm_stats(tracker, rows, 64, NULL, 0, NULL), out = 0;
     for (int i = 0; i < n; i++) {
         int seen = 0;
         for (int j = 0; j < out; j++) if (!strcmp(names[j], rows[i].model)) seen = 1;

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -90,7 +90,7 @@
 #define LMB_EREG_STATS_MAGIC     0x31545345u /* "EST1" */
 #define LMB_EREG_STATS_VERSION   1u
 #define LMB_EREG_STATS_LENGTH    12u
-#define LMB_SWARM_EXEC_MAGIC     0x31584553u /* "SEX1" */
+#define LMB_SWARM_EXEC_MAGIC     0x31585753u /* "SWX1" */
 #define LMB_SWARM_EXEC_VERSION   1u
 
 /* Both arguments must point at the fixed LMB_TOKEN_MAX+1 authentication

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -80,6 +80,19 @@
 #define LMB_HASH_MAGIC 0x48414853u  /* "SHAH": optional hash section marker */
 #define LMB_PEER_AUTH_MAGIC 0x52554150u /* "PAUR": trailing peer-identity block */
 
+/* Optional executor telemetry is negotiated on the existing EREG LMB_OK.
+ * Every extension has its own magic, version, and bounded payload length so
+ * old peers keep using the exact legacy body and new peers can skip versions
+ * they do not understand without changing any opcode. */
+#define LMB_EREG_CAP_MAGIC       0x50414345u /* "ECAP" */
+#define LMB_EREG_CAP_VERSION     1u
+#define LMB_EREG_CAP_STATS       0x00000001u
+#define LMB_EREG_STATS_MAGIC     0x31545345u /* "EST1" */
+#define LMB_EREG_STATS_VERSION   1u
+#define LMB_EREG_STATS_LENGTH    12u
+#define LMB_SWARM_EXEC_MAGIC     0x31584553u /* "SEX1" */
+#define LMB_SWARM_EXEC_VERSION   1u
+
 /* Both arguments must point at the fixed LMB_TOKEN_MAX+1 authentication
  * buffers used by the daemons.  Compare the complete buffers so a remote
  * caller cannot learn a shared invite token one prefix at a time. */

--- a/tracker.c
+++ b/tracker.c
@@ -718,23 +718,25 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
                    lmb_cur_u32(&c, &qbits) || lmb_cur_u32(&c, &hidden) ||
                    lmb_cur_u32(&c, &slots) || lmb_cur_u32(&c, &total_experts);
     }
-    /* A recognized envelope is optional. Unknown trailing bytes are still a
-     * malformed EREG, while a damaged or newer telemetry payload only makes
-     * the statistics unavailable and never invalidates the base heartbeat. */
+    /* A recognized envelope is optional. Unknown trailing bytes and damaged
+     * current-version telemetry are malformed EREG frames. A complete future
+     * version may be skipped with its statistics left unavailable. */
     if (!bad_meta && c.off < c.len) {
         uint32_t smagic = 0, sversion = 0, slen = 0;
         if (lmb_cur_u32(&c, &smagic) || smagic != LMB_EREG_STATS_MAGIC ||
-            lmb_cur_u32(&c, &sversion) || lmb_cur_u32(&c, &slen)) {
+            lmb_cur_u32(&c, &sversion) || lmb_cur_u32(&c, &slen) ||
+            slen > c.len - c.off) {
             bad_meta = 1;
-        } else if (slen > c.len - c.off) {
-            c.off = c.len;
         } else {
             LmbCur stats = { c.p + c.off, slen, 0 };
-            if (sversion == LMB_EREG_STATS_VERSION &&
-                slen == LMB_EREG_STATS_LENGTH &&
-                !lmb_cur_u64(&stats, &exec_calls) &&
-                !lmb_cur_u32(&stats, &exec_inflight) && stats.off == stats.len)
-                have_exec_stats = 1;
+            if (sversion == LMB_EREG_STATS_VERSION) {
+                if (slen != LMB_EREG_STATS_LENGTH ||
+                    lmb_cur_u64(&stats, &exec_calls) ||
+                    lmb_cur_u32(&stats, &exec_inflight) || stats.off != stats.len)
+                    bad_meta = 1;
+                else
+                    have_exec_stats = 1;
+            }
             c.off += slen;
             if (c.off != c.len) bad_meta = 1;
         }

--- a/tracker.c
+++ b/tracker.c
@@ -39,6 +39,9 @@ typedef struct {
     char engine[64], profile[LMB_BUILD_PROFILE_MAX];
     uint32_t bits, hidden, slots, total_experts;
     uint64_t held_bytes, served_bytes, served_reads;
+    uint64_t exec_calls;
+    uint32_t exec_inflight;
+    int have_exec_stats;
     PFile *files; uint32_t nfiles;
     double ts;
     int used;
@@ -704,17 +707,39 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
         bits = c.p + c.off; c.off += bl;
     } else bl = 0;
     uint32_t meta = 0, qbits = 0, hidden = 0, slots = 0, total_experts = 0;
+    uint64_t exec_calls = 0;
+    uint32_t exec_inflight = 0;
+    int have_exec_stats = 0, bad_meta = 0;
     char engine[64] = "", profile[LMB_BUILD_PROFILE_MAX] = "";
     if (c.off < c.len) {
-        if (lmb_cur_u32(&c, &meta) || meta != LMB_EXPERT_MANIFEST_MAGIC ||
-            lmb_cur_str(&c, engine, sizeof engine) ||
-            lmb_cur_str(&c, profile, sizeof profile) ||
-            lmb_cur_u32(&c, &qbits) || lmb_cur_u32(&c, &hidden) ||
-            lmb_cur_u32(&c, &slots) || lmb_cur_u32(&c, &total_experts) ||
-            c.off != c.len) {
-            send_err(fd, "bad ereg metadata"); return NULL;
+        bad_meta = lmb_cur_u32(&c, &meta) || meta != LMB_EXPERT_MANIFEST_MAGIC ||
+                   lmb_cur_str(&c, engine, sizeof engine) ||
+                   lmb_cur_str(&c, profile, sizeof profile) ||
+                   lmb_cur_u32(&c, &qbits) || lmb_cur_u32(&c, &hidden) ||
+                   lmb_cur_u32(&c, &slots) || lmb_cur_u32(&c, &total_experts);
+    }
+    /* A recognized envelope is optional. Unknown trailing bytes are still a
+     * malformed EREG, while a damaged or newer telemetry payload only makes
+     * the statistics unavailable and never invalidates the base heartbeat. */
+    if (!bad_meta && c.off < c.len) {
+        uint32_t smagic = 0, sversion = 0, slen = 0;
+        if (lmb_cur_u32(&c, &smagic) || smagic != LMB_EREG_STATS_MAGIC ||
+            lmb_cur_u32(&c, &sversion) || lmb_cur_u32(&c, &slen)) {
+            bad_meta = 1;
+        } else if (slen > c.len - c.off) {
+            c.off = c.len;
+        } else {
+            LmbCur stats = { c.p + c.off, slen, 0 };
+            if (sversion == LMB_EREG_STATS_VERSION &&
+                slen == LMB_EREG_STATS_LENGTH &&
+                !lmb_cur_u64(&stats, &exec_calls) &&
+                !lmb_cur_u32(&stats, &exec_inflight) && stats.off == stats.len)
+                have_exec_stats = 1;
+            c.off += slen;
+            if (c.off != c.len) bad_meta = 1;
         }
     }
+    if (bad_meta) { send_err(fd, "bad ereg metadata"); return NULL; }
     Peer *slot = NULL;
     int fresh = 0;
     pthread_mutex_lock(&g_lk);
@@ -767,6 +792,9 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
         snprintf(slot->profile, sizeof slot->profile, "%s", profile);
         slot->bits = qbits; slot->hidden = hidden;
         slot->slots = slots; slot->total_experts = total_experts;
+        slot->exec_calls = exec_calls;
+        slot->exec_inflight = exec_inflight;
+        slot->have_exec_stats = have_exec_stats;
         if (bl) {
             uint8_t *nb = (uint8_t *)realloc(slot->ebits, bl);
             if (nb) { slot->ebits = nb; memcpy(slot->ebits, bits, bl);
@@ -780,12 +808,18 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
                name, use_addr, model, nexperts);
         fflush(stdout);
     }
-    if (lmb_send(fd, LMB_OK, NULL, 0, NULL, 0)) {
+    LmbBuf ack = {0};
+    lmb_buf_u32(&ack, LMB_EREG_CAP_MAGIC);
+    lmb_buf_u32(&ack, LMB_EREG_CAP_VERSION);
+    lmb_buf_u32(&ack, LMB_EREG_CAP_STATS);
+    if (lmb_send(fd, LMB_OK, ack.p, (uint32_t)ack.len, NULL, 0)) {
+        free(ack.p);
         pthread_mutex_lock(&g_lk);
         if (slot->ctrl_fd == fd) slot->ctrl_fd = -1;
         pthread_mutex_unlock(&g_lk);
         return NULL;
     }
+    free(ack.p);
     return slot;
 }
 
@@ -975,13 +1009,16 @@ static int handle_placement(int fd, LmbMsg *m) {
 /* ---- SWARM: anonymous by construction ----------------------------------- */
 
 static int handle_swarm(int fd) {
-    LmbBuf b = {0};
+    LmbBuf b = {0}, exec = {0};
     double now = now_s();
     pthread_mutex_lock(&g_lk);
-    uint32_t live = 0;
-    for (int i = 0; i < MAX_PEERS; i++)
-        if (g_peers[i].used && !g_peers[i].is_expert &&
-            now - g_peers[i].ts <= g_stale_s) live++;
+    uint32_t live = 0, live_exec = 0;
+    for (int i = 0; i < MAX_PEERS; i++) {
+        if (!g_peers[i].used || now - g_peers[i].ts > g_stale_s) continue;
+        if (g_peers[i].is_expert) live_exec++;
+        else live++;
+    }
+    /* Keep this legacy storage-peer prefix byte-for-byte compatible. */
     lmb_buf_u32(&b, live);
     for (int i = 0; i < MAX_PEERS; i++) {
         Peer *p = &g_peers[i];
@@ -993,7 +1030,24 @@ static int handle_swarm(int fd) {
         lmb_buf_u32(&b, (uint32_t)(now - p->ts));
         lmb_buf_u32(&b, p->nfiles);
     }
+    /* Executors are anonymous and live in a versioned suffix. Old clients
+     * stop after the storage rows and ignore these trailing bytes. */
+    lmb_buf_u32(&exec, live_exec);
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *p = &g_peers[i];
+        if (!p->used || !p->is_expert || now - p->ts > g_stale_s) continue;
+        lmb_buf_str(&exec, p->model);
+        lmb_buf_u32(&exec, p->have_exec_stats ? 1u : 0u);
+        lmb_buf_u64(&exec, p->have_exec_stats ? p->exec_calls : 0);
+        lmb_buf_u32(&exec, p->have_exec_stats ? p->exec_inflight : 0);
+        lmb_buf_u32(&exec, (uint32_t)(now - p->ts));
+    }
     pthread_mutex_unlock(&g_lk);
+    lmb_buf_u32(&b, LMB_SWARM_EXEC_MAGIC);
+    lmb_buf_u32(&b, LMB_SWARM_EXEC_VERSION);
+    lmb_buf_u32(&b, (uint32_t)exec.len);
+    lmb_buf_bytes(&b, exec.p, exec.len);
+    free(exec.p);
     int rc = lmb_send(fd, LMB_SWARM_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;


### PR DESCRIPTION
## Summary

- negotiate executor telemetry through a versioned capability in the existing EREG `LMB_OK`
- report cumulative calls served and current in-flight work on later heartbeats only
- append anonymous executor rows to `/swarm` in a versioned suffix while preserving the legacy storage-peer prefix
- render storage peers and executors as separate anonymous sections

## Compatibility

- the first EREG on every connection remains legacy-compatible
- capability state resets on reconnect, so an old tracker never receives the optional stats section
- old expert nodes ignore the capability body in `LMB_OK`
- old clients continue parsing the unchanged SWARM prefix and ignore trailing bytes
- truncated or malformed current-version telemetry is rejected, while complete unknown future versions are skipped safely

This is the counters-only telemetry step discussed in #29. It does not change `lumi_pick`, probe scheduling, routing, or failover policy.

## Validation

Validated in Docker on Debian 12:

- forced builds of `tracker`, `lumabri`, `expert_node`, `test_relay_exec`, `test_hedge`, and `test_verify_failover`
- focused old/new protocol matrix for EREG capability negotiation and SWARM compatibility
- first heartbeat accepted by the new tracker without telemetry
- empty-ACK old tracker simulation kept later heartbeats legacy-only
- delayed EXEC reported `in_flight > 0`, then returned to zero
- one direct and one relayed EXEC increased `calls` exactly twice
- `test-relay-exec`
- `test-hedge`
- `verify_failover_test.sh`
- `test-phase2`

The shell scripts were streamed through CRLF normalization inside the container because the Windows checkout had CRLF line endings. No test or documentation files are included in this PR.