### PR TITLE
feat: elastic hold — the share adapts to the swarm, the tracker decides

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -313,3 +313,24 @@ Il tracker, il pool/failover, il batch-union e il relay EXEC sono condivisi;
 il profilo numerico impedisce di mescolare build che potrebbero produrre float
 diversi. Le suite per motore confrontano il risultato remoto e locale byte per
 byte.
+
+## Next milestone: segment execution (the latency protocol)
+
+Per-token latency over a WAN is `n_moe_layers × RTT`: the layers are
+sequential, so 58 layers at 50 ms cannot beat ~3 s/token no matter how many
+experts are covered. The protocol that removes this — the one worth
+inventing — is segment execution:
+
+  SEG_OPEN  <model> <session>            → peer allocates KV for a layer range
+  SEG_RUN   <session> <layer a..b> <hidden state in> → <hidden state out>
+  SEG_CLOSE <session>
+
+A peer that holds a CONTIGUOUS range of layers (dense weights + experts +
+that range's KV) runs the whole block on one round trip: 58 RTTs per token
+become one per segment — two machines, two hops. Failover is a replay: the
+chatter checkpoints the running hidden state every K tokens and can rebuild
+a lost segment's KV on any replica. Bit-identity holds because the segment
+runs the same engine kernels the local path runs; the spot-check applies to
+segments exactly as it does to single experts. Layer-aligned elastic
+assignment (already shipped) is the natural donor shape for this: a donor's
+whole layers become its segment.

--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,9 @@ test-assign-race: tracker
 test-partial-phase2: tracker phase2 fixture
 	./partial_phase2_test.sh
 
+test-elastic: tracker expert_node fixture
+	./elastic_hold_test.sh
+
 test-cas: tracker maintainer liblumabri.so test_shim
 	./cas_test.sh
 
@@ -446,5 +449,5 @@ clean:
         fixture test-phase2 \
         test-phase2-glm test-phase2-inkling test-phase2-kimi \
         test-phase2-deepseek test-engines \
-        patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 \
+        patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 test-elastic \
         test-cas test-key-rotation test-hedge

--- a/elastic_hold_test.sh
+++ b/elastic_hold_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# The share adapts to the swarm. Three nodes join one after another, each
+# with capacity for EVERY expert of tiny_olmoe — so for a moment every
+# expert has three copies. The elastic rebalance must then shrink the
+# surplus: at most EASSIGN_KEEP_REPLICAS (2) copies per expert, full
+# coverage preserved, and the release decided deterministically by the
+# tracker so no two nodes ever drop the same expert at the same time.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ENGINE="${ENGINE:-../colibri/c}"
+MODEL="${MODEL:-$PWD/tiny_olmoe}"
+PORT="${PORT:-7661}"
+
+make -s tracker expert_node ENGINE="$ENGINE"
+[ -f "$MODEL/config.json" ] || make -s fixture
+
+T=$(mktemp -d /tmp/lumabri-elastic.XXXXXX)
+export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+trap cleanup EXIT
+wait_port() {
+    for _ in $(seq 1 300); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; return 0; }
+        sleep 0.1
+    done
+    return 1
+}
+
+TOTAL=$(python3 -c "
+import json; c=json.load(open('$MODEL/config.json'))
+print(c['num_hidden_layers']*c['num_experts'])")
+
+cat > "$T/ask.c" <<'EOF'
+#include "lumabri_proto.h"
+int main(int argc, char **argv) {
+    LmbMsg m = {0};
+    if (lmb_request(argv[1], LMB_EMANIFEST, NULL, 0, &m) || m.op != LMB_EMANIFEST_R)
+        return 1;
+    LmbCur c = { m.body, m.body_len, 0 };
+    uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0, n = 0;
+    uint8_t root[32], sig[64];
+    char engine[64], profile[LMB_BUILD_PROFILE_MAX], model[64];
+    if (lmb_cur_u32(&c, &magic) || magic != LMB_EXPERT_MANIFEST_MAGIC ||
+        lmb_cur_str(&c, engine, sizeof engine) ||
+        lmb_cur_str(&c, profile, sizeof profile) ||
+        lmb_cur_str(&c, model, sizeof model) ||
+        lmb_cur_u32(&c, &bits) || lmb_cur_u32(&c, &have_id) || have_id > 1)
+        return 2;
+    if (have_id && (lmb_cur_bytes(&c, root, sizeof root) ||
+                    lmb_cur_u32(&c, &has_sig) || has_sig > 1 ||
+                    (has_sig && lmb_cur_bytes(&c, sig, sizeof sig))))
+        return 2;
+    if (lmb_cur_u32(&c, &n)) return 2;
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t l, e;
+        if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e)) return 2;
+        printf("%u:%u\n", l, e);
+    }
+    return 0;
+}
+EOF
+cc -O2 -w -I. "$T/ask.c" -o "$T/ask" -lpthread
+
+./tracker --port "$PORT" > "$T/tracker.log" 2>&1 & PIDS+=($!)
+wait_port "$PORT"
+
+echo "· 3 nodi, ognuno con capacità per TUTTI i $TOTAL esperti (surplus voluto)"
+for i in 0 1 2; do
+    p=$((PORT + 10 + i))
+    OMP_NUM_THREADS=1 LUMABRI_REBALANCE_S=10 \
+    ./expert_node --model "$MODEL" --port "$p" --tracker "127.0.0.1:$PORT" \
+        --advertise "127.0.0.1:$p" --model-name tiny_olmoe --name "el-$i" \
+        --hold "$TOTAL" --cache 16 > "$T/n$i.log" 2>&1 & PIDS+=($!)
+    wait_port "$p"
+    for _ in $(seq 1 100); do
+        grep -q "+ expert el-$i" "$T/tracker.log" && break; sleep 0.2
+    done
+done
+for i in 0 1 2; do "$T/ask" "127.0.0.1:$((PORT+10+i))" | sort > "$T/before$i"; done
+B=$(cat "$T/before0" "$T/before1" "$T/before2" | wc -l)
+echo "  repliche totali all'ingresso: $B"
+
+echo "· aspetto i giri di rebalance (LUMABRI_REBALANCE_S=10)…"
+for _ in $(seq 1 12); do
+    sleep 5
+    for i in 0 1 2; do "$T/ask" "127.0.0.1:$((PORT+10+i))" | sort > "$T/after$i"; done
+    A=$(cat "$T/after0" "$T/after1" "$T/after2" | wc -l)
+    [ "$A" -le $((2 * TOTAL)) ] && break
+done
+
+A=$(cat "$T/after0" "$T/after1" "$T/after2" | wc -l)
+COVER=$(cat "$T/after0" "$T/after1" "$T/after2" | sort -u | wc -l)
+OVER=$(cat "$T/after0" "$T/after1" "$T/after2" | sort | uniq -c | awk '$1>2' | wc -l)
+for i in 0 1 2; do printf "  el-%d: %s esperti\n" "$i" "$(wc -l < "$T/after$i")"; done
+echo "  repliche totali dopo: $A (tetto $((2*TOTAL))) · copertura $COVER/$TOTAL · celle oltre 2 repliche: $OVER"
+
+[ "$A" -lt "$B" ]            || { echo "✗ il surplus non si è mai sgonfiato"; exit 1; }
+[ "$A" -le $((2 * TOTAL)) ]  || { echo "✗ più di 2 repliche di diritto per esperto"; exit 1; }
+[ "$COVER" -eq "$TOTAL" ]    || { echo "✗ il rilascio ha aperto buchi di copertura"; exit 1; }
+[ "$OVER" -eq 0 ]            || { echo "✗ $OVER celle ancora sopra le 2 repliche"; exit 1; }
+grep -h "rebalance:" "$T"/n*.log | head -3
+echo "✓ ELASTICO — il surplus si è sgonfiato, la copertura è rimasta intera"

