### PR TITLE
feat: partial phase 2 — covered layers run on the swarm, the rest locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,6 +382,9 @@ test-swarm-fed: tracker maintainer liblumabri.so expert_node test_swarm_fed fixt
 test-assign-race: tracker
 	./assign_race_test.sh
 
+test-partial-phase2: tracker phase2 fixture
+	./partial_phase2_test.sh
+
 test-cas: tracker maintainer liblumabri.so test_shim
 	./cas_test.sh
 
@@ -443,5 +446,5 @@ clean:
         fixture test-phase2 \
         test-phase2-glm test-phase2-inkling test-phase2-kimi \
         test-phase2-deepseek test-engines \
-        patches patches-check test-relay-exec test-swarm-fed test-assign-race \
+        patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 \
         test-cas test-key-rotation test-hedge

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -54,6 +54,8 @@ static struct {
     int *own;                   /* [gid * LUMI_MAX_REP] → peer index, -1 = free */
     unsigned char *relay;       /* tracker tunnel covers this (slot,expert) */
     unsigned char *routed;      /* [n_layers] 1 = this slot routes to experts */
+    unsigned char *layer_ok;    /* [n_layers] 1 = every expert of it has a peer */
+    int ok_layers, routed_layers, announced_ok;
     int n_layers, n_experts, hidden;
     int expected, expected_bits;
     char expected_model[64], profile[LMB_BUILD_PROFILE_MAX];
@@ -365,36 +367,62 @@ static int lumi_relay_coverage(void) {
     return bad ? 0 : 1;
 }
 
+/* Coverage per LAYER, not per model. The engines hand a layer to the swarm
+ * through lumi_layer_on(), so a layer whose every routed expert has a live
+ * holder (or relay) can run remotely even while its neighbours run locally
+ * from the mirror. The old policy was all-or-nothing: one uncovered expert
+ * anywhere kept phase 2 dark and every donor idle — the single deepest
+ * "my expert node does nothing" in the project's history (#52's field
+ * report; a 5%-coverage donor was worth exactly zero). */
 static int lumi_missing_experts(void) {
-    int missing = 0, expected = 0;
+    int missing = 0, expected = 0, ok = 0, routed = 0;
+    if (!L.layer_ok && L.n_layers > 0)
+        L.layer_ok = (unsigned char *)calloc((size_t)L.n_layers, 1);
     for (int l = 0; l < L.n_layers; l++) {
         if (L.routed && !L.routed[l]) continue;
+        routed++;
+        int gap = 0;
         for (int e = 0; e < L.n_experts; e++) {
             expected++;
             size_t gid = (size_t)l * L.n_experts + e;
-            if (L.own[gid * LUMI_MAX_REP] < 0 && (!L.relay || !L.relay[gid])) missing++;
+            if (L.own[gid * LUMI_MAX_REP] < 0 && (!L.relay || !L.relay[gid]))
+                { missing++; gap++; }
         }
+        if (L.layer_ok) L.layer_ok[l] = (gap == 0);
+        if (!gap) ok++;
     }
     L.expected = expected;
+    L.ok_layers = ok;
+    L.routed_layers = routed;
     return missing;
 }
 
 static void lumi_enable_if_complete(void) {
-    if (L.on) return;
     int missing = lumi_missing_experts();
-    if (missing) return;
-    L.on = 1;
-    /* Tell the byte-mirror in this same process to stop reading ahead: from
-     * here on the experts run on peers, and a readahead past a dense block
-     * would pull adjacent expert weights the chatter will never execute. */
-    setenv("LUMABRI_REMOTE_EXPERTS", "1", 1);
+    L.on = L.ok_layers > 0;
+    if (!L.on || L.ok_layers == L.announced_ok) return;
+    L.announced_ok = L.ok_layers;
     int direct = 0;
     for (int i = 0; i < L.npeers; i++) if (!L.peers[i].dead) direct++;
-    fprintf(stderr, "[lumabri] phase 2 active: every expert runs on a peer, "
-                    "%d direct peer(s), %d experts, hidden=%d, %s%s\n",
-            direct, L.expected, L.hidden,
-            L.spread ? "spreading across near replicas" : "nearest replica preferred",
-            L.verify_pct ? " · spot-check verification on" : "");
+    if (!missing) {
+        /* Tell the byte-mirror in this same process to stop reading ahead:
+         * every expert runs on peers, and a readahead past a dense block
+         * would pull adjacent expert weights the chatter will never execute.
+         * Under PARTIAL coverage the mirror must keep reading ahead — the
+         * local layers still stream their experts from it. */
+        setenv("LUMABRI_REMOTE_EXPERTS", "1", 1);
+        fprintf(stderr, "[lumabri] phase 2 active: every expert runs on a peer, "
+                        "%d direct peer(s), %d experts, hidden=%d, %s%s\n",
+                direct, L.expected, L.hidden,
+                L.spread ? "spreading across near replicas" : "nearest replica preferred",
+                L.verify_pct ? " · spot-check verification on" : "");
+    } else
+        fprintf(stderr, "[lumabri] phase 2 partial: %d of %d routed layers run "
+                        "on peers (%d peer(s)); the other %d run locally from "
+                        "the mirror%s\n",
+                L.ok_layers, L.routed_layers, direct,
+                L.routed_layers - L.ok_layers,
+                L.verify_pct ? " · spot-check verification on" : "");
 }
 
 static void lumi_maybe_discover(void) {
@@ -501,17 +529,16 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
     }
 
     int missing = lumi_missing_experts();
-    if (missing) {
-        fprintf(stderr, "[lumabri] %d of %d experts have no peer — ", missing,
-                L.expected);
-        if (discovery) {
-            fprintf(stderr, "running experts locally\n");
-            return; /* layer_on keeps discovering and enables once complete */
-        }
-        fprintf(stderr, "refusing to run "
-                "(a partial explicit network would silently change the model)\n");
+    if (missing && !discovery) {
+        fprintf(stderr, "[lumabri] %d of %d experts have no peer — refusing to "
+                "run (a partial explicit network would silently change the "
+                "model)\n", missing, L.expected);
         exit(1);
     }
+    if (missing && !L.ok_layers)
+        fprintf(stderr, "[lumabri] %d of %d experts have no peer and no layer "
+                "is fully covered — running experts locally (discovery "
+                "continues)\n", missing, L.expected);
     lumi_enable_if_complete();
 }
 
@@ -525,7 +552,8 @@ static LMB_MAYBE_UNUSED void lumi_init(int n_layers, int n_experts, int hidden) 
 static LMB_MAYBE_UNUSED int lumi_layer_on(int layer) {
     lumi_maybe_discover();
     if (!L.on || layer < 0 || layer >= L.n_layers) return 0;
-    return !L.routed || L.routed[layer];
+    if (L.routed && !L.routed[layer]) return 0;
+    return !L.layer_ok || L.layer_ok[layer];
 }
 
 /* nearest live replica of (layer,eid) not yet tried this call, or -1 */

--- a/partial_phase2_test.sh
+++ b/partial_phase2_test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Partial phase 2: HALF the experts live on one peer, the other half on
+# nobody. The old policy kept phase 2 dark for one uncovered expert anywhere
+# — donors idle at 99% coverage. Now coverage gates per LAYER: covered
+# layers run on the swarm, the rest run locally from the snapshot, and the
+# generated tokens must be IDENTICAL to an all-local run. That identity is
+# the only result that matters.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ENGINE="${ENGINE:-../colibri/c}"
+MODEL="${MODEL:-$PWD/tiny_olmoe}"
+PORT="${PORT:-7651}"
+CACHE=16
+GEN="${GEN:-16}"
+
+make -s tracker expert_node olmoe_p2p ENGINE="$ENGINE"
+[ -f "$MODEL/config.json" ] || make -s fixture
+
+T=$(mktemp -d /tmp/lumabri-partial.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+wait_port() {
+    for _ in $(seq 1 300); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
+
+TOTAL=$(python3 -c "
+import json; c=json.load(open('$MODEL/config.json'))
+print(c['num_hidden_layers']*c['num_experts'])")
+HALF=$((TOTAL / 2))
+
+echo "══ A) all local — the truth"
+SNAP="$MODEL" OMP_NUM_THREADS=2 \
+    ./olmoe_p2p "$CACHE" 8 "$MODEL/ref.json" > "$T/local.out" 2>"$T/local.err" || true
+A=$(grep "^C engine" "$T/local.out" || true)
+[ -n "$A" ] || { echo "no tokens from the local run"; tail -20 "$T/local.err"; exit 1; }
+echo "  $A"
+
+echo
+echo "══ one peer holding HALF the experts ($HALF of $TOTAL, whole layers)"
+./tracker --port "$PORT" > "$T/tracker.log" 2>&1 & PIDS+=($!)
+wait_port "$PORT"
+OMP_NUM_THREADS=2 ./expert_node --model "$MODEL" --port $((PORT+1)) \
+    --tracker "127.0.0.1:$PORT" --advertise "127.0.0.1:$((PORT+1))" \
+    --model-name tiny_olmoe --name partial-0 --hold "$HALF" \
+    > "$T/node.log" 2>&1 & PIDS+=($!)
+wait_port $((PORT+1))
+for _ in $(seq 1 100); do
+    grep -q "+ expert partial-0" "$T/tracker.log" && break
+    sleep 0.2
+done
+grep -q "+ expert partial-0" "$T/tracker.log" || { echo "node never registered"; exit 1; }
+
+echo
+echo "══ B) partial swarm — covered layers remote, the rest local"
+SNAP="$MODEL" OMP_NUM_THREADS=2 \
+    LUMABRI_TRACKER="127.0.0.1:$PORT" LUMABRI_MODEL=tiny_olmoe \
+    ./olmoe_p2p "$CACHE" 8 "$MODEL/ref.json" > "$T/p2p.out" 2>"$T/p2p.err" || true
+B=$(grep "^C engine" "$T/p2p.out" || true)
+echo "  $B"
+grep -E "phase 2 partial|remote expert" "$T/p2p.err" | head -3
+
+grep -q "phase 2 partial" "$T/p2p.err" || {
+    echo "✗ partial phase 2 never engaged"; cat "$T/p2p.err" | head; exit 1; }
+grep -qE "[1-9][0-9]* remote expert calls" "$T/p2p.err" || {
+    echo "✗ no expert ever ran remotely"; exit 1; }
+if [ "$A" = "$B" ]; then
+    echo "✓ IDENTICI — metà sciame, metà locale, non un token cambiato"
+else
+    echo "✗ DIVERGENZA:"; echo "  local  : $A"; echo "  partial: $B"; exit 1
+fi

--- a/tracker.c
+++ b/tracker.c
@@ -1208,7 +1208,40 @@ static int handle_eassign(int fd, LmbMsg *m) {
             cnt[k] = 0xffff;                     /* taken: never picked twice */
         }
     }
-    /* pass 2: fill the rest with the least-replicated, rarest first */
+    /* pass 2: whole layers first, least-covered layer first. Phase 2 gates
+     * per layer — a layer fully held by donors runs on the swarm while its
+     * neighbours run locally — so completing layers is worth strictly more
+     * than scattering the same count across all of them: every completed
+     * layer removes one WAN round from every token that routes through it.
+     * A scattered 5% used to light up exactly nothing. */
+    while (n < capacity) {
+        int best = -1;
+        long best_cov = 0;
+        uint32_t best_free = 0;
+        for (uint32_t l = 0; l < slots; l++) {
+            if (!routed[l]) continue;
+            long cov = 0;
+            uint32_t fc = 0;
+            for (uint32_t e = 0; e < nexp; e++) {
+                size_t k = (size_t)l * nexp + e;
+                if (cnt[k] == 0xffff) continue;      /* already mine or picked */
+                cov += cnt[k];
+                fc++;
+            }
+            if (!fc || fc > capacity - n) continue;  /* complete, or won't fit */
+            if (best < 0 || cov < best_cov) { best = (int)l; best_cov = cov; best_free = fc; }
+        }
+        if (best < 0) break;
+        (void)best_free;
+        for (uint32_t e = 0; e < nexp && n < capacity; e++) {
+            size_t k = (size_t)best * nexp + e;
+            if (cnt[k] == 0xffff) continue;
+            pick[n++] = (uint32_t)k;
+            cnt[k] = 0xffff;
+        }
+    }
+    /* pass 3: capacity smaller than any remaining layer — the old
+     * rarest-first scattering fills what is left */
     for (uint16_t want = 0; want < 64 && n < capacity; want++)
         for (size_t k = 0; k < cells && n < capacity; k++) {
             if (!routed[k / nexp] || cnt[k] != want) continue;


### PR DESCRIPTION
## The deepest UX failure in the project

Phase 2 was **all-or-nothing**: one uncovered expert anywhere kept it dark and every donor idle. A 5%-coverage donor was worth exactly zero; "my expert node does nothing" (#52) at 50% coverage; a chatter whose server executor missed a beat at boot silently fell back to downloading 90 GB of experts it then executed alone.

## What changes

**Client** — no engine patch changes (every engine already gates per layer via `lumi_layer_on`):
- coverage tracked **per layer** (`L.layer_ok`): a layer whose every routed expert has a live holder or relay runs on the swarm; the others run locally from the mirror.
- phase 2 turns on as soon as **one** layer is covered — `phase 2 partial: X of Y routed layers` — and re-announces as discovery grows coverage. Full coverage keeps the old message and the readahead cutoff; partial keeps the mirror reading ahead for the local layers.
- explicit `LUMABRI_EXPERTS` with gaps still refuses (unchanged invariant).

**Tracker** — `EASSIGN` assigns **whole layers**, least-covered first (scattering only for sub-layer remainders). Every completed layer removes one WAN round from every token that routes through it.

## Proof

`partial_phase2_test.sh` (`make test-partial-phase2`): one peer holds HALF of tiny_olmoe — the tracker hands it **8 whole layers of 16** — the chatter reports `phase 2 partial: 8 of 16`, runs 992 expert calls remotely, the rest locally, and the tokens are **byte-identical** to an all-local run:

```
[lumabri] phase 2 partial: 8 of 16 routed layers run on peers (1 peer(s)); the other 8 run locally from the mirror
✓ IDENTICI — metà sciame, metà locale, non un token cambiato
```

Full sweep green: phase2_test.sh (full coverage + explicit-gap refusal), swarm_fed_exec_test.sh, assign_test.sh, assign_race_test.sh, chat_proto_test.sh, `check-warnings` (-Werror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)