### PR TITLE
feat: make Segment native to serve and chat

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,7 +2,7 @@
 
 # Running a lumabri swarm on a Hetzner server
 
-Start to finish: a server that holds a model and executes its experts, and
+Start to finish: a server that holds a model and supplies complete inference, and
 clients anywhere that chat with it or donate to it. Roughly 30 minutes,
 most of it waiting for the model to upload.
 
@@ -13,8 +13,8 @@ Hetzner-specific except the firewall section.
 
 ## 0. What to rent
 
-The server's job is to hold the model on disk and execute experts. It does
-**not** need a GPU.
+The server's job is to hold the model on disk and bootstrap complete Segment
+coverage plus the classic expert fallback. It does **not** need a GPU.
 
 | you serve | disk | RAM | reasonable Hetzner box |
 |---|---|---|---|
@@ -44,16 +44,18 @@ adduser --disabled-password --gecos "" lumabri
 ```
 
 Open only what the swarm needs. Ports: **7300** tracker, **7301**
-maintainer (byte serving), **7302** expert executor.
+maintainer (byte serving), **7302** classic expert executor and, by default,
+**7303-7306** four layer-aligned Segment origin ranges. Allow through 7309 if
+you intentionally set up to seven ranges.
 
 ```sh
 ufw allow OpenSSH
-ufw allow 7300:7302/tcp
+ufw allow 7300:7309/tcp
 ufw --force enable
 ```
 
 In the Hetzner Cloud console, apply the same rule in the **Firewall**
-section (inbound TCP 22, 7300-7302) — the cloud firewall sits in front of
+section (inbound TCP 22, 7300-7309) — the cloud firewall sits in front of
 the machine and a ufw rule alone will not open it.
 
 ---
@@ -64,13 +66,15 @@ the machine and a ufw rule alone will not open it.
 su - lumabri
 git clone https://github.com/JustVugg/lumabri.git
 cd lumabri
-make
+git clone https://github.com/JustVugg/colibri.git ../colibri
+make ENGINE=$HOME/colibri/c
 exit                        # back to root for the install step
 cd /home/lumabri/lumabri && make install     # → /usr/local
 ```
 
-To also execute experts (phase 2) the server needs the colibri engine
-source and the patch for the engine your model uses — they are per engine,
+The command above builds automatic Segment execution for every adapter in the
+matching Colibri dev checkout. To retain the classic fine-grained expert
+fallback too, build the patch for the engine your model uses — they are per engine,
 because the engines do not share a shape:
 
 | model | patch | build | node |
@@ -80,6 +84,7 @@ because the engines do not share a shape:
 | Inkling | `inkling-p2p.diff` | `make expert_node_inkling` | `expert_node_inkling` |
 | Kimi K3 | `kimi_k3-p2p.diff` | `make expert_node_kimi` | `expert_node_kimi` |
 | DeepSeek V4 | `deepseek-p2p.diff` | `make expert_node_deepseek` | `expert_node_deepseek` |
+| Qwen3.6 | `qwen36-p2p.diff` | `make expert_node_qwen36` | `expert_node_qwen36` |
 
 DeepSeek is built from whichever layout your colibri checkout ships. Current
 colibri has the unit-amalgamated `deepseek_v4.c`; `make expert_node_deepseek`
@@ -174,13 +179,17 @@ service user:
 su - lumabri -c 'lumabri peer-key'
 ```
 
-Clients can preseed a strict pin file with that value for the three server
-addresses:
+Clients can preseed a strict pin file with that value for every server
+endpoint (the default four Segment ranges use ports 7303-7306):
 
 ```text
 YOUR_SERVER_IP:7300 64_HEX_ENDPOINT_KEY
 YOUR_SERVER_IP:7301 64_HEX_ENDPOINT_KEY
 YOUR_SERVER_IP:7302 64_HEX_ENDPOINT_KEY
+YOUR_SERVER_IP:7303 64_HEX_ENDPOINT_KEY
+YOUR_SERVER_IP:7304 64_HEX_ENDPOINT_KEY
+YOUR_SERVER_IP:7305 64_HEX_ENDPOINT_KEY
+YOUR_SERVER_IP:7306 64_HEX_ENDPOINT_KEY
 ```
 
 Without a strict file, encrypted clients persist first contact in
@@ -276,21 +285,16 @@ systemctl enable --now lumabri
 journalctl -u lumabri -f
 ```
 
-**`--advertise` is what gives the swarm its fastest direct path.** The
-peers register with the tracker under the address they are told to publish,
-and without it they publish `127.0.0.1` — which is correct for this machine
-and useless for everyone. The tracker cannot fix it either: it rewrites a
-localhost registration only when it arrives from off-machine, and these
-arrive over loopback. A remote chatter then gets `127.0.0.1`, cannot connect,
-and falls back to the outbound heartbeat tunnel for both bytes and expert
-execution. That is correct behind symmetric NAT, but it adds a second network
-leg and tracker load. `serve` still warns because direct P2P should be used
-whenever an inbound address is available.
+**A reachable address gives the swarm its fastest path.** `serve` detects a
+public IPv4 attached to the machine and publishes it automatically. If the
+host sits behind NAT, pass `--advertise` only after forwarding the advertised
+ports. Lumabri deliberately does not publish an unreachable Segment chain;
+bytes and classic experts continue through their outbound tracker relay.
 
 You should see, in order: the maintainer announcing how much it holds, the
