### PR TITLE
feat: add direct Segment execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,32 @@ test_segment_discovery: test_segment_discovery.c lumabri_segment_discovery.c \
 	$(CC) $(CFLAGS) -pthread test_segment_discovery.c \
 		lumabri_segment_discovery.c lumabri_segment.c -o $@
 
+# ---- Segment direct data plane (requires Colibri's additive Edge ABI) ---
+# Kept out of `all`: a rolling Lumabri checkout still builds against the
+# Colibri release branch while the corresponding dev PR is under review.
+COLIBRI_SEGMENT_LIB = $(ENGINE)/build/segment/libcolibri_segment_edge.a
+SEGMENT_CFLAGS = $(CFLAGS) -I. -I$(ENGINE) -fopenmp
+SEGMENT_COMMON = segment_colibri.h lumabri_segment.c lumabri_segment.h \
+		lumabri_segment_discovery.c lumabri_segment_discovery.h \
+		lumabri_proto.h lumabri_sign.h lumabri_sha.h $(SECURE_DEPS)
+
+$(COLIBRI_SEGMENT_LIB):
+	$(MAKE) -C $(ENGINE) segment-edge-library
+
+segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
+	$(CC) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
+		lumabri_segment_discovery.c $(COLIBRI_SEGMENT_LIB) -o $@ -lm
+
+segment_chat: segment_chat.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
+	$(CC) $(SEGMENT_CFLAGS) -pthread segment_chat.c lumabri_segment.c \
+		lumabri_segment_discovery.c $(COLIBRI_SEGMENT_LIB) -o $@ -lm
+
+.PHONY: segment-direct
+segment-direct: segment_node segment_chat
+
+test-segment-direct-real: tracker segment-direct
+	bash ./segment_direct_test.sh
+
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh
 
@@ -416,7 +442,7 @@ test-segment-v2: test_segment_v2
 	./test_segment_v2
 
 test-segment-discovery: tracker test_segment_discovery
-	./segment_discovery_test.sh
+	bash ./segment_discovery_test.sh
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery
@@ -440,7 +466,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_key_rotation
 	./test_hedge
 	./test_segment_v2
-	./segment_discovery_test.sh
+	bash ./segment_discovery_test.sh
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)
@@ -456,7 +482,8 @@ install: all
 	install -m 644 liblumabri.so $(DESTDIR)$(PREFIX)/lib/lumabri/
 	@for b in expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	         expert_node_deepseek \
-	         olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p; do \
+	         olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
+	         segment_node segment_chat; do \
 	    [ -f $$b ] && install -m 755 $$b $(DESTDIR)$(PREFIX)/bin/ || true; done
 	@echo "installed under $(DESTDIR)$(PREFIX)"
 
@@ -464,6 +491,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery \
+	      segment_node segment_chat \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	      expert_node_deepseek
@@ -475,4 +503,4 @@ clean:
         test-phase2-deepseek test-engines \
         patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 test-elastic \
         test-cas test-key-rotation test-hedge test-segment-v2 \
-        test-segment-discovery
+        test-segment-discovery segment-direct test-segment-direct-real

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ Build the peers with `make engines`, the patched chat engines with
 `make chatters`, or both with `make phase2-all ENGINE=/path/to/colibri/c`, for
 the engines your colibri checkout actually has.
 
+### Layer segments (opt-in preview)
+
+The direct Segment path keeps whole contiguous layer ranges and their sequence
+state resident on peers, reducing the network boundary from one request per
+layer/expert to one request per segment. It is now executable for all six
+engine families and has a two-peer oracle gate, but is intentionally not the
+default `lumabri chat` path yet. Build and external-server instructions, plus
+the explicit greedy/direct/no-replay limitations, are in
+**[SEGMENT_DIRECT.md](SEGMENT_DIRECT.md)**.
+
 ## Running a swarm
 
 A full server walkthrough (systemd, firewall, operator key, clients) is in

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -1,0 +1,128 @@
+# Direct Segment execution
+
+Lumabri can opt in to Colibri's public Edge/Segment ABI and run one model as a
+chain of layer-aligned peers:
+
+```text
+prompt -> local Edge -> peer A [0:k] -> peer B [k:n] -> local Edge -> token
+```
+
+The implementation is model-neutral. The release gate runs the same direct
+TCP path for GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4. Every
+family is split over two peers and three generated token IDs are compared with
+its independent Colibri tiny-model oracle. The gate also overlaps two OLMoE
+chats against the same executors to exercise real session isolation, and
+retransmits a committed run to prove the cached duplicate response is exact.
+
+This is an opt-in data-plane milestone, not yet the default interactive
+`lumabri chat` path. The ordinary Lumabri and Colibri commands are unchanged.
+
+## Build
+
+Use a Colibri checkout containing the additive Edge runtime:
+
+```sh
+make -C /path/to/colibri/c segment-edge-library
+make segment-direct ENGINE=/path/to/colibri/c
+make tracker
+```
+
+`segment-edge-library` produces a CPU-baseline static archive containing both
+public runtimes and all six adapters. It is not linked into ordinary Colibri
+executables.
+
+## Two-peer example
+
+Start a tracker on the publicly reachable control server:
+
+```sh
+./tracker --port 7300 --peer-bindings ./peer-bindings
+```
+
+Split a four-layer example model over two reachable machines. Both peers must
+use the same model name, model root, tokenizer root, schema and numeric class;
+the latter three model properties are read from Colibri automatically.
+
+```sh
+./segment_node \
+  --engine olmoe --model-dir /models/olmoe --model my-olmoe \
+  --range 0:2 --port 7303 --tracker TRACKER:7300 \
+  --advertise PEER_A_PUBLIC_IP:7303 --name olmoe-a \
+  --model-root MODEL_HEX64 --tokenizer-root TOKENIZER_HEX64 \
+  --context 4096 --max-rows 64 --sessions 4
+```
+
+```sh
+./segment_node \
+  --engine olmoe --model-dir /models/olmoe --model my-olmoe \
+  --range 2:4 --port 7303 --tracker TRACKER:7300 \
+  --advertise PEER_B_PUBLIC_IP:7303 --name olmoe-b \
+  --model-root MODEL_HEX64 --tokenizer-root TOKENIZER_HEX64 \
+  --context 4096 --max-rows 64 --sessions 4
+```
+
+The chatter needs the model's Edge files (tokenizer, embeddings, final
+transform and head), then discovers and freezes a complete compatible route:
+
+```sh
+./segment_chat \
+  --engine olmoe --model-dir /models/olmoe-edge --model my-olmoe \
+  --tracker TRACKER:7300 \
+  --model-root MODEL_HEX64 --tokenizer-root TOKENIZER_HEX64 \
+  --prompt "Hello" --tokens 32 --context 4096 --max-rows 64
+```
+
+For an isolated experiment with no byte-plane maintainer registered under the
+same model name, the two roots may be any shared non-zero 32-byte hex values.
+For a real swarm, `--model-root` must be the content-plane model identity; the
+tracker rejects a different value. Automatic model/tokenizer root selection is
+still part of the CLI integration work and must replace manual input before
+the final UX is declared complete.
+
+Open the Segment port on each executor's firewall. The current transport is
+direct TCP, so an executor behind an unforwarded NAT is not reachable yet.
+
+## Encryption
+
+Set `LUMABRI_ENCRYPT=1` on tracker, executors and chatter to use Lumabri's
+X25519 + ChaCha20-Poly1305 transport with persistent/TOFU or pinned peer
+identities. `LUMABRI_PEER_KEY`, `LUMABRI_KNOWN_HOSTS` and
+`LUMABRI_PEER_PINS` have the same meaning as on the existing data plane.
+
+## Release gate
+
+`test-segment-direct-real` requires the same twelve model/reference variables
+as Colibri's Edge oracle gate:
+
+```sh
+make test-segment-direct-real ENGINE=/path/to/colibri/c \
+  GLM_EDGE_MODEL=... GLM_EDGE_REF=... \
+  INKLING_EDGE_MODEL=... INKLING_EDGE_REF=... \
+  KIMI_EDGE_MODEL=... KIMI_EDGE_REF=... \
+  OLMOE_EDGE_MODEL=... OLMOE_EDGE_REF=... \
+  QWEN_EDGE_MODEL=... QWEN_EDGE_REF=... \
+  DEEPSEEK_EDGE_MODEL=... DEEPSEEK_EDGE_REF=...
+```
+
+Run the same command with `LUMABRI_ENCRYPT=1` to gate encrypted control and
+data planes.
+
+## Deliberate current limits
+
+- Edge v1 selects greedy tokens only. Temperature, top-p and top-k are not
+  silently approximated outside Colibri.
+- Segment relay and NAT hole punching are not implemented; only tracker
+  discovery and direct peer connections are used.
+- Snapshot bytes are not transported yet. If a selected peer dies, the chat
+  stops with an explicit checkpoint/replay error rather than producing a
+  divergent continuation.
+- The archive advertises CPU only. GPU Segment adapters must expose a real
+  Colibri backend before Lumabri may publish CUDA/HIP/Metal/Vulkan capability.
+- Machine profiling, resource governance, automatic donation and local
+  fallback are not part of these standalone binaries yet.
+- One chatter process hosts one active Edge model. This also respects Qwen's
+  currently process-global tokenizer state.
+
+These are roadmap items, not hidden fallbacks. The completed milestone proves
+one RTT per segment, exact multi-session state ownership and real token
+generation over the network for every current model family.

--- a/SEGMENT_V2.md
+++ b/SEGMENT_V2.md
@@ -6,12 +6,13 @@ particular model's KV layout. Colibri owns the model math, weights, accelerator
 and opaque state; Lumabri owns transport, session identity, ordering, leases,
 fencing and route lifecycle.
 
-The wire/session contract and tracker discovery control plane are implemented.
-No production executor dispatches inference opcodes and no model is advertised
-by the normal CLI as Segment-capable yet: registration is available to the
-upcoming executor, while route discovery is kept out of the inference path.
-Public activation is gated on GLM, Inkling, Kimi K3, Qwen3.6, OLMoE and
-DeepSeek V4 all passing the same conformance suite.
+The wire/session contract, tracker discovery and opt-in direct executor are
+implemented. `segment_node` dispatches `SEG_OPEN`, `SEG_RUN`, `SEG_CLOSE` and
+`SEG_HEALTH` through Colibri's public ABI; `segment_chat` keeps Edge math local
+and freezes an immutable complete route before inference. The normal
+interactive CLI does not advertise Segment capability automatically yet.
+Snapshot/restore wire envelopes exist, but snapshot transport and replay are
+still deliberately unadvertised. See [SEGMENT_DIRECT.md](SEGMENT_DIRECT.md).
 
 ## Tracker discovery
 
