### PR TITLE
feat(segment): discover fenced routes via tracker

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -314,7 +314,7 @@ il profilo numerico impedisce di mescolare build che potrebbero produrre float
 diversi. Le suite per motore confrontano il risultato remoto e locale byte per
 byte.
 
-## Next milestone: segment execution (the latency protocol)
+## Segment execution (the latency protocol)
 
 Per-token latency over a WAN is `n_moe_layers × RTT`: the layers are
 sequential, so 58 layers at 50 ms cannot beat ~3 s/token no matter how many
@@ -334,3 +334,12 @@ runs the same engine kernels the local path runs; the spot-check applies to
 segments exactly as it does to single experts. Layer-aligned elastic
 assignment (already shipped) is the natural donor shape for this: a donor's
 whole layers become its segment.
+
+The model-neutral Segment v2 session protocol and tracker discovery are now
+present. A peer can publish one layer-aligned range with its opaque Colibri
+state schema, numeric class, backend, residency and capacity; a chatter gets a
+generation-fenced compatible chain with replicas from an asynchronous control
+thread. What remains before enabling it in `lumabri chat` is the production
+executor/adapter dispatch and then snapshot plus replay failover. Until those
+land, the CLI does not advertise Segment capability and a normal Colibri or
+Lumabri release follows the existing local/Expert paths unchanged.

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all: tracker maintainer liblumabri.so test_shim lumabri
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
+		test_segment_discovery \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -345,8 +346,11 @@ test-engines: test-phase2 test-phase2-glm test-phase2-inkling test-phase2-kimi
 	    echo "   it has no synthetic fixture — MODEL=<dir> make test-engines"; \
 	fi
 
-tracker: tracker.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
-	$(CC) $(CFLAGS) -pthread tracker.c -o $@
+tracker: tracker.c lumabri_segment_discovery.c lumabri_segment_discovery.h \
+		 lumabri_segment.c lumabri_segment.h lumabri_proto.h lumabri_sha.h \
+		 lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread tracker.c lumabri_segment_discovery.c \
+		lumabri_segment.c -o $@
 
 maintainer: maintainer.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread maintainer.c -o $@
@@ -374,6 +378,12 @@ test_verify_failover: test_verify_failover.c lumabri_client.h lumabri_proto.h lu
 test_segment_v2: test_segment_v2.c lumabri_segment.c lumabri_segment.h \
 		 lumabri_proto.h lumabri_sha.h
 	$(CC) $(CFLAGS) -pthread test_segment_v2.c lumabri_segment.c -o $@
+
+test_segment_discovery: test_segment_discovery.c lumabri_segment_discovery.c \
+		lumabri_segment_discovery.h lumabri_segment.c lumabri_segment.h \
+		lumabri_proto.h lumabri_sign.h lumabri_sha.h
+	$(CC) $(CFLAGS) -pthread test_segment_discovery.c \
+		lumabri_segment_discovery.c lumabri_segment.c -o $@
 
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh
@@ -405,7 +415,11 @@ test-hedge: test_hedge
 test-segment-v2: test_segment_v2
 	./test_segment_v2
 
-test: all test_key_rotation test_hedge test_verify_failover test_segment_v2
+test-segment-discovery: tracker test_segment_discovery
+	./segment_discovery_test.sh
+
+test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
+		test_segment_discovery
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -426,6 +440,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2
 	./test_key_rotation
 	./test_hedge
 	./test_segment_v2
+	./segment_discovery_test.sh
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)
@@ -448,7 +463,7 @@ install: all
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
-	      test_verify_failover test_segment_v2 \
+	      test_verify_failover test_segment_v2 test_segment_discovery \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	      expert_node_deepseek
@@ -459,4 +474,5 @@ clean:
         test-phase2-glm test-phase2-inkling test-phase2-kimi \
         test-phase2-deepseek test-engines \
         patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 test-elastic \
-        test-cas test-key-rotation test-hedge test-segment-v2
+        test-cas test-key-rotation test-hedge test-segment-v2 \
+        test-segment-discovery

--- a/README.md
+++ b/README.md
@@ -269,7 +269,10 @@ Per-engine expert identity runs with fixtures
 (`make test-phase2-deepseek MODEL=<dir>`). Assignment, concurrency and signing
 have their own scripts (`assign_test.sh`, `concurrency_test.sh`,
 `sign_test.sh`). The newer mechanisms have focused targets:
-`make test-cas test-key-rotation test-hedge test-relay-exec`. Relay EXEC needs
+`make test-cas test-key-rotation test-hedge test-relay-exec` and
+`make test-segment-v2 test-segment-discovery`. Segment discovery runs six tiny state
+families through a real tracker and checks leases, route generations, replicas,
+draining, compatibility and the asynchronous snapshot. Relay EXEC needs
 an OLMoE engine source under `ENGINE`; its script reports `SKIP` explicitly
 when that external checkout is absent. Every claim in this README has a script
 behind it.

--- a/SEGMENT_V2.md
+++ b/SEGMENT_V2.md
@@ -1,15 +1,47 @@
 # Segment protocol v2
 
-Segment v2 is Lumibri's model-neutral state and ownership protocol for running
+Segment v2 is Lumabri's model-neutral state and ownership protocol for running
 a contiguous range of transformer layers on a peer. It does not encode a
 particular model's KV layout. Colibri owns the model math, weights, accelerator
-and opaque state; Lumibri owns transport, session identity, ordering, leases,
+and opaque state; Lumabri owns transport, session identity, ordering, leases,
 fencing and route lifecycle.
 
-This change defines the wire and session contract only. No production binary
-dispatches the new opcodes and no model is advertised as Segment-capable yet.
+The wire/session contract and tracker discovery control plane are implemented.
+No production executor dispatches inference opcodes and no model is advertised
+by the normal CLI as Segment-capable yet: registration is available to the
+upcoming executor, while route discovery is kept out of the inference path.
 Public activation is gated on GLM, Inkling, Kimi K3, Qwen3.6, OLMoE and
 DeepSeek V4 all passing the same conformance suite.
+
+## Tracker discovery
+
+A signed `SEG_REGISTER` heartbeat advertises a half-open layer range together
+with model/tokenizer roots, engine, state schema, numeric class, dtype/width,
+backend capability, resident RAM/VRAM, session capacity, queue, inflight and
+draining state. Expert and Segment advertisements may share one compute name,
+key and control connection, but retain independent addresses and liveness.
+
+`SEG_ROUTES` asks for one exact model/schema/numeric class and a requested
+layer interval. The tracker returns every compatible live range and replica,
+plus:
+
+- a random lease ID and monotonic fencing epoch per executor;
+- a monotonic route generation for the complete placement;
+- data-plane transport capability (`DIRECT` today; `RELAY` remains reserved
+  until Segment forwarding is implemented rather than inferred from SREG);
+- whether the returned interval union covers the requested chain.
+
+Telemetry-only heartbeats do not churn leases or route generations. A range,
+compatibility, address, capability or draining change does; stale/recovered
+registrations do as well. Draining peers remain known but are excluded from
+new placements. The tracker reserves a durable generation epoch beside its
+peer-binding database, so a restart cannot make a cached generation current
+again or move either monotonic fencing value backwards.
+
+`LmbSegDiscovery` polls this control plane on a dedicated thread and publishes
+a fixed-size immutable `LmbSegRouteSnapshot`. The inference thread copies that
+snapshot; it never asks the tracker. A session binds the selected generation
+at `SEG_OPEN`, so later discovery does not silently move a running chat.
 
 ## Wire operations
 
@@ -109,7 +141,8 @@ fencing are both required during a network partition.
 
 ## Conformance coverage
 
-`test_segment_v2.c` runs the same codec against representative tiny schemas
+`test_segment_v2.c` and `test_segment_discovery.c` run the same contracts
+against representative tiny schemas
 for:
 
 - standard KV;
@@ -119,7 +152,10 @@ for:
 - DeltaNet plus convolution ring state;
 - mHC/compressed-attention/compressor/indexer state.
 
-It also covers truncation, version skew, overflow and shape bounds, two-chat
+They also cover truncation, version skew, overflow and shape bounds, two-chat
 isolation, quota, duplicate and conflicting requests, abort, out-of-order
 execution, fence, restore, stale owners, snapshot checks, close and TTL reap.