-line `ORIGIN: signed the truth of N files with <pubkey>`, the executor
-`serving EXEC on :7302 ... registered with tracker`, and the tracker
-accepting both under `YOUR_SERVER_IP`, not `127.0.0.1`.
+line `ORIGIN: signed the truth of N files with <pubkey>`, the classic executor
+on 7302 and the Segment origin ranges on 7303-7306. The tracker should accept
+all direct endpoints under `YOUR_SERVER_IP`, not `127.0.0.1`.
 
 `--exec-cache 256` is the RAM/SSD trade: 256 expert slots resident, the
 rest streamed from disk on demand. Raise it if the box has spare RAM (the
@@ -313,8 +317,8 @@ ExecStart=/usr/local/bin/lumabri serve \
 ```
 
 Ports go up in tens: each `serve` uses P (its own tracker, unused when it
-joins), P+1 (maintainer) and P+2 (expert executor), so open those in the
-firewall for every model you add. Clients see them all with `/model`, and
+joins), P+1 (maintainer), P+2 (expert executor) and normally P+3 through P+6
+(Segment ranges), so open that block for every model you add. Clients see them all with `/model`, and
 switching works across architectures because the engine binary is chosen
 from each model's `model_type`.
 
@@ -322,12 +326,13 @@ from each model's `model_type`.
 
 ## 6. Clients
 
-Every client needs the binaries (`make && sudo make install`, or just
-`make` and run from the directory) and, for chatting, a colibri build for
-the engine.
+Every client needs Lumabri built against the matching Colibri Segment ABI
+(`make ENGINE=/path/to/colibri/c && sudo make install`). Keep the ordinary or
+P2P Colibri executables installed too if you want the classic fallback when a
+complete Segment route is unavailable.
 
 On first launch the chat asks what you are bringing — Enter for chat only,
-2 to also donate disk, 3 (with `--model-dir`) to also execute experts. The
+2 to also donate disk, 3 to donate compute automatically. The
 donors live as long as the chat does. `--role chat|disk|compute|all` skips
 the question for scripts and services.
 
@@ -337,16 +342,21 @@ the question for scripts and services.
 LUMABRI_ENCRYPT=1 \
 LUMABRI_PEER_PINS=/path/to/peer-pins \
 LUMABRI_PUBKEY=<contents of swarm.pub> \
-lumabri chat --tracker YOUR_SERVER_IP:7300 --engines-dir ~/colibri/c
+lumabri chat --tracker YOUR_SERVER_IP:7300
 ```
+
+`--engines-dir ~/colibri/c` is optional when Lumabri finds the installation;
+it is still a useful explicit fallback path during development.
 
 The public key is not optional in spirit: with it, the client verifies
 every block against the operator's signature and refuses anything
 unsigned. Without it the client still works, but it is trusting the server.
 
-The first answer is slow while the dense weights cross the network; after
-that `~/.lumabri` serves them locally and the swarm is only touched for
-experts. `/swarm` shows the network, `/model` switches model.
+With Segment, the first answer fetches only the local Edge working set
+(tokenizer, embedding, final transform/head) into `~/.lumabri`; layer weights
+and state remain on peers. If Segment is unavailable, the same TUI starts the
+classic expert/CAS path and its dense working set automatically. `/swarm`
+shows the network, `/model` switches model.
 
 Verified chunks are shared across models in `~/.lumabri/cas`; override it
 with `LUMABRI_CAS=/fast/local/path`. To enable the basic straggler hedge, set
@@ -387,9 +397,11 @@ The tracker assigns the 20 GB where the swarm is thinnest (rarest first),
 the donor pulls it — verifying every byte against the signed truth — and
 then serves it.
 
-**Donate compute** — execute experts, the part that actually makes it fast.
-The binary is per engine (§2 has the table); `expert_node` is OLMoE's,
-`expert_node_glm` is GLM's, and so on:
+**Donate compute** — choose `compute` in the normal TUI. If the current chat
+uses Segment, the machine is directly reachable and a range fits after the
+RAM reserve, the tracker assigns its rarest origin range automatically.
+Otherwise Lumabri starts the finer-grained expert donor, including its NAT
+relay. Manual expert commands remain useful diagnostics:
 
 ```sh
 expert_node_glm --model /path/to/model --tracker YOUR_SERVER_IP:7300 \
@@ -402,9 +414,11 @@ and a peer at different bits holds different weights. DeepSeek V4 has no such
 knob — and its peer is the cheap one to run, since the V4 expert store needs
 no dense weights at all.
 
-Chatters discover it automatically and route to it when it is nearer than
-the server. Kill it and they fail over — ultimately back to the server,
-which holds everything.
+Chatters discover it automatically. Ordinary Segment ranges replace matching
+fallback origin ranges on the next route generation, so the original server
+does progressively less work while retaining full coverage. Expert requests
+can fail over to replicas; a selected Segment dying mid-conversation still
+ends that run until checkpoint/replay lands.
 
 ---
 
@@ -454,13 +468,13 @@ Two things worth knowing:
 
 | symptom | cause |
 |---|---|
-| `no swarm at HOST:7300` | cloud firewall: open 7300-7302 in the Hetzner console too |
+| `no swarm at HOST:7300` | cloud firewall: open 7300-7309 in the Hetzner console too |
 | the server logs nothing for minutes on first start | it is hashing the model; the progress lines say how far along |
 | `il motore non è arrivato a essere pronto` | the engine's own last 25 lines are printed underneath — read those |
 | engine killed by signal 9 | out of memory: lower `--ctx` and `--cap`, or take a bigger box |
 | the chatter fills the disk | it mirrors what it reads; on the server use `--local DIR` instead |
 | client says `not signed by the operator key` | server not started with `--key`, or a different key than the client's `LUMABRI_PUBKEY` |
-| `engine not found` on the client | pass `--engines-dir /path/to/colibri/c` |
+| `engine not found` after Segment fallback | install the classic Colibri engine or pass `--engines-dir /path/to/colibri/c` |
 | tracker logs `REJECTED: ... unsigned` | a peer joined a signed swarm without signed truth — that is the defence working |
 | expert cache hit rate very low | raise `--exec-cache`; each slot is one expert of RAM |
 | first start takes minutes | hashing the model; cached afterwards in `.lumabri_hashes/` |

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,15 @@ ENGINE  ?= ../colibri/c
 
 all: tracker maintainer liblumabri.so test_shim lumabri
 
+# A checkout with Colibri's additive ABI gets the transparent Segment path
+# from the ordinary `make`; older/release Colibri trees keep the exact legacy
+# build.  The user still runs only `lumabri serve` and `lumabri chat`.
+HAVE_COLIBRI_SEGMENT := $(and $(wildcard $(ENGINE)/segment_runtime.h),\
+                                  $(wildcard $(ENGINE)/edge_runtime.h))
+ifneq ($(HAVE_COLIBRI_SEGMENT),)
+all: segment-direct
+endif
+
 # Compile every standalone repository-owned binary under the normal warning
 # set and promote warnings to errors. Engine amalgamations are checked by
 # their own upstream builds, because treating their warnings as Lumabri
@@ -386,8 +395,9 @@ test_segment_discovery: test_segment_discovery.c lumabri_segment_discovery.c \
 		lumabri_segment_discovery.c lumabri_segment.c -o $@
 
 # ---- Segment direct data plane (requires Colibri's additive Edge ABI) ---
-# Kept out of `all`: a rolling Lumabri checkout still builds against the
-# Colibri release branch while the corresponding dev PR is under review.
+# `all` includes this only when both additive headers are present. A Lumabri
+# checkout pointed at an older/release Colibri therefore keeps building the
+# legacy product unchanged, while a matching dev checkout gets native UX.
 COLIBRI_SEGMENT_LIB = $(ENGINE)/build/segment/libcolibri_segment_edge.a
 SEGMENT_CFLAGS = $(CFLAGS) -I. -I$(ENGINE) -fopenmp
 SEGMENT_COMMON = segment_colibri.h lumabri_segment.c lumabri_segment.h \
@@ -395,7 +405,7 @@ SEGMENT_COMMON = segment_colibri.h lumabri_segment.c lumabri_segment.h \
 		lumabri_proto.h lumabri_sign.h lumabri_sha.h $(SECURE_DEPS)
 
 $(COLIBRI_SEGMENT_LIB):
-	$(MAKE) -C $(ENGINE) segment-edge-library
+	env -u CFLAGS -u MAKEFLAGS $(MAKE) -C $(ENGINE) MAKEOVERRIDES= segment-edge-library
 
 segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
@@ -481,8 +491,8 @@ install: all
 	install -m 755 lumabri tracker maintainer $(DESTDIR)$(PREFIX)/bin/
 	install -m 644 liblumabri.so $(DESTDIR)$(PREFIX)/lib/lumabri/
 	@for b in expert_node expert_node_glm expert_node_inkling expert_node_kimi \
-	         expert_node_deepseek \
-	         olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
+	         expert_node_deepseek expert_node_qwen36 \
+	         olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p qwen36_p2p \
 	         segment_node segment_chat; do \
 	    [ -f $$b ] && install -m 755 $$b $(DESTDIR)$(PREFIX)/bin/ || true; done
 	@echo "installed under $(DESTDIR)$(PREFIX)"
@@ -492,9 +502,9 @@ clean:
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery \
 	      segment_node segment_chat \
-	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p \
+	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p qwen36_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \
-	      expert_node_deepseek
+	      expert_node_deepseek expert_node_qwen36
 	rm -rf build
 
 .PHONY: all check-warnings test clean install phase2 phase2-glm engines chatters phase2-all \

--- a/Makefile
+++ b/Makefile
@@ -418,8 +418,9 @@ segment_chat: segment_chat.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 .PHONY: segment-direct
 segment-direct: segment_node segment_chat
 
-test-segment-direct-real: tracker segment-direct
+test-segment-direct-real: tracker maintainer liblumabri.so lumabri segment-direct
 	bash ./segment_direct_test.sh
+	bash ./segment_native_test.sh
 
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Run huge mixture-of-experts models from a swarm of peers, with the
 
 One machine shares a model. Any other machine chats with it. Nothing is
 downloaded up front: the bytes an inference actually touches arrive from a peer
-on first use and stay in a local mirror, so the second question is served from
-local disk at full speed. The engine binary is never modified.
+on first use and stay in the shared CAS. With Segment available, the chatter
+keeps only tokenizer, embeddings, final transform/head and conversation state;
+whole layer ranges and their state remain resident on executor peers. Colibri's
+ordinary executables and local-inference behaviour are unchanged.
 
 Any machine may join, GPU or not. The engine was built for CPU and SSD first; a
 GPU only makes it faster, never different, and the output is byte-for-byte the
@@ -16,7 +18,7 @@ from everyone.
 ## Quick start
 
 ```sh
-make
+make ENGINE=/path/to/colibri/c
 ```
 
 On the machine that has a model (any colibri model directory):
@@ -25,15 +27,17 @@ On the machine that has a model (any colibri model directory):
 ./lumabri serve --model /path/to/model
 ```
 
-On a machine that wants to chat (it needs a colibri build for the engine):
+On a machine that wants to chat:
 
 ```sh
-./lumabri chat --tracker <server-ip>:7300 --engines-dir /path/to/colibri/c
+./lumabri chat --tracker <server-ip>:7300
 ```
 
-That is all. The first answer is slower while the working set crosses the
-network. Afterwards the mirror in `~/.lumabri` keeps serving even if the server
-goes offline.
+That is all. The first answer is slower while the Edge working set crosses the
+network. If no complete compatible Segment route exists, the same command
+automatically falls back to the existing expert/CAS engine, then to local
+execution as coverage permits; there is no separate `segment_chat` command for
+an end user.
 
 No model at hand? `make fixture` builds a tiny synthetic one so every step above
 is real, just small.
@@ -50,11 +54,12 @@ The second time it is Enter, Enter, and you are in. Flags still win when you giv
 them, so a script never inherits somebody's saved answers.
 
 When you join it also asks how you want to take part — just chat, or **lend your
-machine too**: hold part of the model on disk, or run some of its experts. Pick
-"run experts" and your computer automatically takes a share of the experts sized
-to its free RAM; as more people do the same, the swarm splits the experts
-between them and each token is computed on several machines at once, so it gets
-faster the more join. Nothing to configure — Enter picks "just chat".
+machine too**. `disk` receives complete rarest-first files up to the chosen GB
+budget (transferred and verified in MiB blocks). `compute` takes the rarest
+tracker-assigned Segment slice when a direct endpoint and enough spare RAM are
+available; otherwise it uses the finer-grained expert donor and its NAT relay.
+Both run at low priority and die with the TUI. Nothing to configure — Enter
+picks "just chat".
 
 Inside the chat, `/swarm` shows the network live and anonymous (peers are
 numbered, never named), and `/model` lists the models on the swarm and switches
@@ -84,6 +89,24 @@ once and can rebuild a different sparse mirror without a byte server.
 from, never which bytes. Writing a model file returns `EROFS`. A block no peer
 can serve is a loud `EIO`, never silent zeros. Byte identity is verified cold,
 warm, and with every peer dead.
+
+**Layers run as stateful segments.** `serve` reads `model_type`, layer count,
+context, CPU count, available RAM and reachable network address, then starts a
+small set of disjoint layer-aligned executors automatically. The origin ranges
+are marked fallback. Compute donors ask only for a model; the tracker promises
+the least-replicated exact range while they load it, and the asynchronous route
+selector prefers their ordinary ranges over the matching origin ranges on the
+next turn. Thus the original server begins with complete coverage and loses its
+pipeline progressively without ever making the route incomplete. Every turn
+uses one request per segment, with its model-specific KV/recurrent/conv state
+kept in an isolated remote session.
+
+The local Edge opens through `liblumabri.so`, so a user supplies neither a model
+directory nor roots: the signed aggregate model identity comes from the tracker
+and only blocks actually read by tokenizer/embedding/head enter the CAS. Four
+origin ranges is the current latency/replacement compromise. Segment endpoints
+are direct TCP today; a server auto-publishes a real public IPv4, refuses to
+guess private/NAT addresses, and retains READ/EXEC relay fallback there.
 
 **Experts run on peers.** For a mixture-of-experts model the chatter keeps only
 the dense weights, the router and the KV cache, and sends the 4 KB activation to
@@ -145,14 +168,15 @@ Build the peers with `make engines`, the patched chat engines with
 `make chatters`, or both with `make phase2-all ENGINE=/path/to/colibri/c`, for
 the engines your colibri checkout actually has.
 
-### Layer segments (opt-in preview)
+### Layer segments
 
-The direct Segment path keeps whole contiguous layer ranges and their sequence
-state resident on peers, reducing the network boundary from one request per
-layer/expert to one request per segment. It is now executable for all six
-engine families and has a two-peer oracle gate, but is intentionally not the
-default `lumabri chat` path yet. Build and external-server instructions, plus
-the explicit greedy/direct/no-replay limitations, are in
+The Segment path keeps whole contiguous layer ranges and their sequence state
+resident on peers, reducing the network boundary from one request per
+layer/expert to one request per segment. It is the preferred path of ordinary
+`lumabri chat` when the matching Colibri ABI and a complete compatible route
+exist. GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4 are all release
+gates; OLMoE is not a special-case definition of complete. Build details and
+the explicit greedy/direct/no-replay limitations are in
 **[SEGMENT_DIRECT.md](SEGMENT_DIRECT.md)**.
 
 ## Running a swarm
@@ -161,32 +185,36 @@ A full server walkthrough (systemd, firewall, operator key, clients) is in
 **[DEPLOY.md](DEPLOY.md)**. The short version:
 
 ```sh
-make && make phase2-all ENGINE=/path/to/colibri/c   # phase2-all optional
+make ENGINE=/path/to/colibri/c
+make phase2-all ENGINE=/path/to/colibri/c           # classic expert fallback
 sudo make install                                    # or PREFIX=$HOME/.local
 ```
 
-On the server, `lumabri serve --model /srv/model` opens TCP 7300 to 7302
-(tracker, maintainer, executor). Add `--advertise <public-ip>` for the fastest
-direct path, and `--key swarm.key` to sign the model. If a byte or compute donor
-cannot accept inbound traffic, its outbound heartbeat doubles as a tracker
-relay. Direct P2P remains preferred; symmetric NAT no longer excludes it from
-the swarm.
+On the server, `lumabri serve --model /srv/model` starts tracker, maintainer,
+classic expert executor and the automatic Segment origin. With the default four
+ranges it opens TCP 7300 through 7306; allow 7300:7309 if deployments may use up
+to seven. A public IPv4 attached to the machine is detected automatically;
+otherwise add `--advertise <reachable-ip>` or Lumabri deliberately withholds
+Segment and uses the proven READ/EXEC relay. Add `--key swarm.key` to sign the
+model.
 
 On every other machine, pick a role:
 
 | you want to | run |
 |---|---|
-| chat | `lumabri chat --tracker SERVER:7300 --engines-dir /path/to/colibri/c` |
+| chat | `lumabri chat --tracker SERVER:7300` |
 | chat on the machine that holds the model | `lumabri chat --local DIR` |
 | donate disk (hold bytes) | `lumabri serve --model ./slice --join SERVER:7300 --model-name NAME --donate GB` |
-| donate compute (run experts) | pick it in the join menu — or `expert_node<engine> --model DIR --tracker SERVER:7300 --hold auto` |
+| donate compute | pick `compute` in the join menu; Segment range or experts are selected automatically |
 
-A disk donor is told which files to hold, rarest first, by the tracker. A
-compute donor says how many experts it can carry — `--hold auto` sizes that to
-its free RAM — and the tracker gives it the set nobody else covers. Donating
-compute does not require owning the model: picked from the menu with no local
-container, the node runs behind the swarm mirror and pulls exactly its
-assigned slice, hash-verified, so the whole model never lands on the donor.
+A disk donor is told which complete files to hold, rarest first, by the tracker;
+the GB budget is a hard placement input, not permission to fill the disk. A
+compute donor needs no model: when Segment is active, directly reachable and a
+quarter-range fits after the system reserve, it receives the least-replicated
+origin range. Otherwise `--hold auto` sizes an expert slice to free RAM and the
+tracker gives it what nobody else covers through direct EXEC or relay. Both
+load through the verified swarm mirror, so the whole model never lands on the
+donor.
 Donors register under `donor-<hostname>-…` (pick one with `--donor-name`);
 a name already owned by another peer key is retried with a numbered suffix
 instead of being silently rejected forever. So several
@@ -196,8 +224,10 @@ tokens. (`--hold N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or
 `--layers …` split it explicitly if you want to size each machine yourself.)
 When two donors happen to hold the *same* expert, add `LUMABRI_SPREAD=1` on the
 chatter to balance the load between them too. Neither donor needs to know the
-others exist. While a reply is generating you can kill a donor: you get one
-failover line and the tokens continue, identical.
+others exist. Expert requests can fail over to another replica. A selected
+stateful Segment dying mid-conversation is different: checkpoint/replay is not
+on the wire yet, so the run stops with that explicit error instead of silently
+restarting from divergent state.
 
 For a manual signing-key rotation, distribute a keyring containing one public
 key per line. `--pubkey keyring` and `LUMABRI_PUBKEY=keyring` accept every key
@@ -258,7 +288,7 @@ name. A restart rebuilds placements from heartbeats but does not reopen names
 for takeover. Per-key and per-source live-name quotas limit table exhaustion;
 they are admission controls, not a claim to solve distributed Sybil attacks.
 
-The server also runs an expert node on the whole model, so a fresh swarm works
+For the classic expert path, the server also runs an expert node on the whole model, so a fresh swarm works
 on day zero with the server executing everything, and donors that join later win
 the calls they are nearest for. The nearest replica sets the speed: an expert
 held at 2 ms and at 30 ms runs at 10.5 tok/s, not 1.4, because only your closest
@@ -280,9 +310,12 @@ Per-engine expert identity runs with fixtures
 have their own scripts (`assign_test.sh`, `concurrency_test.sh`,
 `sign_test.sh`). The newer mechanisms have focused targets:
 `make test-cas test-key-rotation test-hedge test-relay-exec` and
-`make test-segment-v2 test-segment-discovery`. Segment discovery runs six tiny state
-families through a real tracker and checks leases, route generations, replicas,
-draining, compatibility and the asynchronous snapshot. Relay EXEC needs
+`make test-segment-v2 test-segment-discovery test-segment-direct-real`.
+Segment discovery checks leases, route generations, replicas, draining,
+compatibility and the asynchronous snapshot. The direct gate runs all six tiny
+families through real TCP executors, matches independent Colibri token oracles,
+drives the persistent TUI codec, overlaps sessions, and proves rarest-first
+automatic range replacement. Relay EXEC needs
 an OLMoE engine source under `ENGINE`; its script reports `SKIP` explicitly
 when that external checkout is absent. Every claim in this README has a script
 behind it.

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -1,6 +1,6 @@
 # Direct Segment execution
 
-Lumabri can opt in to Colibri's public Edge/Segment ABI and run one model as a
+Lumabri uses Colibri's public Edge/Segment ABI to run one model as a
 chain of layer-aligned peers:
 
 ```text
@@ -14,24 +14,53 @@ its independent Colibri tiny-model oracle. The gate also overlaps two OLMoE
 chats against the same executors to exercise real session isolation, and
 retransmits a committed run to prove the cached duplicate response is exact.
 
-This is an opt-in data-plane milestone, not yet the default interactive
-`lumabri chat` path. The ordinary Lumabri and Colibri commands are unchanged.
+This is now the preferred data plane of the ordinary `lumabri chat` TUI. If
+the runtime, identity or a complete compatible route is absent, startup falls
+back automatically to the existing expert/CAS Colibri path. Colibri's ordinary
+executables remain unchanged.
 
 ## Build
 
 Use a Colibri checkout containing the additive Edge runtime:
 
 ```sh
-make -C /path/to/colibri/c segment-edge-library
-make segment-direct ENGINE=/path/to/colibri/c
-make tracker
+make ENGINE=/path/to/colibri/c
 ```
 
-`segment-edge-library` produces a CPU-baseline static archive containing both
-public runtimes and all six adapters. It is not linked into ordinary Colibri
-executables.
+When the two additive ABI headers exist, ordinary `make` includes
+`segment_node` and `segment_chat`; older Colibri release trees keep the legacy
+build. `segment-edge-library` contains both public runtimes and all six
+adapters, and is not linked into ordinary Colibri executables.
 
-## Two-peer example
+## Normal use
+
+The model owner runs:
+
+```sh
+lumabri serve --model /models/olmoe --advertise PUBLIC_IP
+```
+
+Lumabri detects the family, layer/context shape, CPU/RAM and public IPv4, then
+starts four disjoint fallback executors. A public interface address removes the
+need for `--advertise`; private/NAT addresses are never guessed.
+
+Every client runs the unchanged TUI:
+
+```sh
+lumabri chat --tracker SERVER:7300
+```
+
+It obtains the signed aggregate model identity from the tracker, opens local
+Edge through the CAS mirror, discovers Segment and expert coverage in the
+background and selects the complete Segment chain when available. There are no
+user-facing model roots, tokenizer roots, ranges or `segment_chat` command.
+
+Choosing `compute` in the TUI asks the tracker for the least-replicated exact
+origin range. The node loads that slice from CAS at low priority if it fits
+after the machine reserve and has a reachable direct address; otherwise
+Lumabri donates auto-sized experts over the relay-capable classic path.
+
+## Low-level two-peer diagnostic
 
 Start a tracker on the publicly reachable control server:
 
@@ -61,8 +90,8 @@ the latter three model properties are read from Colibri automatically.
   --context 4096 --max-rows 64 --sessions 4
 ```
 
-The chatter needs the model's Edge files (tokenizer, embeddings, final
-transform and head), then discovers and freezes a complete compatible route:
+The low-level chatter needs the model's Edge files (tokenizer, embeddings,
+final transform and head), then discovers a complete compatible route:
 
 ```sh
 ./segment_chat \
@@ -74,10 +103,10 @@ transform and head), then discovers and freezes a complete compatible route:
 
 For an isolated experiment with no byte-plane maintainer registered under the
 same model name, the two roots may be any shared non-zero 32-byte hex values.
-For a real swarm, `--model-root` must be the content-plane model identity; the
-tracker rejects a different value. Automatic model/tokenizer root selection is
-still part of the CLI integration work and must replace manual input before
-the final UX is declared complete.
+For a real swarm, prefer `--auto-identity`; explicit roots remain only for
+isolated fixtures and protocol diagnosis. A donor may use `--auto-range` in
+place of `--range`: the tracker keeps a short loading promise so concurrent
+donors do not all choose the same rare slice.
 
 Open the Segment port on each executor's firewall. The current transport is
 direct TCP, so an executor behind an unforwarded NAT is not reachable yet.
@@ -118,8 +147,10 @@ data planes.
   divergent continuation.
 - The archive advertises CPU only. GPU Segment adapters must expose a real
   Colibri backend before Lumabri may publish CUDA/HIP/Metal/Vulkan capability.
-- Machine profiling, resource governance, automatic donation and local
-  fallback are not part of these standalone binaries yet.
+- The current governor is conservative rather than complete: CPU/RAM/context
+  choose chunk/session limits, desktop donors are niced and Segment donation
+  is refused when its estimated range would consume the system reserve. Live
+  pressure migration and state replay are still pending.
 - One chatter process hosts one active Edge model. This also respects Qwen's
   currently process-global tokenizer state.
 

--- a/lumabri.c
+++ b/lumabri.c
@@ -24,8 +24,10 @@
  * where mirroring would mean a second copy of the same bytes.
  */
 #define _GNU_SOURCE
+#include <arpa/inet.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <ifaddrs.h>
 #include <math.h>
 #include <pthread.h>
 #include <signal.h>
@@ -192,16 +194,17 @@ static pid_t spawn_argv_logged(char *const argv[], char *const envv[],
     return pid;
 }
 
-static pid_t g_children[8];
+#define MAX_CHILDREN 16
+static pid_t g_children[MAX_CHILDREN];
 static int g_nchildren = 0;
 /* The async handler never reads the mutable table/count.  Each fixed slot is
  * one sig_atomic_t publication, so delivery on any worker thread cannot see a
  * compacted/torn child table. */
-static volatile sig_atomic_t g_signal_children[8];
+static volatile sig_atomic_t g_signal_children[MAX_CHILDREN];
 /* what each child was, and how to start it again: a supervisor that cannot
  * name or restart what died is just a process that happens to be the parent */
-static char **g_cargv[8];
-static const char *g_cwhat[8];
+static char **g_cargv[MAX_CHILDREN];
+static const char *g_cwhat[MAX_CHILDREN];
 
 static void child_publish(int idx, pid_t pid) {
     g_children[idx] = pid;
@@ -213,6 +216,10 @@ static void child_unpublish(int idx) {
 }
 
 static void spawn_tracked(char *const argv[], const char *what) {
+    if (g_nchildren >= MAX_CHILDREN) {
+        fprintf(stderr, "cannot start %s: child supervisor is full\n", what);
+        return;
+    }
     int n = 0;
     while (argv[n]) n++;
     char **copy = (char **)calloc((size_t)n + 1, sizeof *copy);
@@ -230,7 +237,7 @@ static volatile sig_atomic_t g_stopping = 0;
 static void on_sigint(int sig) {
     (void)sig;
     g_stopping = 1;
-    for (int i = 0; i < 8; i++) {
+    for (int i = 0; i < MAX_CHILDREN; i++) {
         sig_atomic_t p = g_signal_children[i];
         if (p > 0) kill((pid_t)p, SIGTERM);
     }
@@ -246,6 +253,19 @@ static const char *expert_node_for(const char *model_type) {
     if (strstr(model_type, "kimi"))     return "expert_node_kimi";
     if (strstr(model_type, "deepseek")) return "expert_node_deepseek";
     if (strstr(model_type, "qwen"))     return "expert_node_qwen36";
+    return NULL;
+}
+
+/* Public Colibri Segment adapter ID for the same model family.  Unlike the
+ * expert executors, these names are the stable ABI IDs rather than binary
+ * basenames. */
+static const char *segment_engine_for(const char *model_type) {
+    if (strstr(model_type, "olmoe"))    return "olmoe";
+    if (strstr(model_type, "glm"))      return "glm";
+    if (strstr(model_type, "inkling")) return "inkling";
+    if (strstr(model_type, "kimi"))     return "kimi";
+    if (strstr(model_type, "deepseek")) return "deepseek_v4";
+    if (strstr(model_type, "qwen"))     return "qwen36";
     return NULL;
 }
 
@@ -270,12 +290,101 @@ static void local_model_type(const char *model_dir, char *out, size_t cap) {
     }
 }
 
+/* All current Colibri families publish num_hidden_layers in config.json.
+ * Keep this deliberately narrow: guessing a different key could advertise a
+ * plausible but incorrect range and execute the wrong graph. */
+static int local_model_u32(const char *model_dir, const char *name,
+                           uint32_t *result) {
+    char path[1200];
+    if (!model_dir || !name || !result ||
+        checked_printf(path, sizeof path, "%s/config.json", model_dir))
+        return -1;
+    FILE *file = fopen(path, "r");
+    if (!file) return -1;
+    if (fseek(file, 0, SEEK_END)) { fclose(file); return -1; }
+    long length = ftell(file);
+    if (length <= 0 || length > 16 * 1024 * 1024 ||
+        fseek(file, 0, SEEK_SET)) { fclose(file); return -1; }
+    char *json = malloc((size_t)length + 1);
+    if (!json) { fclose(file); return -1; }
+    int bad = fread(json, 1, (size_t)length, file) != (size_t)length;
+    fclose(file);
+    json[length] = 0;
+    char quoted[128];
+    if (checked_printf(quoted, sizeof quoted, "\"%s\"", name)) {
+        free(json); return -1;
+    }
+    char *key = bad ? NULL : strstr(json, quoted);
+    char *colon = key ? strchr(key, ':') : NULL;
+    char *end = NULL;
+    errno = 0;
+    unsigned long value = colon ? strtoul(colon + 1, &end, 10) : 0;
+    bad = !colon || errno || end == colon + 1 || !value || value > UINT32_MAX;
+    free(json);
+    if (bad) return -1;
+    *result = (uint32_t)value;
+    return 0;
+}
+
+static int local_model_layers(const char *model_dir, uint32_t *layers) {
+    return local_model_u32(model_dir, "num_hidden_layers", layers);
+}
+
+static uint64_t machine_available_ram(void) {
+    FILE *file = fopen("/proc/meminfo", "r");
+    if (!file) return 0;
+    char line[256];
+    unsigned long long kib = 0;
+    while (fgets(line, sizeof line, file))
+        if (sscanf(line, "MemAvailable: %llu kB", &kib) == 1) break;
+    fclose(file);
+    return (uint64_t)kib * 1024u;
+}
+
+/* A server with a real public IPv4 should need no networking flag. Private,
+ * loopback, link-local and CGNAT addresses are deliberately not guessed:
+ * publishing one to an Internet swarm would create a "complete" Segment
+ * route that remote chatters cannot reach. NAT installations keep the
+ * proven READ/EXEC relay path unless the operator supplies --advertise. */
+static int machine_public_ipv4(char *out, size_t cap) {
+    struct ifaddrs *all = NULL;
+    if (getifaddrs(&all)) return -1;
+    int found = -1;
+    for (struct ifaddrs *it = all; it; it = it->ifa_next) {
+        if (!it->ifa_addr || it->ifa_addr->sa_family != AF_INET) continue;
+        uint32_t ip = ntohl(((struct sockaddr_in *)it->ifa_addr)->sin_addr.s_addr);
+        if ((ip >> 24) == 0 || (ip >> 24) == 10 || (ip >> 24) == 127 ||
+            (ip >> 16) == 0xa9fe || (ip >> 20) == 0xac1 ||
+            (ip >> 16) == 0xc0a8 || (ip >> 22) == 0x0191) continue;
+        char text[INET_ADDRSTRLEN];
+        if (!inet_ntop(AF_INET, &((struct sockaddr_in *)it->ifa_addr)->sin_addr,
+                       text, sizeof text) || strlen(text) >= cap) continue;
+        snprintf(out, cap, "%s", text);
+        found = 0;
+        break;
+    }
+    freeifaddrs(all);
+    return found;
+}
+
+static const char *model_name_for(const char *model_dir, const char *explicit,
+                                  char *storage, size_t cap) {
+    if (explicit && explicit[0]) return explicit;
+    size_t length = strlen(model_dir);
+    while (length > 1 && model_dir[length - 1] == '/') length--;
+    const char *base = model_dir + length;
+    while (base > model_dir && base[-1] != '/') base--;
+    if (!length || (size_t)(model_dir + length - base) >= cap) return NULL;
+    snprintf(storage, cap, "%.*s", (int)(model_dir + length - base), base);
+    return storage;
+}
+
 static int parse_serve_port(const char *s, int *port) {
     char *end = NULL;
     errno = 0;
     long v = strtol(s, &end, 10);
     if (s[0] < '0' || s[0] > '9' || errno == ERANGE || !end || *end ||
-        v < 1 || v > 65533) return -1;
+        v < 1 || v > 65525) return -1;
     *port = (int)v;
     return 0;
 }
@@ -288,7 +397,7 @@ static int cmd_serve(int argc, char **argv) {
         if (!strcmp(argv[i], "--model") && i + 1 < argc) model = argv[++i];
         else if (!strcmp(argv[i], "--port") && i + 1 < argc) {
             if (parse_serve_port(argv[++i], &port)) {
-                fprintf(stderr, "--port must be an integer from 1 to 65533\n");
+                fprintf(stderr, "--port must be an integer from 1 to 65525\n");
                 return 2;
             }
         }
@@ -343,6 +452,14 @@ static int cmd_serve(int argc, char **argv) {
                     C_RED, model, C_R, model);
             return 2;
         }
+    }
+
+    char auto_advertise[INET_ADDRSTRLEN] = "";
+    if (!advertise && machine_public_ipv4(auto_advertise,
+                                           sizeof auto_advertise) == 0) {
+        advertise = auto_advertise;
+        printf("  %srete: pubblico automaticamente %s%s\n",
+               C_DIM, advertise, C_R);
     }
 
     char dir[1024], tracker_bin[1200], maint_bin[1200], portstr[16], mport[16], taddr[64];
@@ -453,11 +570,95 @@ static int cmd_serve(int argc, char **argv) {
                "quando ha finito. Un chatter che si collega prima non lo "
                "trovera' e scarichera' gli esperti.%s\n",
                C_DIM, port + 2, C_R);
+
+    /* Segment bootstrap: the origin publishes complete stateful coverage in
+     * addition to the expert executor.  This binary exists only in builds
+     * made against Colibri's additive Edge/Segment archive; release builds
+     * without it preserve the exact old serve topology. */
+    char segment_bin[1200], segment_model_storage[64];
+    snprintf(segment_bin, sizeof segment_bin, "%s/segment_node", dir);
+    const char *segment_engine = segment_engine_for(mtype);
+    const char *segment_model = model_name_for(
+        model, mname, segment_model_storage, sizeof segment_model_storage);
+    uint32_t segment_layers = 0;
+    int with_segment = 0;
+    if (!disk_donor && !no_exec && advertise && segment_engine && segment_model &&
+        access(segment_bin, X_OK) == 0 &&
+        local_model_layers(model, &segment_layers) == 0) {
+        long cores = sysconf(_SC_NPROCESSORS_ONLN);
+        if (cores < 1) cores = 1;
+        int chunks = lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 4, 1, 7);
+        if ((uint32_t)chunks > segment_layers) chunks = (int)segment_layers;
+        int sessions = (int)(cores / chunks);
+        if (sessions < 1) sessions = 1;
+        if (sessions > 8) sessions = 8;
+        uint32_t segment_context = 4096, model_context = 0;
+        if (!local_model_u32(model, "max_position_embeddings", &model_context) &&
+            model_context < segment_context)
+            segment_context = model_context;
+        char context[16], session_text[16];
+        snprintf(context, sizeof context, "%u", segment_context);
+        snprintf(session_text, sizeof session_text, "%d", sessions);
+
+        /* A few disjoint origin slices retain the single-copy weight total,
+         * but give placement exact boundaries it can replace independently:
+         * as ordinary server-class peers join, each non-fallback slice wins
+         * over its matching origin slice and this machine loses that portion
+         * of the pipeline. Four is the latency/granularity default; the
+         * operator may tune 1..7 without exposing layer ranges to users. */
+        for (int chunk = 0; chunk < chunks; chunk++) {
+            uint32_t begin = (uint32_t)((uint64_t)segment_layers * chunk /
+                                         (uint32_t)chunks);
+            uint32_t end = (uint32_t)((uint64_t)segment_layers * (chunk + 1) /
+                                       (uint32_t)chunks);
+            char sport[16], range[40], sname[64], sadv[80];
+            snprintf(sport, sizeof sport, "%d", port + 3 + chunk);
+            snprintf(range, sizeof range, "%u:%u", begin, end);
+            snprintf(sname, sizeof sname, "segment-%s-%d-%d",
+                     join ? "peer" : "origin", port, chunk);
+            snprintf(sadv, sizeof sadv, "%s:%d",
+                     advertise ? advertise : "127.0.0.1", port + 3 + chunk);
+            char *sargv[32];
+            a = 0;
+            sargv[a++] = segment_bin;
+            sargv[a++] = "--engine";       sargv[a++] = (char *)segment_engine;
+            sargv[a++] = "--model-dir";    sargv[a++] = (char *)model;
+            sargv[a++] = "--model";        sargv[a++] = (char *)segment_model;
+            sargv[a++] = "--range";        sargv[a++] = range;
+            sargv[a++] = "--port";         sargv[a++] = sport;
+            sargv[a++] = "--tracker";      sargv[a++] = taddr;
+            sargv[a++] = "--name";         sargv[a++] = sname;
+            sargv[a++] = "--auto-identity";
+            if (!join) sargv[a++] = "--fallback";
+            sargv[a++] = "--context";      sargv[a++] = context;
+            sargv[a++] = "--max-rows";     sargv[a++] = "16";
+            sargv[a++] = "--sessions";     sargv[a++] = session_text;
+            sargv[a++] = "--advertise";    sargv[a++] = sadv;
+            sargv[a] = NULL;
+            spawn_tracked(sargv, join ? "l'esecutore Segment peer"
+                                      : "l'esecutore Segment origin");
+            with_segment++;
+        }
+        double ram_gb = (double)machine_available_ram() / 1e9;
+        printf("  %sSegment prepara %d fette layer-aligned sulle porte %d-%d "
+               "(%ld CPU, %.1f GB RAM disponibili, %d sessioni/fetta). "
+               "%s%s\n",
+               C_DIM, chunks, port + 3, port + 2 + chunks, cores, ram_gb,
+               sessions, join ? "Sono peer ordinari; " :
+               "Sono il fallback sostituibile; ", C_R);
+    } else if (!disk_donor && !no_exec && !advertise && segment_engine &&
+               access(segment_bin, X_OK) == 0) {
+        printf("  %sSegment non viene pubblicato: questa macchina non espone "
+               "un IPv4 pubblico. READ/EXEC continuano via relay; usa "
+               "--advertise IP solo quando le porte sono raggiungibili.%s\n",
+               C_DIM, C_R);
+    }
     signal(SIGINT, on_sigint);
     signal(SIGTERM, on_sigint);
 
     printf("\n%sserving%s %s %s(tracker %s%s)%s\n", C_GRN, C_R, model, C_DIM, taddr,
-           with_exec ? " · executing experts for the swarm" : "", C_R);
+           with_segment ? " · Segment origin attivo" :
+           (with_exec ? " · executing experts for the swarm" : ""), C_R);
     /* Without --advertise every local peer registers as 127.0.0.1, and the
      * tracker's correction cannot help because these registrations arrive
      * over loopback. A remote chatter then uses the READ/EXEC tracker relay.
@@ -992,7 +1193,13 @@ typedef enum {
     EK_INKLING,        /* inkling:      <|message_user|><|content_text|>…      */
     EK_KIMI            /* kimi_k3:      K3CHAT1 byte-counted wire              */
 } EngKind;