@@ -29,7 +30,9 @@ plus:
 - a monotonic route generation for the complete placement;
 - data-plane transport capability (`DIRECT` today; `RELAY` remains reserved
   until Segment forwarding is implemented rather than inferred from SREG);
-- whether the returned interval union covers the requested chain.
+- whether the returned ranges contain an exact executable chain. Interval
+  union alone is insufficient because overlapping executors would run a layer
+  twice; replicas may overlap, but the selected boundaries must join exactly.
 
 Telemetry-only heartbeats do not churn leases or route generations. A range,
 compatibility, address, capability or draining change does; stale/recovered
@@ -116,10 +119,10 @@ outside the table lock, then calls `run_commit` or `run_abort`. Commit alone
 advances sequence and position.
 
 The table records the last 16 committed request identities and digests. A
-duplicate is never executed twice. The future network executor must retain the
-corresponding response while it is retryable, or return an explicit
-duplicate-without-payload failure and trigger replay; it must never call the
-model again for the same committed request.
+duplicate is never executed twice. The direct executor retains the most recent
+committed activation response for a safe immediate retry. An older recognized
+duplicate returns `NEEDS_RESTORE`; once replay lands, that status will restore
+from a checkpoint rather than ever calling the model twice.
 
 ## Fencing
 
@@ -158,4 +161,7 @@ execution, fence, restore, stale owners, snapshot checks, close and TTL reap.
 The real-tracker discovery gate additionally covers signed registration,
 compatibility filtering, replicas, complete chains, telemetry stability,
 draining, lease rotation and asynchronous snapshots. These are protocol and
-control-plane fixtures, not a claim that the network executors are complete.
+control-plane fixtures. `segment_direct_test.sh` adds the real data plane: two
+peers per family, real prefill/decode, persistent sessions and three oracle
+tokens for all six models, plus overlapping real sessions, in plaintext and
+encrypted modes.

--- a/lumabri_segment_discovery.c
+++ b/lumabri_segment_discovery.c
@@ -1,3 +1,6 @@
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
 #ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
 #endif
@@ -5,6 +8,7 @@
 #include "lumabri_segment_discovery.h"
 
 #include "lumabri_proto.h"