-These are protocol fixtures, not claims that the model adapters are complete.
+The real-tracker discovery gate additionally covers signed registration,
+compatibility filtering, replicas, complete chains, telemetry stability,
+draining, lease rotation and asynchronous snapshots. These are protocol and
+control-plane fixtures, not a claim that the network executors are complete.

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -219,6 +219,14 @@ enum {
     LMB_SEG_RESTORE = 45, LMB_SEG_RESTORE_R = 46,
     LMB_SEG_CLOSE = 47, LMB_SEG_CLOSE_R = 48,
     LMB_SEG_HEALTH = 49, LMB_SEG_HEALTH_R = 50,
+
+    /* Segment control plane. SREG is the signed, persistent heartbeat of a
+     * range-native executor; its reply assigns the lease/fencing owner.
+     * SEG_ROUTES is a model/schema/numeric compatibility query and returns a
+     * generation-fenced immutable placement snapshot. Neither opcode is used
+     * from the per-token or per-layer inference path. */
+    LMB_SEG_REGISTER = 51, LMB_SEG_REGISTER_R = 52,
+    LMB_SEG_ROUTES = 53, LMB_SEG_ROUTES_R = 54,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -298,6 +306,7 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
     case LMB_EPEERS_R:
     case LMB_EMANIFEST_R:
     case LMB_EASSIGN_R:
+    case LMB_SEG_ROUTES_R:
         *body_cap = LMB_MAX_CONTROL_BODY;
         break;
     case LMB_PLACEMENT_R:

--- a/lumabri_segment.h
+++ b/lumabri_segment.h
@@ -1,7 +1,7 @@
 /* lumabri_segment.h — model-neutral Segment v2 wire and session contract.
  *
  * This layer knows nothing about KV, MLA, recurrent or convolutional state.
- * Colibri adapters own those bytes. Lumibri owns the session identity,
+ * Colibri adapters own those bytes. Lumabri owns the session identity,
  * ordering, lease, fencing epoch, route generation and bounded wire shapes.
  */
 #ifndef LUMABRI_SEGMENT_H

--- a/lumabri_segment_discovery.c
+++ b/lumabri_segment_discovery.c
@@ -1,0 +1,461 @@
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include "lumabri_segment_discovery.h"
+
+#include "lumabri_proto.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct { const uint8_t *p; size_t len, off; } DiscCur;
+
+static uint64_t disc_now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+static int disc_str_valid(const char *s, size_t cap) {
+    const char *end = s ? (const char *)memchr(s, '\0', cap) : NULL;
+    return end && end != s;
+}
+
+static int disc_root_valid(const uint8_t root[LMB_SEG_ROOT_BYTES]) {
+    unsigned any = 0;
+    for (size_t i = 0; i < LMB_SEG_ROOT_BYTES; i++) any |= root[i];
+    return any != 0;
+}
+
+static int disc_backend_valid(uint64_t caps) {
+    const uint64_t backends = LMB_SEG_CAP_CPU | LMB_SEG_CAP_CUDA |
+                              LMB_SEG_CAP_HIP | LMB_SEG_CAP_METAL |
+                              LMB_SEG_CAP_VULKAN;
+    return (caps & backends) != 0;
+}
+
+int lmb_seg_advert_valid(const LmbSegAdvert *a) {
+    if (!a || !disc_str_valid(a->peer_name, sizeof a->peer_name) ||
+        !disc_str_valid(a->addr, sizeof a->addr) ||
+        !disc_str_valid(a->model, sizeof a->model) ||
+        !disc_root_valid(a->model_root) ||
+        !disc_root_valid(a->tokenizer_root) ||
+        a->layer_begin >= a->layer_end ||
+        !a->max_context || a->max_context > LMB_SEG_MAX_CONTEXT ||
+        !a->max_rows || a->max_rows > LMB_SEG_MAX_ROWS ||
+        !lmb_seg_dtype_size(a->state_dtype) ||
+        !a->state_width || a->state_width > LMB_SEG_MAX_STATE_WIDTH ||
+        !a->max_sessions || a->active_sessions > a->max_sessions ||
+        (a->flags & ~LMB_SEG_ADVERT_DRAINING) ||
+        (a->capabilities & ~LMB_SEG_CAP_KNOWN_MASK) ||
+        !(a->capabilities & LMB_SEG_CAP_RANGE_NATIVE) ||
+        !(a->capabilities & LMB_SEG_CAP_MULTI_SESSION) ||
+        !disc_backend_valid(a->capabilities) ||
+        !disc_str_valid(a->engine_id, sizeof a->engine_id) ||
+        !disc_str_valid(a->state_schema, sizeof a->state_schema) ||
+        !disc_str_valid(a->numeric_class, sizeof a->numeric_class))
+        return 0;
+    return 1;
+}
+
+int lmb_seg_query_valid(const LmbSegQuery *q) {
+    if (!q || !disc_str_valid(q->model, sizeof q->model) ||
+        !disc_root_valid(q->model_root) ||
+        !disc_root_valid(q->tokenizer_root) ||
+        q->layer_begin >= q->layer_end ||
+        !q->context_tokens || q->context_tokens > LMB_SEG_MAX_CONTEXT ||
+        !q->rows || q->rows > LMB_SEG_MAX_ROWS ||
+        !lmb_seg_dtype_size(q->state_dtype) ||
+        !q->state_width || q->state_width > LMB_SEG_MAX_STATE_WIDTH ||
+        (q->required_capabilities & ~LMB_SEG_CAP_KNOWN_MASK) ||
+        !disc_str_valid(q->engine_id, sizeof q->engine_id) ||
+        !disc_str_valid(q->state_schema, sizeof q->state_schema) ||
+        !disc_str_valid(q->numeric_class, sizeof q->numeric_class))
+        return 0;
+    return 1;
+}
+
+int lmb_seg_advert_compatible(const LmbSegAdvert *a, const LmbSegQuery *q) {
+    return lmb_seg_advert_valid(a) && lmb_seg_query_valid(q) &&
+           !(a->flags & LMB_SEG_ADVERT_DRAINING) &&
+           !strcmp(a->model, q->model) &&
+           !memcmp(a->model_root, q->model_root, LMB_SEG_ROOT_BYTES) &&
+           !memcmp(a->tokenizer_root, q->tokenizer_root, LMB_SEG_ROOT_BYTES) &&
+           a->layer_begin < q->layer_end && a->layer_end > q->layer_begin &&
+           a->max_context >= q->context_tokens && a->max_rows >= q->rows &&
+           a->state_dtype == q->state_dtype && a->state_width == q->state_width &&
+           (a->capabilities & q->required_capabilities) ==
+               q->required_capabilities &&
+           !strcmp(a->engine_id, q->engine_id) &&
+           !strcmp(a->state_schema, q->state_schema) &&
+           !strcmp(a->numeric_class, q->numeric_class);
+}
+
+int lmb_seg_route_complete(const LmbSegRouteSnapshot *s,
+                           const LmbSegQuery *q) {
+    if (!s || !lmb_seg_query_valid(q) || s->count > LMB_SEG_ROUTE_MAX) return 0;
+    uint32_t cursor = q->layer_begin;
+    while (cursor < q->layer_end) {
+        uint32_t farthest = cursor;
+        for (uint32_t i = 0; i < s->count; i++) {
+            const LmbSegAdvert *a = &s->entries[i].advert;
+            if (lmb_seg_advert_compatible(a, q) && a->layer_begin <= cursor &&
+                a->layer_end > farthest)
+                farthest = a->layer_end;
+        }
+        if (farthest == cursor) return 0;
+        cursor = farthest > q->layer_end ? q->layer_end : farthest;
+    }
+    return 1;
+}
+
+static int disc_cur_bytes(DiscCur *c, void *out, size_t n) {
+    if (c->off > c->len || n > c->len - c->off) return -1;
+    if (n) memcpy(out, c->p + c->off, n);
+    c->off += n;
+    return 0;
+}
+
+static int disc_cur_u16(DiscCur *c, uint16_t *v) {
+    uint8_t p[2];
+    if (disc_cur_bytes(c, p, sizeof p)) return -1;
+    *v = (uint16_t)(p[0] | (uint16_t)p[1] << 8);
+    return 0;
+}
+
+static int disc_cur_u32(DiscCur *c, uint32_t *v) {
+    uint8_t p[4];
+    if (disc_cur_bytes(c, p, sizeof p)) return -1;
+    *v = lmb_get32(p);
+    return 0;
+}
+
+static int disc_cur_u64(DiscCur *c, uint64_t *v) {
+    uint32_t lo, hi;
+    if (disc_cur_u32(c, &lo) || disc_cur_u32(c, &hi)) return -1;
+    *v = (uint64_t)lo | (uint64_t)hi << 32;
+    return 0;
+}
+
+static int disc_cur_str(DiscCur *c, char *out, size_t cap) {
+    uint16_t n;
+    if (!cap || disc_cur_u16(c, &n) || !n || n >= cap ||
+        c->off > c->len || n > c->len - c->off ||
+        memchr(c->p + c->off, '\0', n))
+        return -1;
+    memcpy(out, c->p + c->off, n); out[n] = 0; c->off += n;
+    return 0;
+}
+
+static int disc_buf_prefix(LmbBuf *b) {
+    return lmb_buf_u32(b, LMB_SEG_DISCOVERY_MAGIC) ||
+           lmb_buf_u32(b, LMB_SEG_DISCOVERY_VERSION);
+}
+
+static int disc_cur_prefix(DiscCur *c) {
+    uint32_t magic, version;
+    return disc_cur_u32(c, &magic) || disc_cur_u32(c, &version) ||
+           magic != LMB_SEG_DISCOVERY_MAGIC ||
+           version != LMB_SEG_DISCOVERY_VERSION;
+}
+
+static int disc_buf_advert(LmbBuf *b, const LmbSegAdvert *a) {
+    return lmb_buf_str(b, a->peer_name) || lmb_buf_str(b, a->addr) ||
+           lmb_buf_str(b, a->model) ||
+           lmb_buf_bytes(b, a->model_root, sizeof a->model_root) ||
+           lmb_buf_bytes(b, a->tokenizer_root, sizeof a->tokenizer_root) ||
+           lmb_buf_u32(b, a->layer_begin) || lmb_buf_u32(b, a->layer_end) ||
+           lmb_buf_u32(b, a->max_context) || lmb_buf_u32(b, a->max_rows) ||
+           lmb_buf_u32(b, a->state_dtype) || lmb_buf_u32(b, a->state_width) ||
+           lmb_buf_u32(b, a->max_sessions) ||
+           lmb_buf_u32(b, a->active_sessions) ||
+           lmb_buf_u32(b, a->queue_depth) || lmb_buf_u32(b, a->inflight) ||
+           lmb_buf_u32(b, a->flags) || lmb_buf_u64(b, a->capabilities) ||
+           lmb_buf_u64(b, a->resident_ram_bytes) ||
+           lmb_buf_u64(b, a->resident_vram_bytes) ||
+           lmb_buf_str(b, a->engine_id) || lmb_buf_str(b, a->state_schema) ||
+           lmb_buf_str(b, a->numeric_class);
+}
+
+static int disc_cur_advert(DiscCur *c, LmbSegAdvert *a) {
+    return disc_cur_str(c, a->peer_name, sizeof a->peer_name) ||
+           disc_cur_str(c, a->addr, sizeof a->addr) ||
+           disc_cur_str(c, a->model, sizeof a->model) ||
+           disc_cur_bytes(c, a->model_root, sizeof a->model_root) ||
+           disc_cur_bytes(c, a->tokenizer_root, sizeof a->tokenizer_root) ||
+           disc_cur_u32(c, &a->layer_begin) || disc_cur_u32(c, &a->layer_end) ||
+           disc_cur_u32(c, &a->max_context) || disc_cur_u32(c, &a->max_rows) ||
+           disc_cur_u32(c, &a->state_dtype) || disc_cur_u32(c, &a->state_width) ||
+           disc_cur_u32(c, &a->max_sessions) ||
+           disc_cur_u32(c, &a->active_sessions) ||
+           disc_cur_u32(c, &a->queue_depth) || disc_cur_u32(c, &a->inflight) ||
+           disc_cur_u32(c, &a->flags) || disc_cur_u64(c, &a->capabilities) ||
+           disc_cur_u64(c, &a->resident_ram_bytes) ||
+           disc_cur_u64(c, &a->resident_vram_bytes) ||
+           disc_cur_str(c, a->engine_id, sizeof a->engine_id) ||
+           disc_cur_str(c, a->state_schema, sizeof a->state_schema) ||
+           disc_cur_str(c, a->numeric_class, sizeof a->numeric_class);
+}
+
+static int disc_finish(LmbBuf *b, uint8_t **body, uint32_t *body_len) {
+    if (!body || !body_len || b->len > UINT32_MAX ||
+        b->len > LMB_MAX_CONTROL_BODY) {
+        free(b->p); return -1;
+    }
+    *body = b->p; *body_len = (uint32_t)b->len;
+    return 0;
+}
+
+int lmb_seg_advert_encode(const LmbSegAdvert *a,
+                          uint8_t **body, uint32_t *body_len) {
+    if (!lmb_seg_advert_valid(a)) return -1;
+    LmbBuf b = {0};
+    if (disc_buf_prefix(&b) || disc_buf_advert(&b, a)) {
+        free(b.p); return -1;
+    }
+    return disc_finish(&b, body, body_len);
+}
+
+int lmb_seg_advert_decode(const void *body, size_t body_len, LmbSegAdvert *a) {
+    if ((!body && body_len) || !a) return -1;
+    memset(a, 0, sizeof *a);
+    DiscCur c = { body, body_len, 0 };
+    return disc_cur_prefix(&c) || disc_cur_advert(&c, a) || c.off != c.len ||
+           !lmb_seg_advert_valid(a) ? -1 : 0;
+}
+
+static int disc_buf_query(LmbBuf *b, const LmbSegQuery *q) {
+    return lmb_buf_str(b, q->model) ||
+           lmb_buf_bytes(b, q->model_root, sizeof q->model_root) ||
+           lmb_buf_bytes(b, q->tokenizer_root, sizeof q->tokenizer_root) ||
+           lmb_buf_u32(b, q->layer_begin) || lmb_buf_u32(b, q->layer_end) ||
+           lmb_buf_u32(b, q->context_tokens) || lmb_buf_u32(b, q->rows) ||
+           lmb_buf_u32(b, q->state_dtype) || lmb_buf_u32(b, q->state_width) ||
+           lmb_buf_u64(b, q->required_capabilities) ||
+           lmb_buf_str(b, q->engine_id) || lmb_buf_str(b, q->state_schema) ||
+           lmb_buf_str(b, q->numeric_class);
+}
+
+static int disc_cur_query(DiscCur *c, LmbSegQuery *q) {
+    return disc_cur_str(c, q->model, sizeof q->model) ||
+           disc_cur_bytes(c, q->model_root, sizeof q->model_root) ||
+           disc_cur_bytes(c, q->tokenizer_root, sizeof q->tokenizer_root) ||
+           disc_cur_u32(c, &q->layer_begin) || disc_cur_u32(c, &q->layer_end) ||
+           disc_cur_u32(c, &q->context_tokens) || disc_cur_u32(c, &q->rows) ||
+           disc_cur_u32(c, &q->state_dtype) || disc_cur_u32(c, &q->state_width) ||
+           disc_cur_u64(c, &q->required_capabilities) ||
+           disc_cur_str(c, q->engine_id, sizeof q->engine_id) ||
+           disc_cur_str(c, q->state_schema, sizeof q->state_schema) ||
+           disc_cur_str(c, q->numeric_class, sizeof q->numeric_class);
+}
+
+int lmb_seg_query_encode(const LmbSegQuery *q,
+                         uint8_t **body, uint32_t *body_len) {
+    if (!lmb_seg_query_valid(q)) return -1;
+    LmbBuf b = {0};
+    if (disc_buf_prefix(&b) || disc_buf_query(&b, q)) {
+        free(b.p); return -1;
+    }
+    return disc_finish(&b, body, body_len);
+}
+
+int lmb_seg_query_decode(const void *body, size_t body_len, LmbSegQuery *q) {
+    if ((!body && body_len) || !q) return -1;
+    memset(q, 0, sizeof *q);
+    DiscCur c = { body, body_len, 0 };
+    return disc_cur_prefix(&c) || disc_cur_query(&c, q) || c.off != c.len ||
+           !lmb_seg_query_valid(q) ? -1 : 0;
+}
+
+static int disc_buf_owner(LmbBuf *b, const LmbSegOwner *o) {
+    return lmb_buf_bytes(b, o->lease_id.bytes, sizeof o->lease_id.bytes) ||
+           lmb_buf_u64(b, o->fencing_epoch) ||
+           lmb_buf_u64(b, o->route_generation);
+}
+
+static int disc_cur_owner(DiscCur *c, LmbSegOwner *o) {
+    return disc_cur_bytes(c, o->lease_id.bytes, sizeof o->lease_id.bytes) ||
+           disc_cur_u64(c, &o->fencing_epoch) ||
+           disc_cur_u64(c, &o->route_generation);
+}
+
+int lmb_seg_route_encode(const LmbSegRouteSnapshot *s,
+                         uint8_t **body, uint32_t *body_len) {
+    if (!s || !s->route_generation || s->count > LMB_SEG_ROUTE_MAX) return -1;
+    LmbBuf b = {0};
+    int bad = disc_buf_prefix(&b) || lmb_buf_u64(&b, s->route_generation) ||
+              lmb_buf_u32(&b, s->complete != 0) || lmb_buf_u32(&b, s->count);
+    for (uint32_t i = 0; !bad && i < s->count; i++) {
+        const LmbSegRouteEntry *e = &s->entries[i];
+        if (!lmb_seg_advert_valid(&e->advert) ||
+            lmb_seg_id_is_zero(&e->owner.lease_id) ||
+            !e->owner.fencing_epoch ||
+            e->owner.route_generation != s->route_generation ||
+            !e->transport ||
+            (e->transport & ~(LMB_SEG_TRANSPORT_DIRECT |
+                              LMB_SEG_TRANSPORT_RELAY))) {
+            bad = 1; break;
+        }
+        bad = disc_buf_advert(&b, &e->advert) ||
+              disc_buf_owner(&b, &e->owner) ||
+              lmb_buf_u32(&b, e->transport);
+    }
+    if (bad) { free(b.p); return -1; }
+    return disc_finish(&b, body, body_len);
+}
+
+int lmb_seg_route_decode(const void *body, size_t body_len,
+                         LmbSegRouteSnapshot *s) {
+    if ((!body && body_len) || !s) return -1;
+    memset(s, 0, sizeof *s);
+    DiscCur c = { body, body_len, 0 };
+    if (disc_cur_prefix(&c) || disc_cur_u64(&c, &s->route_generation) ||
+        disc_cur_u32(&c, &s->complete) || disc_cur_u32(&c, &s->count) ||
+        !s->route_generation || s->complete > 1 || s->count > LMB_SEG_ROUTE_MAX)
+        return -1;
+    for (uint32_t i = 0; i < s->count; i++) {
+        LmbSegRouteEntry *e = &s->entries[i];
+        if (disc_cur_advert(&c, &e->advert) ||
+            disc_cur_owner(&c, &e->owner) ||
+            disc_cur_u32(&c, &e->transport) ||
+            !lmb_seg_advert_valid(&e->advert) ||
+            lmb_seg_id_is_zero(&e->owner.lease_id) ||
+            !e->owner.fencing_epoch ||
+            e->owner.route_generation != s->route_generation ||
+            !e->transport ||
+            (e->transport & ~(LMB_SEG_TRANSPORT_DIRECT |
+                              LMB_SEG_TRANSPORT_RELAY)))
+            return -1;
+    }
+    if (c.off != c.len) return -1;
+    s->fetched_at_ms = disc_now_ms();
+    return 0;
+}
+
+int lmb_seg_registration_reply_encode(const LmbSegOwner *owner,
+                                      uint8_t **body, uint32_t *body_len) {
+    if (!owner || lmb_seg_id_is_zero(&owner->lease_id) ||
+        !owner->fencing_epoch || !owner->route_generation) return -1;
+    LmbBuf b = {0};
+    if (disc_buf_prefix(&b) || disc_buf_owner(&b, owner)) {
+        free(b.p); return -1;
+    }
+    return disc_finish(&b, body, body_len);
+}
+
+int lmb_seg_registration_reply_decode(const void *body, size_t body_len,
+                                      LmbSegOwner *owner) {
+    if ((!body && body_len) || !owner) return -1;
+    memset(owner, 0, sizeof *owner);
+    DiscCur c = { body, body_len, 0 };
+    return disc_cur_prefix(&c) || disc_cur_owner(&c, owner) || c.off != c.len ||
+           lmb_seg_id_is_zero(&owner->lease_id) || !owner->fencing_epoch ||
+           !owner->route_generation ? -1 : 0;
+}
+
+int lmb_seg_routes_fetch(const char *tracker, const LmbSegQuery *query,
+                         LmbSegRouteSnapshot *snapshot) {
+    if (!tracker || !*tracker || !snapshot) return -1;
+    uint8_t *body = NULL; uint32_t body_len = 0;
+    if (lmb_seg_query_encode(query, &body, &body_len)) return -1;
+    LmbMsg reply = {0};
+    int rc = lmb_request(tracker, LMB_SEG_ROUTES, body, body_len, &reply);
+    free(body);
+    if (rc || reply.op != LMB_SEG_ROUTES_R || reply.pay_len) {
+        lmb_msg_free(&reply); return -1;
+    }
+    rc = lmb_seg_route_decode(reply.body, reply.body_len, snapshot);
+    lmb_msg_free(&reply);
+    if (!rc && snapshot->complete !=
+        (uint32_t)lmb_seg_route_complete(snapshot, query)) return -1;
+    return rc;
+}
+
+struct LmbSegDiscovery {
+    pthread_t thread;
+    pthread_mutex_t lock;
+    pthread_cond_t wake;
+    int stop;
+    int have_snapshot;
+    uint32_t refresh_ms;
+    char tracker[256];
+    LmbSegQuery query;
+    LmbSegRouteSnapshot snapshot;
+};
+
+static void *disc_worker(void *arg) {
+    LmbSegDiscovery *d = (LmbSegDiscovery *)arg;
+    for (;;) {
+        LmbSegRouteSnapshot next;
+        if (!lmb_seg_routes_fetch(d->tracker, &d->query, &next)) {
+            pthread_mutex_lock(&d->lock);
+            /* Generations fence placements. Equal generations still replace
+             * telemetry; a lower generation can only be a stale tracker. */
+            if (!d->have_snapshot ||
+                next.route_generation >= d->snapshot.route_generation) {
+                d->snapshot = next;
+                d->have_snapshot = 1;
+            }
+            pthread_mutex_unlock(&d->lock);
+        }
+        pthread_mutex_lock(&d->lock);
+        if (d->stop) { pthread_mutex_unlock(&d->lock); break; }
+        struct timespec until;
+        clock_gettime(CLOCK_REALTIME, &until);
+        until.tv_sec += d->refresh_ms / 1000u;
+        until.tv_nsec += (long)(d->refresh_ms % 1000u) * 1000000L;
+        if (until.tv_nsec >= 1000000000L) {
+            until.tv_sec++; until.tv_nsec -= 1000000000L;
+        }
+        pthread_cond_timedwait(&d->wake, &d->lock, &until);
+        int stop = d->stop;
+        pthread_mutex_unlock(&d->lock);
+        if (stop) break;
+    }
+    return NULL;
+}
+
+LmbSegDiscovery *lmb_seg_discovery_start(const char *tracker,
+                                         const LmbSegQuery *query,
+                                         uint32_t refresh_ms) {
+    if (!tracker || !*tracker || strlen(tracker) >= 256 ||
+        !lmb_seg_query_valid(query) || refresh_ms < 50 || refresh_ms > 3600000)
+        return NULL;
+    LmbSegDiscovery *d = (LmbSegDiscovery *)calloc(1, sizeof *d);
+    if (!d) return NULL;
+    snprintf(d->tracker, sizeof d->tracker, "%s", tracker);
+    d->query = *query; d->refresh_ms = refresh_ms;
+    if (pthread_mutex_init(&d->lock, NULL)) { free(d); return NULL; }
+    if (pthread_cond_init(&d->wake, NULL)) {
+        pthread_mutex_destroy(&d->lock); free(d); return NULL;
+    }
+    if (pthread_create(&d->thread, NULL, disc_worker, d)) {
+        pthread_cond_destroy(&d->wake); pthread_mutex_destroy(&d->lock);
+        free(d); return NULL;
+    }
+    return d;
+}
+
+int lmb_seg_discovery_snapshot(LmbSegDiscovery *d,
+                               LmbSegRouteSnapshot *snapshot) {
+    if (!d || !snapshot) return -1;
+    pthread_mutex_lock(&d->lock);
+    int have = d->have_snapshot;
+    if (have) *snapshot = d->snapshot;
+    pthread_mutex_unlock(&d->lock);
+    return have;
+}
+
+void lmb_seg_discovery_stop(LmbSegDiscovery *d) {
+    if (!d) return;
+    pthread_mutex_lock(&d->lock);
+    d->stop = 1;
+    pthread_cond_signal(&d->wake);
+    pthread_mutex_unlock(&d->lock);
+    pthread_join(d->thread, NULL);
+    pthread_cond_destroy(&d->wake); pthread_mutex_destroy(&d->lock);
+    free(d);
+}

--- a/lumabri_segment_discovery.h
+++ b/lumabri_segment_discovery.h
@@ -1,0 +1,133 @@
+/* lumabri_segment_discovery.h — tracker control plane for Segment v2.
+ *
+ * Segment execution is stateful, so discovery returns an immutable placement
+ * generation plus a fenced lease for every eligible peer.  Model-specific
+ * state remains opaque: the tracker only matches the schema and numeric class
+ * published by the Colibri adapter.
+ */
+#ifndef LUMABRI_SEGMENT_DISCOVERY_H
+#define LUMABRI_SEGMENT_DISCOVERY_H
+
+#include "lumabri_segment.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define LMB_SEG_DISCOVERY_MAGIC       0x31444753u /* "SGD1" */
+#define LMB_SEG_DISCOVERY_VERSION     1u
+#define LMB_SEG_MODEL_MAX             64u
+#define LMB_SEG_PEER_NAME_MAX         64u
+#define LMB_SEG_ADDR_MAX              64u
+#define LMB_SEG_ROUTE_MAX             64u
+
+enum {
+    LMB_SEG_ADVERT_DRAINING = 1u << 0,
+};
+
+enum {
+    LMB_SEG_TRANSPORT_DIRECT = 1u << 0,
+    /* Reserved until the tracker forwards Segment frames; an SREG control
+     * connection alone is not evidence that the Segment data plane relays. */
+    LMB_SEG_TRANSPORT_RELAY = 1u << 1,
+};
+
+typedef struct {
+    char peer_name[LMB_SEG_PEER_NAME_MAX];
+    char addr[LMB_SEG_ADDR_MAX];
+    char model[LMB_SEG_MODEL_MAX];
+    uint8_t model_root[LMB_SEG_ROOT_BYTES];
+    uint8_t tokenizer_root[LMB_SEG_ROOT_BYTES];
+    uint32_t layer_begin;
+    uint32_t layer_end;
+    uint32_t max_context;
+    uint32_t max_rows;
+    uint32_t state_dtype;
+    uint32_t state_width;
+    uint32_t max_sessions;
+    uint32_t active_sessions;
+    uint32_t queue_depth;
+    uint32_t inflight;
+    uint32_t flags;
+    uint64_t capabilities;
+    uint64_t resident_ram_bytes;
+    uint64_t resident_vram_bytes;
+    char engine_id[LMB_SEG_ENGINE_MAX];
+    char state_schema[LMB_SEG_SCHEMA_MAX];
+    char numeric_class[LMB_SEG_NUMERIC_CLASS_MAX];
+} LmbSegAdvert;
+
+typedef struct {
+    char model[LMB_SEG_MODEL_MAX];
+    uint8_t model_root[LMB_SEG_ROOT_BYTES];
+    uint8_t tokenizer_root[LMB_SEG_ROOT_BYTES];
+    uint32_t layer_begin;
+    uint32_t layer_end;
+    uint32_t context_tokens;
+    uint32_t rows;
+    uint32_t state_dtype;
+    uint32_t state_width;
+    uint64_t required_capabilities;
+    char engine_id[LMB_SEG_ENGINE_MAX];
+    char state_schema[LMB_SEG_SCHEMA_MAX];
+    char numeric_class[LMB_SEG_NUMERIC_CLASS_MAX];
+} LmbSegQuery;
+
+typedef struct {
+    LmbSegAdvert advert;
+    LmbSegOwner owner;
+    uint32_t transport;
+} LmbSegRouteEntry;
+
+/* Fixed-size by design: copying this value produces an immutable routing
+ * snapshot with no shared allocation and no tracker access on the inference
+ * path. Entries include replicas; complete says their interval union covers
+ * the complete requested range. */
+typedef struct {
+    uint64_t route_generation;
+    uint64_t fetched_at_ms;
+    uint32_t complete;
+    uint32_t count;
+    LmbSegRouteEntry entries[LMB_SEG_ROUTE_MAX];
+} LmbSegRouteSnapshot;
+
+int lmb_seg_advert_valid(const LmbSegAdvert *advert);
+int lmb_seg_query_valid(const LmbSegQuery *query);
+int lmb_seg_advert_compatible(const LmbSegAdvert *advert,
+                              const LmbSegQuery *query);
+int lmb_seg_route_complete(const LmbSegRouteSnapshot *snapshot,
+                           const LmbSegQuery *query);
+
+int lmb_seg_advert_encode(const LmbSegAdvert *advert,
+                          uint8_t **body, uint32_t *body_len);
+int lmb_seg_advert_decode(const void *body, size_t body_len,
+                          LmbSegAdvert *advert);
+int lmb_seg_query_encode(const LmbSegQuery *query,
+                         uint8_t **body, uint32_t *body_len);
+int lmb_seg_query_decode(const void *body, size_t body_len,
+                         LmbSegQuery *query);
+int lmb_seg_route_encode(const LmbSegRouteSnapshot *snapshot,
+                         uint8_t **body, uint32_t *body_len);
+int lmb_seg_route_decode(const void *body, size_t body_len,
+                         LmbSegRouteSnapshot *snapshot);
+int lmb_seg_registration_reply_encode(const LmbSegOwner *owner,
+                                      uint8_t **body, uint32_t *body_len);
+int lmb_seg_registration_reply_decode(const void *body, size_t body_len,
+                                      LmbSegOwner *owner);
+
+/* One synchronous fetch for startup/tests. Production chat uses the worker
+ * below so inference never contacts the tracker. */
+int lmb_seg_routes_fetch(const char *tracker, const LmbSegQuery *query,
+                         LmbSegRouteSnapshot *snapshot);
+
+typedef struct LmbSegDiscovery LmbSegDiscovery;
+
+LmbSegDiscovery *lmb_seg_discovery_start(const char *tracker,
+                                         const LmbSegQuery *query,
+                                         uint32_t refresh_ms);
+/* Copies the current immutable value. Returns 1 when a snapshot has been
+ * published, 0 before the first successful tracker response, or -1. */
+int lmb_seg_discovery_snapshot(LmbSegDiscovery *discovery,
+                               LmbSegRouteSnapshot *snapshot);
+void lmb_seg_discovery_stop(LmbSegDiscovery *discovery);
+
+#endif /* LUMABRI_SEGMENT_DISCOVERY_H */

--- a/segment_discovery_test.sh
+++ b/segment_discovery_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Real tracker gate for Segment discovery. The C test keeps every signed SREG
+# control connection open while it checks leases, replicas, draining and the
+# asynchronous route snapshot used by inference.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+T=$(mktemp -d /tmp/lumabri-segdisc.XXXXXX)
+TRACKER_PID=""
+cleanup() {
+    if [[ -n "$TRACKER_PID" ]]; then kill "$TRACKER_PID" 2>/dev/null || true; fi
+    rm -rf "$T"
+}
+trap cleanup EXIT
+
+export HOME="$T"
+./tracker --port 7668 --peer-bindings "$T/bindings" >"$T/tracker.log" 2>&1 &
+TRACKER_PID=$!
+wait_tracker() {
+    for _ in $(seq 1 100); do
+        if (exec 3<>/dev/tcp/127.0.0.1/7668) 2>/dev/null; then
+            exec 3<&-; exec 3>&-; return 0
+        fi
+        sleep 0.05
+    done
+    return 1
+}
+wait_tracker
+if ! kill -0 "$TRACKER_PID" 2>/dev/null; then
+    cat "$T/tracker.log"
+    exit 1
+fi
+
+if ! ./test_segment_discovery 127.0.0.1:7668; then
+    cat "$T/tracker.log"
+    exit 1
+fi
+
+# A tracker restart must reserve a strictly newer high generation epoch, so a
+# chatter cannot confuse a fresh route with a cached pre-restart placement.
+FIRST_EPOCH=$(tr -d '\n' <"$T/bindings.segment-generation")
+kill "$TRACKER_PID"
+wait "$TRACKER_PID" 2>/dev/null || true
+TRACKER_PID=""
+./tracker --port 7668 --peer-bindings "$T/bindings" >"$T/tracker-restart.log" 2>&1 &
+TRACKER_PID=$!
+wait_tracker
+SECOND_EPOCH=$(tr -d '\n' <"$T/bindings.segment-generation")
+if (( SECOND_EPOCH <= FIRST_EPOCH )); then
+    echo "Segment route generation did not advance across tracker restart"
+    cat "$T/tracker-restart.log"
+    exit 1
+fi
+echo "SEGMENT GENERATION: PASS (durable across tracker restart)"

--- a/test_segment_discovery.c
+++ b/test_segment_discovery.c
@@ -1,0 +1,279 @@
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+
+#include "lumabri_segment_discovery.h"
+#include "lumabri_proto.h"
+#include "lumabri_sign.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+typedef struct {
+    const char *engine;
+    const char *schema;
+    const char *numeric;
+    uint32_t dtype;
+    uint32_t width;
+    uint64_t backend;
+} TinyFamily;
+
+static const TinyFamily families[] = {
+    { "olmoe", "kv-standard-v1", "olmoe-f32-strict-tiny",
+      LMB_SEG_DTYPE_F32, 8, LMB_SEG_CAP_CPU },
+    { "glm", "mla-dsa-rope-device-v1", "glm-f16-strict-tiny",
+      LMB_SEG_DTYPE_F16, 12, LMB_SEG_CAP_CUDA },
+    { "inkling", "kv-global-sliding-conv-v1", "inkling-f32-strict-tiny",
+      LMB_SEG_DTYPE_F32, 10, LMB_SEG_CAP_METAL },
+    { "kimi_k3", "mla-kda-conv-attnres-v1", "kimi-bf16-strict-tiny",
+      LMB_SEG_DTYPE_BF16, 14, LMB_SEG_CAP_VULKAN },
+    { "qwen36", "kv-deltanet-conv-ring-v1", "qwen-f16-strict-tiny",
+      LMB_SEG_DTYPE_F16, 16, LMB_SEG_CAP_CUDA },
+    { "deepseek_v4", "mhc-window-compressor-indexer-v1",
+      "dsv4-bf16-strict-tiny", LMB_SEG_DTYPE_BF16, 18, LMB_SEG_CAP_HIP },
+};
+
+static void fill_root(uint8_t root[LMB_SEG_ROOT_BYTES], unsigned seed) {
+    for (size_t i = 0; i < LMB_SEG_ROOT_BYTES; i++)
+        root[i] = (uint8_t)(seed + 19u * (unsigned)i + 1u);
+}
+
+static LmbSegAdvert make_advert(size_t family, unsigned peer,
+                                uint32_t begin, uint32_t end) {
+    const TinyFamily *f = &families[family];
+    LmbSegAdvert a;
+    memset(&a, 0, sizeof a);
+    snprintf(a.peer_name, sizeof a.peer_name, "seg-%s-%u", f->engine, peer);
+    snprintf(a.addr, sizeof a.addr, "127.0.0.1:%u", 7800u + peer);
+    snprintf(a.model, sizeof a.model, "tiny-%s", f->engine);
+    fill_root(a.model_root, (unsigned)family + 10u);
+    fill_root(a.tokenizer_root, (unsigned)family + 80u);
+    a.layer_begin = begin; a.layer_end = end;
+    a.max_context = 4096; a.max_rows = 64;
+    a.state_dtype = f->dtype; a.state_width = f->width;
+    a.max_sessions = 8; a.active_sessions = 1;
+    a.capabilities = LMB_SEG_CAP_RANGE_NATIVE | LMB_SEG_CAP_MULTI_SESSION |
+                     LMB_SEG_CAP_SNAPSHOT | LMB_SEG_CAP_CPU | f->backend;
+    a.resident_ram_bytes = 64u << 20;
+    a.resident_vram_bytes = f->backend == LMB_SEG_CAP_CPU ? 0 : 32u << 20;
+    snprintf(a.engine_id, sizeof a.engine_id, "%s", f->engine);
+    snprintf(a.state_schema, sizeof a.state_schema, "%s", f->schema);
+    snprintf(a.numeric_class, sizeof a.numeric_class, "%s", f->numeric);
+    return a;
+}
+
+static LmbSegQuery query_for(const LmbSegAdvert *a,
+                             uint32_t begin, uint32_t end) {
+    LmbSegQuery q;
+    memset(&q, 0, sizeof q);
+    snprintf(q.model, sizeof q.model, "%s", a->model);
+    memcpy(q.model_root, a->model_root, sizeof q.model_root);
+    memcpy(q.tokenizer_root, a->tokenizer_root, sizeof q.tokenizer_root);
+    q.layer_begin = begin; q.layer_end = end;
+    q.context_tokens = 2048; q.rows = 8;
+    q.state_dtype = a->state_dtype; q.state_width = a->state_width;
+    q.required_capabilities = LMB_SEG_CAP_RANGE_NATIVE |
+                              LMB_SEG_CAP_MULTI_SESSION;
+    snprintf(q.engine_id, sizeof q.engine_id, "%s", a->engine_id);
+    snprintf(q.state_schema, sizeof q.state_schema, "%s", a->state_schema);
+    snprintf(q.numeric_class, sizeof q.numeric_class, "%s", a->numeric_class);
+    return q;
+}
+
+static void test_codecs(void) {
+    for (size_t i = 0; i < sizeof families / sizeof families[0]; i++) {
+        LmbSegAdvert a = make_advert(i, (unsigned)i, 0, 4), decoded;
+        LmbSegQuery q = query_for(&a, 0, 4), qdecoded;
+        uint8_t *body = NULL; uint32_t len = 0;
+        assert(lmb_seg_advert_valid(&a));
+        assert(!lmb_seg_advert_encode(&a, &body, &len));
+        assert(!lmb_seg_advert_decode(body, len, &decoded));
+        assert(!memcmp(&a, &decoded, sizeof a));
+        assert(lmb_seg_advert_decode(body, len - 1, &decoded));
+        free(body); body = NULL;
+        assert(!lmb_seg_query_encode(&q, &body, &len));
+        assert(!lmb_seg_query_decode(body, len, &qdecoded));
+        assert(!memcmp(&q, &qdecoded, sizeof q));
+        assert(lmb_seg_advert_compatible(&a, &q));
+        free(body);
+    }
+
+    LmbSegAdvert a = make_advert(0, 0, 0, 2);
+    LmbSegQuery q = query_for(&a, 0, 4);
+    LmbSegRouteSnapshot route = { .route_generation = 7, .count = 2 };
+    route.entries[0].advert = a;
+    route.entries[1].advert = make_advert(0, 1, 2, 4);
+    for (uint32_t i = 0; i < route.count; i++) {
+        memset(route.entries[i].owner.lease_id.bytes, (int)i + 1,
+               sizeof route.entries[i].owner.lease_id.bytes);
+        route.entries[i].owner.fencing_epoch = i + 1;
+        route.entries[i].owner.route_generation = route.route_generation;
+        route.entries[i].transport = LMB_SEG_TRANSPORT_DIRECT;
+    }
+    route.complete = (uint32_t)lmb_seg_route_complete(&route, &q);
+    assert(route.complete);
+    uint8_t *body = NULL; uint32_t len = 0;
+    LmbSegRouteSnapshot decoded;
+    assert(!lmb_seg_route_encode(&route, &body, &len));
+    assert(!lmb_seg_route_decode(body, len, &decoded));
+    assert(decoded.complete && decoded.count == 2);
+    free(body);
+    route.entries[1].advert.layer_begin = 3;
+    assert(!lmb_seg_route_complete(&route, &q));
+}
+
+typedef struct {
+    int fd;
+    uint8_t pk[32], sk[64];
+    LmbSegOwner owner;
+} Registration;
+
+static int register_advert(const char *tracker, const LmbSegAdvert *a,
+                           unsigned seed_value, Registration *r) {
+    if (r->fd <= 0) {
+        uint8_t seed[32];
+        for (size_t i = 0; i < sizeof seed; i++)
+            seed[i] = (uint8_t)(seed_value + (unsigned)i + 1u);
+        lmb_sign_keypair(r->pk, r->sk, seed);
+        r->fd = lmb_connect(tracker);
+        if (r->fd < 0 || lmb_auth(r->fd)) return -1;
+    }
+    uint8_t nonce[32];
+    if (lmb_request_challenge(r->fd, nonce)) return -1;
+    uint8_t *wire = NULL; uint32_t wire_len = 0;
+    if (lmb_seg_advert_encode(a, &wire, &wire_len)) return -1;
+    LmbBuf body = { wire, wire_len, wire_len };
+    uint8_t msg[512], sig[64];
+    size_t msg_len = lmb_peer_auth_msg(nonce, a->peer_name, a->model, a->addr,
+                                       msg, sizeof msg);
+    if (!msg_len) { free(body.p); return -1; }
+    lmb_sign(sig, msg, msg_len, r->sk);
+    if (lmb_buf_peer_auth(&body, r->pk, sig) ||
+        lmb_send(r->fd, LMB_SEG_REGISTER, body.p, (uint32_t)body.len, NULL, 0)) {
+        free(body.p); return -1;
+    }
+    free(body.p);
+    LmbMsg reply = {0};
+    if (lmb_recv(r->fd, &reply) || reply.op != LMB_SEG_REGISTER_R ||
+        lmb_seg_registration_reply_decode(reply.body, reply.body_len, &r->owner)) {
+        lmb_msg_free(&reply); return -1;
+    }
+    lmb_msg_free(&reply);
+    return 0;
+}
+
+static void test_tracker(const char *tracker) {
+    enum { NF = (int)(sizeof families / sizeof families[0]), NR = NF + 2 };
+    Registration registrations[NR];
+    LmbSegAdvert adverts[NF];
+    memset(registrations, 0, sizeof registrations);
+    for (int i = 0; i < NF; i++) {
+        registrations[i].fd = -1;
+        adverts[i] = make_advert((size_t)i, (unsigned)i + 1u, 0, 4);
+        assert(!register_advert(tracker, &adverts[i], (unsigned)i + 20u,
+                                &registrations[i]));
+    }
+
+    /* A Segment-only compute peer is not an Expert peer. This preserves the
+     * existing chatter path during rolling upgrades. */
+    LmbBuf expert_query = {0}; LmbMsg expert_reply = {0};
+    assert(!lmb_buf_str(&expert_query, adverts[0].model));
+    assert(!lmb_request(tracker, LMB_EPEERS, expert_query.p,
+                        (uint32_t)expert_query.len, &expert_reply));
+    free(expert_query.p);
+    assert(expert_reply.op == LMB_EPEERS_R);
+    LmbCur expert_cur = { expert_reply.body, expert_reply.body_len, 0 };
+    uint32_t expert_count = 1;
+    assert(!lmb_cur_u32(&expert_cur, &expert_count));
+    assert(expert_count == 0 && expert_cur.off == expert_cur.len);
+    lmb_msg_free(&expert_reply);
+
+    for (int i = 0; i < NF; i++) {
+        LmbSegQuery q = query_for(&adverts[i], 0, 4);
+        LmbSegRouteSnapshot s;
+        assert(!lmb_seg_routes_fetch(tracker, &q, &s));
+        assert(s.complete && s.count == 1);
+        assert(s.entries[0].owner.route_generation == s.route_generation);
+        assert(s.entries[0].transport == LMB_SEG_TRANSPORT_DIRECT);
+    }
+
+    /* Telemetry may refresh at heartbeat frequency without fencing sessions
+     * or churning placement generations. */
+    LmbSegQuery oq = query_for(&adverts[0], 0, 4);
+    LmbSegRouteSnapshot os;
+    assert(!lmb_seg_routes_fetch(tracker, &oq, &os));
+    uint64_t generation_before = os.route_generation;
+    LmbSegOwner before = os.entries[0].owner;
+    adverts[0].queue_depth = 3;
+    adverts[0].inflight = 2;
+    adverts[0].resident_ram_bytes += 4096;
+    assert(!register_advert(tracker, &adverts[0], 20, &registrations[0]));
+    assert(!lmb_seg_routes_fetch(tracker, &oq, &os));
+    assert(os.route_generation == generation_before);
+    assert(registrations[0].owner.fencing_epoch == before.fencing_epoch);
+    assert(lmb_seg_id_equal(&registrations[0].owner.lease_id, &before.lease_id));
+
+    /* Material range changes receive a new lease and generation. Add a
+     * second range and one replica: the returned list preserves replicas and
+     * its union forms a complete layer-aligned chain. */
+    adverts[0].layer_end = 2;
+    assert(!register_advert(tracker, &adverts[0], 20, &registrations[0]));
+    assert(registrations[0].owner.route_generation > before.route_generation);
+    assert(registrations[0].owner.fencing_epoch > before.fencing_epoch);
+    assert(!lmb_seg_id_equal(&registrations[0].owner.lease_id, &before.lease_id));
+    LmbSegAdvert upper = make_advert(0, 90, 2, 4);
+    LmbSegAdvert replica = make_advert(0, 91, 2, 4);
+    registrations[NF].fd = registrations[NF + 1].fd = -1;
+    assert(!register_advert(tracker, &upper, 90, &registrations[NF]));
+    assert(!register_advert(tracker, &replica, 91, &registrations[NF + 1]));
+    assert(!lmb_seg_routes_fetch(tracker, &oq, &os));
+    assert(os.complete && os.count == 3);
+
+    /* Draining removes a peer from new placements but does not mutate an old
+     * snapshot already held by a running session. One replica remains. */
+    LmbSegRouteSnapshot old = os;
+    upper.flags = LMB_SEG_ADVERT_DRAINING;
+    assert(!register_advert(tracker, &upper, 90, &registrations[NF]));
+    assert(!lmb_seg_routes_fetch(tracker, &oq, &os));
+    assert(os.complete && os.count == 2);
+    assert(old.count == 3);
+
+    /* Exact roots, schema and numeric class are compatibility gates. */
+    LmbSegQuery incompatible = oq;
+    incompatible.model_root[0] ^= 0x80;
+    assert(!lmb_seg_routes_fetch(tracker, &incompatible, &os));
+    assert(!os.complete && os.count == 0);
+    incompatible = oq;
+    snprintf(incompatible.numeric_class, sizeof incompatible.numeric_class,
+             "different-numeric-class");
+    assert(!lmb_seg_routes_fetch(tracker, &incompatible, &os));
+    assert(!os.complete && os.count == 0);
+
+    /* The control worker publishes snapshots asynchronously. The inference
+     * side only copies the immutable value and never opens a tracker socket. */
+    LmbSegDiscovery *discovery = lmb_seg_discovery_start(tracker, &oq, 50);
+    assert(discovery);
+    int have = 0;
+    for (int i = 0; i < 100 && !have; i++) {
+        usleep(20000);
+        have = lmb_seg_discovery_snapshot(discovery, &os);
+    }
+    assert(have == 1 && os.complete && os.count == 2);
+    lmb_seg_discovery_stop(discovery);
+
+    for (int i = 0; i < NR; i++) if (registrations[i].fd >= 0) close(registrations[i].fd);
+}
+
+int main(int argc, char **argv) {
+    test_codecs();
+    if (argc == 2) test_tracker(argv[1]);
+    else if (argc != 1) {
+        fprintf(stderr, "usage: %s [TRACKER]\n", argv[0]);
+        return 2;
+    }
+    puts("SEGMENT DISCOVERY: PASS (six families, compatibility, leases, routes, async snapshot)");
+    return 0;
+}

