### PR TITLE
fix: a different build is admitted and verified, not refused

### DIFF
--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -215,11 +215,12 @@ static int lumi_add_peer(const char *addr) {
             snprintf(why, sizeof why, "engine: peer='%s' vs local='%s'",
                      engine, LMBE_ENGINE_ID);
         else if (strcmp(profile, L.profile)) {
-            /* Field-aware: identity/ABI (abi/engine/src/math/f32) always gates;
-             * cc/isa gate unless LUMABRI_ALLOW_CODEGEN_SKEW (then a warning, with
-             * the spot-check as the net); omp never gates (version alone changes
-             * no bits). A blanket strcmp used to refuse two boxes for a libgomp
-             * version or a gcc point release with identical output. */
+            /* Field-aware: shape/ABI (abi/engine/f32) always gates; a build
+             * difference (src/math/cc/isa) is admitted by default with the
+             * spot-check as the net, refused under LUMABRI_STRICT=1; omp
+             * never gates (version alone changes no bits). A blanket strcmp
+             * used to refuse two boxes for a libgomp version or a gcc point
+             * release with identical output. */
             char d[192];
             int r = lmb_profile_compat(profile, L.profile,
                                        L.allow_codegen_skew, d, sizeof d);
@@ -227,7 +228,7 @@ static int lumi_add_peer(const char *addr) {
                 snprintf(why, sizeof why, "build %s", d);
             else if (r == 2)
                 fprintf(stderr, "[lumabri] peer %s: build %s — admitted "
-                        "(LUMABRI_ALLOW_CODEGEN_SKEW; spot-check %s)\n",
+                        "(spot-check %s; LUMABRI_STRICT=1 rifiuta)\n",
                         p->addr, d,
                         L.verify_pct ? "on" : "OFF — set LUMABRI_VERIFY=<pct>");
             /* r == 0: differ only in omp — compatible, admit silently */
@@ -460,11 +461,19 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
         if (L.verify_pct < 0) L.verify_pct = 0;
         if (L.verify_pct > 100) L.verify_pct = 100;
     }
-    if (getenv("LUMABRI_ALLOW_CODEGEN_SKEW")) {
+    /* Peers built from a different source, math mode, compiler or ISA are
+     * ADMITTED by default and spot-check verified: demanding byte-identical
+     * toolchains from every stranger on a swarm was the single biggest
+     * reason people bounced off. LUMABRI_STRICT=1 restores the old refusal
+     * (bit-identity lab mode); LUMABRI_ALLOW_CODEGEN_SKEW stays accepted
+     * for compatibility and is now the default. */
+    if (getenv("LUMABRI_STRICT") && atoi(getenv("LUMABRI_STRICT")) != 0) {
+        L.allow_codegen_skew = 0;
+    } else {
         L.allow_codegen_skew = 1;
-        /* A peer with a different cc/isa may round the low bits differently; the
-         * spot-check (rerun on another replica, demand agreement) is what turns
-         * that from an unchecked risk into a caught one. Default a small rate on
+        /* A skewed peer may round the low bits differently; the spot-check
+         * (rerun on another replica, demand agreement) is what turns that
+         * from an unchecked risk into a caught one. Default a small rate on
          * unless the operator set LUMABRI_VERIFY themselves. */
         if (!v && L.verify_pct == 0) L.verify_pct = 5;
     }

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -656,11 +656,23 @@ static LMB_MAYBE_UNUSED int lmb_prof_field(const char *p, const char *key,
  *    gates (two libgomp versions no longer refuse each other).
  * Returns 0 compatible, 1 incompatible (why = the differing field), 2 compatible
  * with a codegen warning (why = the field that may round differently). */
+/* Which differences refuse a peer and which admit it under verification.
+ *
+ * abi/engine/f32 stay hard: a different wire ABI, engine family or float
+ * width produces garbage-shaped activations — no verification can save that.
+ * src/math moved OUT of the hard set: a peer built from a different engine
+ * checkout (or math mode) computes the same shapes and is exactly as
+ * checkable as one built by a different compiler, and refusing it was the
+ * single biggest reason real users could not join a swarm — every machine
+ * had to hold byte-identical colibri+lumabri checkouts AND the same gcc.
+ * Now they are admitted like cc/isa: a warning, spot-check verification,
+ * and LMB strict mode (`LUMABRI_STRICT=1`) for the bit-identity purist —
+ * which restores the refusal for all five. */
 static LMB_MAYBE_UNUSED int lmb_profile_compat(const char *peer, const char *local,
                                                int allow_codegen,
                                                char *why, size_t cap) {
-    static const char *const hard[] = { "abi", "engine", "src", "math", "f32" };
-    static const char *const codegen[] = { "cc", "isa" };
+    static const char *const hard[] = { "abi", "engine", "f32" };
+    static const char *const codegen[] = { "src", "math", "cc", "isa" };
     char a[72], b[72];   /* a profile value; longest in practice is cc= (~40) */
     for (size_t i = 0; i < sizeof hard / sizeof *hard; i++) {
         lmb_prof_field(peer, hard[i], a, sizeof a);

--- a/tracker.c
+++ b/tracker.c
@@ -922,9 +922,16 @@ static int handle_ecover(int fd, LmbMsg *m) {
     pthread_mutex_lock(&g_lk);
     for (int i = 0; i < MAX_PEERS; i++) {
         Peer *q = &g_peers[i];
+        /* Relay coverage matches on shape (engine, bits, hidden, slots,
+         * experts) but no longer on the full build profile: a relayed EXEC
+         * from a peer built with another compiler or checkout is exactly as
+         * spot-checkable as a direct one, and demanding byte-identical
+         * profiles left half the swarm's coverage invisible. The chatter's
+         * own admission gate (lmb_profile_compat, hard fields only) still
+         * refuses shape-incompatible peers it talks to directly. */
         if (!q->used || !q->is_expert || q->ctrl_fd < 0 || q->evfd < 0 ||
             now - q->ts > g_stale_s || strcmp(q->model, model) ||
-            strcmp(q->engine, engine) || strcmp(q->profile, profile) ||
+            strcmp(q->engine, engine) ||
             q->bits != bits || q->hidden != hidden || q->slots != slots ||
             q->total_experts != nexp) continue;
         size_t take = (q->enbits + 7) / 8;


### PR DESCRIPTION
## The wall

The `src=` gate demanded byte-identical colibri+lumabri checkouts **and** the same compiler from every stranger on a swarm. Nobody outside this repo has that, so `incompatible manifest — build src` was the single biggest reason real users bounced off — this machine alone hit it three times in one day across colibri branch switches.

## The net

- **`lmb_profile_compat`**: hard refusal only for shape/ABI (`abi`, `engine`, `f32`) — differences no verification could save. `src` and `math` join `cc`/`isa` in the verifiable class: admitted with a warning, spot-check as the net.
- **Admission is the default**: skew tolerance starts on, with 5% spot-check verification unless `LUMABRI_VERIFY` says otherwise. `LUMABRI_ALLOW_CODEGEN_SKEW` still accepted (now redundant); **`LUMABRI_STRICT=1`** restores the full five-field refusal for bit-identity lab runs.
- **Tracker relay coverage (ECOVER)** matches on shape only (engine, bits, hidden, slots, experts), no longer on the whole build profile.

## Still refused, correctly

`phase2_test.sh`'s compatibility case passes: the fake peer's profile has no `abi` field and a wrong hidden size — shape mismatches, exactly what must stay fatal. `check-warnings` (-Werror) clean.

One less thing every user must type; one less reason to give up at the first connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)