### PR TITLE
fix: donor logs stop shouting over the reply — files + /debug instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,10 @@ compute donor says how many experts it can carry — `--hold auto` sizes that to
 its free RAM — and the tracker gives it the set nobody else covers. Donating
 compute does not require owning the model: picked from the menu with no local
 container, the node runs behind the swarm mirror and pulls exactly its
-assigned slice, hash-verified, so the whole model never lands on the donor. So several
+assigned slice, hash-verified, so the whole model never lands on the donor.
+Donors register under `donor-<hostname>-…` (pick one with `--donor-name`);
+a name already owned by another peer key is retried with a numbered suffix
+instead of being silently rejected forever. So several
 compute donors **split the model into disjoint slices automatically**, and one
 token's experts then run across them in parallel: more machines, faster
 tokens. (`--hold N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or

--- a/expert_node.c
+++ b/expert_node.c
@@ -488,6 +488,33 @@ static int send_ereg(int fd, const uint8_t nonce[32]) {
     return rc;
 }
 
+/* The tracker binds a name to the first peer key that registers it and
+ * refuses every other key from then on (anti-takeover). The reply is an
+ * LMB_ERR on the heartbeat connection — which this loop used to ignore, so a
+ * node whose name was already taken hammered the tracker forever, invisibly
+ * rejected. Rotate to "<name>-2", "-3", … instead: the swarm gets the
+ * donation under a free name, and the log says what happened. */
+static void ereg_name_rotate(void) {
+    static int attempt = 1;
+    char base[sizeof g.name];
+    snprintf(base, sizeof base, "%s", g.name);
+    if (attempt > 1) {                      /* strip the previous "-N" */
+        char *dash = strrchr(base, '-');
+        if (dash) *dash = 0;
+    }
+    if (attempt >= 9) {
+        fprintf(stderr, "[%s] the tracker refuses every name I try — is the "
+                        "bindings table full of stale entries?\n", g.name);
+        return;
+    }
+    attempt++;
+    char next[sizeof g.name];
+    snprintf(next, sizeof next, "%.56s-%u", base, (unsigned)attempt % 10u);
+    fprintf(stderr, "[%s] tracker: name held by another key — retrying as %s\n",
+            g.name, next);
+    snprintf(g.name, sizeof g.name, "%s", next);
+}
+
 static void *control_thread(void *arg) {
     (void)arg;
     int warned = 0;
@@ -519,6 +546,15 @@ static void *control_thread(void *arg) {
             }
             int rc = 0;
             if (m.op == LMB_REXEC_FWD) rc = handle_rexec_fwd(fd, &m);
+            else if (m.op == LMB_ERR) {
+                LmbCur ec = { m.body, m.body_len, 0 };
+                char why[128] = "";
+                if (!lmb_cur_str(&ec, why, sizeof why) && strstr(why, "held")) {
+                    ereg_name_rotate();
+                    lmb_msg_free(&m);
+                    break;              /* reconnect and register the new name */
+                }
+            }
             lmb_msg_free(&m);
             if (rc) break;
             pthread_mutex_lock(&g.identity_lk);

--- a/lumabri.c
+++ b/lumabri.c
@@ -154,15 +154,36 @@ static pid_t spawn_argv(char *const argv[]) {
     return pid;
 }
 
-/* spawn_argv with extra KEY=VAL entries in the child's environment only.
- * The swarm-fed expert node needs the shim wired up (LD_PRELOAD and the
- * mirror's coordinates), and none of that may leak into our own process:
- * a chat client running behind its own shim would mirror every file it
- * touches. */
-static pid_t spawn_argv_env(char *const argv[], char *const envv[]) {
+/* Donor processes used to inherit the chat's terminal, so their stats and
+ * retries printed straight into the streamed reply ("Page[donor-exec] 3114
+ * exec calls…"). Give each donor its own log file instead; /debug tails it.
+ * If the log cannot be opened the donor still runs on the terminal — a
+ * noisy donation beats a missed one. `envv` carries KEY=VAL pairs for the
+ * child's environment only: the swarm-fed expert node needs the shim wired
+ * up (LD_PRELOAD and the mirror's coordinates), and none of that may leak
+ * into our own process — a chat client running behind its own shim would
+ * mirror every file it touches. */
+static char g_donor_logs[8][1200];
+static int g_ndonor_logs = 0;
+
+static const char *donor_log_path(const char *name, char *buf, size_t cap) {
+    const char *home = getenv("HOME") ? getenv("HOME") : ".";
+    char dir[1100];
+    snprintf(dir, sizeof dir, "%s/.lumabri/logs", home);
+    mkdir_p(dir);
+    snprintf(buf, cap, "%s/%s.log", dir, name);
+    if (g_ndonor_logs < 8)
+        snprintf(g_donor_logs[g_ndonor_logs++], sizeof g_donor_logs[0], "%s", buf);
+    return buf;
+}
+
+static pid_t spawn_argv_logged(char *const argv[], char *const envv[],
+                               const char *logpath) {
     pid_t pid = fork();
     if (pid == 0) {
         for (int i = 0; envv && envv[i]; i++) putenv(envv[i]);
+        int lfd = open(logpath, O_WRONLY | O_CREAT | O_APPEND, 0644);
+        if (lfd >= 0) { dup2(lfd, 1); dup2(lfd, 2); close(lfd); }
         execv(argv[0], argv);
         perror(argv[0]);
         _exit(127);
@@ -661,6 +682,8 @@ static struct {
     volatile double local_gb;        /* already in the mirror when we started */
     volatile int    spinning;
     volatile int    booting;
+    volatile int    streaming;       /* a reply is being echoed token by token */
+    volatile int    deferred;        /* net lines swallowed while streaming */
     volatile double last_out;        /* when the child last said anything */
     char            phase[160];      /* its own words for what it is doing */
     char            tail[ETAIL][256];
@@ -725,11 +748,51 @@ static void *stderr_thread(void *arg) {
             continue;
         }
         if (strstr(line, "[lumabri]") || strstr(line, "resident weights") ||
-            strstr(line, "[chat]") || strstr(line, "[USAGE]"))
+            strstr(line, "[chat]") || strstr(line, "[USAGE]")) {
+            /* Mid-reply these lines splice themselves into the streamed text
+             * ("Page[lumabri] peer …") and a redraw can even eat the last
+             * token off the line. They are already in the tail: keep the
+             * reply clean, count them, and let /debug show them. */
+            if (g_eng.streaming) { g_eng.deferred++; continue; }
             fprintf(stderr, "%s  %s%s\n", C_DIM, line, C_R);
+        }
     }
     fclose(f);
     return NULL;
+}
+
+/* /debug: the last engine lines and each donor's log tail — everything that
+ * used to shout over the streamed reply, on demand instead. */
+static void tail_file(const char *path, int max) {
+    FILE *f = fopen(path, "r");
+    if (!f) { printf("    %s(niente ancora)%s\n", C_DIM, C_R); return; }
+    char ring[8][256];
+    int n = 0;
+    if (max > 8) max = 8;
+    char l[256];
+    while (fgets(l, sizeof l, f)) {
+        size_t k = strlen(l);
+        while (k && (l[k - 1] == '\n' || l[k - 1] == '\r')) l[--k] = 0;
+        if (!k) continue;
+        snprintf(ring[n % 8], sizeof ring[0], "%s", l);
+        n++;
+    }
+    fclose(f);
+    int show = n < max ? n : max;
+    for (int i = n - show; i < n; i++)
+        printf("    %s\xe2\x94\x82%s %s\n", C_GRAY, C_R, ring[i % 8]);
+    if (!n) printf("    %s(niente ancora)%s\n", C_DIM, C_R);
+}
+
+static void render_debug(void) {
+    printf("  %sultime righe del motore:%s\n", C_DIM, C_R);
+    tail_dump(15);
+    for (int i = 0; i < g_ndonor_logs; i++) {
+        printf("  %s%s%s\n", C_DIM, g_donor_logs[i], C_R);
+        tail_file(g_donor_logs[i], 8);
+    }
+    if (!g_ndonor_logs)
+        printf("  %snessun donatore in questa sessione%s\n", C_DIM, C_R);
 }
 
 /* one line, rewritten in place: the star, what it is doing, how far along */
@@ -1898,7 +1961,10 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             const char *pub = getenv("LUMABRI_PUBKEY");
             if (pub && pub[0]) { argv[a++] = "--pubkey"; argv[a++] = (char *)pub; }
             argv[a] = NULL;
-            { pid_t np = spawn_argv(argv); child_publish(g_nchildren++, np); }
+            { char lp[1200];
+              pid_t np = spawn_argv_logged(argv, NULL,
+                                           donor_log_path(name, lp, sizeof lp));
+              child_publish(g_nchildren++, np); }
             printf("  %s\xe2\x9c\xa6 dono %.0f GB di %s%s%s%s: il tracker mi assegna "
                    "i file piu\xcc\x80 rari%s\n",
                    C_GRN, r->gb, C_R, C_BOLD, model, C_DIM, C_R);
@@ -1981,14 +2047,17 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             argv[a++] = "--model-name"; argv[a++] = (char *)model;
             argv[a++] = "--hold";       argv[a++] = "auto";   /* the tracker hands us a disjoint slice; the node sizes it to free RAM */
             argv[a] = NULL;
-            { pid_t np = local ? spawn_argv(argv) : spawn_argv_env(argv, envv);
+            { char lp[1200];
+              pid_t np = spawn_argv_logged(argv, local ? NULL : envv,
+                                           donor_log_path(name, lp, sizeof lp));
               child_publish(g_nchildren++, np); }
             if (local)
-                printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s)%s\n",
+                printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s · "
+                       "log in ~/.lumabri/logs, /debug per vederli)%s\n",
                        C_GRN, C_R, C_DIM, node, C_R);
             else
                 printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s, "
-                       "la fetta assegnata arriva dallo sciame)%s\n",
+                       "la fetta assegnata arriva dallo sciame · /debug per i log)%s\n",
                        C_GRN, C_R, C_DIM, node, C_R);
         }
     }
@@ -2085,7 +2154,7 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
         return -1;
     }
     printf("  %s\xe2\x9c\x93 %s pronto in %.1fs%s%s · net %.0f MB · "
-           "/swarm /model /reset /quit%s\n",
+           "/swarm /model /debug /reset /quit%s\n",
            C_GRN, model, nowd() - t0, C_R, C_DIM, g_eng.net_mb, C_R);
     return 0;
 }
@@ -2301,6 +2370,7 @@ static int cmd_chat(int argc, char **argv) {
         if (!L) continue;
         if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) break;
         if (!strcmp(line, "/swarm")) { render_swarm(tracker); continue; }
+        if (!strcmp(line, "/debug")) { render_debug(); continue; }
         if (!strncmp(line, "/model", 6)) {
             const char *arg = line + 6;
             while (*arg == ' ') arg++;
@@ -2358,7 +2428,10 @@ static int cmd_chat(int argc, char **argv) {
         if (eng.proto == PROTO_SERVE2) {
             char *reply = NULL;
             printf("%s%s\xe2\x97\x86 %s%s\n  ", C_BOLD, C_CORAL, model, C_R);
-            if (stream_serve2(&eng, stat, sizeof stat, &reply)) {
+            g_eng.streaming = 1;
+            int dead = stream_serve2(&eng, stat, sizeof stat, &reply);
+            g_eng.streaming = 0;
+            if (dead) {
                 fprintf(stderr, "\n%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);
                 free(reply);
@@ -2369,7 +2442,10 @@ static int cmd_chat(int argc, char **argv) {
             free(reply);
         } else if (eng.proto == PROTO_FRAMED) {
             if (!is_reset) printf("%s%s\xe2\x97\x86 %s%s\n  ", C_BOLD, C_CORAL, model, C_R);
-            if (stream_until_end(&eng, stat, sizeof stat)) {
+            g_eng.streaming = 1;
+            int dead = stream_until_end(&eng, stat, sizeof stat);
+            g_eng.streaming = 0;
+            if (dead) {
                 fprintf(stderr, "\n%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);
                 break;
@@ -2393,6 +2469,12 @@ static int cmd_chat(int argc, char **argv) {
             printf("%s%s\xe2\x97\x86 %s%s\n", C_BOLD, C_CORAL, model, C_R);
             printf("  %s\n", text);
             free(reply);
+        }
+
+        if (g_eng.deferred) {
+            printf("  %s\xe2\x9c\xa6 %d righe di rete durante la risposta — "
+                   "/debug per vederle%s\n", C_DIM, g_eng.deferred, C_R);
+            g_eng.deferred = 0;
         }
 
         /* STAT <tokens> <tok/s> <cache hit%> <rss GB> */

--- a/lumabri.c
+++ b/lumabri.c
@@ -1472,7 +1472,34 @@ static int find_engines(char *dst, size_t cap) {
  * a compute donor is an expert node, and chatters already discover it by
  * heartbeat. The role is entirely a client-side decision.
  */
-typedef struct { int disk, compute; double gb; char model_dir[1024]; } Role;
+typedef struct {
+    int disk, compute;
+    double gb;
+    char model_dir[1024];
+    char donor_name[48];        /* --donor-name; "" = auto from the hostname */
+} Role;
+
+/* Donor names used to be "donor-exec-<port>" — the same string on every
+ * machine that donates on the default port. The tracker binds a name to the
+ * first peer key that registers it (anti-takeover), so the second machine on
+ * Earth to donate was silently rejected forever. Put the hostname in the
+ * automatic name so machines stop colliding; --donor-name overrides it. */
+static void donor_base_name(const Role *r, char *out, size_t cap) {
+    if (r->donor_name[0]) { snprintf(out, cap, "%s", r->donor_name); return; }
+    char host[64] = "";
+    if (gethostname(host, sizeof host - 1)) host[0] = 0;
+    char clean[24];
+    size_t n = 0;
+    for (const char *p = host; *p && n < sizeof clean - 1; p++) {
+        char c = *p;
+        if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-')
+            clean[n++] = c;
+    }
+    clean[n] = 0;
+    if (n) snprintf(out, cap, "donor-%s", clean);
+    else   snprintf(out, cap, "donor");
+}
 
 /* free space where the donated slice would live, in GB */
 static double free_gb_at(const char *path) {
@@ -1851,9 +1878,11 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             printf("  %snon riesco ad avviare il maintainer: dono disco saltato%s\n",
                    C_DIM, C_R);
         } else {
+            char base[48];
+            donor_base_name(r, base, sizeof base);
             snprintf(portstr, sizeof portstr, "%d", port);
             snprintf(gbstr, sizeof gbstr, "%.2f", r->gb);
-            snprintf(name, sizeof name, "donor-%d", port);
+            snprintf(name, sizeof name, "%s-disk-%d", base, port);
             char *argv[20];
             int a = 0;
             argv[a++] = bin;
@@ -1937,9 +1966,10 @@ static void role_start(const Role *r, const char *tracker, const char *model,
                 if (!getenv("PIN")) envv[ne++] = (char *)"PIN=0";
                 envv[ne] = NULL;
             }
-            char portstr[16], name[64];
+            char portstr[16], name[64], base[48];
+            donor_base_name(r, base, sizeof base);
             snprintf(portstr, sizeof portstr, "%d", port);
-            snprintf(name, sizeof name, "donor-exec-%d", port);
+            snprintf(name, sizeof name, "%s-exec-%d", base, port);
             char *argv[20];
             int a = 0;
             argv[a++] = bin;
@@ -2065,6 +2095,7 @@ static int cmd_chat(int argc, char **argv) {
     const char *engine_path = NULL, *engines_dir = getenv("LUMABRI_ENGINES");
     const char *want_model = NULL, *local_dir = NULL;
     const char *role_arg = NULL, *model_dir_arg = NULL;
+    const char *donor_name_arg = NULL;
     double donate_gb = 0;
     int max_new = 256, ctx = 2048, cap_experts = 64;
     for (int i = 0; i < argc; i++) {
@@ -2079,12 +2110,13 @@ static int cmd_chat(int argc, char **argv) {
         else if (!strcmp(argv[i], "--role") && i + 1 < argc) role_arg = argv[++i];
         else if (!strcmp(argv[i], "--model-dir") && i + 1 < argc) model_dir_arg = argv[++i];
         else if (!strcmp(argv[i], "--donate") && i + 1 < argc) donate_gb = atof(argv[++i]);
+        else if (!strcmp(argv[i], "--donor-name") && i + 1 < argc) donor_name_arg = argv[++i];
         else if (!strcmp(argv[i], "--plain")) g_tty = 0;
         else { fprintf(stderr, "usage: lumabri chat [--tracker H:P] [--model NAME] "
                                "[--local DIR] [--engine BIN] [--engines-dir DIR]\n"
                                "                    [--max-new N] [--ctx N] [--cap N]\n"
                                "                    [--role chat|disk|compute|all] "
-                               "[--donate GB] [--model-dir DIR]\n");
+                               "[--donate GB] [--model-dir DIR] [--donor-name S]\n");
                return 2; }
     }
 
@@ -2208,6 +2240,8 @@ static int cmd_chat(int argc, char **argv) {
     /* the role, before the engine boots: a donor started now warms up while
      * the dense weights cross the wire, instead of after */
     Role role = {0};
+    if (donor_name_arg)
+        snprintf(role.donor_name, sizeof role.donor_name, "%s", donor_name_arg);
     if (!local_dir && role_arg) {
         char bad[40];
         if (role_unknown(role_arg, bad, sizeof bad)) {


### PR DESCRIPTION
## The problem (seen live)

Donor processes inherited the chat's terminal, so their stats spliced themselves into the streamed reply:

```
Page[donor-exec-7701] 3114 exec calls · 1041 cold loads · 66.6% RAM hit
st[donor-exec-7701] 3159 exec calls · 1044 cold loads · 67.0% RAM hit
```

and the engine's `[lumabri]` retry lines landed mid-line too — a redraw could even eat the first token of an answer ("Ciao" → "iao").

## Three parts

- **Donor logs → files.** Every donor (maintainer and expert node) writes to `~/.lumabri/logs/<name>.log`, opened in the child between fork and exec. If the log cannot be opened the donor still runs on the terminal — a noisy donation beats a missed one.
- **`[lumabri]` lines deferred while streaming.** They stay in the engine tail ring; after the answer the chat prints one dim summary: *"N righe di rete durante la risposta — /debug per vederle"*.
- **`/debug` chat command.** Shows the engine tail and each donor log's last lines on demand. Help line now reads `/swarm /model /debug /reset /quit`.

## Note: this branch is stacked on #61

It contains #61's commit (donor naming). Merge #61 first, then this one shows only its own diff.

## Verified

`chat_proto_test.sh` passes (both stream paths flip the streaming flag); `make check-warnings` (-Werror) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)