+#include "lumabri_secure.h"
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -97,19 +101,35 @@ int lmb_seg_advert_compatible(const LmbSegAdvert *a, const LmbSegQuery *q) {
 int lmb_seg_route_complete(const LmbSegRouteSnapshot *s,
                            const LmbSegQuery *q) {
     if (!s || !lmb_seg_query_valid(q) || s->count > LMB_SEG_ROUTE_MAX) return 0;
-    uint32_t cursor = q->layer_begin;
-    while (cursor < q->layer_end) {
-        uint32_t farthest = cursor;
+    /* Coverage is not interval union: executors cannot run half of an
+     * advertised range, and overlapping ranges would execute a layer twice.
+     * Track the exact boundaries reachable from query.begin instead. */
+    uint32_t reachable[LMB_SEG_ROUTE_MAX + 1];
+    size_t reachable_count = 1;
+    reachable[0] = q->layer_begin;
+    for (uint32_t pass = 0; pass < s->count; pass++) {
+        int changed = 0;
         for (uint32_t i = 0; i < s->count; i++) {
             const LmbSegAdvert *a = &s->entries[i].advert;
-            if (lmb_seg_advert_compatible(a, q) && a->layer_begin <= cursor &&
-                a->layer_end > farthest)
-                farthest = a->layer_end;
+            if (!lmb_seg_advert_compatible(a, q) ||
+                a->layer_begin < q->layer_begin || a->layer_end > q->layer_end)
+                continue;
+            int begin_reachable = 0, end_known = 0;
+            for (size_t j = 0; j < reachable_count; j++) {
+                begin_reachable |= reachable[j] == a->layer_begin;
+                end_known |= reachable[j] == a->layer_end;
+            }
+            if (begin_reachable && !end_known &&
+                reachable_count < LMB_SEG_ROUTE_MAX + 1) {
+                reachable[reachable_count++] = a->layer_end;
+                changed = 1;
+            }
         }
-        if (farthest == cursor) return 0;
-        cursor = farthest > q->layer_end ? q->layer_end : farthest;
+        if (!changed) break;
     }
-    return 1;
+    for (size_t i = 0; i < reachable_count; i++)
+        if (reachable[i] == q->layer_end) return 1;
+    return 0;
 }
 
 static int disc_cur_bytes(DiscCur *c, void *out, size_t n) {
@@ -359,6 +379,10 @@ int lmb_seg_registration_reply_decode(const void *body, size_t body_len,
 int lmb_seg_routes_fetch(const char *tracker, const LmbSegQuery *query,
                          LmbSegRouteSnapshot *snapshot) {
     if (!tracker || !*tracker || !snapshot) return -1;
+    /* Transport hooks are translation-unit local. This module owns the
+     * tracker sockets, so encryption must be initialized here as well as in
+     * the calling executable. */
+    if (lmb_secure_init()) return -1;
     uint8_t *body = NULL; uint32_t body_len = 0;
     if (lmb_seg_query_encode(query, &body, &body_len)) return -1;
     LmbMsg reply = {0};

--- a/lumabri_segment_discovery.h
+++ b/lumabri_segment_discovery.h
@@ -80,8 +80,8 @@ typedef struct {
 
 /* Fixed-size by design: copying this value produces an immutable routing
  * snapshot with no shared allocation and no tracker access on the inference
- * path. Entries include replicas; complete says their interval union covers
- * the complete requested range. */
+ * path. Entries include replicas; complete says at least one exact-boundary
+ * executor chain covers the complete requested range. */
 typedef struct {
     uint64_t route_generation;
     uint64_t fetched_at_ms;

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1,0 +1,508 @@
+#define _DEFAULT_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
+#include "lumabri_proto.h"
+#include "lumabri_segment.h"
+#include "lumabri_segment_discovery.h"
+#include "lumabri_sign.h"
+#include "lumabri_secure.h"
+#include "segment_colibri.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct {
+    LmbSegRouteEntry route;
+    int fd;
+    LmbSegOpen open;
+    uint64_t sequence;
+    uint64_t position;
+} RemoteSegment;
+
+static int retry_first_run;
+
+static void sleep_ms(unsigned ms) {
+    struct timespec ts = { (time_t)(ms / 1000u),
+                           (long)(ms % 1000u) * 1000000L };
+    while (nanosleep(&ts, &ts) && errno == EINTR) { }
+}
+
+static const char *arg_value(int argc, char **argv, const char *name) {
+    for (int i = 1; i + 1 < argc; i++) if (!strcmp(argv[i], name)) return argv[i + 1];
+    return NULL;
+}
+
+static void usage(const char *program) {
+    fprintf(stderr,
+        "usage: %s --engine ID --model-dir DIR --model NAME "
+        "--tracker HOST:PORT --model-root HEX64 --tokenizer-root HEX64 "
+        "(--prompt TEXT | --prompt-ids CSV) [--expect-ids CSV] "
+        "[--tokens N] [--context N] [--max-rows N] [--retry-first-run]\n",
+        program);
+}
+
+static int parse_ids(const char *text, int32_t **ids, size_t *count) {
+    if (!text || !*text || !ids || !count) return -1;
+    size_t n = 1;
+    for (const char *p = text; *p; p++) if (*p == ',') n++;
+    int32_t *values = malloc(n * sizeof *values);
+    if (!values) return -1;
+    const char *p = text;
+    for (size_t i = 0; i < n; i++) {
+        char *end = NULL;
+        errno = 0;
+        long value = strtol(p, &end, 10);
+        if (errno || end == p || value < INT32_MIN || value > INT32_MAX ||
+            (i + 1 < n ? *end != ',' : *end != '\0')) {
+            free(values); return -1;
+        }
+        values[i] = (int32_t)value;
+        p = end + (i + 1 < n);
+    }
+    *ids = values; *count = n;
+    return 0;
+}
+
+static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
+                        RemoteSegment *chain, size_t *chain_count) {
+    unsigned viable[LMB_SEG_ROUTE_MAX] = {0};
+    for (uint32_t pass = 0; pass < snapshot->count; pass++) {
+        int changed = 0;
+        for (uint32_t i = 0; i < snapshot->count; i++) {
+            const LmbSegRouteEntry *entry = &snapshot->entries[i];
+            if (viable[i] || !(entry->transport & LMB_SEG_TRANSPORT_DIRECT) ||
+                entry->advert.layer_begin >= entry->advert.layer_end ||
+                entry->advert.layer_end > layers) continue;
+            int reaches_end = entry->advert.layer_end == layers;
+            for (uint32_t j = 0; j < snapshot->count && !reaches_end; j++)
+                reaches_end = viable[j] &&
+                    snapshot->entries[j].advert.layer_begin ==
+                    entry->advert.layer_end;
+            if (reaches_end) { viable[i] = 1; changed = 1; }
+        }
+        if (!changed) break;
+    }
+    uint32_t cursor = 0;
+    size_t count = 0;
+    while (cursor < layers && count < LMB_SEG_ROUTE_MAX) {
+        const LmbSegRouteEntry *best = NULL;
+        for (uint32_t i = 0; i < snapshot->count; i++) {
+            const LmbSegRouteEntry *candidate = &snapshot->entries[i];
+            if (!viable[i] ||
+                candidate->advert.layer_begin != cursor ||
+                candidate->advert.layer_end > layers) continue;
+            if (!best || candidate->advert.layer_end > best->advert.layer_end ||
+                (candidate->advert.layer_end == best->advert.layer_end &&
+                 candidate->advert.queue_depth + candidate->advert.inflight <
+                 best->advert.queue_depth + best->advert.inflight))
+                best = candidate;
+        }
+        if (!best) return -1;
+        memset(&chain[count], 0, sizeof chain[count]);
+        chain[count].route = *best;
+        chain[count].fd = -1;
+        cursor = best->advert.layer_end;
+        count++;
+    }
+    if (cursor != layers) return -1;
+    *chain_count = count;
+    return 0;
+}
+
+static int reply_ok(const LmbMsg *msg, uint32_t expected_op,
+                    const LmbSegId *session, const LmbSegId *request,
+                    uint64_t generation, LmbSegReply *reply) {
+    if (msg->op != expected_op ||
+        lmb_seg_reply_decode(msg->body, msg->body_len, reply) ||
+        !lmb_seg_id_equal(&reply->session_id, session) ||
+        !lmb_seg_id_equal(&reply->request_id, request) ||
+        reply->route_generation != generation ||
+        (reply->status != LMB_SEG_STATUS_OK &&
+         reply->status != LMB_SEG_STATUS_DUPLICATE)) return -1;
+    return 0;
+}
+
+static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
+                       const uint8_t model_root[32],
+                       const uint8_t tokenizer_root[32], uint32_t context,
+                       uint32_t max_rows) {
+    const LmbSegAdvert *advert = &remote->route.advert;
+    LmbSegOpen *open = &remote->open;
+    memset(open, 0, sizeof *open);
+    open->session_id = *session_id;
+    lmb_random(open->request_id.bytes, sizeof open->request_id.bytes);
+    open->owner = remote->route.owner;
+    memcpy(open->model_root, model_root, sizeof open->model_root);
+    memcpy(open->tokenizer_root, tokenizer_root, sizeof open->tokenizer_root);
+    open->layer_begin = advert->layer_begin;
+    open->layer_end = advert->layer_end;
+    open->context_tokens = context;
+    open->max_rows = max_rows;
+    open->state_dtype = advert->state_dtype;
+    open->state_width = advert->state_width;
+    open->ttl_ms = 60000;
+    open->capabilities = advert->capabilities;
+    snprintf(open->engine_id, sizeof open->engine_id, "%s", advert->engine_id);
+    snprintf(open->state_schema, sizeof open->state_schema, "%s",
+             advert->state_schema);
+    snprintf(open->numeric_class, sizeof open->numeric_class, "%s",
+             advert->numeric_class);
+    uint8_t *body = NULL;
+    uint32_t body_len = 0;
+    if (lmb_seg_open_encode(open, &body, &body_len)) return -1;
+    remote->fd = lmb_connect(advert->addr);
+    if (remote->fd < 0 ||
+        lmb_send(remote->fd, LMB_SEG_OPEN, body, body_len, NULL, 0)) {
+        free(body); return -1;
+    }
+    free(body);
+    LmbMsg msg = {0};
+    LmbSegReply reply;
+    int bad = lmb_recv(remote->fd, &msg) ||
+              reply_ok(&msg, LMB_SEG_OPEN_R, session_id, &open->request_id,
+                       open->owner.route_generation, &reply) || msg.pay_len;
+    lmb_msg_free(&msg);
+    if (bad) return -1;
+    remote->sequence = reply.next_sequence;
+    remote->position = reply.next_position;
+    return 0;
+}
+
+static int remote_run(RemoteSegment *remote, const int32_t *tokens,
+                      uint32_t rows, const void *input, size_t bytes,
+                      void *output) {
+    LmbSegRun run;
+    memset(&run, 0, sizeof run);
+    run.session_id = remote->open.session_id;
+    lmb_random(run.request_id.bytes, sizeof run.request_id.bytes);
+    run.owner = remote->open.owner;
+    run.sequence = remote->sequence;
+    run.position = remote->position;
+    run.rows = rows;
+    run.token_count = rows;
+    run.token_ids = tokens;
+    uint8_t *body = NULL;
+    uint32_t body_len = 0;
+    if (lmb_seg_run_encode(&run, &body, &body_len) || bytes > UINT32_MAX)
+        return -1;
+    int bad = lmb_send(remote->fd, LMB_SEG_RUN, body, body_len,
+                       input, (uint32_t)bytes);
+    if (bad) { free(body); return -1; }
+    LmbMsg msg = {0};
+    LmbSegReply reply;
+    bad = lmb_recv(remote->fd, &msg) ||
+          reply_ok(&msg, LMB_SEG_RUN_R, &run.session_id, &run.request_id,
+                   run.owner.route_generation, &reply) ||
+          msg.pay_len != bytes;
+    if (!bad) {
+        memcpy(output, msg.pay, bytes);
+        if (reply.next_sequence != run.sequence + 1 ||
+            reply.next_position != run.position + rows) bad = 1;
+        else {
+            remote->sequence = reply.next_sequence;
+            remote->position = reply.next_position;
+        }
+    }
+    lmb_msg_free(&msg);
+    if (!bad && retry_first_run) {
+        retry_first_run = 0;
+        bad = lmb_send(remote->fd, LMB_SEG_RUN, body, body_len,
+                       input, (uint32_t)bytes);
+        memset(&msg, 0, sizeof msg);
+        LmbSegReply duplicate;
+        if (!bad) bad = lmb_recv(remote->fd, &msg) ||
+            reply_ok(&msg, LMB_SEG_RUN_R, &run.session_id, &run.request_id,
+                     run.owner.route_generation, &duplicate) ||
+            duplicate.status != LMB_SEG_STATUS_DUPLICATE ||
+            duplicate.next_sequence != remote->sequence ||
+            duplicate.next_position != remote->position ||
+            msg.pay_len != bytes || memcmp(msg.pay, output, bytes);
+        lmb_msg_free(&msg);
+    }
+    free(body);
+    return bad ? -1 : 0;
+}
+
+static void remote_close(RemoteSegment *remote) {
+    if (remote->fd < 0) return;
+    LmbSegControl control;
+    memset(&control, 0, sizeof control);
+    control.session_id = remote->open.session_id;
+    lmb_random(control.request_id.bytes, sizeof control.request_id.bytes);
+    control.owner = remote->open.owner;
+    control.sequence = remote->sequence;
+    uint8_t *body = NULL;
+    uint32_t body_len = 0;
+    if (!lmb_seg_control_encode(&control, &body, &body_len)) {
+        (void)lmb_send(remote->fd, LMB_SEG_CLOSE, body, body_len, NULL, 0);
+        LmbMsg reply = {0};
+        if (!lmb_recv(remote->fd, &reply)) lmb_msg_free(&reply);
+    }
+    free(body);
+    lmb_close(remote->fd);
+    remote->fd = -1;
+}
+
+static int chain_run(RemoteSegment *chain, size_t count,
+                     const int32_t *tokens, uint32_t rows,
+                     uint8_t **first, uint8_t **second, size_t bytes) {
+    uint8_t *input = *first, *output = *second;
+    for (size_t i = 0; i < count; i++) {
+        if (remote_run(&chain[i], tokens, rows, input, bytes, output)) return -1;
+        uint8_t *swap = input; input = output; output = swap;
+    }
+    *first = input;
+    *second = output;
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    /* lmb_random shares the header-only signing implementation; retain the
+     * primitive in warning-clean builds even though the chatter does not sign. */
+    (void)lmb_sign;
+    const char *engine_id = arg_value(argc, argv, "--engine");
+    const char *model_dir = arg_value(argc, argv, "--model-dir");
+    const char *model = arg_value(argc, argv, "--model");
+    const char *tracker = arg_value(argc, argv, "--tracker");
+    const char *model_root_text = arg_value(argc, argv, "--model-root");
+    const char *tokenizer_root_text = arg_value(argc, argv, "--tokenizer-root");
+    const char *prompt = arg_value(argc, argv, "--prompt");
+    const char *prompt_ids_text = arg_value(argc, argv, "--prompt-ids");
+    const char *expect_ids_text = arg_value(argc, argv, "--expect-ids");
+    for (int i = 1; i < argc; i++)
+        if (!strcmp(argv[i], "--retry-first-run")) retry_first_run = 1;
+    if (!engine_id || !model_dir || !model || !tracker || !model_root_text ||
+        !tokenizer_root_text || (!!prompt == !!prompt_ids_text)) {
+        usage(argv[0]); return 2;
+    }
+    if (strlen(engine_id) >= LMB_SEG_ENGINE_MAX ||
+        strlen(model) >= LMB_SEG_MODEL_MAX || strlen(tracker) >= 256) {
+        usage(argv[0]); return 2;
+    }
+    uint8_t model_root[32], tokenizer_root[32];
+    if (lmb_hex_root(model_root_text, model_root) ||
+        lmb_hex_root(tokenizer_root_text, tokenizer_root)) {
+        fprintf(stderr, "roots must be non-zero 64-character hex values\n");
+        return 2;
+    }
+    uint32_t wanted_tokens = 3;
+    const char *value = arg_value(argc, argv, "--tokens");
+    if (value && lmb_parse_u32(value, 1, 4096, &wanted_tokens)) {
+        usage(argv[0]); return 2;
+    }
+    int32_t *expected = NULL;
+    size_t expected_count = 0;
+    if (expect_ids_text &&
+        (parse_ids(expect_ids_text, &expected, &expected_count) ||
+         expected_count != wanted_tokens)) {
+        fprintf(stderr, "--expect-ids must contain exactly --tokens IDs\n");
+        return 2;
+    }
+    if (lmb_secure_init()) return 1;
+    if (lmb_colibri_register_all()) {
+        fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
+    }
+    ColiEdgeEngineOptions edge_options = {
+        .struct_size = sizeof edge_options,
+        .model_dir = model_dir,
+    };
+    ColiEdgeEngine *edge = NULL;
+    char error[256];
+    if (coli_edge_engine_open(engine_id, &edge_options, &edge,
+                              error, sizeof error)) {
+        fprintf(stderr, "cannot open Colibri Edge engine: %s\n", error);
+        return 1;
+    }
+    ColiEdgeCapabilities cap = { .struct_size = sizeof cap };
+    if (coli_edge_engine_capabilities(edge, &cap, error, sizeof error)) {
+        fprintf(stderr, "cannot read Edge capabilities: %s\n", error);
+        return 1;
+    }
+    uint32_t context = cap.max_context_tokens < 4096 ? cap.max_context_tokens : 4096;
+    uint32_t max_rows = cap.max_batch_rows < 64 ? cap.max_batch_rows : 64;
+    if (((value = arg_value(argc, argv, "--context")) &&
+         lmb_parse_u32(value, 1, cap.max_context_tokens, &context)) ||
+        ((value = arg_value(argc, argv, "--max-rows")) &&
+         lmb_parse_u32(value, 1, cap.max_batch_rows, &max_rows))) {
+        usage(argv[0]); return 2;
+    }
+    LmbSegQuery query;
+    memset(&query, 0, sizeof query);
+    snprintf(query.model, sizeof query.model, "%s", model);
+    memcpy(query.model_root, model_root, sizeof model_root);
+    memcpy(query.tokenizer_root, tokenizer_root, sizeof tokenizer_root);
+    query.layer_end = cap.num_layers;
+    query.context_tokens = context;
+    query.rows = max_rows;
+    query.state_dtype = cap.state_dtype;
+    query.state_width = cap.state_width;
+    query.required_capabilities = LMB_SEG_CAP_RANGE_NATIVE |
+                                  LMB_SEG_CAP_MULTI_SESSION;
+    snprintf(query.engine_id, sizeof query.engine_id, "%s", cap.engine_id);
+    snprintf(query.state_schema, sizeof query.state_schema, "%s", cap.state_schema);
+    snprintf(query.numeric_class, sizeof query.numeric_class, "%s", cap.numeric_class);
+    LmbSegDiscovery *discovery = lmb_seg_discovery_start(tracker, &query, 250);
+    if (!discovery) { fprintf(stderr, "cannot start Segment discovery\n"); return 1; }
+    LmbSegRouteSnapshot snapshot;
+    memset(&snapshot, 0, sizeof snapshot);
+    int have = 0, fetched = 0;
+    for (int i = 0; i < 60 && !have; i++) {
+        sleep_ms(250);
+        have = lmb_seg_discovery_snapshot(discovery, &snapshot);
+        if (have > 0) fetched = 1;
+        if (have > 0 && !snapshot.complete) have = 0;
+    }
+    if (!have) {
+        fprintf(stderr, "no complete compatible Segment chain after 15 seconds "
+                        "(snapshot=%s, compatible peers=%u, engine=%s, "
+                        "schema=%s, numeric=%s, dtype=%u, width=%u, "
+                        "layers=0:%u, rows=%u, context=%u)\n",
+                fetched ? "yes" : "no", fetched ? snapshot.count : 0,
+                query.engine_id, query.state_schema, query.numeric_class,
+                query.state_dtype, query.state_width, query.layer_end,
+                query.rows, query.context_tokens);
+        lmb_seg_discovery_stop(discovery); return 1;
+    }
+    RemoteSegment chain[LMB_SEG_ROUTE_MAX];
+    size_t chain_count = 0;
+    if (select_chain(&snapshot, cap.num_layers, chain, &chain_count)) {
+        fprintf(stderr, "tracker coverage cannot form an executor-aligned chain\n");
+        lmb_seg_discovery_stop(discovery); return 1;
+    }
+    LmbSegId session_id;
+    lmb_random(session_id.bytes, sizeof session_id.bytes);
+    for (size_t i = 0; i < chain_count; i++) {
+        if (remote_open(&chain[i], &session_id, model_root, tokenizer_root,
+                        context, max_rows)) {
+            fprintf(stderr, "cannot open segment %s at %s\n",
+                    chain[i].route.advert.peer_name, chain[i].route.advert.addr);
+            for (size_t j = 0; j < i; j++) remote_close(&chain[j]);
+            lmb_seg_discovery_stop(discovery); return 1;
+        }
+    }
+    printf("[lumabri] route generation %llu: ",
+           (unsigned long long)snapshot.route_generation);
+    for (size_t i = 0; i < chain_count; i++)
+        printf("%s%s[%u:%u]", i ? " -> " : "",
+               chain[i].route.advert.peer_name,
+               chain[i].route.advert.layer_begin,
+               chain[i].route.advert.layer_end);
+    printf("\n"); fflush(stdout);
+
+    size_t prompt_count = 0;
+    int32_t *prompt_tokens = NULL;
+    if (prompt_ids_text) {
+        if (parse_ids(prompt_ids_text, &prompt_tokens, &prompt_count)) {
+            fprintf(stderr, "invalid --prompt-ids list\n"); return 2;
+        }
+    } else {
+        if (coli_edge_tokenize(edge, prompt, strlen(prompt), NULL, 0,
+                               &prompt_count, error, sizeof error) || !prompt_count) {
+            fprintf(stderr, "cannot tokenize prompt: %s\n", error); return 1;
+        }
+        prompt_tokens = malloc(prompt_count * sizeof *prompt_tokens);
+        size_t actual_count = 0;
+        if (!prompt_tokens ||
+            coli_edge_tokenize(edge, prompt, strlen(prompt), prompt_tokens,
+                               prompt_count, &actual_count, error, sizeof error) ||
+            actual_count != prompt_count) {
+            fprintf(stderr, "cannot tokenize prompt: %s\n", error); return 1;
+        }
+    }
+    if (prompt_count + wanted_tokens > context) {
+        fprintf(stderr, "prompt plus output exceeds context (%u)\n", context);
+        return 1;
+    }
+    int32_t *generated = malloc(wanted_tokens * sizeof *generated);
+    size_t max_bytes = lmb_state_bytes(max_rows, cap.state_width, cap.state_dtype);
+    uint8_t *buffer_a = max_bytes ? malloc(max_bytes) : NULL;
+    uint8_t *buffer_b = max_bytes ? malloc(max_bytes) : NULL;
+    if (!generated || !buffer_a || !buffer_b) return 1;
+    uint8_t *final_state = NULL;
+    uint32_t final_rows = 0;
+    for (size_t offset = 0; offset < prompt_count; offset += max_rows) {
+        uint32_t rows = (uint32_t)(prompt_count - offset);
+        if (rows > max_rows) rows = max_rows;
+        size_t bytes = lmb_state_bytes(rows, cap.state_width, cap.state_dtype);
+        ColiEdgeEmbedRequest embed = {
+            .struct_size = sizeof embed, .rows = rows,
+            .token_ids = prompt_tokens + offset, .token_count = rows,
+            .output = buffer_a, .output_bytes = bytes,
+        };
+        if (coli_edge_embed(edge, &embed, error, sizeof error)) {
+            fprintf(stderr, "embedding failed: %s\n", error); return 1;
+        }
+        uint8_t *first = buffer_a, *second = buffer_b;
+        if (chain_run(chain, chain_count, prompt_tokens + offset, rows,
+                      &first, &second, bytes)) {
+            fprintf(stderr, "Segment peer failed; session ended because checkpoint/replay is not available yet\n");
+            return 1;
+        }
+        final_state = first; final_rows = rows;
+        if (first != buffer_a) { uint8_t *swap = buffer_a; buffer_a = buffer_b; buffer_b = swap; }
+    }
+    size_t element = cap.state_dtype == COLI_EDGE_DTYPE_F32 ? 4u : 2u;
+    const uint8_t *last = final_state + (size_t)(final_rows - 1) * cap.state_width * element;
+    ColiEdgeSelectRequest select = {
+        .struct_size = sizeof select, .rows = 1,
+        .input = last, .input_bytes = (size_t)cap.state_width * element,
+        .token_ids = generated, .token_capacity = 1,
+    };
+    if (coli_edge_select(edge, &select, error, sizeof error)) {
+        fprintf(stderr, "token selection failed: %s\n", error); return 1;
+    }
+    size_t generated_count = 1;
+    while (generated_count < wanted_tokens &&
+           generated[generated_count - 1] != cap.eos_token_id) {
+        int32_t token = generated[generated_count - 1];
+        size_t bytes = lmb_state_bytes(1, cap.state_width, cap.state_dtype);
+        ColiEdgeEmbedRequest embed = {
+            .struct_size = sizeof embed, .rows = 1,
+            .token_ids = &token, .token_count = 1,
+            .output = buffer_a, .output_bytes = bytes,
+        };
+        if (coli_edge_embed(edge, &embed, error, sizeof error)) {
+            fprintf(stderr, "embedding failed: %s\n", error); return 1;
+        }
+        uint8_t *first = buffer_a, *second = buffer_b;
+        if (chain_run(chain, chain_count, &token, 1, &first, &second, bytes)) {
+            fprintf(stderr, "Segment peer failed; session ended because checkpoint/replay is not available yet\n");
+            return 1;
+        }
+        select.input = first;
+        select.token_ids = generated + generated_count;
+        if (coli_edge_select(edge, &select, error, sizeof error)) {
+            fprintf(stderr, "token selection failed: %s\n", error); return 1;
+        }
+        generated_count++;
+    }
+    size_t text_bytes = 0;
+    if (coli_edge_detokenize(edge, generated, generated_count, NULL, 0,
+                             &text_bytes, error, sizeof error)) {
+        fprintf(stderr, "detokenize sizing failed: %s\n", error); return 1;
+    }
+    char *text = malloc(text_bytes + 1);
+    if (!text || coli_edge_detokenize(edge, generated, generated_count,
+                                      text, text_bytes + 1, &text_bytes,
+                                      error, sizeof error)) {
+        fprintf(stderr, "detokenize failed: %s\n", error); return 1;
+    }
+    text[text_bytes] = 0;
+    printf("%s\n", text);
+    printf("[lumabri] token-ids:");
+    for (size_t i = 0; i < generated_count; i++) printf("%s%d", i ? "," : " ", generated[i]);
+    printf("\n");
+    if (expected && (generated_count != expected_count ||
+        memcmp(generated, expected, expected_count * sizeof *expected))) {
+        fprintf(stderr, "generated token IDs differ from independent oracle\n");
+        return 1;
+    }
+    for (size_t i = 0; i < chain_count; i++) remote_close(&chain[i]);
+    lmb_seg_discovery_stop(discovery);
+    coli_edge_engine_close(edge);
+    free(text); free(prompt_tokens); free(generated); free(expected);
+    free(buffer_a); free(buffer_b);
+    return 0;
+}

--- a/segment_colibri.h
+++ b/segment_colibri.h
@@ -1,0 +1,70 @@
+/* Shared, additive bridge to Colibri's public Segment/Edge ABI. */
+#ifndef LUMABRI_SEGMENT_COLIBRI_H
+#define LUMABRI_SEGMENT_COLIBRI_H
+
+#include "edge_adapters.h"
+#include "edge_runtime.h"
+#include "segment_adapters.h"
+#include "segment_runtime.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int lmb_colibri_register_all(void) {
+    return coli_glm_segment_adapter_register() ||
+           coli_inkling_segment_adapter_register() ||
+           coli_kimi_segment_adapter_register() ||
+           coli_olmoe_segment_adapter_register() ||
+           coli_qwen36_segment_adapter_register() ||
+           coli_deepseek_v4_segment_adapter_register() ||
+           coli_glm_edge_adapter_register() ||
+           coli_inkling_edge_adapter_register() ||
+           coli_kimi_edge_adapter_register() ||
+           coli_olmoe_edge_adapter_register() ||
+           coli_qwen36_edge_adapter_register() ||
+           coli_deepseek_v4_edge_adapter_register();
+}
+
+static int lmb_hex_root(const char *hex, uint8_t out[32]) {
+    if (!hex || strlen(hex) != 64) return -1;
+    unsigned any = 0;
+    for (size_t i = 0; i < 32; i++) {
+        unsigned hi, lo;
+        char a = hex[2 * i], b = hex[2 * i + 1];
+        if (a >= '0' && a <= '9') hi = (unsigned)(a - '0');
+        else if (a >= 'a' && a <= 'f') hi = (unsigned)(a - 'a' + 10);
+        else if (a >= 'A' && a <= 'F') hi = (unsigned)(a - 'A' + 10);
+        else return -1;
+        if (b >= '0' && b <= '9') lo = (unsigned)(b - '0');
+        else if (b >= 'a' && b <= 'f') lo = (unsigned)(b - 'a' + 10);
+        else if (b >= 'A' && b <= 'F') lo = (unsigned)(b - 'A' + 10);
+        else return -1;
+        out[i] = (uint8_t)((hi << 4) | lo);
+        any |= out[i];
+    }
+    return any ? 0 : -1;
+}
+
+static size_t lmb_state_bytes(uint32_t rows, uint32_t width, uint32_t dtype) {
+    size_t element = dtype == 1 ? 4u : (dtype == 2 || dtype == 3 ? 2u : 0u);
+    if (!element || !rows || !width || width > SIZE_MAX / rows ||
+        (size_t)width * rows > SIZE_MAX / element) return 0;
+    return (size_t)rows * width * element;
+}
+
+static int lmb_parse_u32(const char *text, uint32_t minimum,
+                         uint32_t maximum, uint32_t *value) {
+    if (!text || !*text || !value || minimum > maximum) return -1;
+    char *end = NULL;
+    errno = 0;
+    unsigned long parsed = strtoul(text, &end, 10);
+    if (errno || end == text || *end || parsed < minimum || parsed > maximum)
+        return -1;
+    *value = (uint32_t)parsed;
+    return 0;
+}
+
+#endif

--- a/segment_direct_test.sh
+++ b/segment_direct_test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Real network gate: every current Colibri family is split across two direct
+# Segment peers and its first three greedy tokens must match the independent
+# tiny-model oracle. No family is accepted from registration alone.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+SEGMENT_NODE_BIN=${SEGMENT_NODE_BIN:-./segment_node}
+SEGMENT_CHAT_BIN=${SEGMENT_CHAT_BIN:-./segment_chat}
+
+: "${GLM_EDGE_MODEL:?set GLM_EDGE_MODEL}"
+: "${GLM_EDGE_REF:?set GLM_EDGE_REF}"
+: "${INKLING_EDGE_MODEL:?set INKLING_EDGE_MODEL}"
+: "${INKLING_EDGE_REF:?set INKLING_EDGE_REF}"
+: "${KIMI_EDGE_MODEL:?set KIMI_EDGE_MODEL}"
+: "${KIMI_EDGE_REF:?set KIMI_EDGE_REF}"
+: "${OLMOE_EDGE_MODEL:?set OLMOE_EDGE_MODEL}"
+: "${OLMOE_EDGE_REF:?set OLMOE_EDGE_REF}"
+: "${QWEN_EDGE_MODEL:?set QWEN_EDGE_MODEL}"
+: "${QWEN_EDGE_REF:?set QWEN_EDGE_REF}"
+: "${DEEPSEEK_EDGE_MODEL:?set DEEPSEEK_EDGE_MODEL}"
+: "${DEEPSEEK_EDGE_REF:?set DEEPSEEK_EDGE_REF}"
+
+TMP=$(mktemp -d /tmp/lumabri-segment-direct.XXXXXX)
+TRACKER_PID=""
+NODE_PIDS=()
+cleanup() {
+    for pid in "${NODE_PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+    for pid in "${NODE_PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
+    if [[ -n "$TRACKER_PID" ]]; then
+        kill "$TRACKER_PID" 2>/dev/null || true
+        wait "$TRACKER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+wait_port() {
+    local port=$1
+    for _ in $(seq 1 200); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            exec 3<&-; exec 3>&-; return 0
+        fi
+        sleep 0.025
+    done
+    return 1
+}
+
+env LUMABRI_PEER_KEY="$TMP/tracker.peer.key" \
+    LUMABRI_KNOWN_HOSTS="$TMP/tracker.known_hosts" \
+    ./tracker --port 7868 --peer-bindings "$TMP/bindings" \
+    >"$TMP/tracker.log" 2>&1 &
+TRACKER_PID=$!
+wait_port 7868
+
+families=(glm inkling kimi olmoe qwen36 deepseek_v4)
+models=("$GLM_EDGE_MODEL" "$INKLING_EDGE_MODEL" "$KIMI_EDGE_MODEL" \
+        "$OLMOE_EDGE_MODEL" "$QWEN_EDGE_MODEL" "$DEEPSEEK_EDGE_MODEL")
+refs=("$GLM_EDGE_REF" "$INKLING_EDGE_REF" "$KIMI_EDGE_REF" \
+      "$OLMOE_EDGE_REF" "$QWEN_EDGE_REF" "$DEEPSEEK_EDGE_REF")
+layers=(5 8 6 4 8 3)
+splits=(2 4 3 2 4 1)
+
+for index in "${!families[@]}"; do
+    family=${families[$index]}
+    model_dir=${models[$index]}
+    ref=${refs[$index]}
+    total=${layers[$index]}
+    split=${splits[$index]}
+    model="tiny-$family"
+    model_root=$(printf '%064x' $((index + 1)))
+    tokenizer_root=$(printf '%064x' $((index + 17)))
+    oracle=$(python3 -c '
+import json,sys
+family,path=sys.argv[1:]
+root=json.load(open(path, encoding="utf-8"))
+case=root.get("cases",{}).get("short") if family in ("kimi","deepseek_v4") else root
+if not case: raise SystemExit("reference has no short case")
+prompt=case["prompt_ids"]
+full=case.get("greedy_full_ids", case.get("full_ids"))
+if not full or len(full) < len(prompt)+3: raise SystemExit("reference has fewer than three oracle tokens")
+print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt)+3])))
+' "$family" "$ref")
+    prompt_ids=${oracle%%|*}
+    expected=${oracle#*|}
+
+    run_env=(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/$family.peer.key"
+             LUMABRI_KNOWN_HOSTS="$TMP/$family.known_hosts")
+    case "$family" in
+        glm) run_env+=(GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16) ;;
+        inkling) run_env+=(INK_SEGMENT_BITS=0) ;;
+        kimi) run_env+=(COLI_RAM_OVERCOMMIT=1 K3_BITS=32 K3_MLA_BITS=32
+                        K3_HEAD_BITS=32 K3_IDOT=0) ;;
+    esac
+
+    "${run_env[@]}" "$SEGMENT_NODE_BIN" --engine "$family" --model-dir "$model_dir" \
+        --model "$model" --range "0:$split" --port 7869 \
+        --tracker 127.0.0.1:7868 --advertise 127.0.0.1:7869 \
+        --name "$family-left" --model-root "$model_root" \
+        --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16 \
+        --sessions 4 >"$TMP/$family-left.log" 2>&1 &
+    left=$!
+    "${run_env[@]}" "$SEGMENT_NODE_BIN" --engine "$family" --model-dir "$model_dir" \
+        --model "$model" --range "$split:$total" --port 7870 \
+        --tracker 127.0.0.1:7868 --advertise 127.0.0.1:7870 \
+        --name "$family-right" --model-root "$model_root" \
+        --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16 \
+        --sessions 4 >"$TMP/$family-right.log" 2>&1 &
+    right=$!
+    NODE_PIDS=("$left" "$right")
+    if ! wait_port 7869 || ! wait_port 7870; then
+        cat "$TMP/$family-left.log" "$TMP/$family-right.log"
+        exit 1
+    fi
+    if ! "${run_env[@]}" "$SEGMENT_CHAT_BIN" --engine "$family" \
+        --model-dir "$model_dir" --model "$model" --tracker 127.0.0.1:7868 \
+        --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
+        --prompt-ids "$prompt_ids" --tokens 3 --expect-ids "$expected" \
+        --context 64 --max-rows 16 --retry-first-run; then
+        cat "$TMP/$family-left.log" "$TMP/$family-right.log" "$TMP/tracker.log"
+        exit 1
+    fi
+    if [[ "$family" == olmoe ]]; then
+        client_pids=()
+        for client in 1 2; do
+            "${run_env[@]}" "$SEGMENT_CHAT_BIN" --engine "$family" \
+                --model-dir "$model_dir" --model "$model" \
+                --tracker 127.0.0.1:7868 --model-root "$model_root" \
+                --tokenizer-root "$tokenizer_root" --prompt-ids "$prompt_ids" \
+                --tokens 3 --expect-ids "$expected" --context 64 --max-rows 16 \
+                >"$TMP/$family-client-$client.log" 2>&1 &
+            client_pids+=("$!")
+        done
+        clients_ok=1
+        for pid in "${client_pids[@]}"; do
+            if ! wait "$pid"; then clients_ok=0; fi
+        done
+        if (( ! clients_ok )); then
+            cat "$TMP/$family-client-1.log" "$TMP/$family-client-2.log" \
+                "$TMP/$family-left.log" "$TMP/$family-right.log"
+            exit 1
+        fi
+        echo "SEGMENT DIRECT olmoe: PASS (two concurrent isolated sessions)"
+    fi
+    kill "$left" "$right" 2>/dev/null || true
+    wait "$left" 2>/dev/null || true
+    wait "$right" 2>/dev/null || true
+    NODE_PIDS=()
+    echo "SEGMENT DIRECT $family: PASS (two peers, three oracle tokens)"
+done
+
+echo "SEGMENT DIRECT: PASS (all six Colibri families)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -1,0 +1,658 @@
+#define _DEFAULT_SOURCE
+#define _POSIX_C_SOURCE 200809L
+
+#include "lumabri_proto.h"
+#include "lumabri_segment.h"
+#include "lumabri_segment_discovery.h"
+#include "lumabri_sign.h"
+#include "lumabri_secure.h"
+#include "segment_colibri.h"
+
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NODE_SESSIONS_MAX 256u
+#define NODE_CONNECTIONS_MAX 256u
+
+typedef struct {
+    int used;
+    LmbSegId id;
+    ColiSegmentSession *session;
+    pthread_mutex_t lock;
+    LmbSegId cached_request;
+    uint8_t *cached_output;
+    size_t cached_bytes;
+} NodeSession;
+
+typedef struct {
+    pthread_mutex_t lock;
+    char tracker[256];
+    LmbSegAdvert advert;
+    uint8_t pk[32], sk[64];
+    LmbSegOwner owner;
+    int ready;
+    volatile sig_atomic_t stop;
+} TrackerRegistration;
+
+typedef struct {
+    ColiSegmentEngine *engine;
+    ColiSegmentCapabilities cap;
+    LmbSegAdvert advert;
+    LmbSegTable *table;
+    NodeSession sessions[NODE_SESSIONS_MAX];
+    pthread_mutex_t sessions_lock;
+    pthread_mutex_t connections_lock;
+    pthread_cond_t connections_drained;
+    int connection_fds[NODE_CONNECTIONS_MAX];
+    unsigned active_connections;
+    TrackerRegistration registration;
+} Node;
+
+static volatile sig_atomic_t g_stop;
+static int g_listen_fd = -1;
+
+static uint64_t now_ms(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+static void stop_handler(int sig) {
+    (void)sig;
+    g_stop = 1;
+    /* Bypass the optional secure close macro: libc close is async-signal-safe
+     * and listening sockets never enter the encrypted-fd registry. */
+    int fd = g_listen_fd;
+    g_listen_fd = -1;
+    if (fd >= 0) (close)(fd);
+}
+
+static int owner_same_lease(const LmbSegOwner *a, const LmbSegOwner *b) {
+    return lmb_seg_id_equal(&a->lease_id, &b->lease_id) &&
+           a->fencing_epoch == b->fencing_epoch &&
+           a->route_generation >= b->route_generation;
+}
+
+static int registration_owner(TrackerRegistration *r,
+                              const LmbSegOwner *candidate) {
+    pthread_mutex_lock(&r->lock);
+    int ok = r->ready && owner_same_lease(candidate, &r->owner);
+    pthread_mutex_unlock(&r->lock);
+    return ok;
+}
+
+static int tracker_heartbeat(int fd, const uint8_t nonce[32],
+                             TrackerRegistration *r) {
+    LmbSegAdvert advert;
+    pthread_mutex_lock(&r->lock);
+    advert = r->advert;
+    pthread_mutex_unlock(&r->lock);
+    uint8_t *wire = NULL;
+    uint32_t wire_len = 0;
+    if (lmb_seg_advert_encode(&advert, &wire, &wire_len)) return -1;
+    LmbBuf body = { wire, wire_len, wire_len };
+    uint8_t auth[512], sig[64];
+    size_t auth_len = lmb_peer_auth_msg(nonce, advert.peer_name, advert.model,
+                                        advert.addr, auth, sizeof auth);
+    if (!auth_len) { free(body.p); return -1; }
+    lmb_sign(sig, auth, auth_len, r->sk);
+    if (lmb_buf_peer_auth(&body, r->pk, sig) ||
+        lmb_send(fd, LMB_SEG_REGISTER, body.p, (uint32_t)body.len, NULL, 0)) {
+        free(body.p);
+        return -1;
+    }
+    free(body.p);
+    LmbMsg reply = {0};
+    LmbSegOwner owner;
+    int received = !lmb_recv(fd, &reply);
+    if (received && reply.op == LMB_ERR)
+        fprintf(stderr, "[segment-node] tracker rejected registration: %.*s\n",
+                (int)reply.body_len, reply.body ? (char *)reply.body : "");
+    int bad = !received || reply.op != LMB_SEG_REGISTER_R || reply.pay_len ||
+              lmb_seg_registration_reply_decode(reply.body, reply.body_len,
+                                                 &owner);
+    lmb_msg_free(&reply);
+    if (bad) return -1;
+    pthread_mutex_lock(&r->lock);
+    r->owner = owner;
+    r->ready = 1;
+    pthread_mutex_unlock(&r->lock);
+    return 0;
+}
+
+static void *registration_worker(void *opaque) {
+    TrackerRegistration *r = (TrackerRegistration *)opaque;
+    while (!r->stop) {
+        int fd = lmb_connect(r->tracker);
+        uint8_t nonce[32];
+        if (fd < 0 || lmb_auth(fd) || lmb_request_challenge(fd, nonce)) {
+            if (fd >= 0) lmb_close(fd);
+            sleep(1);
+            continue;
+        }
+        while (!r->stop && !tracker_heartbeat(fd, nonce, r)) {
+            for (int i = 0; i < 20 && !r->stop; i++) usleep(100000);
+        }
+        lmb_close(fd);
+        pthread_mutex_lock(&r->lock);
+        r->ready = 0;
+        pthread_mutex_unlock(&r->lock);
+    }
+    return NULL;
+}
+
+static int open_matches_node(Node *node, const LmbSegOpen *open) {
+    const LmbSegAdvert *a = &node->advert;
+    return !memcmp(open->model_root, a->model_root, sizeof a->model_root) &&
+           !memcmp(open->tokenizer_root, a->tokenizer_root,
+                   sizeof a->tokenizer_root) &&
+           open->layer_begin == a->layer_begin &&
+           open->layer_end == a->layer_end &&
+           open->context_tokens <= a->max_context &&
+           open->max_rows <= a->max_rows &&
+           open->state_dtype == a->state_dtype &&
+           open->state_width == a->state_width &&
+           (open->capabilities & a->capabilities) == open->capabilities &&
+           !strcmp(open->engine_id, a->engine_id) &&
+           !strcmp(open->state_schema, a->state_schema) &&
+           !strcmp(open->numeric_class, a->numeric_class) &&
+           registration_owner(&node->registration, &open->owner);
+}
+
+static NodeSession *session_find(Node *node, const LmbSegId *id) {
+    for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
+        if (node->sessions[i].used && lmb_seg_id_equal(&node->sessions[i].id, id))
+            return &node->sessions[i];
+    return NULL;
+}
+
+static NodeSession *session_empty(Node *node) {
+    for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
+        if (!node->sessions[i].used) return &node->sessions[i];
+    return NULL;
+}
+
+static void session_release(Node *node, NodeSession *slot) {
+    pthread_mutex_lock(&slot->lock);
+    coli_segment_session_destroy(slot->session);
+    free(slot->cached_output);
+    pthread_mutex_unlock(&slot->lock);
+    pthread_mutex_destroy(&slot->lock);
+    memset(slot, 0, sizeof *slot);
+    pthread_mutex_lock(&node->registration.lock);
+    if (node->registration.advert.active_sessions)
+        node->registration.advert.active_sessions--;
+    pthread_mutex_unlock(&node->registration.lock);
+}
+
+static void *session_reaper(void *opaque) {
+    Node *node = (Node *)opaque;
+    while (!g_stop) {
+        pthread_mutex_lock(&node->sessions_lock);
+        LmbSegId expired;
+        while (lmb_seg_table_reap_expired(node->table, now_ms(), &expired)) {
+            NodeSession *slot = session_find(node, &expired);
+            if (slot) session_release(node, slot);
+        }
+        pthread_mutex_unlock(&node->sessions_lock);
+        for (int i = 0; i < 10 && !g_stop; i++) usleep(100000);
+    }
+    return NULL;
+}
+
+static int connection_add(Node *node, int fd) {
+    int added = 0;
+    pthread_mutex_lock(&node->connections_lock);
+    for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) {
+        if (node->connection_fds[i] >= 0) continue;
+        node->connection_fds[i] = fd;
+        node->active_connections++;
+        added = 1;
+        break;
+    }
+    pthread_mutex_unlock(&node->connections_lock);
+    return added ? 0 : -1;
+}
+
+static void connection_remove(Node *node, int fd) {
+    pthread_mutex_lock(&node->connections_lock);
+    for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) {
+        if (node->connection_fds[i] != fd) continue;
+        node->connection_fds[i] = -1;
+        if (node->active_connections) node->active_connections--;
+        break;
+    }
+    if (!node->active_connections) pthread_cond_signal(&node->connections_drained);
+    pthread_mutex_unlock(&node->connections_lock);
+}
+
+static LmbSegReply make_reply(const LmbSegId *session_id,
+                              const LmbSegId *request_id,
+                              const LmbSegOwner *owner,
+                              LmbSegStatus status) {
+    LmbSegReply reply;
+    memset(&reply, 0, sizeof reply);
+    if (session_id) reply.session_id = *session_id;
+    if (request_id) reply.request_id = *request_id;
+    reply.status = (uint32_t)status;
+    if (owner) {
+        reply.fencing_epoch = owner->fencing_epoch;
+        reply.route_generation = owner->route_generation;
+    }
+    return reply;
+}
+
+static void reply_state(Node *node, LmbSegReply *reply) {
+    int needs_restore = 0;
+    (void)lmb_seg_table_state(node->table, &reply->session_id,
+                              &reply->next_sequence, &reply->next_position,
+                              &needs_restore);
+}
+
+static int send_reply(int fd, uint32_t op, LmbSegReply *reply,
+                      const void *pay, size_t pay_len) {
+    uint8_t *body = NULL;
+    uint32_t body_len = 0;
+    if (pay_len > UINT32_MAX || lmb_seg_reply_encode(reply, &body, &body_len))
+        return -1;
+    int rc = lmb_send(fd, op, body, body_len, pay, (uint32_t)pay_len);
+    free(body);
+    return rc;
+}
+
+static int handle_open(Node *node, int fd, const LmbMsg *msg) {
+    LmbSegOpen open;
+    if (msg->pay_len || lmb_seg_open_decode(msg->body, msg->body_len, &open))
+        return -1;
+    LmbSegStatus status = LMB_SEG_STATUS_BAD_REQUEST;
+    if (open_matches_node(node, &open)) {
+        pthread_mutex_lock(&node->sessions_lock);
+        NodeSession *slot = session_find(node, &open.session_id);
+        if (slot) {
+            status = lmb_seg_table_open(node->table, &open, now_ms());
+        } else if (!(slot = session_empty(node))) {
+            status = LMB_SEG_STATUS_QUOTA;
+        } else {
+            ColiSegmentSessionOptions options = {
+                .struct_size = sizeof options,
+                .context_tokens = open.context_tokens,
+            };
+            ColiSegmentSession *session = NULL;
+            char error[256];
+            if (coli_segment_session_create(node->engine, &options, &session,
+                                            error, sizeof error)) {
+                fprintf(stderr, "[segment-node] session create: %s\n", error);
+                status = LMB_SEG_STATUS_INTERNAL;
+            } else {
+                status = lmb_seg_table_open(node->table, &open, now_ms());
+                if (status == LMB_SEG_STATUS_OK) {
+                    memset(slot, 0, sizeof *slot);
+                    if (pthread_mutex_init(&slot->lock, NULL)) {
+                        (void)lmb_seg_table_close(node->table,
+                            &(LmbSegControl){ .session_id = open.session_id,
+                                .request_id = open.request_id,
+                                .owner = open.owner });
+                        coli_segment_session_destroy(session);
+                        status = LMB_SEG_STATUS_INTERNAL;
+                        pthread_mutex_unlock(&node->sessions_lock);
+                        LmbSegReply reply = make_reply(
+                            &open.session_id, &open.request_id,
+                            &open.owner, status);
+                        return send_reply(fd, LMB_SEG_OPEN_R, &reply, NULL, 0);
+                    }
+                    slot->used = 1;
+                    slot->id = open.session_id;
+                    slot->session = session;
+                    pthread_mutex_lock(&node->registration.lock);
+                    node->registration.advert.active_sessions++;
+                    pthread_mutex_unlock(&node->registration.lock);
+                } else {
+                    coli_segment_session_destroy(session);
+                }
+            }
+        }
+        pthread_mutex_unlock(&node->sessions_lock);
+    }
+    LmbSegReply reply = make_reply(&open.session_id, &open.request_id,
+                                   &open.owner, status);
+    if (status == LMB_SEG_STATUS_OK || status == LMB_SEG_STATUS_DUPLICATE)
+        reply_state(node, &reply);
+    return send_reply(fd, LMB_SEG_OPEN_R, &reply, NULL, 0);
+}
+
+static int handle_run(Node *node, int fd, const LmbMsg *msg) {
+    int32_t *tokens = calloc(node->cap.max_batch_rows, sizeof *tokens);
+    if (!tokens) return -1;
+    LmbSegRun run;
+    if (lmb_seg_run_decode(msg->body, msg->body_len, &run, tokens,
+                           node->cap.max_batch_rows)) {
+        free(tokens);
+        return -1;
+    }
+    LmbSegStatus status = lmb_seg_table_run_begin(
+        node->table, &run, msg->pay, msg->pay_len, now_ms());
+    LmbSegReply reply = make_reply(&run.session_id, &run.request_id,
+                                   &run.owner, status);
+    if (status == LMB_SEG_STATUS_DUPLICATE) {
+        pthread_mutex_lock(&node->sessions_lock);
+        NodeSession *slot = session_find(node, &run.session_id);
+        if (slot) pthread_mutex_lock(&slot->lock);
+        pthread_mutex_unlock(&node->sessions_lock);
+        if (slot && lmb_seg_id_equal(&slot->cached_request, &run.request_id) &&
+            slot->cached_output) {
+            reply_state(node, &reply);
+            int rc = send_reply(fd, LMB_SEG_RUN_R, &reply,
+                                slot->cached_output, slot->cached_bytes);
+            pthread_mutex_unlock(&slot->lock);
+            free(tokens);
+            return rc;
+        }
+        if (slot) pthread_mutex_unlock(&slot->lock);
+        reply.status = LMB_SEG_STATUS_NEEDS_RESTORE;
+    } else if (status == LMB_SEG_STATUS_OK) {
+        pthread_mutex_lock(&node->sessions_lock);
+        NodeSession *slot = session_find(node, &run.session_id);
+        ColiSegmentSession *session = slot ? slot->session : NULL;
+        pthread_mutex_unlock(&node->sessions_lock);
+        size_t bytes = lmb_state_bytes(run.rows, node->cap.state_width,
+                                       node->cap.state_dtype);
+        uint8_t *output = bytes ? malloc(bytes) : NULL;
+        if (!session || !output || bytes != msg->pay_len) {
+            status = LMB_SEG_STATUS_INTERNAL;
+        } else {
+            pthread_mutex_lock(&node->registration.lock);
+            node->registration.advert.inflight++;
+            pthread_mutex_unlock(&node->registration.lock);
+            ColiSegmentRunRequest request = {
+                .struct_size = sizeof request,
+                .rows = run.rows,
+                .position = run.position,
+                .token_ids = run.token_ids,
+                .token_count = run.token_count,
+                .input = msg->pay,
+                .input_bytes = msg->pay_len,
+                .output = output,
+                .output_bytes = bytes,
+            };
+            char error[256];
+            if (coli_segment_run(session, &request, error, sizeof error)) {
+                fprintf(stderr, "[segment-node] run: %s\n", error);
+                status = LMB_SEG_STATUS_INTERNAL;
+            }
+            pthread_mutex_lock(&node->registration.lock);
+            if (node->registration.advert.inflight)
+                node->registration.advert.inflight--;
+            pthread_mutex_unlock(&node->registration.lock);
+        }
+        if (status != LMB_SEG_STATUS_OK) {
+            (void)lmb_seg_table_run_abort(node->table, &run);
+            free(output);
+        } else {
+            pthread_mutex_lock(&node->sessions_lock);
+            slot = session_find(node, &run.session_id);
+            if (slot) pthread_mutex_lock(&slot->lock);
+            pthread_mutex_unlock(&node->sessions_lock);
+            status = lmb_seg_table_run_commit(node->table, &run, now_ms());
+            if (status == LMB_SEG_STATUS_OK && slot) {
+                free(slot->cached_output);
+                slot->cached_output = output;
+                slot->cached_bytes = bytes;
+                slot->cached_request = run.request_id;
+                reply.status = status;
+                reply_state(node, &reply);
+                int rc = send_reply(fd, LMB_SEG_RUN_R, &reply, output, bytes);
+                pthread_mutex_unlock(&slot->lock);
+                free(tokens);
+                return rc;
+            }
+            if (slot) pthread_mutex_unlock(&slot->lock);
+            free(output);
+        }
+        reply.status = status;
+    }
+    reply_state(node, &reply);
+    free(tokens);
+    return send_reply(fd, LMB_SEG_RUN_R, &reply, NULL, 0);
+}
+
+static int handle_control(Node *node, int fd, const LmbMsg *msg) {
+    LmbSegControl control;
+    if (msg->pay_len ||
+        lmb_seg_control_decode(msg->body, msg->body_len, &control)) return -1;
+    LmbSegStatus status;
+    uint32_t response_op;
+    if (msg->op == LMB_SEG_CLOSE) {
+        status = lmb_seg_table_close(node->table, &control);
+        response_op = LMB_SEG_CLOSE_R;
+        if (status == LMB_SEG_STATUS_OK) {
+            pthread_mutex_lock(&node->sessions_lock);
+            NodeSession *slot = session_find(node, &control.session_id);
+            if (slot) session_release(node, slot);
+            pthread_mutex_unlock(&node->sessions_lock);
+        }
+    } else {
+        uint64_t next_sequence = 0, next_position = 0;
+        int needs_restore = 0;
+        status = lmb_seg_table_state(node->table, &control.session_id,
+                                     &next_sequence, &next_position,
+                                     &needs_restore);
+        response_op = LMB_SEG_HEALTH_R;
+    }
+    LmbSegReply reply = make_reply(&control.session_id, &control.request_id,
+                                   &control.owner, status);
+    if (status == LMB_SEG_STATUS_OK && msg->op != LMB_SEG_CLOSE)
+        reply_state(node, &reply);
+    return send_reply(fd, response_op, &reply, NULL, 0);
+}
+
+typedef struct { Node *node; int fd; } Connection;
+
+static void *connection_worker(void *opaque) {
+    Connection *connection = (Connection *)opaque;
+    Node *node = connection->node;
+    int fd = connection->fd;
+    free(connection);
+    for (;;) {
+        LmbMsg msg = {0};
+        if (lmb_recv(fd, &msg)) break;
+        int rc;
+        if (msg.op == LMB_SEG_OPEN) rc = handle_open(node, fd, &msg);
+        else if (msg.op == LMB_SEG_RUN) rc = handle_run(node, fd, &msg);
+        else if (msg.op == LMB_SEG_CLOSE || msg.op == LMB_SEG_HEALTH)
+            rc = handle_control(node, fd, &msg);
+        else rc = lmb_send(fd, LMB_ERR, "unsupported Segment operation", 29,
+                           NULL, 0);
+        lmb_msg_free(&msg);
+        if (rc) break;
+    }
+    lmb_close(fd);
+    connection_remove(node, fd);
+    return NULL;
+}
+
+static void usage(const char *program) {
+    fprintf(stderr,
+        "usage: %s --engine ID --model-dir DIR --model NAME --range A:B "
+        "--port N --tracker HOST:PORT --advertise HOST:PORT --name PEER "
+        "--model-root HEX64 --tokenizer-root HEX64 [--context N] "
+        "[--max-rows N] [--sessions N]\n", program);
+}
+
+static const char *arg_value(int argc, char **argv, const char *name) {
+    for (int i = 1; i + 1 < argc; i++) if (!strcmp(argv[i], name)) return argv[i + 1];
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    const char *engine_id = arg_value(argc, argv, "--engine");
+    const char *model_dir = arg_value(argc, argv, "--model-dir");
+    const char *model = arg_value(argc, argv, "--model");
+    const char *range = arg_value(argc, argv, "--range");
+    const char *port_text = arg_value(argc, argv, "--port");
+    const char *tracker = arg_value(argc, argv, "--tracker");
+    const char *advertise = arg_value(argc, argv, "--advertise");
+    const char *name = arg_value(argc, argv, "--name");
+    const char *model_root = arg_value(argc, argv, "--model-root");
+    const char *tokenizer_root = arg_value(argc, argv, "--tokenizer-root");
+    if (!engine_id || !model_dir || !model || !range || !port_text || !tracker ||
+        !advertise || !name || !model_root || !tokenizer_root) {
+        usage(argv[0]); return 2;
+    }
+    unsigned begin, end;
+    char trailing;
+    uint32_t port;
+    if (strlen(engine_id) >= LMB_SEG_ENGINE_MAX ||
+        strlen(model) >= LMB_SEG_MODEL_MAX ||
+        strlen(tracker) >= sizeof ((TrackerRegistration *)0)->tracker ||
+        strlen(advertise) >= LMB_SEG_ADDR_MAX ||
+        strlen(name) >= LMB_SEG_PEER_NAME_MAX ||
+        sscanf(range, "%u:%u%c", &begin, &end, &trailing) != 2 || begin >= end ||
+        lmb_parse_u32(port_text, 1, 65535, &port)) {
+        usage(argv[0]); return 2;
+    }
+    uint32_t context = 4096, max_rows = 256, max_sessions = 16;
+    const char *value;
+    if (((value = arg_value(argc, argv, "--context")) &&
+         lmb_parse_u32(value, 1, LMB_SEG_MAX_CONTEXT, &context)) ||
+        ((value = arg_value(argc, argv, "--max-rows")) &&
+         lmb_parse_u32(value, 1, LMB_SEG_MAX_ROWS, &max_rows)) ||
+        ((value = arg_value(argc, argv, "--sessions")) &&
+         lmb_parse_u32(value, 1, NODE_SESSIONS_MAX, &max_sessions))) {
+        usage(argv[0]); return 2;
+    }
+    if (lmb_secure_init()) return 1;
+    if (lmb_colibri_register_all()) {
+        fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
+    }
+    Node node;
+    memset(&node, 0, sizeof node);
+    for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) node.connection_fds[i] = -1;
+    pthread_mutex_init(&node.sessions_lock, NULL);
+    pthread_mutex_init(&node.connections_lock, NULL);
+    pthread_cond_init(&node.connections_drained, NULL);
+    ColiSegmentEngineOptions options = {
+        .struct_size = sizeof options,
+        .model_dir = model_dir,
+        .layer_begin = begin,
+        .layer_end = end,
+        .context_tokens = context,
+    };
+    char error[256];
+    if (coli_segment_engine_open(engine_id, &options, &node.engine,
+                                 error, sizeof error)) {
+        fprintf(stderr, "cannot open Colibri Segment engine: %s\n", error);
+        return 1;
+    }
+    node.cap.struct_size = sizeof node.cap;
+    if (coli_segment_engine_capabilities(node.engine, &node.cap,
+                                         error, sizeof error)) {
+        fprintf(stderr, "cannot read Segment capabilities: %s\n", error);
+        return 1;
+    }
+    if (end > node.cap.num_layers || context > node.cap.max_context_tokens ||
+        max_rows > node.cap.max_batch_rows) {
+        fprintf(stderr, "requested range/context/rows exceed model capabilities\n");
+        return 1;
+    }
+    LmbSegAdvert *a = &node.advert;
+    snprintf(a->peer_name, sizeof a->peer_name, "%s", name);
+    snprintf(a->addr, sizeof a->addr, "%s", advertise);
+    snprintf(a->model, sizeof a->model, "%s", model);
+    if (lmb_hex_root(model_root, a->model_root) ||
+        lmb_hex_root(tokenizer_root, a->tokenizer_root)) {
+        fprintf(stderr, "roots must be non-zero 64-character hex values\n");
+        return 2;
+    }
+    a->layer_begin = begin; a->layer_end = end;
+    a->max_context = context; a->max_rows = max_rows;
+    a->state_dtype = node.cap.state_dtype; a->state_width = node.cap.state_width;
+    a->max_sessions = max_sessions;
+    a->capabilities = node.cap.flags & LMB_SEG_CAP_KNOWN_MASK;
+    /* Snapshot/replay is intentionally not on the network data plane yet. */
+    a->capabilities &= ~LMB_SEG_CAP_SNAPSHOT;
+    snprintf(a->engine_id, sizeof a->engine_id, "%s", node.cap.engine_id);
+    snprintf(a->state_schema, sizeof a->state_schema, "%s", node.cap.state_schema);
+    snprintf(a->numeric_class, sizeof a->numeric_class, "%s", node.cap.numeric_class);
+    if (!lmb_seg_advert_valid(a)) {
+        fprintf(stderr, "generated Segment advert is invalid\n"); return 1;
+    }
+    node.table = lmb_seg_table_create(max_sessions);
+    if (!node.table) { fprintf(stderr, "cannot create session table\n"); return 1; }
+    TrackerRegistration *registration = &node.registration;
+    pthread_mutex_init(&registration->lock, NULL);
+    snprintf(registration->tracker, sizeof registration->tracker, "%s", tracker);
+    registration->advert = *a;
+    char peer_key_path[512];
+    if (lmb_peer_identity(lmb_peer_key_path(peer_key_path,
+                                            sizeof peer_key_path),
+                          registration->sk, registration->pk)) {
+        fprintf(stderr, "cannot load persistent peer identity from %s\n",
+                peer_key_path);
+        return 1;
+    }
+    signal(SIGINT, stop_handler); signal(SIGTERM, stop_handler); signal(SIGPIPE, SIG_IGN);
+    g_listen_fd = lmb_listen((int)port);
+    if (g_listen_fd < 0) { perror("segment listen"); return 1; }
+    pthread_t registration_thread, reaper_thread;
+    if (pthread_create(&registration_thread, NULL, registration_worker,
+                       registration)) {
+        fprintf(stderr, "cannot start tracker registration\n"); return 1;
+    }
+    if (pthread_create(&reaper_thread, NULL, session_reaper, &node)) {
+        fprintf(stderr, "cannot start session reaper\n");
+        registration->stop = 1;
+        pthread_join(registration_thread, NULL);
+        return 1;
+    }
+    printf("[segment-node] %s %s layers %u:%u at %s (tracker %s)\n",
+           engine_id, model, begin, end, advertise, tracker);
+    fflush(stdout);
+    while (!g_stop) {
+        int fd = accept(g_listen_fd, NULL, NULL);
+        if (fd < 0) { if (g_stop) break; continue; }
+        if (lmb_secure_server(fd)) { lmb_close(fd); continue; }
+        lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_IO_TIMEOUT_MS",
+                           LMB_DEFAULT_IO_TIMEOUT_MS, 100, 3600000));
+        Connection *connection = malloc(sizeof *connection);
+        if (!connection) { close(fd); continue; }
+        connection->node = &node; connection->fd = fd;
+        if (connection_add(&node, fd)) {
+            free(connection); lmb_close(fd); continue;
+        }
+        pthread_t thread;
+        if (pthread_create(&thread, NULL, connection_worker, connection)) {
+            connection_remove(&node, fd);
+            free(connection); lmb_close(fd); continue;
+        }
+        pthread_detach(thread);
+    }
+    registration->stop = 1;
+    pthread_join(reaper_thread, NULL);
+    pthread_join(registration_thread, NULL);
+    pthread_mutex_lock(&node.connections_lock);
+    for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++)
+        if (node.connection_fds[i] >= 0)
+            shutdown(node.connection_fds[i], SHUT_RDWR);
+    while (node.active_connections)
+        pthread_cond_wait(&node.connections_drained, &node.connections_lock);
+    pthread_mutex_unlock(&node.connections_lock);
+    pthread_mutex_lock(&node.sessions_lock);
+    for (size_t i = 0; i < NODE_SESSIONS_MAX; i++) {
+        NodeSession *slot = &node.sessions[i];
+        if (!slot->used) continue;
+        session_release(&node, slot);
+    }
+    pthread_mutex_unlock(&node.sessions_lock);
+    lmb_seg_table_destroy(node.table);
+    if (coli_segment_engine_close(node.engine, error, sizeof error))
+        fprintf(stderr, "[segment-node] engine close: %s\n", error);
+    memset(registration->sk, 0, sizeof registration->sk);
+    pthread_cond_destroy(&node.connections_drained);
+    pthread_mutex_destroy(&node.connections_lock);
+    pthread_mutex_destroy(&node.sessions_lock);
+    pthread_mutex_destroy(&registration->lock);
+    return 0;
+}