-typedef struct { pid_t pid; int to, from; Proto proto; EngKind kind; } Engine;
+typedef struct {
+    pid_t pid;
+    int to, from;
+    Proto proto;
+    EngKind kind;
+    int segment;
+} Engine;
 
 /* Map the resolved engine binary name to its kind. Unknown ⇒ EK_GLM, the safe
  * default: the framed dialect with no client-side templating, which is exactly
@@ -1281,6 +1488,12 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
 #define OLMO_U0   "|||IP_ADDRESS|||<|user|>\n"
 #define OLMO_UL   "|||IP_ADDRESS|||\n<|user|>\n"
 #define OLMO_ASST "\n<|assistant|>\n"
+/* GLM-5.2 (colibri.c's official chat_template.jinja path).  The monolithic
+ * engine applies this internally; Segment Edge deliberately accepts exact
+ * bytes, so only the Segment Serve2 path reaches this case. */
+#define GLM_BOS  "[gMASK]<sop>"
+#define GLM_U    "<|user|>"
+#define GLM_ASST "<|assistant|><think></think>"
 /* qwen36 (qwen36.c: ChatML, no BOS). */
 #define QW_U    "<|im_start|>user\n"
 #define QW_ASST "<|im_end|>\n<|im_start|>assistant\n"
@@ -1296,7 +1509,11 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
  * the SUBMIT payload; reply!=NULL builds a *completed* turn — user text plus the
  * assistant's reply, for the running history. 0, or -1 on OOM. */
 static int serve2_turn(Cap *c, EngKind k, int first, const char *u, const char *reply) {
+    (void)first;
     switch (k) {
+    case EK_GLM:
+        if (cap_str(c, GLM_U) || cap_str(c, u) || cap_str(c, GLM_ASST)) return -1;
+        return reply ? cap_str(c, reply) : 0;
     case EK_DEEPSEEK:
         if (cap_str(c, DS_USER) || cap_str(c, u) || cap_str(c, DS_ASST)) return -1;
         return reply ? cap_str(c, reply) : 0;
@@ -1318,13 +1535,14 @@ static int serve2_turn(Cap *c, EngKind k, int first, const char *u, const char *
         if (cap_addf(c, "M user %zu\n", strlen(u)) || cap_str(c, u)) return -1;
         return reply ? (cap_addf(c, "M assistant %zu\n", strlen(reply)) ||
                         cap_str(c, reply)) : 0;
-    default:                                    /* EK_GLM never speaks serve-codec */
+    default:
         return -1;
     }
 }
 
 /* The once-at-front SUBMIT prefix (kept out of the stored history). */
 static int serve2_prefix(Cap *c, EngKind k) {
+    if (k == EK_GLM)      return cap_str(c, GLM_BOS);
     if (k == EK_DEEPSEEK) return cap_str(c, DS_BOS);
     if (k == EK_KIMI)     return cap_str(c, "K3CHAT1\n");
     return 0;
@@ -1450,9 +1668,74 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
     e->pid = pid; e->to = in_pipe[1]; e->from = out_pipe[0];
     e->proto = PROTO_UNKNOWN;
     e->kind = engine_kind_of(engine);
+    e->segment = 0;
     pthread_t t;
     pthread_create(&t, NULL, stderr_thread, (void *)(intptr_t)err_pipe[0]);
     pthread_detach(t);
+    return 0;
+}
+
+/* Segment speaks the same SUBMIT/DATA/DONE codec already consumed by the TUI,
+ * but its Edge loader runs over Lumabri's virtual mirror.  Therefore a client
+ * with no model directory fetches only config/tokenizer/embedding/head through
+ * the existing signed CAS, while all transformer layers stay on the selected
+ * peers. */
+static int segment_engine_spawn(const char *engine, const char *shim,
+                                const char *tracker, const char *model,
+                                const char *model_type, int ctx, Engine *e) {
+    const char *segment_id = segment_engine_for(model_type);
+    if (!segment_id) return -1;
+    const char *home = getenv("HOME") ? getenv("HOME") : ".";
+    char vroot[1024], cache[1024], cas[1024];
+    const char *vroot_env = getenv("LUMABRI_VROOT");
+    const char *cache_env = getenv("LUMABRI_CACHE");
+    if (vroot_env && vroot_env[0]) snprintf(vroot, sizeof vroot, "%s", vroot_env);
+    else snprintf(vroot, sizeof vroot, "%s/.lumabri/%s/vroot", home, model);
+    if (cache_env && cache_env[0]) snprintf(cache, sizeof cache, "%s", cache_env);
+    else snprintf(cache, sizeof cache, "%s/.lumabri/%s/cache", home, model);
+    snprintf(cas, sizeof cas, "%s/.lumabri/cas", home);
+    mkdir_p(cache);
+
+    int in_pipe[2], out_pipe[2], err_pipe[2];
+    if (pipe(in_pipe) || pipe(out_pipe) || pipe(err_pipe)) return -1;
+    pid_t pid = fork();
+    if (pid == 0) {
+        dup2(in_pipe[0], 0); dup2(out_pipe[1], 1); dup2(err_pipe[1], 2);
+        close(in_pipe[1]); close(out_pipe[0]); close(err_pipe[0]);
+        setenv("LD_PRELOAD", shim, 1);
+        setenv("LUMABRI_VROOT", vroot, 1);
+        setenv("LUMABRI_CACHE", cache, 1);
+        setenv("LUMABRI_CAS", cas, 0);
+        setenv("LUMABRI_TRACKER", tracker, 1);
+        setenv("LUMABRI_MODEL", model, 1);
+        setenv("LUMABRI_STATS", "2", 1);
+        char context[32];
+        snprintf(context, sizeof context, "%d", ctx);
+        char *argv[] = {
+            (char *)engine,
+            "--serve",
+            "--engine", (char *)segment_id,
+            "--model-dir", vroot,
+            "--model", (char *)model,
+            "--tracker", (char *)tracker,
+            "--context", context,
+            "--max-rows", "16",
+            "--discovery-timeout-ms", "2500",
+            NULL
+        };
+        execv(engine, argv);
+        perror(engine);
+        _exit(127);
+    }
+    close(in_pipe[0]); close(out_pipe[1]); close(err_pipe[1]);
+    e->pid = pid; e->to = in_pipe[1]; e->from = out_pipe[0];
+    e->proto = PROTO_UNKNOWN;
+    e->kind = engine_kind_of(model_type);
+    e->segment = 1;
+    pthread_t thread;
+    pthread_create(&thread, NULL, stderr_thread,
+                   (void *)(intptr_t)err_pipe[0]);
+    pthread_detach(thread);
     return 0;
 }
 
@@ -2057,10 +2340,129 @@ static int free_port(int from) {
     return 0;
 }
 
+/* Prefer one tracker-assigned Segment slice when this chat is already using
+ * Segment and the machine can publish a genuinely reachable address. Home
+ * NAT peers keep donating through the mature EXEC relay instead of poisoning
+ * discovery with an endpoint that only looks public from the tracker. */
+static int role_start_segment(const Role *r, const char *tracker,
+                              const char *model, const char *model_type,
+                              int context, uint64_t model_bytes) {
+    const char *engine = segment_engine_for(model_type ? model_type : "");
+    if (!engine) return 0;
+    char dir[1024], bin[1200], shim[1200];
+    exe_dir(dir, sizeof dir);
+    snprintf(bin, sizeof bin, "%s/segment_node", dir);
+    if (access(bin, X_OK)) return 0;
+    snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
+    if (access(shim, R_OK))
+        snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
+
+    char host[INET_ADDRSTRLEN] = "";
+    const char *forced = getenv("LUMABRI_ADVERTISE");
+    struct in_addr forced_address;
+    if (forced && forced[0]) {
+        if (strlen(forced) >= sizeof host ||
+            inet_pton(AF_INET, forced, &forced_address) != 1)
+            return 0;
+        snprintf(host, sizeof host, "%s", forced);
+    }
+    else if (!strncmp(tracker, "127.0.0.1:", 10) ||
+             !strncmp(tracker, "localhost:", 10))
+        snprintf(host, sizeof host, "127.0.0.1");
+    else if (machine_public_ipv4(host, sizeof host))
+        return 0;
+
+    /* The origin's default four-way partition makes one slice roughly a
+     * quarter of the checkpoint. Keep both a fixed OS reserve and 25% of the
+     * currently available RAM; if it would not fit, the expert donor below
+     * is the finer-grained, auto-sized contribution. This is intentionally
+     * conservative: a donation must never win by pushing the desktop to swap. */
+    uint64_t available = machine_available_ram();
+    uint64_t reserve = available / 4;
+    if (reserve < 4ull * 1000 * 1000 * 1000)
+        reserve = 4ull * 1000 * 1000 * 1000;
+    uint64_t estimated = model_bytes / 4 + model_bytes / 20;
+    if (!available || reserve >= available || estimated > available - reserve)
+        return 0;
+
+    char probe[1100];
+    snprintf(probe, sizeof probe, "%s/config.json", r->model_dir);
+    int local = r->model_dir[0] && access(probe, R_OK) == 0;
+    if (!local && access(shim, R_OK)) return 0;
+
+    const char *home = getenv("HOME") ? getenv("HOME") : ".";
+    char vroot[1024], cachedir[1024], casdir[1040];
+    char e_pre[1216], e_vr[1040], e_ca[1040], e_cs[1056];
+    char e_tr[160], e_mo[96];
+    char *envv[8];
+    int ne = 0;
+    if (!local) {
+        const char *ve = getenv("LUMABRI_VROOT");
+        const char *ce = getenv("LUMABRI_CACHE");
+        if (ve && ve[0]) snprintf(vroot, sizeof vroot, "%s", ve);
+        else snprintf(vroot, sizeof vroot, "%s/.lumabri/%s/vroot", home, model);
+        if (ce && ce[0]) snprintf(cachedir, sizeof cachedir, "%s", ce);
+        else snprintf(cachedir, sizeof cachedir, "%s/.lumabri/%s/cache", home, model);
+        snprintf(casdir, sizeof casdir, "%s/.lumabri/cas", home);
+        mkdir_p(cachedir);
+        snprintf(e_pre, sizeof e_pre, "LD_PRELOAD=%s", shim);
+        snprintf(e_vr, sizeof e_vr, "LUMABRI_VROOT=%s", vroot);
+        snprintf(e_ca, sizeof e_ca, "LUMABRI_CACHE=%s", cachedir);
+        snprintf(e_cs, sizeof e_cs, "LUMABRI_CAS=%s", casdir);
+        snprintf(e_tr, sizeof e_tr, "LUMABRI_TRACKER=%s", tracker);
+        snprintf(e_mo, sizeof e_mo, "LUMABRI_MODEL=%s", model);
+        envv[ne++] = e_pre; envv[ne++] = e_vr; envv[ne++] = e_ca;
+        if (!getenv("LUMABRI_CAS")) envv[ne++] = e_cs;
+        envv[ne++] = e_tr; envv[ne++] = e_mo; envv[ne] = NULL;
+    }
+
+    int port = free_port(7801);
+    if (!port) return 0;
+    long cores = sysconf(_SC_NPROCESSORS_ONLN);
+    int sessions = cores > 1 ? (int)(cores / 2) : 1;
+    if (sessions > 4) sessions = 4;
+    char port_text[16], context_text[16], sessions_text[16];
+    char address[80], name[64], base[48];
+    snprintf(port_text, sizeof port_text, "%d", port);
+    snprintf(context_text, sizeof context_text, "%d", context);
+    snprintf(sessions_text, sizeof sessions_text, "%d", sessions);
+    snprintf(address, sizeof address, "%s:%d", host, port);
+    donor_base_name(r, base, sizeof base);
+    snprintf(name, sizeof name, "%s-segment-%d", base, port);
+    char *argv[30];
+    int a = 0;
+    argv[a++] = bin;
+    argv[a++] = "--engine";        argv[a++] = (char *)engine;
+    argv[a++] = "--model-dir";     argv[a++] = local ? (char *)r->model_dir : vroot;
+    argv[a++] = "--model";         argv[a++] = (char *)model;
+    argv[a++] = "--auto-range";
+    argv[a++] = "--port";          argv[a++] = port_text;
+    argv[a++] = "--tracker";       argv[a++] = (char *)tracker;
+    argv[a++] = "--advertise";     argv[a++] = address;
+    argv[a++] = "--name";          argv[a++] = name;
+    argv[a++] = "--auto-identity";
+    argv[a++] = "--context";       argv[a++] = context_text;
+    argv[a++] = "--max-rows";      argv[a++] = "16";
+    argv[a++] = "--sessions";      argv[a++] = sessions_text;
+    argv[a] = NULL;
+    if (g_nchildren >= MAX_CHILDREN) return 0;
+    char logpath[1200];
+    pid_t pid = spawn_argv_logged(argv, local ? NULL : envv,
+                                  donor_log_path(name, logpath,
+                                                 sizeof logpath));
+    if (pid <= 0) return 0;
+    child_publish(g_nchildren++, pid);
+    printf("  %s\xe2\x9c\xa6 eseguo una fetta Segment assegnata dal tracker "
+           "per lo sciame%s %s(priorita' bassa, %d sessioni massime)%s\n",
+           C_GRN, C_R, C_DIM, sessions, C_R);
+    return 1;
+}
+
 /* Start whatever was chosen. Never fatal: a donation that cannot start is a
  * missed contribution, not a reason to refuse someone a conversation. */
 static void role_start(const Role *r, const char *tracker, const char *model,
-                       const char *model_type) {
+                       const char *model_type, int segment_active, int context,
+                       uint64_t model_bytes) {
     char dir[1024];
     exe_dir(dir, sizeof dir);
 
@@ -2103,6 +2505,10 @@ static void role_start(const Role *r, const char *tracker, const char *model,
     }
 
     if (r->compute) {
+        int segment_started = segment_active &&
+            role_start_segment(r, tracker, model, model_type, context,
+                               model_bytes);
+        if (!segment_started) {
         const char *node = expert_node_for(model_type ? model_type : "");
         char bin[1200];
         snprintf(bin, sizeof bin, "%s/%s", dir, node ? node : "expert_node");
@@ -2191,6 +2597,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
                        "la fetta assegnata arriva dallo sciame · /debug per i log)%s\n",
                        C_GRN, C_R, C_DIM, node, C_R);
         }
+        }
     }
     if (r->disk || r->compute)
         printf("  %sfinche\xcc\x81 questa chat resta aperta. Per un donatore che "
@@ -2246,6 +2653,54 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
                sw->nfiles, (double)sw->total_bytes / 1e9, sw->npeers,
                mtype[0] ? mtype : "?", C_R);
         disk_preflight(model, sw->total_bytes);