--- a/tracker.c
+++ b/tracker.c
@@ -23,6 +23,7 @@
 #include <time.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_segment_discovery.h"
 #include "lumabri_sha.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
@@ -42,11 +43,14 @@ typedef struct {
     uint64_t exec_calls;
     uint32_t exec_inflight;
     int have_exec_stats;
+    double expert_ts;
     PFile *files; uint32_t nfiles;
     double ts;
     int used;
     unsigned refs;              /* control/relay users holding this slot */
-    int is_expert;              /* EREG peer: executes experts, holds no files */
+    int is_expert;              /* compute identity (Expert and/or Segment) */
+    int has_expert;             /* EREG capability is independently present */
+    int has_segment;            /* SREG capability is independently present */
     uint8_t pubkey[32];         /* this name's identity, bound on first claim */
     int has_key;
     uint32_t nexperts;
@@ -55,6 +59,10 @@ typedef struct {
      * overlap, and so cannot assign a newcomer the part nobody covers. Sent
      * on the EREG heartbeat; 2.4 KB for a 19456-expert model. */
     uint8_t *ebits; uint32_t enbits;
+    LmbSegAdvert segment;
+    LmbSegOwner segment_owner;
+    double segment_ts;
+    int segment_live;
 
     /* relay mailbox: one in-flight request per peer, serialized. The
      * chatter thread queues it and waits; the peer's control thread
@@ -79,6 +87,68 @@ static char g_token[LMB_TOKEN_MAX + 1]; /* --token: private swarm, invite requir
 static LmbConnGate g_conn_gate = LMB_CONN_GATE_INIT;
 static double g_stale_s = STALE_S;
 static int g_max_names_per_source = 16;
+static uint64_t g_segment_route_generation = 1;
+static int g_segment_generation_ready;
+static char g_bindings_path[512];
+
+/* Reserve one 32-bit generation epoch per tracker process. The durable high
+ * half means a tracker restart can never publish a generation below a route
+ * still cached by a chatter or held by a live executor. The low half is ample
+ * for topology changes during one process lifetime and needs no fsync on each
+ * heartbeat. Rolling trackers serialize epoch allocation with flock. */
+static int segment_generation_init(void) {
+    char path[sizeof g_bindings_path + 32];
+    if (!g_bindings_path[0] ||
+        snprintf(path, sizeof path, "%s.segment-generation", g_bindings_path) >=
+            (int)sizeof path)
+        return -1;
+    int flags = O_RDWR | O_CREAT;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    int fd = open(path, flags, 0600);
+    if (fd < 0 || flock(fd, LOCK_EX)) { if (fd >= 0) close(fd); return -1; }
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode) || st.st_uid != geteuid() ||
+        (st.st_mode & 022)) {
+        flock(fd, LOCK_UN); close(fd); errno = EACCES; return -1;
+    }
+    char buf[64] = {0};
+    ssize_t n = pread(fd, buf, sizeof buf - 1, 0);
+    char *end = NULL;
+    unsigned long long previous = 0;
+    if (n < 0) { flock(fd, LOCK_UN); close(fd); return -1; }
+    if (n) {
+        errno = 0;
+        previous = strtoull(buf, &end, 10);
+        if (errno || end == buf || (*end && *end != '\n') ||
+            previous >= UINT32_MAX) {
+            flock(fd, LOCK_UN); close(fd); errno = EINVAL; return -1;
+        }
+    }
+    uint32_t epoch = (uint32_t)previous + 1u;
+    int out_len = snprintf(buf, sizeof buf, "%u\n", epoch);
+    /* The decimal counter never shrinks when incremented, so overwrite first
+     * and fsync without truncating the last valid epoch before the new one is
+     * durable. */
+    int bad = out_len <= 0 ||
+              pwrite(fd, buf, (size_t)out_len, 0) != out_len || fsync(fd);
+    flock(fd, LOCK_UN); close(fd);
+    if (bad) return -1;
+    g_segment_route_generation = (uint64_t)epoch << 32 | 1u;
+    return 0;
+}
+
+static void segment_generation_bump(void) {
+    /* Exhausting four billion topology changes without restarting is not a
+     * useful operating state; fail closed at the reserved epoch boundary. */
+    if ((uint32_t)g_segment_route_generation == UINT32_MAX) {
+        fprintf(stderr, "[tracker] Segment generation epoch exhausted; "
+                        "restart to reserve the next durable epoch\n");
+        abort();
+    }
+    g_segment_route_generation++;
+}
 
 /* Unlike liveness/placement state, identity ownership must survive a tracker
  * restart.  Otherwise "TOFU" means only "trust until the process exits" and
@@ -87,7 +157,6 @@ static int g_max_names_per_source = 16;
 typedef struct { char name[64]; uint8_t pubkey[32]; int is_expert; } Binding;
 static Binding g_bindings[MAX_BINDINGS];
 static int g_nbindings;
-static char g_bindings_path[512];
 
 static int binding_name_ok(const char *s) {
     if (!s || !*s || strlen(s) >= 64) return 0;
@@ -811,6 +880,11 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert &&
             !strcmp(g_peers[i].name, name)) { slot = &g_peers[i]; break; }
+    if (slot && slot->has_segment && strcmp(slot->segment.model, model)) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "one compute name cannot mix models");
+        return NULL;
+    }
     if (!slot) {
         slot = peer_slot_new(1, NULL);
         fresh = slot != NULL;
@@ -834,8 +908,9 @@ static Peer *handle_ereg(int fd, LmbMsg *m, const uint8_t *nonce) {
         use_addr = fixed;
     }
     if (slot) {
-        slot->used = 1; slot->is_expert = 1;
+        slot->used = 1; slot->is_expert = 1; slot->has_expert = 1;
         slot->nexperts = nexperts; slot->ts = now_s();
+        slot->expert_ts = slot->ts;
         slot->ctrl_fd = fd;
         snprintf(slot->name, sizeof slot->name, "%s", name);
         snprintf(slot->addr, sizeof slot->addr, "%s", use_addr);
@@ -888,18 +963,221 @@ static int handle_epeers(int fd, LmbMsg *m) {
     pthread_mutex_lock(&g_lk);
     uint32_t n = 0;
     for (int i = 0; i < MAX_PEERS; i++)
-        if (g_peers[i].used && g_peers[i].is_expert &&
-            now - g_peers[i].ts <= g_stale_s &&
+        if (g_peers[i].used && g_peers[i].is_expert && g_peers[i].has_expert &&
+            now - g_peers[i].expert_ts <= g_stale_s &&
             (!want[0] || !strcmp(g_peers[i].model, want))) n++;
     lmb_buf_u32(&b, n);
     for (int i = 0; i < MAX_PEERS; i++)
-        if (g_peers[i].used && g_peers[i].is_expert &&
-            now - g_peers[i].ts <= g_stale_s &&
+        if (g_peers[i].used && g_peers[i].is_expert && g_peers[i].has_expert &&
+            now - g_peers[i].expert_ts <= g_stale_s &&
             (!want[0] || !strcmp(g_peers[i].model, want)))
             lmb_buf_str(&b, g_peers[i].addr);
     pthread_mutex_unlock(&g_lk);
     int rc = lmb_send(fd, LMB_EPEERS_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
+    return rc;
+}
+
+/* ---- SREG / SEG_ROUTES: stateful range discovery -----------------------
+ * A Segment heartbeat shares the compute identity and persistent control
+ * connection used by EREG, but it is a distinct capability. This matters for
+ * transition releases: a range-only peer must never appear in EPEERS and an
+ * old expert-only peer must never be selected for a stateful session. */
+
+static int segment_model_root_ok(const LmbSegAdvert *advert) {
+    for (int i = 0; i < MAX_MODELS; i++)
+        if (g_models[i].used && !strcmp(g_models[i].id.model, advert->model))
+            return !memcmp(g_models[i].id.root, advert->model_root,
+                           LMB_SEG_ROOT_BYTES);
+    /* Private/development swarms may register compute before the origin. The
+     * query still requires an exact root; once a signed origin is known, a
+     * conflicting heartbeat is rejected here. */
+    return 1;
+}
+
+static int segment_route_shape_equal(const LmbSegAdvert *a,
+                                     const LmbSegAdvert *b) {
+    return !strcmp(a->peer_name, b->peer_name) &&
+           !strcmp(a->addr, b->addr) && !strcmp(a->model, b->model) &&
+           !memcmp(a->model_root, b->model_root, LMB_SEG_ROOT_BYTES) &&
+           !memcmp(a->tokenizer_root, b->tokenizer_root, LMB_SEG_ROOT_BYTES) &&
+           a->layer_begin == b->layer_begin && a->layer_end == b->layer_end &&
+           a->max_context == b->max_context && a->max_rows == b->max_rows &&
+           a->state_dtype == b->state_dtype && a->state_width == b->state_width &&
+           a->max_sessions == b->max_sessions && a->flags == b->flags &&
+           a->capabilities == b->capabilities &&
+           !strcmp(a->engine_id, b->engine_id) &&
+           !strcmp(a->state_schema, b->state_schema) &&
+           !strcmp(a->numeric_class, b->numeric_class);
+}
+
+static Peer *handle_segment_register(int fd, LmbMsg *m, const uint8_t *nonce) {
+    if (!g_segment_generation_ready) {
+        send_err(fd, "segment discovery is unavailable: no durable generation");
+        return NULL;
+    }
+    uint8_t peer_pk[32], peer_sig[64], next_lease[LMB_SEG_ID_BYTES];
+    int have_auth = 0;
+    size_t blen = peer_auth_strip(m, peer_pk, peer_sig, &have_auth);
+    LmbSegAdvert advert;
+    if (lmb_seg_advert_decode(m->body, blen, &advert)) {
+        send_err(fd, "bad segment registration"); return NULL;
+    }
+    if (!have_auth || !nonce) {
+        send_err(fd, "segment registration must be signed (CHALLENGE first)");
+        return NULL;
+    }
+    uint8_t authmsg[512];
+    size_t auth_len = lmb_peer_auth_msg(nonce, advert.peer_name, advert.model,
+                                        advert.addr, authmsg, sizeof authmsg);
+    if (!auth_len || lmb_sign_verify(peer_sig, authmsg, auth_len, peer_pk)) {
+        send_err(fd, "bad identity signature"); return NULL;
+    }
+    if (lmb_secure_enabled() && !lmb_secure_peer_matches(fd, peer_pk)) {
+        send_err(fd, "channel/registration identity mismatch"); return NULL;
+    }
+    char source[64]; connection_source(fd, source);
+    char fixed[64];
+    struct sockaddr_in sin; socklen_t sl = sizeof sin;
+    if (!strncmp(advert.addr, "127.0.0.1:", 10) &&
+        getpeername(fd, (struct sockaddr *)&sin, &sl) == 0 &&
+        sin.sin_family == AF_INET && ntohl(sin.sin_addr.s_addr) != INADDR_LOOPBACK) {
+        snprintf(fixed, sizeof fixed, "%s:%s", inet_ntoa(sin.sin_addr),
+                 strchr(advert.addr, ':') + 1);
+        snprintf(advert.addr, sizeof advert.addr, "%s", fixed);
+    }
+    lmb_random(next_lease, sizeof next_lease);
+
+    Peer *slot = NULL;
+    int fresh = 0, changed = 0;
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+    if (!segment_model_root_ok(&advert)) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "segment model root differs from tracker identity");
+        return NULL;
+    }
+    if (name_key_ok(advert.peer_name, 1, peer_pk) < 0) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "name held by another key"); return NULL;
+    }
+    if (!identity_has_room(peer_pk, advert.peer_name, 1, source)) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "peer identity or source admission quota reached");
+        return NULL;
+    }
+    for (int i = 0; i < MAX_PEERS; i++)
+        if (g_peers[i].used && g_peers[i].is_expert &&
+            !strcmp(g_peers[i].name, advert.peer_name)) {
+            slot = &g_peers[i]; break;
+        }
+    if (slot && slot->has_expert && strcmp(slot->model, advert.model)) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "one compute name cannot mix models");
+        return NULL;
+    }
+    if (!slot) { slot = peer_slot_new(1, NULL); fresh = slot != NULL; }
+    if (slot && binding_check_or_add(advert.peer_name, 1, peer_pk)) {
+        pthread_mutex_unlock(&g_lk);
+        send_err(fd, "cannot persist compute identity binding"); return NULL;
+    }
+    if (slot) {
+        int was_live = slot->has_segment && slot->segment_live &&
+                       now - slot->segment_ts <= g_stale_s;
+        changed = !was_live || !segment_route_shape_equal(&slot->segment, &advert);
+        if (changed) {
+            memcpy(slot->segment_owner.lease_id.bytes, next_lease,
+                   sizeof slot->segment_owner.lease_id.bytes);
+            segment_generation_bump();
+            slot->segment_owner.fencing_epoch = g_segment_route_generation;
+        }
+        slot->segment = advert;
+        slot->segment_ts = now; slot->segment_live = 1;
+        slot->used = 1; slot->is_expert = 1; slot->has_segment = 1;
+        slot->ts = now; slot->ctrl_fd = fd;
+        memcpy(slot->pubkey, peer_pk, 32); slot->has_key = 1;
+        snprintf(slot->name, sizeof slot->name, "%s", advert.peer_name);
+        /* Expert and Segment listeners may use different ports. Keep addr as
+         * the expert data-plane endpoint once EREG exists; Segment routes use
+         * the independent address stored in slot->segment. */
+        if (!slot->has_expert) {
+            snprintf(slot->addr, sizeof slot->addr, "%s", advert.addr);
+            snprintf(slot->model, sizeof slot->model, "%s", advert.model);
+        }
+        snprintf(slot->source, sizeof slot->source, "%s", source);
+        slot->segment_owner.route_generation = g_segment_route_generation;
+    }
+    pthread_mutex_unlock(&g_lk);
+    if (!slot) { send_err(fd, "peer table full"); return NULL; }
+    if (fresh || changed) {
+        printf("[tracker] + segment %s @ %s (%s, layers %u:%u%s)\n",
+               advert.peer_name, advert.addr, advert.model,
+               advert.layer_begin, advert.layer_end,
+               advert.flags & LMB_SEG_ADVERT_DRAINING ? ", draining" : "");
+        fflush(stdout);
+    }
+    uint8_t *reply = NULL; uint32_t reply_len = 0;
+    LmbSegOwner owner;
+    pthread_mutex_lock(&g_lk);
+    owner = slot->segment_owner;
+    owner.route_generation = g_segment_route_generation;
+    pthread_mutex_unlock(&g_lk);
+    if (lmb_seg_registration_reply_encode(&owner, &reply, &reply_len)) {
+        send_err(fd, "cannot encode segment lease"); return NULL;
+    }
+    int rc = lmb_send(fd, LMB_SEG_REGISTER_R, reply, reply_len, NULL, 0);
+    free(reply);
+    return rc ? NULL : slot;
+}
+
+static int handle_segment_routes(int fd, LmbMsg *m) {
+    if (!g_segment_generation_ready) {
+        send_err(fd, "segment discovery is unavailable: no durable generation");
+        return 0;
+    }
+    LmbSegQuery query;
+    if (m->pay_len || lmb_seg_query_decode(m->body, m->body_len, &query)) {
+        send_err(fd, "bad segment route query"); return -1;
+    }
+    LmbSegRouteSnapshot snapshot;
+    memset(&snapshot, 0, sizeof snapshot);
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+    /* Liveness is a material placement change, but only once per transition;
+     * repeated queries cannot churn the route generation. */
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *p = &g_peers[i];
+        if (p->used && p->has_segment && p->segment_live &&
+            now - p->segment_ts > g_stale_s) {
+            p->segment_live = 0;
+            segment_generation_bump();
+        }
+    }
+    snapshot.route_generation = g_segment_route_generation;
+    for (int i = 0; i < MAX_PEERS && snapshot.count < LMB_SEG_ROUTE_MAX; i++) {
+        Peer *p = &g_peers[i];
+        if (!p->used || !p->has_segment || !p->segment_live ||
+            now - p->segment_ts > g_stale_s ||
+            !lmb_seg_advert_compatible(&p->segment, &query)) continue;
+        LmbSegRouteEntry *entry = &snapshot.entries[snapshot.count++];
+        entry->advert = p->segment;
+        entry->owner = p->segment_owner;
+        entry->owner.route_generation = snapshot.route_generation;
+        if (entry->advert.addr[0]) entry->transport |= LMB_SEG_TRANSPORT_DIRECT;
+        /* Do not infer Segment relay from the persistent SREG connection.
+         * This tracker can relay READ/EXEC today, but it does not forward the
+         * stateful Segment operations yet. The reserved bit is published only
+         * when that data-plane handler exists. */
+    }
+    snapshot.complete = (uint32_t)lmb_seg_route_complete(&snapshot, &query);
+    pthread_mutex_unlock(&g_lk);
+
+    uint8_t *body = NULL; uint32_t body_len = 0;
+    if (lmb_seg_route_encode(&snapshot, &body, &body_len)) {
+        send_err(fd, "cannot encode segment routes"); return -1;
+    }
+    int rc = lmb_send(fd, LMB_SEG_ROUTES_R, body, body_len, NULL, 0);
+    free(body);
     return rc;
 }
 
