### PR TITLE
feat: donate compute with no model on disk — the swarm feeds the assigned slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ all: tracker maintainer liblumabri.so test_shim lumabri
 # their own upstream builds, because treating their warnings as Lumabri
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
-	$(MAKE) -B all test_relay_exec test_key_rotation test_hedge \
-		test_verify_failover CFLAGS='$(CFLAGS) -Werror'
+	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
+		test_hedge test_verify_failover CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
 
@@ -360,6 +360,12 @@ test_verify_failover: test_verify_failover.c lumabri_client.h lumabri_proto.h lu
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh
 
+test_swarm_fed: test_swarm_fed.c lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_swarm_fed.c -o $@
+
+test-swarm-fed: tracker maintainer liblumabri.so expert_node test_swarm_fed fixture
+	./swarm_fed_exec_test.sh
+
 test-cas: tracker maintainer liblumabri.so test_shim
 	./cas_test.sh
 
@@ -410,7 +416,8 @@ install: all
 
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim lumabri \
-	      test_relay_exec test_key_rotation test_hedge test_verify_failover \
+	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
+	      test_verify_failover \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	      expert_node_deepseek
@@ -420,4 +427,5 @@ clean:
         fixture test-phase2 \
         test-phase2-glm test-phase2-inkling test-phase2-kimi \
         test-phase2-deepseek test-engines \
-        patches patches-check test-relay-exec test-cas test-key-rotation test-hedge
+        patches patches-check test-relay-exec test-swarm-fed test-cas \
+        test-key-rotation test-hedge

--- a/README.md
+++ b/README.md
@@ -173,7 +173,10 @@ On every other machine, pick a role:
 
 A disk donor is told which files to hold, rarest first, by the tracker. A
 compute donor says how many experts it can carry — `--hold auto` sizes that to
