### PR TITLE
fix: EASSIGN race — two nodes asking back-to-back received the same slice (#52)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,9 @@ test_swarm_fed: test_swarm_fed.c lumabri_proto.h
 test-swarm-fed: tracker maintainer liblumabri.so expert_node test_swarm_fed fixture
 	./swarm_fed_exec_test.sh
 
+test-assign-race: tracker
+	./assign_race_test.sh
+
 test-cas: tracker maintainer liblumabri.so test_shim
 	./cas_test.sh
 
@@ -427,5 +430,5 @@ clean:
         fixture test-phase2 \
         test-phase2-glm test-phase2-inkling test-phase2-kimi \
         test-phase2-deepseek test-engines \
-        patches patches-check test-relay-exec test-swarm-fed test-cas \
-        test-key-rotation test-hedge
+        patches patches-check test-relay-exec test-swarm-fed test-assign-race \
+        test-cas test-key-rotation test-hedge

--- a/assign_race_test.sh
+++ b/assign_race_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# The race behind #52: a node asks EASSIGN, then spends minutes loading its
+# slice before the first EREG makes the holding visible. A second node asking
+# in that window used to receive the SAME "least-covered" slice — half the
+# model assigned twice, the other half to nobody. The tracker now remembers
+# what it promised. Two back-to-back asks, no EREG in between, must come back
+# disjoint and covering; a re-ask under the first name must keep its slice.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+make -s tracker
+
+T=$(mktemp -d /tmp/lumabri-assignrace.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+
+cat > "$T/ask.c" <<'EOF'
+/* one EASSIGN, prints the picked cells (layer*nexp+expert), one per line */
+#include "lumabri_proto.h"
+int main(int argc, char **argv) {
+    if (argc != 4) return 2;                 /* TRACKER NAME CAPACITY */
+    uint32_t slots = 4, nexp = 8, cap = (uint32_t)atoi(argv[3]);
+    uint8_t routed[4] = { 1, 1, 1, 1 };
+    LmbBuf b = {0};
+    lmb_buf_str(&b, "race-model");
+    lmb_buf_str(&b, argv[2]);
+    lmb_buf_u32(&b, slots); lmb_buf_u32(&b, nexp); lmb_buf_u32(&b, cap);
+    lmb_buf_u32(&b, slots); lmb_buf_bytes(&b, routed, slots);
+    LmbMsg m = {0};
+    if (lmb_request(argv[1], LMB_EASSIGN, b.p, (uint32_t)b.len, &m) ||
+        m.op != LMB_EASSIGN_R) return 1;
+    LmbCur c = { m.body, m.body_len, 0 };
+    uint32_t n = 0;
+    if (lmb_cur_u32(&c, &n)) return 1;
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t l, e;
+        if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e)) return 1;
+        printf("%u\n", l * nexp + e);
+    }
+    return 0;
+}
+EOF
+cc -O2 -Wall -I. -pthread "$T/ask.c" -o "$T/ask"
+
+./tracker --port 7641 > "$T/tracker.log" 2>&1 & PIDS+=($!)
+for _ in $(seq 1 100); do
+    (exec 3<>/dev/tcp/127.0.0.1/7641) 2>/dev/null && { exec 3<&-; break; }
+    sleep 0.1
+done
+
+# 32 cells in all; each asks for 16, back to back, nobody EREG-registered
+"$T/ask" 127.0.0.1:7641 node-a 16 | sort > "$T/a"
+"$T/ask" 127.0.0.1:7641 node-b 16 | sort > "$T/b"
+
+na=$(wc -l < "$T/a"); nb=$(wc -l < "$T/b")
+[ "$na" -eq 16 ] && [ "$nb" -eq 16 ] || {
+    echo "✗ expected 16+16 experts, got $na+$nb"; exit 1; }
+dup=$(comm -12 "$T/a" "$T/b" | wc -l)
+[ "$dup" -eq 0 ] || {
+    echo "✗ the two slices overlap on $dup experts — the promise was forgotten"
+    exit 1; }
+tot=$(sort "$T/a" "$T/b" | uniq | wc -l)
+[ "$tot" -eq 32 ] || { echo "✗ union covers $tot of 32"; exit 1; }
+echo "✓ two back-to-back asks: disjoint halves, full cover, no EREG needed"
+
+# a re-ask mid-load keeps the promised slice — no churn, no re-download
+"$T/ask" 127.0.0.1:7641 node-a 16 | sort > "$T/a2"
+cmp -s "$T/a" "$T/a2" || { echo "✗ re-ask changed node-a's slice"; exit 1; }
+echo "✓ re-ask under the same name keeps its promised slice"
+echo "ASSIGN RACE: PASS"

