### PR TITLE
fix: donor names carry the hostname, and a held name rotates instead of dying

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,10 @@ compute donor says how many experts it can carry — `--hold auto` sizes that to
 its free RAM — and the tracker gives it the set nobody else covers. Donating
 compute does not require owning the model: picked from the menu with no local
 container, the node runs behind the swarm mirror and pulls exactly its
-assigned slice, hash-verified, so the whole model never lands on the donor. So several
+assigned slice, hash-verified, so the whole model never lands on the donor.
+Donors register under `donor-<hostname>-…` (pick one with `--donor-name`);
+a name already owned by another peer key is retried with a numbered suffix
+instead of being silently rejected forever. So several
 compute donors **split the model into disjoint slices automatically**, and one
 token's experts then run across them in parallel: more machines, faster
 tokens. (`--hold N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or

--- a/expert_node.c
+++ b/expert_node.c
@@ -488,6 +488,33 @@ static int send_ereg(int fd, const uint8_t nonce[32]) {
     return rc;
 }
 
+/* The tracker binds a name to the first peer key that registers it and
+ * refuses every other key from then on (anti-takeover). The reply is an
+ * LMB_ERR on the heartbeat connection — which this loop used to ignore, so a
+ * node whose name was already taken hammered the tracker forever, invisibly
+ * rejected. Rotate to "<name>-2", "-3", … instead: the swarm gets the
+ * donation under a free name, and the log says what happened. */
+static void ereg_name_rotate(void) {
+    static int attempt = 1;
+    char base[sizeof g.name];
+    snprintf(base, sizeof base, "%s", g.name);
+    if (attempt > 1) {                      /* strip the previous "-N" */
+        char *dash = strrchr(base, '-');
+        if (dash) *dash = 0;
+    }
+    if (attempt >= 9) {
+        fprintf(stderr, "[%s] the tracker refuses every name I try — is the "
+                        "bindings table full of stale entries?\n", g.name);
+        return;
+    }
+    attempt++;
+    char next[sizeof g.name];
+    snprintf(next, sizeof next, "%.56s-%u", base, (unsigned)attempt % 10u);
+    fprintf(stderr, "[%s] tracker: name held by another key — retrying as %s\n",
+            g.name, next);
+    snprintf(g.name, sizeof g.name, "%s", next);
+}
+
 static void *control_thread(void *arg) {
     (void)arg;
     int warned = 0;
@@ -519,6 +546,15 @@ static void *control_thread(void *arg) {
             }
             int rc = 0;
             if (m.op == LMB_REXEC_FWD) rc = handle_rexec_fwd(fd, &m);
+            else if (m.op == LMB_ERR) {
+                LmbCur ec = { m.body, m.body_len, 0 };
+                char why[128] = "";
+                if (!lmb_cur_str(&ec, why, sizeof why) && strstr(why, "held")) {
+                    ereg_name_rotate();
+                    lmb_msg_free(&m);
+                    break;              /* reconnect and register the new name */
+                }
+            }
             lmb_msg_free(&m);
             if (rc) break;
             pthread_mutex_lock(&g.identity_lk);

--- a/lumabri.c
+++ b/lumabri.c
@@ -1472,7 +1472,34 @@ static int find_engines(char *dst, size_t cap) {
  * a compute donor is an expert node, and chatters already discover it by
  * heartbeat. The role is entirely a client-side decision.
  */
-typedef struct { int disk, compute; double gb; char model_dir[1024]; } Role;
+typedef struct {
+    int disk, compute;
+    double gb;
+    char model_dir[1024];
+    char donor_name[48];        /* --donor-name; "" = auto from the hostname */
+} Role;
+
+/* Donor names used to be "donor-exec-<port>" — the same string on every
+ * machine that donates on the default port. The tracker binds a name to the
+ * first peer key that registers it (anti-takeover), so the second machine on
+ * Earth to donate was silently rejected forever. Put the hostname in the
+ * automatic name so machines stop colliding; --donor-name overrides it. */
+static void donor_base_name(const Role *r, char *out, size_t cap) {
+    if (r->donor_name[0]) { snprintf(out, cap, "%s", r->donor_name); return; }
+    char host[64] = "";
+    if (gethostname(host, sizeof host - 1)) host[0] = 0;
+    char clean[24];
+    size_t n = 0;
+    for (const char *p = host; *p && n < sizeof clean - 1; p++) {
+        char c = *p;
+        if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-')
+            clean[n++] = c;
+    }
+    clean[n] = 0;
+    if (n) snprintf(out, cap, "donor-%s", clean);
+    else   snprintf(out, cap, "donor");
+}
 
 /* free space where the donated slice would live, in GB */
 static double free_gb_at(const char *path) {
@@ -1851,9 +1878,11 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             printf("  %snon riesco ad avviare il maintainer: dono disco saltato%s\n",
                    C_DIM, C_R);
         } else {
+            char base[48];
+            donor_base_name(r, base, sizeof base);
             snprintf(portstr, sizeof portstr, "%d", port);
             snprintf(gbstr, sizeof gbstr, "%.2f", r->gb);
-            snprintf(name, sizeof name, "donor-%d", port);
+            snprintf(name, sizeof name, "%s-disk-%d", base, port);
             char *argv[20];
             int a = 0;
             argv[a++] = bin;
@@ -1937,9 +1966,10 @@ static void role_start(const Role *r, const char *tracker, const char *model,
                 if (!getenv("PIN")) envv[ne++] = (char *)"PIN=0";
                 envv[ne] = NULL;
             }
-            char portstr[16], name[64];
+            char portstr[16], name[64], base[48];
+            donor_base_name(r, base, sizeof base);
             snprintf(portstr, sizeof portstr, "%d", port);
-            snprintf(name, sizeof name, "donor-exec-%d", port);
+            snprintf(name, sizeof name, "%s-exec-%d", base, port);
             char *argv[20];
             int a = 0;
             argv[a++] = bin;
@@ -2065,6 +2095,7 @@ static int cmd_chat(int argc, char **argv) {
     const char *engine_path = NULL, *engines_dir = getenv("LUMABRI_ENGINES");
     const char *want_model = NULL, *local_dir = NULL;
     const char *role_arg = NULL, *model_dir_arg = NULL;
+    const char *donor_name_arg = NULL;
     double donate_gb = 0;
     int max_new = 256, ctx = 2048, cap_experts = 64;
     for (int i = 0; i < argc; i++) {
@@ -2079,12 +2110,13 @@ static int cmd_chat(int argc, char **argv) {
         else if (!strcmp(argv[i], "--role") && i + 1 < argc) role_arg = argv[++i];
         else if (!strcmp(argv[i], "--model-dir") && i + 1 < argc) model_dir_arg = argv[++i];
         else if (!strcmp(argv[i], "--donate") && i + 1 < argc) donate_gb = atof(argv[++i]);
+        else if (!strcmp(argv[i], "--donor-name") && i + 1 < argc) donor_name_arg = argv[++i];
         else if (!strcmp(argv[i], "--plain")) g_tty = 0;
         else { fprintf(stderr, "usage: lumabri chat [--tracker H:P] [--model NAME] "
                                "[--local DIR] [--engine BIN] [--engines-dir DIR]\n"
                                "                    [--max-new N] [--ctx N] [--cap N]\n"
                                "                    [--role chat|disk|compute|all] "
-                               "[--donate GB] [--model-dir DIR]\n");
+                               "[--donate GB] [--model-dir DIR] [--donor-name S]\n");
                return 2; }
     }
 
@@ -2208,6 +2240,8 @@ static int cmd_chat(int argc, char **argv) {
     /* the role, before the engine boots: a donor started now warms up while
      * the dense weights cross the wire, instead of after */
     Role role = {0};
+    if (donor_name_arg)
+        snprintf(role.donor_name, sizeof role.donor_name, "%s", donor_name_arg);
     if (!local_dir && role_arg) {
         char bad[40];
         if (role_unknown(role_arg, bad, sizeof bad)) {


### PR DESCRIPTION
## The bug (observed live against a real swarm)

Every machine that donates on the default port registered as the same name — `donor-exec-7701`. The tracker binds a name to the **first peer key** that registers it (anti-takeover, #18), so the second machine on Earth to donate was rejected forever. And invisibly: the tracker's `LMB_ERR` reply landed in a control loop that only handled `LMB_REXEC_FWD`, so the node hammered the tracker with doomed heartbeats while the swarm never saw its experts.

Server-side symptom (endless):
```
[tracker] REJECTED: expert donor-exec-7701 is already held by another key
```
Client-side symptom: a donor that serves nobody, "0 first-holder", and no replicas when the origin fails.

## The fix, two halves

- **lumabri** names donors `donor-<hostname>-disk|exec-<port>` (hostname sanitized to `[a-z0-9-]`), so machines stop colliding by construction. `--donor-name NAME` picks the base explicitly.
- **expert_node** now reads the EREG reply: on *"name held by another key"* it rotates to `<name>-2`, `-3`, … (bounded at 9), logs what happened, and re-registers under the free name.

## Verified live

Two nodes with different peer keys (`LUMABRI_PEER_KEY`) and the same name against one tracker:

```
[collide-exec-1] tracker: name held by another key — retrying as collide-exec-1-2
[tracker] + expert collide-exec-1-2 @ 127.0.0.1:7623 (tiny_olmoe, 128 experts)
```

`swarm_fed_exec_test.sh` still passes with the modified node; `make check-warnings` (-Werror) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)