--- a/test_segment_discovery.c
+++ b/test_segment_discovery.c
@@ -123,6 +123,17 @@ static void test_codecs(void) {
     free(body);
     route.entries[1].advert.layer_begin = 3;
     assert(!lmb_seg_route_complete(&route, &q));
+
+    /* Interval union alone is insufficient: 0:3 plus 2:4 overlaps layer 2
+     * and cannot be executed as a chain. A shorter replica 0:2 makes 2:4
+     * reachable and must be selected instead of greedy-farthest 0:3. */
+    route.count = 2;
+    route.entries[0].advert = make_advert(0, 2, 0, 3);
+    route.entries[1].advert = make_advert(0, 3, 2, 4);
+    assert(!lmb_seg_route_complete(&route, &q));
+    route.entries[2].advert = make_advert(0, 4, 0, 2);
+    route.count = 3;
+    assert(lmb_seg_route_complete(&route, &q));
 }
 
 typedef struct {
@@ -218,7 +229,7 @@ static void test_tracker(const char *tracker) {
 
     /* Material range changes receive a new lease and generation. Add a
      * second range and one replica: the returned list preserves replicas and
-     * its union forms a complete layer-aligned chain. */
+     * contains a complete exact-boundary chain. */
     adverts[0].layer_end = 2;
     assert(!register_advert(tracker, &adverts[0], 20, &registrations[0]));
     assert(registrations[0].owner.route_generation > before.route_generation);


### PR DESCRIPTION
## Summary

- Adds an opt-in direct Segment data plane for GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4.
- Keeps full layer ranges and Colibri session state resident on each peer: one network boundary per segment, not per layer or expert.
- Uses asynchronous tracker discovery, immutable exact-chain routing, signed leases and persistent peer connections.
- Enforces session isolation, ordering/fencing, TTL cleanup and byte-identical retry of the most recent committed request.
- Keeps ordinary Lumabri and Colibri commands unchanged; the new target stays outside make all.

## Dependency and compatibility

Depends on the additive Colibri Edge/Segment archive from https://github.com/JustVugg/colibri/pull/1245, targeting Colibri dev. The current Colibri release path remains untouched.

## Explicit preview limits

- Edge v1 sampling is greedy only; temperature, top-p and top-k are not approximated.
- Segment transport is direct TCP; relay and NAT hole punching are still roadmap work.
- Snapshot/replay is not advertised yet; peer loss terminates the session with a clear error.
- The current archive advertises CPU only; no false GPU capability is published.
- Machine governor, automatic donation and local fallback are not wired into the standalone preview binaries yet.

## Verification

- Full existing Lumabri make test: PASS.
- Lumabri make check-warnings: PASS.
- Real two-peer Edge -> Segment -> Edge oracle gate: PASS for all six model families.
- Two concurrent isolated OLMoE chats: PASS.
- Exact duplicate retransmission gate: PASS for every family.
- Encrypted six-family gate: PASS.
- ASan + UBSan + Werror six-family gate after final lifecycle changes: PASS.
- Exact-chain overlap regression and asynchronous discovery tests: PASS.

This PR is intentionally opened for review only and is not merged.