+    }
+
+    /* Prefer a complete Segment route when the optional runtime is installed.
+     * The probe is the real engine boot: Edge files arrive through the same
+     * signed mirror, then discovery either publishes READY or exits.  Exiting
+     * before READY is an ordinary coverage miss, not a chat failure; the
+     * unchanged expert/local engine starts immediately afterwards. */
+    if (!local_dir && !getenv("LUMABRI_NO_SEGMENT")) {
+        char self[1024], segment_bin[1200];
+        exe_dir(self, sizeof self);
+        snprintf(segment_bin, sizeof segment_bin, "%s/segment_chat", self);
+        if (access(segment_bin, X_OK) == 0 &&
+            segment_engine_for(mtype) != NULL) {
+            printf("  %sprovo una catena Segment completa; se manca uso "
+                   "automaticamente expert/CAS%s\n", C_DIM, C_R);
+            if (!segment_engine_spawn(segment_bin, shim, tracker, model,
+                                      mtype, ctx, e)) {
+                g_eng.booting = 1;
+                g_eng.last_out = nowd();
+                g_eng.spinning = 1;
+                pthread_t segment_spinner;
+                if (g_tty)
+                    pthread_create(&segment_spinner, NULL, spinner_thread,
+                                   (void *)"cerco segmenti compatibili");
+                double segment_started = nowd();
+                int segment_ready = engine_wait_ready(e);
+                g_eng.spinning = 0;
+                if (g_tty) pthread_join(segment_spinner, NULL);
+                g_eng.booting = 0;
+                if (!segment_ready) {
+                    e->proto = PROTO_SERVE2;
+                    printf("  %s\xe2\x9c\x93 %s pronto via Segment in %.1fs%s%s "
+                           "\xc2\xb7 Edge nel CAS \xc2\xb7 /swarm /model /debug "
+                           "/storage /reset /quit%s\n",
+                           C_GRN, model, nowd() - segment_started, C_R,
+                           C_DIM, C_R);
+                    return 0;
+                }
+                engine_stop(e);
+                if (getenv("LUMABRI_SEGMENT_REQUIRED")) {
+                    printf("  %sSegment richiesto ma non disponibile%s\n",
+                           C_RED, C_R);
+                    return -1;
+                }
+                printf("  %snessuna catena Segment completa: continuo con "
+                       "il percorso expert/CAS%s\n", C_DIM, C_R);
+            }
+        }
     }
 
     char engine[1200];