--- a/expert_node.c
+++ b/expert_node.c
@@ -120,6 +120,7 @@ static struct {
     pthread_cond_t c_cv;
     pthread_mutex_t load_lk;    /* the engine loader is used one call at a time */
     char name[64], model[64], advertise[64], tracker[64];
+    int want_hold;              /* auto/numeric --hold capacity; 0 = no EASSIGN */
     char token[LMB_TOKEN_MAX + 1];
     char profile[LMB_BUILD_PROFILE_MAX];
     uint8_t peer_sk[64], peer_pk[32];   /* identity to the tracker */
@@ -455,6 +456,93 @@ static void *conn_thread(void *arg) {
     }
     close(fd);
     lmb_conn_gate_leave(&g_conn_gate);
+    return NULL;
+}
+
+/* Ask the tracker which experts to hold (capacity `hold`); returns a
+ * malloc'd [n_slots*n_experts] bitmap, or NULL when the tracker is old,
+ * unreachable, or the reply is malformed. Shared by the startup assignment
+ * and the elastic rebalance below. */
+static uint8_t *eassign_request(int hold) {
+    size_t cells = (size_t)g.n_slots * g.n_experts;
+    LmbBuf b = {0};
+    lmb_buf_str(&b, g.model);
+    lmb_buf_str(&b, g.name);          /* so the tracker can recognise us */
+    lmb_buf_u32(&b, (uint32_t)g.n_slots);
+    lmb_buf_u32(&b, (uint32_t)g.n_experts);
+    lmb_buf_u32(&b, (uint32_t)hold);
+    uint8_t *routed = (uint8_t *)calloc((size_t)g.n_slots, 1);
+    if (!routed) { free(b.p); return NULL; }
+    for (int l = 0; l < g.n_slots; l++) routed[l] = lmbe_routed(l) ? 1 : 0;
+    lmb_buf_u32(&b, (uint32_t)g.n_slots);
+    lmb_buf_bytes(&b, routed, (size_t)g.n_slots);
+    free(routed);
+    LmbMsg r = {0};
+    int rc = lmb_request(g.tracker, LMB_EASSIGN, b.p, (uint32_t)b.len, &r);
+    free(b.p);
+    if (rc || r.op != LMB_EASSIGN_R) {
+        fprintf(stderr, "[%s] the tracker did not assign experts "
+                        "(older tracker?) — keeping what --layers/--stride "
+                        "chose\n", g.name);
+        lmb_msg_free(&r);
+        return NULL;
+    }
+    LmbCur c = { r.body, r.body_len, 0 };
+    uint32_t n = 0;
+    uint8_t *assigned = (uint8_t *)calloc(cells ? cells : 1, 1);
+    int bad = !assigned || lmb_cur_u32(&c, &n) || n > (uint32_t)hold ||
+              (size_t)n > cells || r.pay_len != 0;
+    for (uint32_t i = 0; !bad && i < n; i++) {
+        uint32_t l, e;
+        if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e) ||
+            !expert_index_ok(l, e) || !lmbe_routed((int)l)) { bad = 1; break; }
+        assigned[(size_t)l * (size_t)g.n_experts + e] = 1;
+    }
+    if (!bad && c.off != c.len) bad = 1;
+    lmb_msg_free(&r);
+    if (bad) {
+        fprintf(stderr, "[%s] tracker returned an invalid expert assignment — "
+                        "keeping the local selection\n", g.name);
+        free(assigned);
+        return NULL;
+    }
+    return assigned;
+}
+
+/* ---- elastic hold ---------------------------------------------------------
+ * The share adapts to the swarm. Every LUMABRI_REBALANCE_S the node re-asks
+ * the tracker; the tracker keeps at most a fixed number of ranked replicas
+ * per expert, so as donors join, the surplus copies are released and the
+ * freed capacity refills with whatever the swarm still lacks. Dropping is a
+ * bitmap clear (a stale chatter gets a refusal and refetches the manifest,
+ * exactly as if the node had restarted); loading is lazy — the cache pulls
+ * a newly-held expert on its first call. Only meaningful in cache mode,
+ * which --hold auto always sets. */
+static void *rebalance_thread(void *arg) {
+    (void)arg;
+    long period = 600;
+    const char *e = getenv("LUMABRI_REBALANCE_S");
+    if (e && atol(e) >= 10) period = atol(e);
+    size_t cells = (size_t)g.n_slots * g.n_experts;
+    for (;;) {
+        sleep((unsigned)period);
+        uint8_t *want = eassign_request(g.want_hold);
+        if (!want) continue;
+        int add = 0, drop = 0, total = 0;
+        for (size_t k = 0; k < cells; k++) {
+            if (want[k] && !g.holds[k]) add++;
+            if (!want[k] && g.holds[k]) drop++;
+            total += want[k] ? 1 : 0;
+        }
+        if (add || drop) {
+            memcpy(g.holds, want, cells);   /* byte stores; exec reads bytes */
+            g.nholds = total;
+            printf("[%s] rebalance: +%d \xe2\x88\x92%d experts (now %d) — the "
+                   "swarm changed shape\n", g.name, add, drop, total);
+            fflush(stdout);
+        }
+        free(want);
+    }
     return NULL;
 }
 