-its free RAM — and the tracker gives it the set nobody else covers. So several
+its free RAM — and the tracker gives it the set nobody else covers. Donating
+compute does not require owning the model: picked from the menu with no local
+container, the node runs behind the swarm mirror and pulls exactly its
+assigned slice, hash-verified, so the whole model never lands on the donor. So several
 compute donors **split the model into disjoint slices automatically**, and one
 token's experts then run across them in parallel: more machines, faster
 tokens. (`--hold N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or

--- a/lumabri.c
+++ b/lumabri.c
@@ -154,6 +154,22 @@ static pid_t spawn_argv(char *const argv[]) {
     return pid;
 }
 
+/* spawn_argv with extra KEY=VAL entries in the child's environment only.
+ * The swarm-fed expert node needs the shim wired up (LD_PRELOAD and the
+ * mirror's coordinates), and none of that may leak into our own process:
+ * a chat client running behind its own shim would mirror every file it
+ * touches. */
+static pid_t spawn_argv_env(char *const argv[], char *const envv[]) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        for (int i = 0; envv && envv[i]; i++) putenv(envv[i]);
+        execv(argv[0], argv);
+        perror(argv[0]);
+        _exit(127);
+    }
+    return pid;
+}
+
 static pid_t g_children[8];
 static int g_nchildren = 0;
 /* The async handler never reads the mutable table/count.  Each fixed slot is
@@ -1763,14 +1779,13 @@ static int role_pick(Role *r, const char *model, int have_model_dir) {
            C_CORAL, C_R, C_DIM, C_R);
     printf("    %s2%s  chatti e doni disco  %stieni un pezzo di %s per lo sciame%s\n",
            C_CORAL, C_R, C_DIM, model, C_R);
-    if (have_model_dir) {
+    if (have_model_dir)
         printf("    %s3%s  chatti e doni calcolo %sesegui esperti per gli altri%s\n",
                C_CORAL, C_R, C_DIM, C_R);
-        printf("    %s4%s  tutti e due%s\n", C_CORAL, C_R, C_R);
-    } else {
-        printf("    %s3%s  %sdonare calcolo: serve il modello sul tuo disco "
-               "(--model-dir DIR)%s\n", C_GRAY, C_R, C_DIM, C_R);
-    }
+    else
+        printf("    %s3%s  chatti e doni calcolo %sla tua fetta di esperti "
+               "arriva dallo sciame%s\n", C_CORAL, C_R, C_DIM, C_R);
+    printf("    %s4%s  tutti e due%s\n", C_CORAL, C_R, C_R);
     printf("\n  %sinvio = solo chattare%s\n", C_DIM, C_R);
     printf("\n%s\xe2\x94\x82%s %s%s\xe2\x80\xba%s ", C_GRAY, C_R, C_CORAL, C_BOLD, C_R);
     fflush(stdout);
@@ -1780,7 +1795,7 @@ static int role_pick(Role *r, const char *model, int have_model_dir) {
     int c = line[0] ? line[0] : '1';
     if (c == 'q') return -1;
     if (c == '2' || c == '4') r->disk = 1;
-    if ((c == '3' || c == '4') && have_model_dir) r->compute = 1;
+    if (c == '3' || c == '4') r->compute = 1;
     if (!r->disk && !r->compute) return 0;
 
     if (r->disk) {
@@ -1866,26 +1881,85 @@ static void role_start(const Role *r, const char *tracker, const char *model,
         char bin[1200];
         snprintf(bin, sizeof bin, "%s/%s", dir, node ? node : "expert_node");
         int port = free_port(7701);
+        /* Which container does the node read? The user's local copy when
+         * there is one. Otherwise the model's vroot behind the shim: every
+         * loader read becomes a verified block fetch from the swarm, so the
+         * node pulls exactly the experts the tracker assigned it — donating
+         * compute no longer requires owning the model. Weights still never
+         * cross the EXEC channel; this is the disk-donor delivery path,
+         * hash-verified, feeding an executor. */
+        char probe[1100], shim[1200];
+        snprintf(probe, sizeof probe, "%s/config.json", r->model_dir);
+        int local = r->model_dir[0] && access(probe, R_OK) == 0;
+        snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
+        if (access(shim, R_OK))
+            snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
         if (!node || !port || access(bin, X_OK)) {
             printf("  %snessun expert node per %s (make engines): dono calcolo "
                    "saltato%s\n", C_DIM, model_type ? model_type : "?", C_R);
+        } else if (!local && access(shim, R_OK)) {
+            printf("  %sliblumabri.so mancante (make): dono calcolo saltato%s\n",
+                   C_DIM, C_R);
         } else {
+            /* same mirror the chatter uses: dense blocks are shared, and the
+             * shim's cache lock is shared for a process lifetime */
+            const char *home = getenv("HOME") ? getenv("HOME") : ".";
+            char vroot[1024], cachedir[1024], casdir[1040];
+            char e_pre[1216], e_vr[1040], e_ca[1040], e_cs[1056],
+                 e_tr[160], e_mo[96];
+            char *envv[8];
+            int ne = 0;
+            if (!local) {
+                const char *ve = getenv("LUMABRI_VROOT");
+                const char *ce = getenv("LUMABRI_CACHE");
+                if (ve && ve[0]) snprintf(vroot, sizeof vroot, "%s", ve);
+                else snprintf(vroot, sizeof vroot, "%s/.lumabri/%s/vroot",
+                              home, model);
+                if (ce && ce[0]) snprintf(cachedir, sizeof cachedir, "%s", ce);
+                else snprintf(cachedir, sizeof cachedir, "%s/.lumabri/%s/cache",
+                              home, model);
+                snprintf(casdir, sizeof casdir, "%s/.lumabri/cas", home);
+                mkdir_p(cachedir);              /* the vroot stays virtual */
+                snprintf(e_pre, sizeof e_pre, "LD_PRELOAD=%s", shim);
+                snprintf(e_vr, sizeof e_vr, "LUMABRI_VROOT=%s", vroot);
+                snprintf(e_ca, sizeof e_ca, "LUMABRI_CACHE=%s", cachedir);
+                snprintf(e_cs, sizeof e_cs, "LUMABRI_CAS=%s", casdir);
+                snprintf(e_tr, sizeof e_tr, "LUMABRI_TRACKER=%s", tracker);
+                snprintf(e_mo, sizeof e_mo, "LUMABRI_MODEL=%s", model);
+                envv[ne++] = e_pre;
+                envv[ne++] = e_vr;
+                envv[ne++] = e_ca;
+                if (!getenv("LUMABRI_CAS")) envv[ne++] = e_cs;
+                envv[ne++] = e_tr;
+                envv[ne++] = e_mo;
+                /* AUTOPIN behind the shim would mirror GBs of experts the
+                 * tracker never assigned; an explicit PIN still wins */
+                if (!getenv("PIN")) envv[ne++] = (char *)"PIN=0";
+                envv[ne] = NULL;
+            }
             char portstr[16], name[64];
             snprintf(portstr, sizeof portstr, "%d", port);
             snprintf(name, sizeof name, "donor-exec-%d", port);
             char *argv[20];
             int a = 0;
             argv[a++] = bin;
-            argv[a++] = "--model";      argv[a++] = (char *)r->model_dir;
+            argv[a++] = "--model";      argv[a++] = local ? (char *)r->model_dir
+                                                          : vroot;
             argv[a++] = "--port";       argv[a++] = portstr;
             argv[a++] = "--tracker";    argv[a++] = (char *)tracker;
             argv[a++] = "--name";       argv[a++] = name;
             argv[a++] = "--model-name"; argv[a++] = (char *)model;
             argv[a++] = "--hold";       argv[a++] = "auto";   /* the tracker hands us a disjoint slice; the node sizes it to free RAM */
             argv[a] = NULL;
-            { pid_t np = spawn_argv(argv); child_publish(g_nchildren++, np); }
-            printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s)%s\n",
-                   C_GRN, C_R, C_DIM, node, C_R);
+            { pid_t np = local ? spawn_argv(argv) : spawn_argv_env(argv, envv);
+              child_publish(g_nchildren++, np); }
+            if (local)
+                printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s)%s\n",
+                       C_GRN, C_R, C_DIM, node, C_R);
+            else
+                printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s, "
+                       "la fetta assegnata arriva dallo sciame)%s\n",
+                       C_GRN, C_R, C_DIM, node, C_R);
         }
     }
     if (r->disk || r->compute)

--- a/swarm_fed_exec_test.sh
+++ b/swarm_fed_exec_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# A compute donor with no model on disk. A tracker+maintainer hold tiny_olmoe;
+# one expert_node reads the container from disk (the truth), a second runs
+# behind the shim with --model pointing into the model's vroot — every loader
+# read becomes a verified block fetch from the swarm, so it pulls exactly the
+# experts it holds. The same EXEC against both must be byte-identical.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s tracker maintainer liblumabri.so expert_node test_swarm_fed fixture
+
+T=$(mktemp -d /tmp/lumabri-swarmfed.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
+PIDS=()
+cleanup() {
+    if [ "${#PIDS[@]}" -gt 0 ]; then
+        kill "${PIDS[@]}" 2>/dev/null || true
+        wait "${PIDS[@]}" 2>/dev/null || true
+    fi
+    rm -rf "$T"
+}
+trap cleanup EXIT
+
+wait_port() {
+    for _ in $(seq 1 300); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    echo "port $1 never opened"
+    return 1
+}
+
+./tracker --port 7591 >"$T/tracker.log" 2>&1 & PIDS+=($!)
+./maintainer --root tiny_olmoe --port 7592 --tracker 127.0.0.1:7591 \
+    --name sf-origin --model-name tiny-olmoe >"$T/maint.log" 2>&1 & PIDS+=($!)
+wait_port 7591
+wait_port 7592
+sleep .3
+
+echo "── A) the truth: an expert node reading the container from disk"
+OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 \
+./expert_node --model tiny_olmoe --port 7593 --name sf-local \
+    >"$T/local.log" 2>&1 & PIDS+=($!)
+wait_port 7593 || { tail -20 "$T/local.log"; exit 1; }
+
+echo "── B) the same node with NO model on disk: fed through the swarm mirror"
+OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 \
+env LD_PRELOAD="$PWD/liblumabri.so" LUMABRI_TRACKER=127.0.0.1:7591 \
+    LUMABRI_MODEL=tiny-olmoe LUMABRI_VROOT="$T/vroot" \
+    LUMABRI_CACHE="$T/cache" LUMABRI_CAS="$T/cas" PIN=0 \
+./expert_node --model "$T/vroot" --port 7594 --name sf-fed \
+    >"$T/fed.log" 2>&1 & PIDS+=($!)
+wait_port 7594 || { tail -20 "$T/fed.log"; exit 1; }
+
+# the vroot must have stayed virtual: the fed node never had a container
+[ ! -e "$T/vroot" ] || { echo "✗ the vroot materialised on disk"; exit 1; }
+
+DIM=$(sed -n 's/.*"hidden_size"[: ]*\([0-9]*\).*/\1/p' tiny_olmoe/config.json)
+./test_swarm_fed 127.0.0.1:7593 127.0.0.1:7594 "$DIM" 0 1
+./test_swarm_fed 127.0.0.1:7593 127.0.0.1:7594 "$DIM" 15 7
+echo "✓ SWARM-FED DONOR: identical experts with no model on the donor's disk"

--- a/test_swarm_fed.c
+++ b/test_swarm_fed.c
@@ -1,0 +1,40 @@
+/* The same expert, the same activation rows, two nodes: one reading the
+ * container from disk, one fed through the shim's swarm mirror with no model
+ * on its disk at all. The replies must be byte-identical — anything else
+ * means a swarm-fed compute donor would poison phase 2. */
+#include "lumabri_proto.h"
+
+int main(int argc, char **argv) {
+    if (argc != 6) {
+        fprintf(stderr, "usage: %s NODE_LOCAL NODE_FED DIM LAYER EID\n", argv[0]);
+        return 2;
+    }
+    const char *node_a = argv[1], *node_b = argv[2];
+    uint32_t dim = (uint32_t)atoi(argv[3]), layer = (uint32_t)atoi(argv[4]);
+    uint32_t eid = (uint32_t)atoi(argv[5]), rows = 3;
+    float *x = (float *)malloc((size_t)rows * dim * sizeof(float));
+    if (!x) return 2;
+    for (size_t i = 0; i < (size_t)rows * dim; i++)
+        x[i] = (float)((int)(i % 31) - 15) / 31.0f;
+
+    LmbBuf exec = {0};
+    lmb_buf_u32(&exec, layer); lmb_buf_u32(&exec, eid);
+    lmb_buf_u32(&exec, dim); lmb_buf_u32(&exec, rows);
+    uint32_t pay_len = rows * dim * (uint32_t)sizeof(float);
+    LmbMsg a = {0}, b = {0};
+    int bad = lmb_request_pay(node_a, LMB_EXEC, exec.p, (uint32_t)exec.len,
+                              x, pay_len, &a) ||
+              a.op != LMB_EXEC_R || a.pay_len != pay_len;
+    if (bad) { fprintf(stderr, "no EXEC reply from the local node\n"); return 1; }
+    bad = lmb_request_pay(node_b, LMB_EXEC, exec.p, (uint32_t)exec.len,
+                          x, pay_len, &b) ||
+          b.op != LMB_EXEC_R || b.pay_len != pay_len;
+    if (bad) { fprintf(stderr, "no EXEC reply from the swarm-fed node\n"); return 1; }
+    if (memcmp(a.pay, b.pay, pay_len)) {
+        fprintf(stderr, "swarm-fed EXEC differs from the local container's\n");
+        return 1;
+    }
+    free(exec.p); free(x); lmb_msg_free(&a); lmb_msg_free(&b);
+    puts("SWARM-FED EXEC: PASS (byte-identical to the local container)");
+    return 0;
+}


### PR DESCRIPTION
## The problem

Choosing **"chatti e doni calcolo"** (option 3) required the whole model container on the donor's disk — the menu greyed it out otherwise. That defeats the point of a swarm: the server already has the model, and a donor offering RAM+CPU had to first obtain 150+ GB by other means.

## The insight

The delivery channel existed all along. The shim (`liblumabri.so`) already mirrors — hash-verified, block by block — everything a process behind it touches; it is how every chatter gets the dense part today. It was just never put in front of an expert node.

## What changes

- **`role_start`**: when the compute role starts without a local container, the expert node is launched behind the shim with `--model` pointing into the model's **vroot**. `lmbe_open`/`lmbe_slot_load` read through the shim, so the node pulls **exactly the experts the tracker assigned it** (`--hold auto`, the least-covered slice — #55) and nothing else. `PIN=0` keeps AUTOPIN from mirroring experts it was never assigned. The chatter's cache/CAS are reused: dense blocks are shared, and the shim's cache lock is shared-for-lifetime by design.
- **`role_pick`**: option 3 is no longer greyed out without `--model-dir`; the hint becomes *"la tua fetta di esperti arriva dallo sciame"*.
- **`spawn_argv_env`**: sets the child's environment only — the chat process must never run behind its own shim.
- A **local container keeps the old path byte-for-byte**: same argv, plain `spawn_argv`, no shim.
- Weights still never cross the EXEC channel — this is the disk-donor delivery path feeding an executor, not a new wire. Ephemeral as asked: experts live in the node's RAM for the session; what persists is only the ordinary mirror cache of the slice.

## Proof

`swarm_fed_exec_test.sh` (run by `make test-swarm-fed`): a tracker+maintainer hold `tiny_olmoe`; node A reads the container from disk, node B runs behind the shim with an **empty disk** — the test asserts the vroot never materialised — and the same `EXEC` against both is **byte-identical** on two experts (layer 0 and 15):

```
SWARM-FED EXEC: PASS (byte-identical to the local container)
SWARM-FED EXEC: PASS (byte-identical to the local container)
✓ SWARM-FED DONOR: identical experts with no model on the donor's disk
```

`make check-warnings` covers the new probe; `-Werror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)