@@ -2507,7 +2962,8 @@ static int cmd_chat(int argc, char **argv) {
     if (role.disk || role.compute) {
         signal(SIGINT, on_sigint);            /* the donors die with the chat */
         signal(SIGTERM, on_sigint);
-        role_start(&role, tracker, model, sw.model_type);
+        role_start(&role, tracker, model, sw.model_type, eng.segment, ctx,
+                   sw.total_bytes);
     }
 
     char *conv = calloc(1, 1);   /* serve-codec conversation history (after bos) */

--- a/lumabri.c
+++ b/lumabri.c
@@ -983,6 +983,10 @@ static void *stderr_thread(void *arg) {
         tail_push(line);
         g_eng.last_out = nowd();
 
+        /* Route detail remains available under /debug, but must never race
+         * the readiness handshake and land after the first TUI prompt. */
+        if (!strncmp(line, "[segment-route]", 15)) continue;
+
         double mb, rate, gb, pct;
         if (sscanf(line, "[lumabri] net %lf MB", &mb) == 1) {
             g_eng.net_mb = mb;

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -86,6 +86,8 @@
  * opts in, so adding the wire vocabulary does not change local inference. */
 #define LMB_SEG_V2_MAGIC          0x32474553u /* "SEG2" */
 #define LMB_SEG_V2_VERSION        2u
+#define LMB_SEG_ASSIGN_MAGIC      0x31415347u /* "GSA1" */
+#define LMB_SEG_ASSIGN_VERSION    1u
 
 /* Optional executor telemetry is negotiated on the existing EREG LMB_OK.
  * Every extension has its own magic, version, and bounded payload length so
@@ -227,6 +229,10 @@ enum {
      * from the per-token or per-layer inference path. */
     LMB_SEG_REGISTER = 51, LMB_SEG_REGISTER_R = 52,
     LMB_SEG_ROUTES = 53, LMB_SEG_ROUTES_R = 54,
+    /* A compute donor names the model/engine and receives one of the
+     * origin's exact layer-aligned ranges, rarest first.  The subsequent
+     * signed SEG_REGISTER remains the authority; this is only placement. */
+    LMB_SEG_ASSIGN = 55, LMB_SEG_ASSIGN_R = 56,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,

--- a/lumabri_segment_discovery.c
+++ b/lumabri_segment_discovery.c
@@ -53,7 +53,8 @@ int lmb_seg_advert_valid(const LmbSegAdvert *a) {
         !lmb_seg_dtype_size(a->state_dtype) ||
         !a->state_width || a->state_width > LMB_SEG_MAX_STATE_WIDTH ||
         !a->max_sessions || a->active_sessions > a->max_sessions ||
-        (a->flags & ~LMB_SEG_ADVERT_DRAINING) ||
+        (a->flags & ~(LMB_SEG_ADVERT_DRAINING |
+                      LMB_SEG_ADVERT_FALLBACK)) ||
         (a->capabilities & ~LMB_SEG_CAP_KNOWN_MASK) ||
         !(a->capabilities & LMB_SEG_CAP_RANGE_NATIVE) ||
         !(a->capabilities & LMB_SEG_CAP_MULTI_SESSION) ||

--- a/lumabri_segment_discovery.h
+++ b/lumabri_segment_discovery.h
@@ -22,6 +22,10 @@
 
 enum {
     LMB_SEG_ADVERT_DRAINING = 1u << 0,
+    /* An origin may keep complete coverage online so a new swarm works from
+     * minute zero.  Placement prefers ordinary donated ranges and consumes a
+     * fallback range only where no non-fallback exact chain is available. */
+    LMB_SEG_ADVERT_FALLBACK = 1u << 1,
 };
 
 enum {

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -128,6 +128,7 @@ static int parse_ids(const char *text, int32_t **ids, size_t *count) {
 }
 
 static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
+                        uint32_t required_context, uint32_t required_rows,
                         RemoteSegment *chain, size_t *chain_count) {
     uint64_t fallback_layers[LMB_SEG_ROUTE_MAX] = {0};
     uint64_t load_cost[LMB_SEG_ROUTE_MAX] = {0};
@@ -139,7 +140,9 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
             const LmbSegRouteEntry *entry = &snapshot->entries[i];
             if (!(entry->transport & LMB_SEG_TRANSPORT_DIRECT) ||
                 entry->advert.layer_begin >= entry->advert.layer_end ||
-                entry->advert.layer_end > layers) continue;
+                entry->advert.layer_end > layers ||
+                entry->advert.max_context < required_context ||
+                entry->advert.max_rows < required_rows) continue;
             uint64_t own_fallback =
                 entry->advert.flags & LMB_SEG_ADVERT_FALLBACK
                     ? entry->advert.layer_end - entry->advert.layer_begin : 0;
@@ -647,9 +650,10 @@ cleanup:
     return rc;
 }
 
-static void route_print(FILE *stream, const LmbSegRouteSnapshot *snapshot,
+static void route_print(FILE *stream, const char *prefix,
+                        const LmbSegRouteSnapshot *snapshot,
                         const RemoteSegment *chain, size_t chain_count) {
-    fprintf(stream, "[lumabri] Segment route generation %llu: ",
+    fprintf(stream, "%s Segment route generation %llu: ", prefix,
             (unsigned long long)snapshot->route_generation);
     for (size_t index = 0; index < chain_count; index++)
         fprintf(stream, "%s%s[%u:%u]%s", index ? " -> " : "",
@@ -731,12 +735,13 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
         char error[256] = "no complete compatible Segment chain";
         GenerationResult result;
         int bad = have <= 0 || !snapshot.complete ||
-                  select_chain(&snapshot, cap->num_layers,
+                  select_chain(&snapshot, cap->num_layers, context, max_rows,
                                chain, &chain_count);
         if (!bad) {
             if (conversation.active && conversation.route_generation !=
                                        snapshot.route_generation)
-                route_print(stderr, &snapshot, chain, chain_count);
+                route_print(stderr, "[segment-route]", &snapshot,
+                            chain, chain_count);
             bad = segment_generate(edge, cap, chain, chain_count,
                                    model_root, tokenizer_root,
                                    context, max_rows, prompt, prompt_bytes,
@@ -848,7 +853,10 @@ int main(int argc, char **argv) {
     memcpy(query.model_root, model_root, sizeof model_root);
     memcpy(query.tokenizer_root, tokenizer_root, sizeof tokenizer_root);
     query.layer_end = cap.num_layers;
-    query.context_tokens = context;
+    /* Ask discovery for capability truth, not for the caller's preferred
+     * context. Selection below first tries the preference and only then
+     * negotiates down to the largest complete executor chain. */
+    query.context_tokens = 1;
     query.rows = max_rows;
     query.state_dtype = cap.state_dtype;
     query.state_width = cap.state_width;
@@ -883,11 +891,42 @@ int main(int argc, char **argv) {
     }
     RemoteSegment chain[LMB_SEG_ROUTE_MAX];
     size_t chain_count = 0;
-    if (select_chain(&snapshot, cap.num_layers, chain, &chain_count)) {
-        fprintf(stderr, "tracker coverage cannot form an executor-aligned chain\n");
-        lmb_seg_discovery_stop(discovery); return 1;
+    uint32_t requested_context = context;
+    if (select_chain(&snapshot, cap.num_layers, context, max_rows,
+                     chain, &chain_count)) {
+        uint32_t ceiling = context;
+        int selected = 0;
+        while (ceiling > 1 && !selected) {
+            uint32_t next = 0;
+            for (uint32_t i = 0; i < snapshot.count; i++) {
+                uint32_t available = snapshot.entries[i].advert.max_context;
+                if (available < ceiling && available > next) next = available;
+            }
+            if (!next) break;
+            ceiling = next;
+            if (!select_chain(&snapshot, cap.num_layers, ceiling, max_rows,
+                              chain, &chain_count)) {
+                context = ceiling;
+                selected = 1;
+            }
+        }
+        if (!selected) {
+            fprintf(stderr, "tracker coverage cannot form an "
+                            "executor-aligned chain\n");
+            lmb_seg_discovery_stop(discovery); return 1;
+        }
     }
-    route_print(serve_mode ? stderr : stdout, &snapshot, chain, chain_count);
+    for (size_t i = 0; i < chain_count; i++)
+        if (chain[i].route.advert.max_context < context)
+            context = chain[i].route.advert.max_context;
+    if (context < requested_context) {
+        fprintf(stderr, "[lumabri] Segment context negotiated to %u tokens "
+                        "(requested %u; executor capability)\n",
+                context, requested_context);
+    }
+    route_print(serve_mode ? stderr : stdout,
+                serve_mode ? "[segment-route]" : "[lumabri]",
+                &snapshot, chain, chain_count);
     if (serve_mode) {
         int result = segment_serve_loop(edge, &cap, discovery,
                                         model_root, tokenizer_root,

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -21,7 +21,30 @@ typedef struct {
     uint64_t position;
 } RemoteSegment;
 
+typedef struct {
+    int active;
+    uint64_t route_generation;
+    RemoteSegment chain[LMB_SEG_ROUTE_MAX];
+    size_t chain_count;
+    /* Tokens whose state is already committed on every remote range. The
+     * final sampled token is deliberately absent until the next turn sends
+     * it through the chain. */
+    int32_t *committed_tokens;
+    size_t committed_count;
+} SegmentConversation;
+
+typedef struct {
+    char *text;
+    size_t text_bytes;
+    int32_t *tokens;
+    size_t token_count;
+    size_t prompt_count;
+    double elapsed_seconds;
+} GenerationResult;
+
 static int retry_first_run;
+
+#define SEGMENT_FRAME_READY "\x01\x01" "READY" "\x01\x01"
 
 static void sleep_ms(unsigned ms) {
     struct timespec ts = { (time_t)(ms / 1000u),
@@ -34,13 +57,52 @@ static const char *arg_value(int argc, char **argv, const char *name) {
     return NULL;
 }
 
+static int has_arg(int argc, char **argv, const char *name) {
+    for (int i = 1; i < argc; i++) if (!strcmp(argv[i], name)) return 1;
+    return 0;
+}
+
 static void usage(const char *program) {
     fprintf(stderr,
         "usage: %s --engine ID --model-dir DIR --model NAME "
-        "--tracker HOST:PORT --model-root HEX64 --tokenizer-root HEX64 "
-        "(--prompt TEXT | --prompt-ids CSV) [--expect-ids CSV] "
-        "[--tokens N] [--context N] [--max-rows N] [--retry-first-run]\n",
+        "--tracker HOST:PORT [--model-root HEX64 --tokenizer-root HEX64] "
+        "((--prompt TEXT | --prompt-ids CSV) | --serve) "
+        "[--expect-ids CSV] [--tokens N] [--context N] [--max-rows N] "
+        "[--discovery-timeout-ms N] [--retry-first-run]\n",
         program);
+}
+
+static int model_identity_resolve(const char *tracker, const char *model,
+                                  const char *model_root_text,
+                                  const char *tokenizer_root_text,
+                                  uint8_t model_root[32],
+                                  uint8_t tokenizer_root[32]) {
+    if (model_root_text || tokenizer_root_text) {
+        if (!model_root_text || !tokenizer_root_text ||
+            lmb_hex_root(model_root_text, model_root) ||
+            lmb_hex_root(tokenizer_root_text, tokenizer_root))
+            return -1;
+        return 0;
+    }
+    LmbModelIdentity identity;
+    if (lmb_model_identity_get(tracker, model, &identity)) return -1;
+    const char *pubkey = getenv("LUMABRI_PUBKEY");
+    if (pubkey && pubkey[0]) {
+        LmbTrustKeys trust = {0};
+        size_t bytes = 0;
+        uint8_t *message = lmb_model_id_msg(identity.model, identity.root,
+                                            &bytes);
+        int bad = lmb_trust_load_spec(&trust, pubkey) || !identity.has_sig ||
+                  !message || lmb_trust_verify(&trust, identity.sig,
+                                               message, bytes);
+        free(message);
+        if (bad) return -1;
+    }
+    memcpy(model_root, identity.root, 32);
+    /* tokenizer.json belongs to the signed inventory represented by this
+     * root, so the aggregate identity is also a stable tokenizer identity. */
+    memcpy(tokenizer_root, identity.root, 32);
+    return 0;
 }
 
 static int parse_ids(const char *text, int32_t **ids, size_t *count) {
@@ -67,20 +129,69 @@ static int parse_ids(const char *text, int32_t **ids, size_t *count) {
 
 static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                         RemoteSegment *chain, size_t *chain_count) {
+    uint64_t fallback_layers[LMB_SEG_ROUTE_MAX] = {0};
+    uint64_t load_cost[LMB_SEG_ROUTE_MAX] = {0};
+    uint32_t hops[LMB_SEG_ROUTE_MAX] = {0};
     unsigned viable[LMB_SEG_ROUTE_MAX] = {0};
     for (uint32_t pass = 0; pass < snapshot->count; pass++) {
         int changed = 0;
         for (uint32_t i = 0; i < snapshot->count; i++) {
             const LmbSegRouteEntry *entry = &snapshot->entries[i];
-            if (viable[i] || !(entry->transport & LMB_SEG_TRANSPORT_DIRECT) ||
+            if (!(entry->transport & LMB_SEG_TRANSPORT_DIRECT) ||
                 entry->advert.layer_begin >= entry->advert.layer_end ||
                 entry->advert.layer_end > layers) continue;
-            int reaches_end = entry->advert.layer_end == layers;
-            for (uint32_t j = 0; j < snapshot->count && !reaches_end; j++)
-                reaches_end = viable[j] &&
-                    snapshot->entries[j].advert.layer_begin ==
-                    entry->advert.layer_end;
-            if (reaches_end) { viable[i] = 1; changed = 1; }
+            uint64_t own_fallback =
+                entry->advert.flags & LMB_SEG_ADVERT_FALLBACK
+                    ? entry->advert.layer_end - entry->advert.layer_begin : 0;
+            uint64_t own_load = (uint64_t)entry->advert.queue_depth +
+                                entry->advert.inflight;
+            if (entry->advert.layer_end == layers) {
+                if (!viable[i] || own_fallback < fallback_layers[i] ||
+                    (own_fallback == fallback_layers[i] && 1 < hops[i]) ||
+                    (own_fallback == fallback_layers[i] && hops[i] == 1 &&
+                     own_load < load_cost[i])) {
+                    viable[i] = 1;
+                    fallback_layers[i] = own_fallback;
+                    load_cost[i] = own_load;
+                    hops[i] = 1;
+                    changed = 1;
+                }
+                continue;
+            }
+            int found = 0;
+            uint64_t best_fallback = UINT64_MAX, best_load = UINT64_MAX;
+            uint32_t best_hops = UINT32_MAX;
+            for (uint32_t j = 0; j < snapshot->count; j++) {
+                if (!viable[j] || snapshot->entries[j].advert.layer_begin !=
+                                  entry->advert.layer_end) continue;
+                uint64_t candidate_fallback = own_fallback + fallback_layers[j];
+                uint64_t candidate_load = own_load + load_cost[j];
+                uint32_t candidate_hops = 1 + hops[j];
+                if (!found || candidate_fallback < best_fallback ||
+                    (candidate_fallback == best_fallback &&
+                     candidate_hops < best_hops) ||
+                    (candidate_fallback == best_fallback &&
+                     candidate_hops == best_hops &&
+                     candidate_load < best_load)) {
+                    found = 1;
+                    best_fallback = candidate_fallback;
+                    best_hops = candidate_hops;
+                    best_load = candidate_load;
+                }
+            }
+            if (found) {
+                if (!viable[i] || best_fallback < fallback_layers[i] ||
+                    (best_fallback == fallback_layers[i] &&
+                     best_hops < hops[i]) ||
+                    (best_fallback == fallback_layers[i] &&
+                     best_hops == hops[i] && best_load < load_cost[i])) {
+                    viable[i] = 1;
+                    fallback_layers[i] = best_fallback;
+                    hops[i] = best_hops;
+                    load_cost[i] = best_load;
+                    changed = 1;
+                }
+            }
         }
         if (!changed) break;
     }
@@ -93,10 +204,18 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
             if (!viable[i] ||
                 candidate->advert.layer_begin != cursor ||
                 candidate->advert.layer_end > layers) continue;
-            if (!best || candidate->advert.layer_end > best->advert.layer_end ||
-                (candidate->advert.layer_end == best->advert.layer_end &&
-                 candidate->advert.queue_depth + candidate->advert.inflight <
-                 best->advert.queue_depth + best->advert.inflight))
+            if (!best) { best = candidate; continue; }
+            uint32_t best_index = (uint32_t)(best - snapshot->entries);
+            if (fallback_layers[i] < fallback_layers[best_index] ||
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 hops[i] < hops[best_index]) ||
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 hops[i] == hops[best_index] &&
+                 load_cost[i] < load_cost[best_index]) ||
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 hops[i] == hops[best_index] &&
+                 load_cost[i] == load_cost[best_index] &&
+                 candidate->advert.layer_end > best->advert.layer_end))
                 best = candidate;
         }
         if (!best) return -1;
@@ -142,7 +261,7 @@ static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
     open->max_rows = max_rows;
     open->state_dtype = advert->state_dtype;
     open->state_width = advert->state_width;
-    open->ttl_ms = 60000;
+    open->ttl_ms = LMB_SEG_MAX_TTL_MS;
     open->capabilities = advert->capabilities;
     snprintf(open->engine_id, sizeof open->engine_id, "%s", advert->engine_id);
     snprintf(open->state_schema, sizeof open->state_schema, "%s",
@@ -155,7 +274,9 @@ static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
     remote->fd = lmb_connect(advert->addr);
     if (remote->fd < 0 ||
         lmb_send(remote->fd, LMB_SEG_OPEN, body, body_len, NULL, 0)) {
-        free(body); return -1;
+        free(body);
+        if (remote->fd >= 0) { lmb_close(remote->fd); remote->fd = -1; }
+        return -1;
     }
     free(body);
     LmbMsg msg = {0};
@@ -164,7 +285,7 @@ static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
               reply_ok(&msg, LMB_SEG_OPEN_R, session_id, &open->request_id,
                        open->owner.route_generation, &reply) || msg.pay_len;
     lmb_msg_free(&msg);
-    if (bad) return -1;
+    if (bad) { lmb_close(remote->fd); remote->fd = -1; return -1; }
     remote->sequence = reply.next_sequence;
     remote->position = reply.next_position;
     return 0;
@@ -245,6 +366,31 @@ static void remote_close(RemoteSegment *remote) {
     remote->fd = -1;
 }
 
+static void conversation_reset(SegmentConversation *conversation) {
+    if (!conversation) return;
+    for (size_t i = 0; i < conversation->chain_count; i++)
+        remote_close(&conversation->chain[i]);
+    free(conversation->committed_tokens);
+    memset(conversation, 0, sizeof *conversation);
+}
+
+static int conversation_route_equal(const SegmentConversation *conversation,
+                                    const RemoteSegment *desired,
+                                    size_t desired_count,
+                                    uint64_t generation) {
+    if (!conversation || !conversation->active ||
+        conversation->route_generation != generation ||
+        conversation->chain_count != desired_count) return 0;
+    for (size_t i = 0; i < desired_count; i++) {
+        const LmbSegAdvert *a = &conversation->chain[i].route.advert;
+        const LmbSegAdvert *b = &desired[i].route.advert;
+        if (a->layer_begin != b->layer_begin || a->layer_end != b->layer_end ||
+            strcmp(a->peer_name, b->peer_name) || strcmp(a->addr, b->addr))
+            return 0;
+    }
+    return 1;
+}
+
 static int chain_run(RemoteSegment *chain, size_t count,
                      const int32_t *tokens, uint32_t rows,
                      uint8_t **first, uint8_t **second, size_t bytes) {
@@ -255,6 +401,367 @@ static int chain_run(RemoteSegment *chain, size_t count,
     }
     *first = input;
     *second = output;
+    return 0;
+}
+
+static double monotonic_seconds(void) {
+    struct timespec value;
+    clock_gettime(CLOCK_MONOTONIC, &value);
+    return (double)value.tv_sec + (double)value.tv_nsec * 1e-9;
+}
+
+static void generation_result_free(GenerationResult *result) {
+    if (!result) return;
+    free(result->text);
+    free(result->tokens);
+    memset(result, 0, sizeof *result);
+}
+
+static int segment_generate(ColiEdgeEngine *edge,
+                            const ColiEdgeCapabilities *cap,
+                            RemoteSegment *chain, size_t chain_count,
+                            const uint8_t model_root[32],
+                            const uint8_t tokenizer_root[32],
+                            uint32_t context, uint32_t max_rows,
+                            const char *prompt, size_t prompt_bytes,
+                            const int32_t *provided_tokens,
+                            size_t provided_count, uint32_t wanted_tokens,
+                            SegmentConversation *conversation,
+                            uint64_t route_generation,
+                            GenerationResult *result,
+                            char *error, size_t error_size) {
+    memset(result, 0, sizeof *result);
+    double started = monotonic_seconds();
+    size_t opened = 0;
+    int32_t *prompt_tokens = NULL;
+    int32_t *generated = NULL;
+    uint8_t *buffer_a = NULL, *buffer_b = NULL;
+    RemoteSegment *active_chain = chain;
+    size_t active_count = chain_count;
+    size_t prefilled = 0;
+    int rc = -1;
+
+    size_t prompt_count = provided_count;
+    if (provided_tokens) {
+        if (!provided_count || provided_count > SIZE_MAX / sizeof *prompt_tokens)
+            goto cleanup;
+        prompt_tokens = malloc(provided_count * sizeof *prompt_tokens);
+        if (!prompt_tokens) goto cleanup;
+        memcpy(prompt_tokens, provided_tokens,
+               provided_count * sizeof *prompt_tokens);
+    } else {
+        if (!prompt ||
+            coli_edge_tokenize(edge, prompt, prompt_bytes, NULL, 0,
+                               &prompt_count, error, error_size) ||
+            !prompt_count || prompt_count > SIZE_MAX / sizeof *prompt_tokens)
+            goto cleanup;
+        prompt_tokens = malloc(prompt_count * sizeof *prompt_tokens);
+        size_t actual_count = 0;
+        if (!prompt_tokens ||
+            coli_edge_tokenize(edge, prompt, prompt_bytes, prompt_tokens,
+                               prompt_count, &actual_count,
+                               error, error_size) ||
+            actual_count != prompt_count)
+            goto cleanup;
+    }
+
+    if (conversation) {
+        int same_route = conversation_route_equal(conversation, chain,
+                                                  chain_count,
+                                                  route_generation);
+        int same_prefix = same_route &&
+            conversation->committed_count <= prompt_count &&
+            (!conversation->committed_count ||
+             !memcmp(conversation->committed_tokens, prompt_tokens,
+                     conversation->committed_count * sizeof *prompt_tokens));
+        if (!same_prefix) {
+            conversation_reset(conversation);
+            memcpy(conversation->chain, chain,
+                   chain_count * sizeof *conversation->chain);
+            conversation->chain_count = chain_count;
+            conversation->route_generation = route_generation;
+            for (size_t i = 0; i < chain_count; i++)
+                conversation->chain[i].fd = -1;
+        } else {
+            prefilled = conversation->committed_count;
+            if (prefilled)
+                fprintf(stderr, "[lumabri] Segment KV reuse: %zu/%zu prompt "
+                        "tokens already resident\n", prefilled, prompt_count);
+        }
+        active_chain = conversation->chain;
+        active_count = conversation->chain_count;
+    }
+
+    if (!conversation || !conversation->active) {
+        LmbSegId session_id;
+        lmb_random(session_id.bytes, sizeof session_id.bytes);
+        for (; opened < active_count; opened++) {
+            active_chain[opened].fd = -1;
+            if (remote_open(&active_chain[opened], &session_id, model_root,
+                            tokenizer_root, context, max_rows)) {
+                snprintf(error, error_size, "cannot open segment %s at %s",
+                         active_chain[opened].route.advert.peer_name,
+                         active_chain[opened].route.advert.addr);
+                goto cleanup;
+            }
+        }
+        if (conversation) conversation->active = 1;
+    } else {
+        opened = active_count;
+    }
+    if (prompt_count > context || wanted_tokens > context - prompt_count) {
+        snprintf(error, error_size, "prompt plus output exceeds context (%u)",
+                 context);
+        goto cleanup;
+    }
+    if (prefilled >= prompt_count) {
+        /* We do not keep the last hidden row at Edge. A normal chat turn
+         * always appends role/user tokens; an identical resubmission safely
+         * rebuilds instead of sampling from stale or duplicated state. */
+        if (conversation) {
+            conversation_reset(conversation);
+            snprintf(error, error_size, "Segment prompt did not extend the "
+                     "resident conversation; retry after session rebuild");
+        }
+        goto cleanup;
+    }
+    generated = malloc((size_t)wanted_tokens * sizeof *generated);
+    size_t max_bytes = lmb_state_bytes(max_rows, cap->state_width,
+                                       cap->state_dtype);
+    buffer_a = max_bytes ? malloc(max_bytes) : NULL;
+    buffer_b = max_bytes ? malloc(max_bytes) : NULL;
+    if (!generated || !buffer_a || !buffer_b) {
+        snprintf(error, error_size, "out of memory preparing Segment run");
+        goto cleanup;
+    }
+    uint8_t *final_state = NULL;
+    uint32_t final_rows = 0;
+    for (size_t offset = prefilled; offset < prompt_count; offset += max_rows) {
+        uint32_t rows = (uint32_t)(prompt_count - offset);
+        if (rows > max_rows) rows = max_rows;
+        size_t bytes = lmb_state_bytes(rows, cap->state_width,
+                                       cap->state_dtype);
+        ColiEdgeEmbedRequest embed = {
+            .struct_size = sizeof embed, .rows = rows,
+            .token_ids = prompt_tokens + offset, .token_count = rows,
+            .output = buffer_a, .output_bytes = bytes,
+        };
+        if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
+        uint8_t *first = buffer_a, *second = buffer_b;
+        if (chain_run(active_chain, active_count, prompt_tokens + offset, rows,
+                      &first, &second, bytes)) {
+            snprintf(error, error_size, "Segment peer failed; checkpoint/replay "
+                     "is not available yet");
+            goto cleanup;
+        }
+        final_state = first;
+        final_rows = rows;
+        if (first != buffer_a) {
+            uint8_t *swap = buffer_a; buffer_a = buffer_b; buffer_b = swap;
+        }
+    }
+    size_t element = cap->state_dtype == COLI_EDGE_DTYPE_F32 ? 4u : 2u;
+    const uint8_t *last = final_state +
+        (size_t)(final_rows - 1) * cap->state_width * element;
+    ColiEdgeSelectRequest select = {
+        .struct_size = sizeof select, .rows = 1,
+        .input = last, .input_bytes = (size_t)cap->state_width * element,
+        .token_ids = generated, .token_capacity = 1,
+    };
+    if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
+    size_t generated_count = 1;
+    while (generated_count < wanted_tokens &&
+           generated[generated_count - 1] != cap->eos_token_id) {
+        int32_t token = generated[generated_count - 1];
+        size_t bytes = lmb_state_bytes(1, cap->state_width, cap->state_dtype);
+        ColiEdgeEmbedRequest embed = {
+            .struct_size = sizeof embed, .rows = 1,
+            .token_ids = &token, .token_count = 1,
+            .output = buffer_a, .output_bytes = bytes,
+        };
+        if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
+        uint8_t *first = buffer_a, *second = buffer_b;
+        if (chain_run(active_chain, active_count, &token, 1,
+                      &first, &second, bytes)) {
+            snprintf(error, error_size, "Segment peer failed; checkpoint/replay "
+                     "is not available yet");
+            goto cleanup;
+        }
+        select.input = first;
+        select.token_ids = generated + generated_count;
+        if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
+        generated_count++;
+    }
+    size_t text_bytes = 0;
+    if (coli_edge_detokenize(edge, generated, generated_count, NULL, 0,
+                             &text_bytes, error, error_size)) goto cleanup;
+    char *text = malloc(text_bytes + 1);
+    if (!text || coli_edge_detokenize(edge, generated, generated_count,
+                                      text, text_bytes + 1, &text_bytes,
+                                      error, error_size)) {
+        free(text);
+        goto cleanup;
+    }
+    text[text_bytes] = 0;
+    if (conversation) {
+        size_t generated_committed = generated_count ? generated_count - 1 : 0;
+        size_t committed_count = prompt_count + generated_committed;
+        if (committed_count > SIZE_MAX / sizeof *prompt_tokens) {
+            free(text); goto cleanup;
+        }
+        int32_t *committed = malloc(committed_count * sizeof *committed);
+        if (!committed) {
+            free(text);
+            snprintf(error, error_size, "out of memory retaining Segment KV "
+                     "token prefix");
+            goto cleanup;
+        }
+        memcpy(committed, prompt_tokens, prompt_count * sizeof *committed);
+        if (generated_committed)
+            memcpy(committed + prompt_count, generated,
+                   generated_committed * sizeof *committed);
+        free(conversation->committed_tokens);
+        conversation->committed_tokens = committed;
+        conversation->committed_count = committed_count;
+    }
+    result->text = text;
+    result->text_bytes = text_bytes;
+    result->tokens = generated;
+    result->token_count = generated_count;
+    result->prompt_count = prompt_count;
+    result->elapsed_seconds = monotonic_seconds() - started;
+    generated = NULL;
+    rc = 0;
+
+cleanup:
+    if (conversation) {
+        if (rc) conversation_reset(conversation);
+    } else {
+        for (size_t index = 0; index < opened; index++)
+            remote_close(&active_chain[index]);
+    }
+    free(prompt_tokens);
+    free(generated);
+    free(buffer_a);
+    free(buffer_b);
+    return rc;
+}
+
+static void route_print(FILE *stream, const LmbSegRouteSnapshot *snapshot,
+                        const RemoteSegment *chain, size_t chain_count) {
+    fprintf(stream, "[lumabri] Segment route generation %llu: ",
+            (unsigned long long)snapshot->route_generation);
+    for (size_t index = 0; index < chain_count; index++)
+        fprintf(stream, "%s%s[%u:%u]%s", index ? " -> " : "",
+                chain[index].route.advert.peer_name,
+                chain[index].route.advert.layer_begin,
+                chain[index].route.advert.layer_end,
+                chain[index].route.advert.flags & LMB_SEG_ADVERT_FALLBACK
+                    ? "(fallback)" : "");
+    fputc('\n', stream);
+    if (getenv("LUMABRI_SEGMENT_DEBUG_ROUTES"))
+        for (uint32_t index = 0; index < snapshot->count; index++) {
+            const LmbSegRouteEntry *entry = &snapshot->entries[index];
+            fprintf(stream, "[lumabri] Segment candidate %s[%u:%u] "
+                    "flags=%u load=%u/%u transport=%u context=%u rows=%u "
+                    "numeric=%s\n",
+                    entry->advert.peer_name, entry->advert.layer_begin,
+                    entry->advert.layer_end, entry->advert.flags,
+                    entry->advert.queue_depth, entry->advert.inflight,
+                    entry->transport, entry->advert.max_context,
+                    entry->advert.max_rows, entry->advert.numeric_class);
+        }
+    fflush(stream);
+}
+
+static int read_exact_stdin(void *output, size_t bytes) {
+    unsigned char *cursor = output;
+    while (bytes) {
+        size_t got = fread(cursor, 1, bytes, stdin);
+        if (!got) return -1;
+        cursor += got;
+        bytes -= got;
+    }
+    return 0;
+}
+
+static int segment_serve_loop(ColiEdgeEngine *edge,
+                              const ColiEdgeCapabilities *cap,
+                              LmbSegDiscovery *discovery,
+                              const uint8_t model_root[32],
+                              const uint8_t tokenizer_root[32],
+                              uint32_t context, uint32_t max_rows) {
+    printf(SEGMENT_FRAME_READY "\nSTAT 0 0 0 0\n");
+    fflush(stdout);
+    fprintf(stderr, "[lumabri] Segment Edge v1 is greedy; temperature/top-p "
+            "remain on the classic path\n");
+    SegmentConversation conversation;
+    memset(&conversation, 0, sizeof conversation);
+    char header[512];
+    while (fgets(header, sizeof header, stdin)) {
+        unsigned request_id = 0, slot = 0, max_tokens = 0;
+        size_t prompt_bytes = 0;
+        double temperature = 0.0, top_p = 0.0;
+        char trailing = 0;
+        if (sscanf(header, "SUBMIT %u %u %zu %u %lf %lf %c",
+                   &request_id, &slot, &prompt_bytes, &max_tokens,
+                   &temperature, &top_p, &trailing) != 6 ||
+            !max_tokens || max_tokens > 4096 || prompt_bytes > (64u << 20)) {
+            printf("ERROR %u invalid Segment SUBMIT\n", request_id);
+            fflush(stdout);
+            continue;
+        }
+        (void)slot; (void)temperature; (void)top_p;
+        char *prompt = malloc(prompt_bytes + 1);
+        if (!prompt || read_exact_stdin(prompt, prompt_bytes)) {
+            free(prompt); conversation_reset(&conversation); return 1;
+        }
+        prompt[prompt_bytes] = 0;
+        int terminator = fgetc(stdin);
+        if (terminator != '\n') {
+            free(prompt); conversation_reset(&conversation); return 1;
+        }
+        printf("ACCEPT %u\n", request_id);
+        fflush(stdout);
+
+        LmbSegRouteSnapshot snapshot;
+        int have = lmb_seg_discovery_snapshot(discovery, &snapshot);
+        RemoteSegment chain[LMB_SEG_ROUTE_MAX];
+        size_t chain_count = 0;
+        char error[256] = "no complete compatible Segment chain";
+        GenerationResult result;
+        int bad = have <= 0 || !snapshot.complete ||
+                  select_chain(&snapshot, cap->num_layers,
+                               chain, &chain_count);
+        if (!bad) {
+            if (conversation.active && conversation.route_generation !=
+                                       snapshot.route_generation)
+                route_print(stderr, &snapshot, chain, chain_count);
+            bad = segment_generate(edge, cap, chain, chain_count,
+                                   model_root, tokenizer_root,
+                                   context, max_rows, prompt, prompt_bytes,
+                                   NULL, 0, max_tokens, &conversation,
+                                   snapshot.route_generation, &result,
+                                   error, sizeof error);
+        }
+        free(prompt);
+        if (bad) {
+            printf("ERROR %u %s\n", request_id, error);
+            fflush(stdout);
+            continue;
+        }
+        printf("DATA %u %zu\n", request_id, result.text_bytes);
+        if (result.text_bytes)
+            fwrite(result.text, 1, result.text_bytes, stdout);
+        fputc('\n', stdout);
+        double rate = result.elapsed_seconds > 0.0
+            ? (double)result.token_count / result.elapsed_seconds : 0.0;
+        printf("DONE %u STAT %zu %.3f 0 0 %zu 0\n", request_id,
+               result.token_count, rate, result.prompt_count);
+        fflush(stdout);
+        generation_result_free(&result);
+    }
+    conversation_reset(&conversation);
     return 0;
 }
 
@@ -271,10 +778,12 @@ int main(int argc, char **argv) {
     const char *prompt = arg_value(argc, argv, "--prompt");
     const char *prompt_ids_text = arg_value(argc, argv, "--prompt-ids");
     const char *expect_ids_text = arg_value(argc, argv, "--expect-ids");
+    int serve_mode = has_arg(argc, argv, "--serve");
     for (int i = 1; i < argc; i++)
         if (!strcmp(argv[i], "--retry-first-run")) retry_first_run = 1;
-    if (!engine_id || !model_dir || !model || !tracker || !model_root_text ||
-        !tokenizer_root_text || (!!prompt == !!prompt_ids_text)) {
+    if (!engine_id || !model_dir || !model || !tracker ||
+        (serve_mode ? (prompt || prompt_ids_text || expect_ids_text)
+                    : (!!prompt == !!prompt_ids_text))) {
         usage(argv[0]); return 2;
     }
     if (strlen(engine_id) >= LMB_SEG_ENGINE_MAX ||
@@ -282,11 +791,6 @@ int main(int argc, char **argv) {
         usage(argv[0]); return 2;
     }
     uint8_t model_root[32], tokenizer_root[32];
-    if (lmb_hex_root(model_root_text, model_root) ||
-        lmb_hex_root(tokenizer_root_text, tokenizer_root)) {
-        fprintf(stderr, "roots must be non-zero 64-character hex values\n");
-        return 2;
-    }
     uint32_t wanted_tokens = 3;
     const char *value = arg_value(argc, argv, "--tokens");
     if (value && lmb_parse_u32(value, 1, 4096, &wanted_tokens)) {
@@ -301,6 +805,13 @@ int main(int argc, char **argv) {
         return 2;
     }
     if (lmb_secure_init()) return 1;
+    if (model_identity_resolve(tracker, model, model_root_text,
+                               tokenizer_root_text, model_root,
+                               tokenizer_root)) {
+        fprintf(stderr, "cannot resolve a trusted model identity for %s\n",
+                model);
+        return 1;
+    }
     if (lmb_colibri_register_all()) {
         fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
     }
@@ -322,10 +833,13 @@ int main(int argc, char **argv) {
     }
     uint32_t context = cap.max_context_tokens < 4096 ? cap.max_context_tokens : 4096;
     uint32_t max_rows = cap.max_batch_rows < 64 ? cap.max_batch_rows : 64;
+    uint32_t discovery_timeout_ms = serve_mode ? 2500u : 15000u;
     if (((value = arg_value(argc, argv, "--context")) &&
          lmb_parse_u32(value, 1, cap.max_context_tokens, &context)) ||
         ((value = arg_value(argc, argv, "--max-rows")) &&
-         lmb_parse_u32(value, 1, cap.max_batch_rows, &max_rows))) {
+         lmb_parse_u32(value, 1, cap.max_batch_rows, &max_rows)) ||
+        ((value = arg_value(argc, argv, "--discovery-timeout-ms")) &&
+         lmb_parse_u32(value, 250, 60000, &discovery_timeout_ms))) {
         usage(argv[0]); return 2;
     }
     LmbSegQuery query;
@@ -348,17 +862,19 @@ int main(int argc, char **argv) {
     LmbSegRouteSnapshot snapshot;
     memset(&snapshot, 0, sizeof snapshot);
     int have = 0, fetched = 0;
-    for (int i = 0; i < 60 && !have; i++) {
+    uint32_t discovery_attempts = (discovery_timeout_ms + 249u) / 250u;
+    for (uint32_t i = 0; i < discovery_attempts && !have; i++) {
         sleep_ms(250);
         have = lmb_seg_discovery_snapshot(discovery, &snapshot);
         if (have > 0) fetched = 1;
         if (have > 0 && !snapshot.complete) have = 0;
     }
     if (!have) {
-        fprintf(stderr, "no complete compatible Segment chain after 15 seconds "
+        fprintf(stderr, "no complete compatible Segment chain after %.2f seconds "
                         "(snapshot=%s, compatible peers=%u, engine=%s, "
                         "schema=%s, numeric=%s, dtype=%u, width=%u, "
                         "layers=0:%u, rows=%u, context=%u)\n",
+                (double)discovery_timeout_ms / 1000.0,
                 fetched ? "yes" : "no", fetched ? snapshot.count : 0,
                 query.engine_id, query.state_schema, query.numeric_class,
                 query.state_dtype, query.state_width, query.layer_end,
@@ -371,138 +887,61 @@ int main(int argc, char **argv) {
         fprintf(stderr, "tracker coverage cannot form an executor-aligned chain\n");
         lmb_seg_discovery_stop(discovery); return 1;
     }
-    LmbSegId session_id;
-    lmb_random(session_id.bytes, sizeof session_id.bytes);
-    for (size_t i = 0; i < chain_count; i++) {
-        if (remote_open(&chain[i], &session_id, model_root, tokenizer_root,
-                        context, max_rows)) {
-            fprintf(stderr, "cannot open segment %s at %s\n",
-                    chain[i].route.advert.peer_name, chain[i].route.advert.addr);
-            for (size_t j = 0; j < i; j++) remote_close(&chain[j]);
-            lmb_seg_discovery_stop(discovery); return 1;
-        }
+    route_print(serve_mode ? stderr : stdout, &snapshot, chain, chain_count);
+    if (serve_mode) {
+        int result = segment_serve_loop(edge, &cap, discovery,
+                                        model_root, tokenizer_root,
+                                        context, max_rows);
+        lmb_seg_discovery_stop(discovery);
+        coli_edge_engine_close(edge);
+        free(expected);
+        return result;
     }
-    printf("[lumabri] route generation %llu: ",
-           (unsigned long long)snapshot.route_generation);
-    for (size_t i = 0; i < chain_count; i++)
-        printf("%s%s[%u:%u]", i ? " -> " : "",
-               chain[i].route.advert.peer_name,
-               chain[i].route.advert.layer_begin,
-               chain[i].route.advert.layer_end);
-    printf("\n"); fflush(stdout);
 
     size_t prompt_count = 0;
     int32_t *prompt_tokens = NULL;
-    if (prompt_ids_text) {
-        if (parse_ids(prompt_ids_text, &prompt_tokens, &prompt_count)) {
-            fprintf(stderr, "invalid --prompt-ids list\n"); return 2;
-        }
-    } else {
-        if (coli_edge_tokenize(edge, prompt, strlen(prompt), NULL, 0,
-                               &prompt_count, error, sizeof error) || !prompt_count) {
-            fprintf(stderr, "cannot tokenize prompt: %s\n", error); return 1;
-        }
-        prompt_tokens = malloc(prompt_count * sizeof *prompt_tokens);
-        size_t actual_count = 0;
-        if (!prompt_tokens ||
-            coli_edge_tokenize(edge, prompt, strlen(prompt), prompt_tokens,
-                               prompt_count, &actual_count, error, sizeof error) ||
-            actual_count != prompt_count) {
-            fprintf(stderr, "cannot tokenize prompt: %s\n", error); return 1;
-        }
+    if (prompt_ids_text && parse_ids(prompt_ids_text, &prompt_tokens,
+                                     &prompt_count)) {
+        fprintf(stderr, "invalid --prompt-ids list\n");
+        lmb_seg_discovery_stop(discovery);
+        coli_edge_engine_close(edge);
+        free(expected);
+        return 2;
     }
-    if (prompt_count + wanted_tokens > context) {
-        fprintf(stderr, "prompt plus output exceeds context (%u)\n", context);
+    GenerationResult generated;
+    int bad = segment_generate(edge, &cap, chain, chain_count,
+                               model_root, tokenizer_root,
+                               context, max_rows,
+                               prompt, prompt ? strlen(prompt) : 0,
+                               prompt_tokens, prompt_count, wanted_tokens,
+                               NULL, 0,
+                               &generated, error, sizeof error);
+    free(prompt_tokens);
+    if (bad) {
+        fprintf(stderr, "%s\n", error[0] ? error : "Segment generation failed");
+        lmb_seg_discovery_stop(discovery);
+        coli_edge_engine_close(edge);
+        free(expected);
         return 1;
     }
-    int32_t *generated = malloc(wanted_tokens * sizeof *generated);
-    size_t max_bytes = lmb_state_bytes(max_rows, cap.state_width, cap.state_dtype);
-    uint8_t *buffer_a = max_bytes ? malloc(max_bytes) : NULL;
-    uint8_t *buffer_b = max_bytes ? malloc(max_bytes) : NULL;
-    if (!generated || !buffer_a || !buffer_b) return 1;
-    uint8_t *final_state = NULL;
-    uint32_t final_rows = 0;
-    for (size_t offset = 0; offset < prompt_count; offset += max_rows) {
-        uint32_t rows = (uint32_t)(prompt_count - offset);
-        if (rows > max_rows) rows = max_rows;
-        size_t bytes = lmb_state_bytes(rows, cap.state_width, cap.state_dtype);
-        ColiEdgeEmbedRequest embed = {
-            .struct_size = sizeof embed, .rows = rows,
-            .token_ids = prompt_tokens + offset, .token_count = rows,
-            .output = buffer_a, .output_bytes = bytes,
-        };
-        if (coli_edge_embed(edge, &embed, error, sizeof error)) {
-            fprintf(stderr, "embedding failed: %s\n", error); return 1;
-        }
-        uint8_t *first = buffer_a, *second = buffer_b;
-        if (chain_run(chain, chain_count, prompt_tokens + offset, rows,
-                      &first, &second, bytes)) {
-            fprintf(stderr, "Segment peer failed; session ended because checkpoint/replay is not available yet\n");
-            return 1;
-        }
-        final_state = first; final_rows = rows;
-        if (first != buffer_a) { uint8_t *swap = buffer_a; buffer_a = buffer_b; buffer_b = swap; }
-    }
-    size_t element = cap.state_dtype == COLI_EDGE_DTYPE_F32 ? 4u : 2u;
-    const uint8_t *last = final_state + (size_t)(final_rows - 1) * cap.state_width * element;
-    ColiEdgeSelectRequest select = {
-        .struct_size = sizeof select, .rows = 1,
-        .input = last, .input_bytes = (size_t)cap.state_width * element,
-        .token_ids = generated, .token_capacity = 1,
-    };
-    if (coli_edge_select(edge, &select, error, sizeof error)) {
-        fprintf(stderr, "token selection failed: %s\n", error); return 1;
-    }
-    size_t generated_count = 1;
-    while (generated_count < wanted_tokens &&
-           generated[generated_count - 1] != cap.eos_token_id) {
-        int32_t token = generated[generated_count - 1];
-        size_t bytes = lmb_state_bytes(1, cap.state_width, cap.state_dtype);
-        ColiEdgeEmbedRequest embed = {
-            .struct_size = sizeof embed, .rows = 1,
-            .token_ids = &token, .token_count = 1,
-            .output = buffer_a, .output_bytes = bytes,
-        };
-        if (coli_edge_embed(edge, &embed, error, sizeof error)) {
-            fprintf(stderr, "embedding failed: %s\n", error); return 1;
-        }
-        uint8_t *first = buffer_a, *second = buffer_b;
-        if (chain_run(chain, chain_count, &token, 1, &first, &second, bytes)) {
-            fprintf(stderr, "Segment peer failed; session ended because checkpoint/replay is not available yet\n");
-            return 1;
-        }
-        select.input = first;
-        select.token_ids = generated + generated_count;
-        if (coli_edge_select(edge, &select, error, sizeof error)) {
-            fprintf(stderr, "token selection failed: %s\n", error); return 1;
-        }
-        generated_count++;
-    }
-    size_t text_bytes = 0;
-    if (coli_edge_detokenize(edge, generated, generated_count, NULL, 0,
-                             &text_bytes, error, sizeof error)) {
-        fprintf(stderr, "detokenize sizing failed: %s\n", error); return 1;
-    }
-    char *text = malloc(text_bytes + 1);
-    if (!text || coli_edge_detokenize(edge, generated, generated_count,
-                                      text, text_bytes + 1, &text_bytes,
-                                      error, sizeof error)) {
-        fprintf(stderr, "detokenize failed: %s\n", error); return 1;
-    }
-    text[text_bytes] = 0;
-    printf("%s\n", text);
+    printf("%s\n", generated.text);
     printf("[lumabri] token-ids:");
-    for (size_t i = 0; i < generated_count; i++) printf("%s%d", i ? "," : " ", generated[i]);
+    for (size_t i = 0; i < generated.token_count; i++)
+        printf("%s%d", i ? "," : " ", generated.tokens[i]);
     printf("\n");
-    if (expected && (generated_count != expected_count ||
-        memcmp(generated, expected, expected_count * sizeof *expected))) {
+    if (expected && (generated.token_count != expected_count ||
+        memcmp(generated.tokens, expected,
+               expected_count * sizeof *expected))) {
         fprintf(stderr, "generated token IDs differ from independent oracle\n");
+        generation_result_free(&generated);
+        lmb_seg_discovery_stop(discovery);
+        coli_edge_engine_close(edge);
+        free(expected);
         return 1;
     }
-    for (size_t i = 0; i < chain_count; i++) remote_close(&chain[i]);
+    generation_result_free(&generated);
     lmb_seg_discovery_stop(discovery);
     coli_edge_engine_close(edge);
-    free(text); free(prompt_tokens); free(generated); free(expected);
-    free(buffer_a); free(buffer_b);
+    free(expected);
     return 0;
 }

--- a/segment_direct_test.sh
+++ b/segment_direct_test.sh
@@ -98,14 +98,14 @@ print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt
         --tracker 127.0.0.1:7868 --advertise 127.0.0.1:7869 \
         --name "$family-left" --model-root "$model_root" \
         --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16 \
-        --sessions 4 >"$TMP/$family-left.log" 2>&1 &
+        --sessions 4 --fallback >"$TMP/$family-left.log" 2>&1 &
     left=$!
     "${run_env[@]}" "$SEGMENT_NODE_BIN" --engine "$family" --model-dir "$model_dir" \
         --model "$model" --range "$split:$total" --port 7870 \
         --tracker 127.0.0.1:7868 --advertise 127.0.0.1:7870 \
         --name "$family-right" --model-root "$model_root" \
         --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16 \
-        --sessions 4 >"$TMP/$family-right.log" 2>&1 &
+        --sessions 4 --fallback >"$TMP/$family-right.log" 2>&1 &
     right=$!
     NODE_PIDS=("$left" "$right")
     if ! wait_port 7869 || ! wait_port 7870; then
@@ -120,7 +120,75 @@ print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt
         cat "$TMP/$family-left.log" "$TMP/$family-right.log" "$TMP/tracker.log"
         exit 1
     fi
+
+    # The user-facing TUI drives the same engine through Colibri's
+    # SUBMIT/DATA/DONE gateway codec.  Exercise that persistent mode for every
+    # family as well as the token-ID oracle above; a single text turn is enough
+    # to prove tokenizer, framing, route/session lifecycle and clean EOF.
+    serve_output=$(printf 'SUBMIT 1 0 2 2 0.7 0.95\nhi\n' | \
+        "${run_env[@]}" "$SEGMENT_CHAT_BIN" --serve --engine "$family" \
+        --model-dir "$model_dir" --model "$model" \
+        --tracker 127.0.0.1:7868 --model-root "$model_root" \
+        --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16)
+    if ! grep -q $'\001\001READY\001\001' <<<"$serve_output" ||
+       ! grep -q '^DATA 1 ' <<<"$serve_output" ||
+       ! grep -q '^DONE 1 STAT ' <<<"$serve_output"; then
+        printf '%s\n' "$serve_output"
+        cat "$TMP/$family-left.log" "$TMP/$family-right.log"
+        echo "SEGMENT DIRECT $family: serve-codec gate failed" >&2
+        exit 1
+    fi
     if [[ "$family" == olmoe ]]; then
+        # A second request must reuse the remote state established by the
+        # first one. Keep generation to one token so the committed prefix is
+        # exactly the first prompt, then append a new turn and require the
+        # executor's explicit reuse diagnostic.
+        "${run_env[@]}" python3 - "$SEGMENT_CHAT_BIN" "$model_dir" "$model" \
+            "$model_root" "$tokenizer_root" <<'PY'
+import subprocess, sys
+
+binary, model_dir, model, model_root, tokenizer_root = sys.argv[1:]
+process = subprocess.Popen([
+    binary, "--serve", "--engine", "olmoe", "--model-dir", model_dir,
+    "--model", model, "--tracker", "127.0.0.1:7868",
+    "--model-root", model_root, "--tokenizer-root", tokenizer_root,
+    "--context", "64", "--max-rows", "16",
+], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+def line():
+    value = process.stdout.readline()
+    if not value:
+        raise RuntimeError("Segment gateway closed unexpectedly")
+    return value
+
+if b"READY" not in line() or not line().startswith(b"STAT "):
+    raise RuntimeError("Segment gateway did not become ready")
+
+def turn(request_id, prompt):
+    header = f"SUBMIT {request_id} 0 {len(prompt)} 1 0.7 0.95\n".encode()
+    process.stdin.write(header + prompt + b"\n")
+    process.stdin.flush()
+    if line() != f"ACCEPT {request_id}\n".encode():
+        raise RuntimeError("Segment request was not accepted")
+    data_header = line().split()
+    if data_header[:2] != [b"DATA", str(request_id).encode()]:
+        raise RuntimeError("Segment response has no DATA frame")
+    size = int(data_header[2])
+    data = process.stdout.read(size)
+    if len(data) != size or process.stdout.read(1) != b"\n":
+        raise RuntimeError("Segment DATA frame is truncated")
+    if not line().startswith(f"DONE {request_id} STAT ".encode()):
+        raise RuntimeError("Segment response has no DONE frame")
+
+turn(91, b"hi\n")
+turn(92, b"hi\nthere\n")
+process.stdin.close()
+if process.wait(timeout=15):
+    raise RuntimeError("Segment gateway exited with an error")
+diagnostics = process.stderr.read().decode("utf-8", "replace")
+if "Segment KV reuse:" not in diagnostics:
+    raise RuntimeError("the second turn did not reuse remote Segment state")
+PY
         client_pids=()
         for client in 1 2; do
             "${run_env[@]}" "$SEGMENT_CHAT_BIN" --engine "$family" \
@@ -140,13 +208,38 @@ print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt
                 "$TMP/$family-left.log" "$TMP/$family-right.log"
             exit 1
         fi
-        echo "SEGMENT DIRECT olmoe: PASS (two concurrent isolated sessions)"
+        # A normal compute donor never receives layer numbers from a user.
+        # It asks the tracker for the rarest exact origin slice; the selected
+        # route must replace that fallback while retaining the other half.
+        "${run_env[@]}" "$SEGMENT_NODE_BIN" --engine "$family" \
+            --model-dir "$model_dir" --model "$model" --auto-range --port 7871 \
+            --tracker 127.0.0.1:7868 --advertise 127.0.0.1:7871 \
+            --name "$family-auto" --model-root "$model_root" \
+            --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16 \
+            --sessions 4 >"$TMP/$family-auto.log" 2>&1 &
+        auto=$!
+        NODE_PIDS+=("$auto")
+        if ! wait_port 7871; then
+            cat "$TMP/$family-auto.log" "$TMP/tracker.log"
+            exit 1
+        fi
+        auto_output=$("${run_env[@]}" "$SEGMENT_CHAT_BIN" --engine "$family" \
+            --model-dir "$model_dir" --model "$model" \
+            --tracker 127.0.0.1:7868 --model-root "$model_root" \
+            --tokenizer-root "$tokenizer_root" --prompt-ids "$prompt_ids" \
+            --tokens 3 --expect-ids "$expected" --context 64 --max-rows 16)
+        if ! grep -q "${family}-auto\[0:${split}\].*${family}-right\[${split}:${total}\](fallback)" \
+             <<<"$auto_output"; then
+            printf '%s\n' "$auto_output"
+            cat "$TMP/$family-auto.log" "$TMP/tracker.log"
+            exit 1
+        fi
+        echo "SEGMENT DIRECT olmoe: PASS (KV reuse + concurrent isolated sessions)"
     fi
-    kill "$left" "$right" 2>/dev/null || true
-    wait "$left" 2>/dev/null || true
-    wait "$right" 2>/dev/null || true
+    for pid in "${NODE_PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+    for pid in "${NODE_PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
     NODE_PIDS=()
-    echo "SEGMENT DIRECT $family: PASS (two peers, three oracle tokens)"
+    echo "SEGMENT DIRECT $family: PASS (two peers, oracle + TUI codec)"
 done
 
 echo "SEGMENT DIRECT: PASS (all six Colibri families)"

--- a/segment_native_test.sh
+++ b/segment_native_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# User-facing gate: launch the ordinary serve/chat commands, intentionally ask
+# for more context than the tiny origin advertises, and require Segment rather
+# than allowing the classic fallback to hide an integration regression.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${OLMOE_EDGE_MODEL:?set OLMOE_EDGE_MODEL}"
+
+TMP=$(mktemp -d /tmp/lumabri-segment-native.XXXXXX)
+SERVER_PID=""
+cleanup() {
+    if [[ -n "$SERVER_PID" ]]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+wait_port() {
+    local port=$1
+    for _ in $(seq 1 400); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            exec 3<&-; exec 3>&-; return 0
+        fi
+        sleep 0.025
+    done
+    return 1
+}
+
+mkdir -p "$TMP/server-home" "$TMP/client-home"
+HOME="$TMP/server-home" ./lumabri key --out "$TMP/swarm" >/dev/null
+
+HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 OMP_NUM_THREADS=2 \
+    ./lumabri serve --model "$OLMOE_EDGE_MODEL" --port 7880 \
+    --advertise 127.0.0.1 --key "$TMP/swarm.key" \
+    >"$TMP/server.log" 2>&1 &
+SERVER_PID=$!
+
+if ! wait_port 7880 || ! wait_port 7883 || ! wait_port 7884; then
+    cat "$TMP/server.log"
+    echo "SEGMENT NATIVE: origin did not become ready" >&2
+    exit 1
+fi
+
+set +e
+printf 'hi\n/quit\n' | HOME="$TMP/client-home" OMP_NUM_THREADS=2 \
+    LUMABRI_PUBKEY="$TMP/swarm.pub" LUMABRI_SEGMENT_REQUIRED=1 \
+    ./lumabri chat --plain --tracker 127.0.0.1:7880 --ctx 2048 \
+    --max-new 2 --role chat >"$TMP/chat.log" 2>&1
+status=$?
+set -e
+if (( status != 0 )) || ! grep -q 'pronto via Segment' "$TMP/chat.log" ||
+   ! grep -q 'Segment context negotiated to' "$TMP/chat.log" ||
+   grep -q 'continuo con il percorso expert/CAS' "$TMP/chat.log" ||
+   grep -q 'Segment route generation' "$TMP/chat.log"; then
+    cat "$TMP/server.log" "$TMP/chat.log"
+    echo "SEGMENT NATIVE: ordinary serve/chat gate failed" >&2
+    exit 1
+fi
+
+echo "SEGMENT NATIVE: PASS (serve + TUI chat, automatic context negotiation)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/resource.h>
 
 #define NODE_SESSIONS_MAX 256u
 #define NODE_CONNECTIONS_MAX 256u
@@ -476,14 +477,53 @@ static void *connection_worker(void *opaque) {
 static void usage(const char *program) {
     fprintf(stderr,
         "usage: %s --engine ID --model-dir DIR --model NAME --range A:B "
-        "--port N --tracker HOST:PORT --advertise HOST:PORT --name PEER "
-        "--model-root HEX64 --tokenizer-root HEX64 [--context N] "
-        "[--max-rows N] [--sessions N]\n", program);
+        "(--range A:B | --auto-range) --port N --tracker HOST:PORT "
+        "--advertise HOST:PORT --name PEER "
+        "(--auto-identity | --model-root HEX64 --tokenizer-root HEX64) "
+        "[--fallback] [--context N] [--max-rows N] [--sessions N]\n",
+        program);
 }
 
 static const char *arg_value(int argc, char **argv, const char *name) {
     for (int i = 1; i + 1 < argc; i++) if (!strcmp(argv[i], name)) return argv[i + 1];
     return NULL;
+}
+
+static int has_arg(int argc, char **argv, const char *name) {
+    for (int i = 1; i < argc; i++) if (!strcmp(argv[i], name)) return 1;
+    return 0;
+}
+
+static int auto_range_get(const char *tracker, const char *model,
+                          const char *name, const char *engine_id,
+                          const uint8_t model_root[LMB_SEG_ROOT_BYTES],
+                          unsigned *begin, unsigned *end) {
+    LmbBuf body = {0};
+    if (lmb_buf_u32(&body, LMB_SEG_ASSIGN_MAGIC) ||
+        lmb_buf_u32(&body, LMB_SEG_ASSIGN_VERSION) ||
+        lmb_buf_str(&body, model) || lmb_buf_str(&body, name) ||
+        lmb_buf_str(&body, engine_id) ||
+        lmb_buf_bytes(&body, model_root, LMB_SEG_ROOT_BYTES)) {
+        free(body.p); return -1;
+    }
+    LmbMsg reply = {0};
+    int rc = lmb_request(tracker, LMB_SEG_ASSIGN, body.p,
+                         (uint32_t)body.len, &reply);
+    free(body.p);
+    if (rc || reply.op != LMB_SEG_ASSIGN_R || reply.pay_len) {
+        lmb_msg_free(&reply); return -1;
+    }
+    LmbCur cursor = { reply.body, reply.body_len, 0 };
+    uint32_t magic = 0, version = 0, first = 0, last = 0;
+    rc = lmb_cur_u32(&cursor, &magic) ||
+         lmb_cur_u32(&cursor, &version) ||
+         lmb_cur_u32(&cursor, &first) || lmb_cur_u32(&cursor, &last) ||
+         cursor.off != cursor.len || magic != LMB_SEG_ASSIGN_MAGIC ||
+         version != LMB_SEG_ASSIGN_VERSION || first >= last;
+    lmb_msg_free(&reply);
+    if (rc) return -1;
+    *begin = first; *end = last;
+    return 0;
 }
 
 int main(int argc, char **argv) {
@@ -497,11 +537,17 @@ int main(int argc, char **argv) {
     const char *name = arg_value(argc, argv, "--name");
     const char *model_root = arg_value(argc, argv, "--model-root");
     const char *tokenizer_root = arg_value(argc, argv, "--tokenizer-root");
-    if (!engine_id || !model_dir || !model || !range || !port_text || !tracker ||
-        !advertise || !name || !model_root || !tokenizer_root) {
+    int auto_identity = has_arg(argc, argv, "--auto-identity");
+    int auto_range = has_arg(argc, argv, "--auto-range");
+    int fallback = has_arg(argc, argv, "--fallback");
+    if (!engine_id || !model_dir || !model || ((range != NULL) == auto_range) ||
+        !port_text || !tracker ||
+        !advertise || !name ||
+        (auto_identity ? (model_root || tokenizer_root)
+                       : (!model_root || !tokenizer_root))) {
         usage(argv[0]); return 2;
     }
-    unsigned begin, end;
+    unsigned begin = 0, end = 0;
     char trailing;
     uint32_t port;
     if (strlen(engine_id) >= LMB_SEG_ENGINE_MAX ||
@@ -509,7 +555,8 @@ int main(int argc, char **argv) {
         strlen(tracker) >= sizeof ((TrackerRegistration *)0)->tracker ||
         strlen(advertise) >= LMB_SEG_ADDR_MAX ||
         strlen(name) >= LMB_SEG_PEER_NAME_MAX ||
-        sscanf(range, "%u:%u%c", &begin, &end, &trailing) != 2 || begin >= end ||
+        (range && (sscanf(range, "%u:%u%c", &begin, &end, &trailing) != 2 ||
+                   begin >= end)) ||
         lmb_parse_u32(port_text, 1, 65535, &port)) {
         usage(argv[0]); return 2;
     }
@@ -524,8 +571,72 @@ int main(int argc, char **argv) {
         usage(argv[0]); return 2;
     }
     if (lmb_secure_init()) return 1;
+    signal(SIGINT, stop_handler); signal(SIGTERM, stop_handler);
+    signal(SIGPIPE, SIG_IGN);
+    if (fallback) (void)setpriority(PRIO_PROCESS, 0, 10);
     if (lmb_colibri_register_all()) {
         fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
+    }
+    uint8_t resolved_model_root[LMB_SEG_ROOT_BYTES];
+    uint8_t resolved_tokenizer_root[LMB_SEG_ROOT_BYTES];
+    if (auto_identity) {
+        LmbModelIdentity identity;
+        int announced = 0;
+        while (!g_stop && lmb_model_identity_get(tracker, model, &identity)) {
+            if (!announced) {
+                fprintf(stderr, "[segment-node] waiting for model identity "
+                        "%s from tracker %s\n", model, tracker);
+                announced = 1;
+            }
+            struct timespec pause = {1, 0};
+            while (!g_stop && nanosleep(&pause, &pause) && errno == EINTR) { }
+        }
+        if (g_stop) return 0;
+        const char *pubkey = getenv("LUMABRI_PUBKEY");
+        if (pubkey && pubkey[0]) {
+            LmbTrustKeys trust = {0};
+            size_t bytes = 0;
+            uint8_t *message = lmb_model_id_msg(identity.model, identity.root,
+                                                &bytes);
+            int bad = lmb_trust_load_spec(&trust, pubkey) || !identity.has_sig ||
+                      !message || lmb_trust_verify(&trust, identity.sig,
+                                                   message, bytes);
+            free(message);
+            if (bad) {
+                fprintf(stderr, "[segment-node] untrusted model identity\n");
+                return 1;
+            }
+        }
+        memcpy(resolved_model_root, identity.root,
+               sizeof resolved_model_root);
+        /* tokenizer.json is a member of the aggregate signed inventory. */
+        memcpy(resolved_tokenizer_root, identity.root,
+               sizeof resolved_tokenizer_root);
+    } else if (lmb_hex_root(model_root, resolved_model_root) ||
+               lmb_hex_root(tokenizer_root, resolved_tokenizer_root)) {
+        fprintf(stderr, "roots must be non-zero 64-character hex values\n");
+        return 2;
+    }
+
+    if (auto_range) {
+        int announced = 0;
+        while (!g_stop && auto_range_get(tracker, model, name, engine_id,
+                                         resolved_model_root, &begin, &end)) {
+            if (!announced) {
+                fprintf(stderr, "[segment-node] waiting for an automatic "
+                        "range assignment for %s\n", model);
+                announced = 1;
+            }
+            struct timespec pause = {1, 0};
+            while (!g_stop && nanosleep(&pause, &pause) && errno == EINTR) { }
+        }
+        if (g_stop) return 0;
+        fprintf(stderr, "[segment-node] tracker assigned layers %u:%u\n",
+                begin, end);
+        /* A desktop compute donation must lose scheduling contests to the
+         * user's own applications. Server origins use --fallback, which
+         * applies the same priority; explicit low-level nodes remain neutral. */
+        (void)setpriority(PRIO_PROCESS, 0, 10);
     }
     Node node;
     memset(&node, 0, sizeof node);
@@ -561,15 +672,14 @@ int main(int argc, char **argv) {
     snprintf(a->peer_name, sizeof a->peer_name, "%s", name);
     snprintf(a->addr, sizeof a->addr, "%s", advertise);
     snprintf(a->model, sizeof a->model, "%s", model);
-    if (lmb_hex_root(model_root, a->model_root) ||
-        lmb_hex_root(tokenizer_root, a->tokenizer_root)) {
-        fprintf(stderr, "roots must be non-zero 64-character hex values\n");
-        return 2;
-    }
+    memcpy(a->model_root, resolved_model_root, sizeof a->model_root);
+    memcpy(a->tokenizer_root, resolved_tokenizer_root,
+           sizeof a->tokenizer_root);
     a->layer_begin = begin; a->layer_end = end;
     a->max_context = context; a->max_rows = max_rows;
     a->state_dtype = node.cap.state_dtype; a->state_width = node.cap.state_width;
     a->max_sessions = max_sessions;
+    if (fallback) a->flags |= LMB_SEG_ADVERT_FALLBACK;
     a->capabilities = node.cap.flags & LMB_SEG_CAP_KNOWN_MASK;
     /* Snapshot/replay is intentionally not on the network data plane yet. */
     a->capabilities &= ~LMB_SEG_CAP_SNAPSHOT;
@@ -593,7 +703,6 @@ int main(int argc, char **argv) {
                 peer_key_path);
         return 1;
     }
-    signal(SIGINT, stop_handler); signal(SIGTERM, stop_handler); signal(SIGPIPE, SIG_IGN);
     g_listen_fd = lmb_listen((int)port);
     if (g_listen_fd < 0) { perror("segment listen"); return 1; }
     pthread_t registration_thread, reaper_thread;

--- a/tracker.c
+++ b/tracker.c
@@ -91,6 +91,23 @@ static uint64_t g_segment_route_generation = 1;
 static int g_segment_generation_ready;
 static char g_bindings_path[512];
 
+/* A range assignment is a short promise, like expert EASSIGN's promise: it
+ * stops several donors booting concurrently from all selecting the same
+ * rare slice before their heavyweight engines finish loading and register.
+ * It is not a lease and grants no execution authority. */
+#define MAX_SEGMENT_PROMISES 128
+#define SEGMENT_PROMISE_TTL_S 300.0
+typedef struct {
+    int used;
+    char model[LMB_SEG_MODEL_MAX];
+    char name[LMB_SEG_PEER_NAME_MAX];
+    char engine[LMB_SEG_ENGINE_MAX];
+    uint8_t model_root[LMB_SEG_ROOT_BYTES];
+    uint32_t begin, end;
+    double ts;
+} SegmentPromise;
+static SegmentPromise g_segment_promises[MAX_SEGMENT_PROMISES];
+
 /* Reserve one 32-bit generation epoch per tracker process. The durable high
  * half means a tracker restart can never publish a generation below a route
  * still cached by a chatter or held by a live executor. The low half is ample
@@ -1106,6 +1123,10 @@ static Peer *handle_segment_register(int fd, LmbMsg *m, const uint8_t *nonce) {
         }
         snprintf(slot->source, sizeof slot->source, "%s", source);
         slot->segment_owner.route_generation = g_segment_route_generation;
+        for (int i = 0; i < MAX_SEGMENT_PROMISES; i++)
+            if (g_segment_promises[i].used &&
+                !strcmp(g_segment_promises[i].name, advert.peer_name))
+                g_segment_promises[i].used = 0;
     }
     pthread_mutex_unlock(&g_lk);
     if (!slot) { send_err(fd, "peer table full"); return NULL; }
@@ -1178,6 +1199,173 @@ static int handle_segment_routes(int fd, LmbMsg *m) {
     }
     int rc = lmb_send(fd, LMB_SEG_ROUTES_R, body, body_len, NULL, 0);
     free(body);
+    return rc;
+}
+
+/* A donor does not choose layer numbers. It asks for the least-replicated
+ * exact fallback slice, then opens that range through the same Colibri ABI
+ * and registers normally. Exact origin boundaries guarantee that replacing
+ * one donor never makes the full chain unrouteable. */
+static int handle_segment_assign(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    uint32_t magic = 0, version = 0;
+    char model[LMB_SEG_MODEL_MAX], name[LMB_SEG_PEER_NAME_MAX];
+    char engine[LMB_SEG_ENGINE_MAX];
+    uint8_t root[LMB_SEG_ROOT_BYTES];
+    if (m->pay_len || lmb_cur_u32(&c, &magic) ||
+        lmb_cur_u32(&c, &version) || magic != LMB_SEG_ASSIGN_MAGIC ||
+        version != LMB_SEG_ASSIGN_VERSION ||
+        lmb_cur_str(&c, model, sizeof model) ||
+        lmb_cur_str(&c, name, sizeof name) ||
+        lmb_cur_str(&c, engine, sizeof engine) ||
+        lmb_cur_bytes(&c, root, sizeof root) || c.off != c.len) {
+        send_err(fd, "bad segment assignment request"); return -1;
+    }
+    unsigned nonzero = 0;
+    for (size_t i = 0; i < sizeof root; i++) nonzero |= root[i];
+    if (!model[0] || !name[0] || !engine[0] || !nonzero) {
+        send_err(fd, "incomplete segment assignment identity"); return -1;
+    }
+
+    uint32_t chosen_begin = 0, chosen_end = 0;
+    uint32_t best_replicas = UINT32_MAX, best_load = UINT32_MAX;
+    int retained = 0;
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+
+    /* A restart keeps its previous slice: no unnecessary weight churn. */
+    for (int i = 0; i < MAX_PEERS && !chosen_end; i++) {
+        Peer *p = &g_peers[i];
+        if (p->used && p->has_segment && p->segment_live &&
+            now - p->segment_ts <= g_stale_s &&
+            !strcmp(p->segment.peer_name, name) &&
+            !strcmp(p->segment.model, model) &&
+            !strcmp(p->segment.engine_id, engine) &&
+            !memcmp(p->segment.model_root, root, sizeof root)) {
+            chosen_begin = p->segment.layer_begin;
+            chosen_end = p->segment.layer_end;
+            retained = 1;
+        }
+    }
+    for (int i = 0; i < MAX_SEGMENT_PROMISES && !chosen_end; i++) {
+        SegmentPromise *promise = &g_segment_promises[i];
+        if (promise->used && now - promise->ts > SEGMENT_PROMISE_TTL_S)
+            promise->used = 0;
+        if (promise->used && !strcmp(promise->name, name) &&
+            !strcmp(promise->model, model) &&
+            !strcmp(promise->engine, engine) &&
+            !memcmp(promise->model_root, root, sizeof root)) {
+            chosen_begin = promise->begin;
+            chosen_end = promise->end;
+            retained = 1;
+        }
+    }
+
+    for (int i = 0; i < MAX_PEERS && !retained; i++) {
+        Peer *origin = &g_peers[i];
+        if (!origin->used || !origin->has_segment || !origin->segment_live ||
+            now - origin->segment_ts > g_stale_s ||
+            !(origin->segment.flags & LMB_SEG_ADVERT_FALLBACK) ||
+            (origin->segment.flags & LMB_SEG_ADVERT_DRAINING) ||
+            strcmp(origin->segment.model, model) ||
+            strcmp(origin->segment.engine_id, engine) ||
+            memcmp(origin->segment.model_root, root, sizeof root)) continue;
+        int duplicate = 0;
+        for (int j = 0; j < i; j++) {
+            Peer *previous = &g_peers[j];
+            if (previous->used && previous->has_segment &&
+                previous->segment_live &&
+                (previous->segment.flags & LMB_SEG_ADVERT_FALLBACK) &&
+                !strcmp(previous->segment.model, model) &&
+                !strcmp(previous->segment.engine_id, engine) &&
+                !memcmp(previous->segment.model_root, root, sizeof root) &&
+                previous->segment.layer_begin == origin->segment.layer_begin &&
+                previous->segment.layer_end == origin->segment.layer_end) {
+                duplicate = 1; break;
+            }
+        }
+        if (duplicate) continue;
+
+        uint32_t replicas = 0;
+        for (int j = 0; j < MAX_PEERS; j++) {
+            Peer *peer = &g_peers[j];
+            if (!peer->used || !peer->has_segment || !peer->segment_live ||
+                now - peer->segment_ts > g_stale_s ||
+                (peer->segment.flags & (LMB_SEG_ADVERT_FALLBACK |
+                                        LMB_SEG_ADVERT_DRAINING)) ||
+                strcmp(peer->segment.model, model) ||
+                strcmp(peer->segment.engine_id, engine) ||
+                memcmp(peer->segment.model_root, root, sizeof root)) continue;
+            if (peer->segment.layer_begin == origin->segment.layer_begin &&
+                peer->segment.layer_end == origin->segment.layer_end)
+                replicas++;
+        }
+        for (int j = 0; j < MAX_SEGMENT_PROMISES; j++) {
+            SegmentPromise *promise = &g_segment_promises[j];
+            if (!promise->used || now - promise->ts > SEGMENT_PROMISE_TTL_S ||
+                !strcmp(promise->name, name) ||
+                strcmp(promise->model, model) ||
+                strcmp(promise->engine, engine) ||
+                memcmp(promise->model_root, root, sizeof root)) continue;
+            if (promise->begin == origin->segment.layer_begin &&
+                promise->end == origin->segment.layer_end)
+                replicas++;
+        }
+        uint64_t raw_load = (uint64_t)origin->segment.active_sessions +
+                            origin->segment.queue_depth + origin->segment.inflight;
+        uint32_t load = raw_load > UINT32_MAX ? UINT32_MAX : (uint32_t)raw_load;
+        if (replicas < best_replicas ||
+            (replicas == best_replicas && load < best_load) ||
+            (replicas == best_replicas && load == best_load &&
+             origin->segment.layer_begin < chosen_begin)) {
+            best_replicas = replicas;
+            best_load = load;
+            chosen_begin = origin->segment.layer_begin;
+            chosen_end = origin->segment.layer_end;
+        }
+    }
+
+    if (chosen_end) {
+        SegmentPromise *slot = NULL;
+        for (int i = 0; i < MAX_SEGMENT_PROMISES; i++) {
+            if (g_segment_promises[i].used &&
+                !strcmp(g_segment_promises[i].name, name)) {
+                slot = &g_segment_promises[i]; break;
+            }
+            if (!slot && (!g_segment_promises[i].used ||
+                now - g_segment_promises[i].ts > SEGMENT_PROMISE_TTL_S))
+                slot = &g_segment_promises[i];
+        }
+        if (slot) {
+            memset(slot, 0, sizeof *slot);
+            slot->used = 1; slot->ts = now;
+            slot->begin = chosen_begin; slot->end = chosen_end;
+            snprintf(slot->model, sizeof slot->model, "%s", model);
+            snprintf(slot->name, sizeof slot->name, "%s", name);
+            snprintf(slot->engine, sizeof slot->engine, "%s", engine);
+            memcpy(slot->model_root, root, sizeof root);
+        }
+    }
+    pthread_mutex_unlock(&g_lk);
+    if (!chosen_end) {
+        send_err(fd, "no compatible origin Segment slice"); return 0;
+    }
+    LmbBuf reply = {0};
+    lmb_buf_u32(&reply, LMB_SEG_ASSIGN_MAGIC);
+    lmb_buf_u32(&reply, LMB_SEG_ASSIGN_VERSION);
+    lmb_buf_u32(&reply, chosen_begin);
+    lmb_buf_u32(&reply, chosen_end);
+    int rc = lmb_send(fd, LMB_SEG_ASSIGN_R, reply.p,
+                      (uint32_t)reply.len, NULL, 0);
+    free(reply.p);
+    if (retained)
+        printf("[tracker] Segment assign %s: %s layers %u:%u (retained)\n",
+               name, model, chosen_begin, chosen_end);
+    else
+        printf("[tracker] Segment assign %s: %s layers %u:%u "
+               "(%u replica%s)\n", name, model, chosen_begin, chosen_end,
+               best_replicas, best_replicas == 1 ? "" : "s");
+    fflush(stdout);
     return rc;
 }
 
@@ -2004,6 +2192,7 @@ static void *conn_thread(void *arg) {
             break;
         }
         case LMB_SEG_ROUTES: rc = handle_segment_routes(fd, &m); break;
+        case LMB_SEG_ASSIGN: rc = handle_segment_assign(fd, &m); break;
         case LMB_HASHES:    rc = handle_hashes(fd, &m); break;
         case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;


### PR DESCRIPTION
## Summary

- make ordinary Lumabri serve detect the model and machine, then supervise complete layer-aligned Segment origin coverage
- mark the origin as fallback and assign rare ranges automatically so compute donors progressively replace server work
- make ordinary Lumabri chat prefer a complete asynchronous Segment route while preserving the existing TUI and automatic expert/CAS fallback
- resolve model identity through the tracker and load only tokenizer, embedding, final transform and head through the signed CAS Edge mirror
- retain remote per-model state across turns, including explicit KV reuse and safe reconstruction after a route generation change
- cover GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4 in the real tiny-model gate
- keep disk donation rarest-first; select an automatic low-priority Segment range only when direct reachability and conservative RAM reserve permit it, otherwise use classic expert donation

## Validation

- make check-warnings ENGINE=/tmp/colibri-edge-runtime/c
- make test ENGINE=/tmp/colibri-edge-runtime/c
- six-family direct TCP oracle and persistent TUI codec gate
- two-turn remote KV reuse, concurrent isolated sessions and automatic rarest-range replacement
- six-family ASan/UBSan direct gate
- isolated make install gate includes segment_node and segment_chat

## Honest current limits

- Segment Edge v1 is greedy; temperature and top-p remain on the classic path
- Segment endpoints are direct TCP; private or NAT machines use the existing READ/EXEC relay fallback
- if a selected stateful Segment peer dies mid-conversation, the run ends explicitly because checkpoint/replay is a later PR

This is intentionally stacked on #73. No merge is performed by this PR creation.