@@ -850,52 +938,19 @@ int main(int argc, char **argv) {
         lmb_buf_str(&b, g.model);
         lmb_buf_str(&b, g.name);          /* so the tracker can recognise us */
         lmb_buf_u32(&b, (uint32_t)g.n_slots);
-        lmb_buf_u32(&b, (uint32_t)g.n_experts);
-        lmb_buf_u32(&b, (uint32_t)hold);
-        uint8_t *routed = (uint8_t *)calloc((size_t)g.n_slots, 1);
-        for (int l = 0; l < g.n_slots; l++) routed[l] = lmbe_routed(l) ? 1 : 0;
-        lmb_buf_u32(&b, (uint32_t)g.n_slots);
-        lmb_buf_bytes(&b, routed, (size_t)g.n_slots);
-        free(routed);
+        uint8_t *assigned = eassign_request(hold);
         (void)cells;
-        LmbMsg r = {0};
-        int rc = lmb_request(g.tracker, LMB_EASSIGN, b.p, (uint32_t)b.len, &r);
-        free(b.p);
-        if (rc || r.op != LMB_EASSIGN_R) {
-            fprintf(stderr, "[%s] the tracker did not assign experts "
-                            "(older tracker?) — keeping what --layers/--stride "
-                            "chose\n", g.name);
-            lmb_msg_free(&r);
-        } else {
-            LmbCur c = { r.body, r.body_len, 0 };
-            uint32_t n = 0;
-            uint8_t *assigned = (uint8_t *)calloc(cells ? cells : 1, 1);
-            int assigned_n = 0, bad = !assigned || lmb_cur_u32(&c, &n) ||
-                                         n > (uint32_t)hold ||
-                                         (size_t)n > cells || r.pay_len != 0;
-            for (uint32_t i = 0; !bad && i < n; i++) {
-                uint32_t l, e;
-                if (lmb_cur_u32(&c, &l) || lmb_cur_u32(&c, &e) ||
-                    !expert_index_ok(l, e) || !lmbe_routed((int)l)) {
-                    bad = 1; break;
-                }
-                size_t gid = (size_t)l * (size_t)g.n_experts + e;
-                if (!assigned[gid]) { assigned[gid] = 1; assigned_n++; }
-            }
-            if (!bad && c.off != c.len) bad = 1;
-            if (bad) {
-                fprintf(stderr, "[%s] tracker returned an invalid expert assignment — "
-                                "keeping the local selection\n", g.name);
-            } else {
-                memcpy(g.holds, assigned, cells);
-                g.nholds = assigned_n;
-                printf("[%s] the tracker assigned %d experts (asked for %d): "
-                       "the least replicated of %s\n",
-                       g.name, g.nholds, hold, g.model);
-            }
+        if (assigned) {
+            int assigned_n = 0;
+            for (size_t k = 0; k < cells; k++) assigned_n += assigned[k] ? 1 : 0;
+            memcpy(g.holds, assigned, cells);
+            g.nholds = assigned_n;
             free(assigned);
-            lmb_msg_free(&r);
+            printf("[%s] the tracker assigned %d experts (asked for %d): "
+                   "the least replicated of %s\n",
+                   g.name, g.nholds, hold, g.model);
         }
+        g.want_hold = hold;             /* the rebalance thread re-asks with this */
     }
     if (!g.nholds) { fprintf(stderr, "[%s] no experts selected\n", g.name); return 1; }
     if (dense)
@@ -970,6 +1025,10 @@ int main(int argc, char **argv) {
     lmb_conn_gate_init(&g_conn_gate);
     if (lmb_secure_init()) return 1;
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }
+    if (g.tracker[0] && g.want_hold > 0 && g.ncs > 0) {
+        pthread_create(&t, NULL, rebalance_thread, NULL);
+        pthread_detach(t);
+    }
     pthread_create(&t, NULL, stats_thread, NULL); pthread_detach(t);
 
     for (;;) {

--- a/tracker.c
+++ b/tracker.c
@@ -1157,6 +1157,16 @@ static int handle_eassign(int fd, LmbMsg *m) {
      * different slice. The tracker is the memory here — the node sends
      * nothing about its past, because on a fresh start it has no past and
      * would have to claim it holds everything. */
+    /* Deterministic replica rank, for the elastic release below: among the
+     * holders of one expert, order by a hash of the NAME mixed with the cell, so the surplus spreads across nodes instead of electing one loser. Only the tracker
+     * computes it, so two nodes can never disagree about who is surplus —
+     * the failure mode where every replica politely releases the same cell
+     * at the same time and coverage drops to zero. */
+    uint64_t myh = 1469598103934665603ull;
+    for (const char *s = name; *s; s++) { myh ^= (uint8_t)*s; myh *= 1099511628211ull; }
+    uint8_t *lower = (uint8_t *)calloc(cells, 1);   /* higher-rank holders */
+    if (!lower) { free(cnt); free(pick); free(mine); send_err(fd, "oom"); return -1; }
+
     pthread_mutex_lock(&g_lk);
     double now = now_s();
     int have_mine = 0;
@@ -1170,8 +1180,14 @@ static int handle_eassign(int fd, LmbMsg *m) {
             continue;
         }
         if (now - p->ts > g_stale_s) continue;
+        uint64_t ph = 1469598103934665603ull;
+        for (const char *s = p->name; *s; s++) { ph ^= (uint8_t)*s; ph *= 1099511628211ull; }
         for (size_t k = 0; k < cells && k < p->enbits; k++)
-            if (p->ebits[k >> 3] & (1u << (k & 7))) cnt[k]++;
+            if (p->ebits[k >> 3] & (1u << (k & 7))) {
+                cnt[k]++;
+                uint64_t mix = (uint64_t)k * 0x9E3779B97F4A7C15ull;
+                if ((ph ^ mix) < (myh ^ mix) && lower[k] < 255) lower[k]++;
+            }
     }
     /* Slices promised to nodes still loading count as coverage too (#52),
      * and this node's own promise is its past on a re-ask mid-load. A live
@@ -1194,16 +1210,33 @@ static int handle_eassign(int fd, LmbMsg *m) {
                 !strcmp(g_peers[j].name, pr->name) &&
                 !strcmp(g_peers[j].model, model)) { live = 1; break; }
         if (live) continue;
+        uint64_t ph = 1469598103934665603ull;
+        for (const char *s = pr->name; *s; s++) { ph ^= (uint8_t)*s; ph *= 1099511628211ull; }
         for (size_t k = 0; k < cells && (k >> 3) < pr->nbytes; k++)
-            if (pr->bits[k >> 3] & (1u << (k & 7))) cnt[k]++;
+            if (pr->bits[k >> 3] & (1u << (k & 7))) {
+                cnt[k]++;
+                uint64_t mix = (uint64_t)k * 0x9E3779B97F4A7C15ull;
+                if ((ph ^ mix) < (myh ^ mix) && lower[k] < 255) lower[k]++;
+            }
     }
     pthread_mutex_unlock(&g_lk);
 
-    /* pass 1: keep what it already had — no churn, no re-download */
+    /* pass 1: keep what it already had — no churn, no re-download — UNLESS
+     * the expert is a surplus copy: this node ranks at or below the keep
+     * limit among its holders. Releasing it is what makes the share elastic:
+     * as donors join, over-replicated experts are let go and the freed
+     * capacity refills with what the swarm still lacks. Released cells are
+     * marked unpickable for THIS reply, or pass 2 would hand them straight
+     * back and nothing would ever shrink. */
+    #define EASSIGN_KEEP_REPLICAS 2
     uint32_t n = 0;
     for (size_t k = 0; k < cells && n < capacity; k++) {
         if (!routed[k / nexp]) continue;
         if (mine[k >> 3] & (1u << (k & 7))) {
+            if (lower[k] >= EASSIGN_KEEP_REPLICAS) {
+                cnt[k] = 0xfffe;                 /* released: not pickable now */
+                continue;
+            }
             pick[n++] = (uint32_t)k;
             cnt[k] = 0xffff;                     /* taken: never picked twice */
         }
@@ -1224,7 +1257,7 @@ static int handle_eassign(int fd, LmbMsg *m) {
             uint32_t fc = 0;
             for (uint32_t e = 0; e < nexp; e++) {
                 size_t k = (size_t)l * nexp + e;
-                if (cnt[k] == 0xffff) continue;      /* already mine or picked */
+                if (cnt[k] >= 0xfffe) continue;      /* mine, picked or released */
                 cov += cnt[k];
                 fc++;
             }
@@ -1235,7 +1268,7 @@ static int handle_eassign(int fd, LmbMsg *m) {
         (void)best_free;
         for (uint32_t e = 0; e < nexp && n < capacity; e++) {
             size_t k = (size_t)best * nexp + e;
-            if (cnt[k] == 0xffff) continue;
+            if (cnt[k] >= 0xfffe) continue;
             pick[n++] = (uint32_t)k;
             cnt[k] = 0xffff;
         }
@@ -1269,7 +1302,7 @@ static int handle_eassign(int fd, LmbMsg *m) {
         lmb_buf_u32(&b, pick[i] / nexp);
         lmb_buf_u32(&b, pick[i] % nexp);
     }
-    free(cnt); free(pick); free(mine);
+    free(cnt); free(pick); free(mine); free(lower);
     int rc = lmb_send(fd, LMB_EASSIGN_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     printf("[tracker] assign: %u experts of %s to an executor "


### PR DESCRIPTION
## "Piano piano che i peer aumentano la mia parte diminuisce"

Every `LUMABRI_REBALANCE_S` (default 600 s) a donor **re-asks** the tracker for its slice. The tracker keeps at most **2 rightful copies per expert** (`EASSIGN_KEEP_REPLICAS`), ranked by a name-hash **mixed per cell**:

- **deterministic and tracker-side** — two nodes can never politely release the same expert at the same moment and open a coverage hole;
- **per-cell mixing** — the surplus spreads across nodes instead of electing one loser;
- released cells are unpickable within the same reply, or pass 2 would hand them straight back.

Dropping is a bitmap clear (a stale chatter gets a refusal and refetches the manifest, as if the node restarted); acquiring is lazy — cache mode loads a newly-held expert on its first call. The **server's whole-model executor never rebalances**: it is the replica of last resort — it executes everything on day zero and simply stops *winning* calls as nearer donors appear.

## Proof (`make test-elastic`)

Three nodes, each with capacity for **all 128** experts of tiny_olmoe — 384 replicas at entry:

```
repliche totali dopo: 256 (tetto 256) · copertura 128/128 · celle oltre 2 repliche: 0
[el-0] rebalance: +0 −32 experts (now 96) — the swarm changed shape
[el-1] rebalance: +0 −30 experts (now 98) — the swarm changed shape
[el-2] rebalance: +0 −66 experts (now 62) — the swarm changed shape
```

Full sweep green: phase2, partial-phase2, assign, assign-race, swarm-fed, chat-proto, `check-warnings` (-Werror).

DESIGN.md gains the next milestone: **segment execution** (`SEG_OPEN/RUN/CLOSE`) — the protocol that turns 58 RTTs per token into one per segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)