@@ -929,8 +1207,9 @@ static int handle_ecover(int fd, LmbMsg *m) {
          * profiles left half the swarm's coverage invisible. The chatter's
          * own admission gate (lmb_profile_compat, hard fields only) still
          * refuses shape-incompatible peers it talks to directly. */
-        if (!q->used || !q->is_expert || q->ctrl_fd < 0 || q->evfd < 0 ||
-            now - q->ts > g_stale_s || strcmp(q->model, model) ||
+        if (!q->used || !q->is_expert || !q->has_expert ||
+            q->ctrl_fd < 0 || q->evfd < 0 ||
+            now - q->expert_ts > g_stale_s || strcmp(q->model, model) ||
             strcmp(q->engine, engine) ||
             q->bits != bits || q->hidden != hidden || q->slots != slots ||
             q->total_experts != nexp) continue;
@@ -1076,8 +1355,10 @@ static int handle_swarm(int fd) {
     uint32_t live = 0, live_exec = 0;
     for (int i = 0; i < MAX_PEERS; i++) {
         if (!g_peers[i].used || now - g_peers[i].ts > g_stale_s) continue;
-        if (g_peers[i].is_expert) live_exec++;
-        else live++;
+        if (g_peers[i].is_expert) {
+            if (g_peers[i].has_expert &&
+                now - g_peers[i].expert_ts <= g_stale_s) live_exec++;
+        } else live++;
     }
     /* Keep this legacy storage-peer prefix byte-for-byte compatible. */
     lmb_buf_u32(&b, live);
@@ -1096,12 +1377,13 @@ static int handle_swarm(int fd) {
     lmb_buf_u32(&exec, live_exec);
     for (int i = 0; i < MAX_PEERS; i++) {
         Peer *p = &g_peers[i];
-        if (!p->used || !p->is_expert || now - p->ts > g_stale_s) continue;
+        if (!p->used || !p->is_expert || !p->has_expert ||
+            now - p->expert_ts > g_stale_s) continue;
         lmb_buf_str(&exec, p->model);
         lmb_buf_u32(&exec, p->have_exec_stats ? 1u : 0u);
         lmb_buf_u64(&exec, p->have_exec_stats ? p->exec_calls : 0);
         lmb_buf_u32(&exec, p->have_exec_stats ? p->exec_inflight : 0);
-        lmb_buf_u32(&exec, (uint32_t)(now - p->ts));
+        lmb_buf_u32(&exec, (uint32_t)(now - p->expert_ts));
     }
     pthread_mutex_unlock(&g_lk);
     lmb_buf_u32(&b, LMB_SWARM_EXEC_MAGIC);
@@ -1172,14 +1454,15 @@ static int handle_eassign(int fd, LmbMsg *m) {
     int have_mine = 0;
     for (int i = 0; i < MAX_PEERS; i++) {
         Peer *p = &g_peers[i];
-        if (!p->used || !p->is_expert || strcmp(p->model, model) || !p->ebits) continue;
+        if (!p->used || !p->is_expert || !p->has_expert ||
+            strcmp(p->model, model) || !p->ebits) continue;
         if (!strcmp(p->name, name)) {                 /* this node, as it was */
             memcpy(mine, p->ebits, ((cells + 7) / 8 < (p->enbits + 7) / 8
                                     ? (cells + 7) / 8 : (p->enbits + 7) / 8));
             have_mine = 1;
             continue;
         }
-        if (now - p->ts > g_stale_s) continue;
+        if (now - p->expert_ts > g_stale_s) continue;
         uint64_t ph = 1469598103934665603ull;
         for (const char *s = p->name; *s; s++) { ph ^= (uint8_t)*s; ph *= 1099511628211ull; }
         for (size_t k = 0; k < cells && k < p->enbits; k++)
@@ -1206,7 +1489,9 @@ static int handle_eassign(int fd, LmbMsg *m) {
         }
         int live = 0;
         for (int j = 0; j < MAX_PEERS; j++)
-            if (g_peers[j].used && g_peers[j].is_expert && g_peers[j].ebits &&
+            if (g_peers[j].used && g_peers[j].is_expert &&
+                g_peers[j].has_expert && g_peers[j].ebits &&
+                now - g_peers[j].expert_ts <= g_stale_s &&
                 !strcmp(g_peers[j].name, pr->name) &&
                 !strcmp(g_peers[j].model, model)) { live = 1; break; }
         if (live) continue;
@@ -1413,7 +1698,8 @@ static int handle_rexec(int fd, LmbMsg *m) {
     for (int i = 0; i < MAX_PEERS && !p; i++) {
         Peer *q = &g_peers[i];
         uint32_t gid = (uint32_t)gid64;
-        if (!q->used || !q->is_expert || now - q->ts > g_stale_s ||
+        if (!q->used || !q->is_expert || !q->has_expert ||
+            now - q->expert_ts > g_stale_s ||
             q->ctrl_fd < 0 || q->evfd < 0 || strcmp(q->model, model) || gid >= q->enbits ||
             !(q->ebits[gid >> 3] & (uint8_t)(1u << (gid & 7)))) continue;
         p = q; p->refs++;
@@ -1700,6 +1986,24 @@ static void *conn_thread(void *arg) {
         case LMB_EASSIGN:   rc = handle_eassign(fd, &m); break;
         case LMB_EPEERS:    rc = handle_epeers(fd, &m); break;
         case LMB_ECOVER:    rc = handle_ecover(fd, &m); break;
+        case LMB_SEG_REGISTER: {
+            Peer *p = handle_segment_register(fd, &m,
+                                               have_nonce ? nonce : NULL);
+            if (p) {
+                if (!ctrl) {
+                    pthread_mutex_lock(&g_lk); p->refs++; pthread_mutex_unlock(&g_lk);
+                    ctrl = p;
+                } else if (ctrl != p) {
+                    pthread_mutex_lock(&g_lk);
+                    if (p->ctrl_fd == fd) p->ctrl_fd = -1;
+                    pthread_mutex_unlock(&g_lk);
+                    send_err(fd, "one compute identity per control connection");
+                    rc = -1;
+                }
+            } else rc = -1;
+            break;
+        }
+        case LMB_SEG_ROUTES: rc = handle_segment_routes(fd, &m); break;
         case LMB_HASHES:    rc = handle_hashes(fd, &m); break;
         case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;
@@ -1759,6 +2063,12 @@ int main(int argc, char **argv) {
                 g_bindings_path[0] ? g_bindings_path : "the state directory");
         return 1;
     }
+    if (segment_generation_init())
+        fprintf(stderr, "[tracker] warning: cannot reserve a durable Segment "
+                        "route generation next to %s; legacy services remain "
+                        "available but Segment discovery is disabled\n",
+                g_bindings_path);
+    else g_segment_generation_ready = 1;
     lmb_conn_gate_init(&g_conn_gate);
     if (lmb_secure_init()) return 1;
     int lfd = lmb_listen(port);


### PR DESCRIPTION
## Summary

- add signed Segment registration to the tracker with exact model root, tokenizer root, engine, state schema and numeric-class compatibility
- return layer-aligned ranges and replicas with random leases, monotonic fencing, durable route generations, draining and live capacity telemetry
- add an asynchronous discovery worker that publishes fixed-size immutable route snapshots outside the inference path
- keep Expert and Segment capability/address/liveness independent while sharing one compute identity and control connection
- cover OLMoE, GLM-5.2, Inkling, Kimi K3, Qwen3.6 and DeepSeek V4 with the same tiny discovery gate

## Release safety

Existing local and Expert paths do not register Segment capability and keep their current behavior. A Segment-only peer is explicitly excluded from EPEERS. If the tracker cannot reserve durable Segment generations, legacy tracker services still start and only Segment discovery is disabled.

This PR implements the control plane, not the inference data plane. It does not claim production SEG_RUN dispatch, Segment relay, snapshot/replay failover or automatic CLI activation. The RELAY transport bit remains reserved until forwarding actually exists.

## Validation

- make test
- make check-warnings
- ASan + UBSan build and end-to-end Segment discovery test, with leak detection disabled because LeakSanitizer is unsupported under the runner ptrace environment
- real tracker restart verifies that route generation epochs advance durably

The existing relay EXEC test reports its documented SKIP locally because this isolated Lumabri worktree has no external OLMoE source at ENGINE=../colibri/c; all repository-owned gates pass.