--- a/tracker.c
+++ b/tracker.c
@@ -663,6 +663,57 @@ static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
     return slot;
 }
 
+/* ---- promised expert assignments -----------------------------------------
+ * An EASSIGN answer is a promise: the node spends minutes loading its slice
+ * before the first EREG heartbeat makes the holding visible. Counting only
+ * registered peers made two nodes that asked back-to-back both receive the
+ * same "least-covered" slice — half the model assigned twice, the other half
+ * to nobody (#52). Remember what was promised and count it as coverage until
+ * the EREG arrives (reality supersedes the promise) or it goes stale. All
+ * access under g_lk. */
+#define MAX_PROMISES 64
+#define PROMISE_TTL_S 1800.0
+typedef struct {
+    int used;
+    char model[64], name[64];
+    uint8_t *bits; size_t nbytes;        /* same layout as Peer.ebits */
+    double ts;
+} Promise;
+static Promise g_promise[MAX_PROMISES];
+
+static void promise_clear(const char *model, const char *name) {
+    for (int i = 0; i < MAX_PROMISES; i++)
+        if (g_promise[i].used && !strcmp(g_promise[i].model, model) &&
+            !strcmp(g_promise[i].name, name)) {
+            free(g_promise[i].bits);
+            memset(&g_promise[i], 0, sizeof g_promise[i]);
+        }
+}
+
+static void promise_store(const char *model, const char *name,
+                          const uint8_t *bits, size_t nbytes) {
+    Promise *slot = NULL;
+    for (int i = 0; i < MAX_PROMISES && !slot; i++)
+        if (g_promise[i].used && !strcmp(g_promise[i].model, model) &&
+            !strcmp(g_promise[i].name, name)) slot = &g_promise[i];
+    for (int i = 0; i < MAX_PROMISES && !slot; i++)
+        if (!g_promise[i].used) slot = &g_promise[i];
+    if (!slot) {                          /* full: the stalest promise goes */
+        slot = &g_promise[0];
+        for (int i = 1; i < MAX_PROMISES; i++)
+            if (g_promise[i].ts < slot->ts) slot = &g_promise[i];
+        free(slot->bits);
+        memset(slot, 0, sizeof *slot);
+    }
+    uint8_t *nb = (uint8_t *)realloc(slot->bits, nbytes);
+    if (!nb) return;                      /* a lost promise, not a lost donor */
+    memcpy(nb, bits, nbytes);
+    slot->bits = nb; slot->nbytes = nbytes;
+    slot->used = 1; slot->ts = now_s();
+    snprintf(slot->model, sizeof slot->model, "%s", model);
+    snprintf(slot->name, sizeof slot->name, "%s", name);
+}
+
 /* ---- EREG / EPEERS: expert nodes -----------------------------------------
  * Same shape as REGISTER: a heartbeat that names a model and an address.
  * Expert peers never enter placements (they hold no files); EPEERS is how a
@@ -771,6 +822,7 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
             uint8_t *nb = (uint8_t *)realloc(slot->ebits, bl);
             if (nb) { slot->ebits = nb; memcpy(slot->ebits, bits, bl);
                       slot->enbits = bl * 8; }
+            promise_clear(model, name);   /* the promise became a holding */
         }
     }
     pthread_mutex_unlock(&g_lk);
@@ -1044,17 +1096,43 @@ static int handle_eassign(int fd, LmbMsg *m) {
      * would have to claim it holds everything. */
     pthread_mutex_lock(&g_lk);
     double now = now_s();
+    int have_mine = 0;
     for (int i = 0; i < MAX_PEERS; i++) {
         Peer *p = &g_peers[i];
         if (!p->used || !p->is_expert || strcmp(p->model, model) || !p->ebits) continue;
         if (!strcmp(p->name, name)) {                 /* this node, as it was */
             memcpy(mine, p->ebits, ((cells + 7) / 8 < (p->enbits + 7) / 8
                                     ? (cells + 7) / 8 : (p->enbits + 7) / 8));
+            have_mine = 1;
             continue;
         }
         if (now - p->ts > g_stale_s) continue;
         for (size_t k = 0; k < cells && k < p->enbits; k++)
             if (p->ebits[k >> 3] & (1u << (k & 7))) cnt[k]++;
+    }
+    /* Slices promised to nodes still loading count as coverage too (#52),
+     * and this node's own promise is its past on a re-ask mid-load. A live
+     * EREG under the same name has already been counted above and wins. */
+    for (int i = 0; i < MAX_PROMISES; i++) {
+        Promise *pr = &g_promise[i];
+        if (!pr->used || strcmp(pr->model, model)) continue;
+        if (now - pr->ts > PROMISE_TTL_S) continue;
+        if (!strcmp(pr->name, name)) {
+            if (!have_mine) {
+                size_t nb = (cells + 7) / 8 < pr->nbytes ? (cells + 7) / 8
+                                                         : pr->nbytes;
+                memcpy(mine, pr->bits, nb);
+            }
+            continue;
+        }
+        int live = 0;
+        for (int j = 0; j < MAX_PEERS; j++)
+            if (g_peers[j].used && g_peers[j].is_expert && g_peers[j].ebits &&
+                !strcmp(g_peers[j].name, pr->name) &&
+                !strcmp(g_peers[j].model, model)) { live = 1; break; }
+        if (live) continue;
+        for (size_t k = 0; k < cells && (k >> 3) < pr->nbytes; k++)
+            if (pr->bits[k >> 3] & (1u << (k & 7))) cnt[k]++;
     }
     pthread_mutex_unlock(&g_lk);
 
@@ -1074,6 +1152,20 @@ static int handle_eassign(int fd, LmbMsg *m) {
             pick[n++] = (uint32_t)k;
             cnt[k] = 0xffff;
         }
+
+    /* remember the promise, so the NEXT asker sees this slice as covered */
+    {
+        size_t nb = (cells + 7) / 8;
+        uint8_t *pb = (uint8_t *)calloc(nb, 1);
+        if (pb) {
+            for (uint32_t i = 0; i < n; i++)
+                pb[pick[i] >> 3] |= (uint8_t)(1u << (pick[i] & 7));
+            pthread_mutex_lock(&g_lk);
+            promise_store(model, name, pb, nb);
+            pthread_mutex_unlock(&g_lk);
+            free(pb);
+        }
+    }
 
     LmbBuf b = {0};
     lmb_buf_u32(&b, n);


### PR DESCRIPTION
## The bug (reported live in #52 by @brad-evony)

Two nodes at `--hold 9728` (half of GLM's 19456 experts) both received experts 0..9727:

```
[lumabri] peer 10.0.0.26:7401: 9728 experts (9728 first-holder) · rtt 0.93 ms
[lumabri] peer 10.0.0.29:7401: 9728 experts (0 first-holder) · rtt 0.89 ms
[lumabri] 9728 of 19456 experts have no peer — running experts locally
```

Half the model assigned twice, the other half to nobody — the chatter fell back to running 9728 experts locally through the mirror.

## The race

`handle_eassign` counts replicas only over **EREG-registered** peers — but a node registers only **after** loading its slice, which takes minutes on a 190 GB half. Ask in that window and the tracker still sees zero coverage, so it hands out the same "least-covered" slice again. `assign_test.sh` never caught it because it waits for each node's heartbeat before starting the next.

## The fix

An assignment is a **promise the tracker remembers** (`g_promise`, under `g_lk`):

- promised slices count as coverage for the next asker;
- a node's own promise is its past on a re-ask mid-load — same slice back, no churn, no re-download;
- the first EREG carrying real holdings **clears** the promise (reality supersedes it);
- a promise goes stale after 30 minutes, so a node that died holding one does not block its slice forever.

## Proof

`assign_race_test.sh` reproduces the exact failure — two back-to-back EASSIGNs, **no EREG in between** — and asserts disjoint halves, full cover, and a stable re-ask:

- against the pre-fix tracker: `✗ the two slices overlap on 16 experts` (100% overlap, brad's symptom exactly)
- with the fix: `ASSIGN RACE: PASS`

`assign_test.sh` (the sequential path, including restart stability) still passes; `make check-warnings` (-Werror) clean. `make test-assign-race` runs the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)