### PR TITLE
fix(segment): say why an executor was unreachable, and stop printing EOS

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -205,6 +205,9 @@ static volatile sig_atomic_t g_signal_children[MAX_CHILDREN];
  * name or restart what died is just a process that happens to be the parent */
 static char **g_cargv[MAX_CHILDREN];
 static const char *g_cwhat[MAX_CHILDREN];
+/* Children that must not share the operator's terminal keep their own log,
+ * and keep it across a supervised restart. */
+static char *g_clog[MAX_CHILDREN];
 
 static void child_publish(int idx, pid_t pid) {
     g_children[idx] = pid;
@@ -215,7 +218,13 @@ static void child_unpublish(int idx) {
     g_children[idx] = 0;
 }
 
-static void spawn_tracked(char *const argv[], const char *what) {
+/* logpath == NULL keeps the child on the operator's terminal, which is what
+ * the tracker and the maintainer want. Several Segment slices share one
+ * origin, and unbuffered stderr from N processes interleaves mid-line: an
+ * operator was shown "run: hybrid b" and "run: q<garbage>v" instead of two
+ * whole diagnoses. Those get a file each. */
+static void spawn_tracked_logged(char *const argv[], const char *what,
+                                 const char *logpath) {
     if (g_nchildren >= MAX_CHILDREN) {
         fprintf(stderr, "cannot start %s: child supervisor is full\n", what);
         return;
@@ -224,12 +233,19 @@ static void spawn_tracked(char *const argv[], const char *what) {
     while (argv[n]) n++;
     char **copy = (char **)calloc((size_t)n + 1, sizeof *copy);
     for (int i = 0; i < n; i++) copy[i] = strdup(argv[i]);
-    pid_t pid = spawn_argv(argv);          /* the slow part, outside the mask */
+    char *log = logpath ? strdup(logpath) : NULL;
+    /* the slow part, outside the mask */
+    pid_t pid = log ? spawn_argv_logged(argv, NULL, log) : spawn_argv(argv);
     int idx = g_nchildren;
     g_cargv[idx] = copy;
     g_cwhat[idx] = what;
+    g_clog[idx] = log;
     child_publish(idx, pid);
     g_nchildren++;
+}
+
+static void spawn_tracked(char *const argv[], const char *what) {
+    spawn_tracked_logged(argv, what, NULL);
 }
 
 static volatile sig_atomic_t g_stopping = 0;
@@ -635,17 +651,28 @@ static int cmd_serve(int argc, char **argv) {
             sargv[a++] = "--sessions";     sargv[a++] = session_text;
             sargv[a++] = "--advertise";    sargv[a++] = sadv;
             sargv[a] = NULL;
-            spawn_tracked(sargv, join ? "l'esecutore Segment peer"
-                                      : "l'esecutore Segment origin");
+            char slog[1200];
+            spawn_tracked_logged(sargv, join ? "l'esecutore Segment peer"
+                                             : "l'esecutore Segment origin",
+                                 donor_log_path(sname, slog, sizeof slog));
             with_segment++;
         }
         double ram_gb = (double)machine_available_ram() / 1e9;
+        const char *home = getenv("HOME") ? getenv("HOME") : ".";
         printf("  %sSegment prepara %d fette layer-aligned sulle porte %d-%d "
                "(%ld CPU, %.1f GB RAM disponibili, %d sessioni/fetta). "
                "%s%s\n",
                C_DIM, chunks, port + 3, port + 2 + chunks, cores, ram_gb,
                sessions, join ? "Sono peer ordinari; " :
                "Sono il fallback sostituibile; ", C_R);
+        /* Their diagnostics belong in one file per slice: N unbuffered
+         * writers on one terminal shred each other's lines exactly when
+         * something has gone wrong and the line matters most. */
+        printf("  %slog delle fette: %s/.lumabri/logs/segment-%s-%d-*.log · "
+               "apri le porte %d-%d sul firewall, altrimenti pubblichi una "
+               "catena che i chatter non riescono ad aprire%s\n",
+               C_DIM, home, join ? "peer" : "origin", port,
+               port + 3, port + 2 + chunks, C_R);
     } else if (!disk_donor && !no_exec && !advertise && segment_engine &&
                access(segment_bin, X_OK) == 0) {
         printf("  %sSegment non viene pubblicato: questa macchina non espone "
@@ -695,7 +722,9 @@ static int cmd_serve(int argc, char **argv) {
                    "scaricano gli esperti invece di farli eseguire%s\n", C_DIM, C_R);
             fflush(stdout);
             sleep(5);
-            pid_t np = spawn_argv(g_cargv[idx]);
+            pid_t np = g_clog[idx]
+                ? spawn_argv_logged(g_cargv[idx], NULL, g_clog[idx])
+                : spawn_argv(g_cargv[idx]);
             child_publish(idx, np);
             printf("  %s%s riavviato%s\n", C_DIM, g_cwhat[idx], C_R);
             fflush(stdout);

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -803,11 +803,31 @@ static LMB_MAYBE_UNUSED void lmb_conn_gate_leave(LmbConnGate *g) {
     atomic_fetch_sub(&g->active, 1);
 }
 
+/* Why the most recent lmb_connect_ms in this translation unit failed. A
+ * filtered port and a dead process both surface as "cannot connect", and an
+ * operator needs opposite actions for them: one is a firewall rule, the other
+ * is a process that is not running. Only the value read immediately after a
+ * failed connect is meaningful. */
+static LMB_MAYBE_UNUSED int lmb_connect_errno;
+
+static LMB_MAYBE_UNUSED const char *lmb_connect_why(void) {
+    switch (lmb_connect_errno) {
+    case 0:            return "unreachable";
+    case ETIMEDOUT:    return "no reply before the timeout — the port is "
+                              "filtered or the host is unreachable (firewall?)";
+    case ECONNREFUSED: return "connection refused — nothing is listening there";
+    case EHOSTUNREACH: return "no route to the host";
+    case ENETUNREACH:  return "no route to that network";
+    default:           return strerror(lmb_connect_errno);
+    }
+}
+
 /* addr is "host:port". Bounded connect: an unreachable peer must cost
  * `timeout_ms`, not the kernel's minutes — the caller has a relay to fall
  * back to. Returns a blocking fd with TCP_NODELAY, or -1. */
 static int lmb_connect_ms(const char *addr, int timeout_ms) {
     char host[256];
+    lmb_connect_errno = 0;
     const char *colon = strrchr(addr, ':');
     if (!colon || (size_t)(colon - addr) >= sizeof host) return -1;
     memcpy(host, addr, (size_t)(colon - addr)); host[colon - addr] = 0;
@@ -826,11 +846,17 @@ static int lmb_connect_ms(const char *addr, int timeout_ms) {
             struct pollfd pf = { fd, POLLOUT, 0 };
             int err = -1;
             socklen_t el = sizeof err;
-            if (poll(&pf, 1, timeout_ms) > 0 &&
+            int ready = poll(&pf, 1, timeout_ms);
+            if (ready > 0 &&
                 getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &el) == 0 && err == 0)
                 r = 0;
+            else
+                lmb_connect_errno = ready == 0 ? ETIMEDOUT
+                                   : (err > 0 ? err : errno);
+        } else if (r < 0) {
+            lmb_connect_errno = errno;
         }
-        if (r == 0) { fcntl(fd, F_SETFL, fl); break; }
+        if (r == 0) { fcntl(fd, F_SETFL, fl); lmb_connect_errno = 0; break; }
         close(fd); fd = -1;
     }
     freeaddrinfo(res);

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -246,10 +246,38 @@ static int reply_ok(const LmbMsg *msg, uint32_t expected_op,
     return 0;
 }
 
+static const char *segment_status_name(uint32_t status) {
+    switch (status) {
+    case LMB_SEG_STATUS_OK:            return "ok";
+    case LMB_SEG_STATUS_DUPLICATE:     return "duplicate";
+    case LMB_SEG_STATUS_BAD_REQUEST:   return "bad request — the executor's "
+        "model identity, layer range, context, rows or numeric class does not "
+        "match what the tracker advertised";
+    case LMB_SEG_STATUS_NOT_FOUND:     return "session not found";
+    case LMB_SEG_STATUS_STALE_OWNER:   return "stale owner — the route moved "
+        "under this session";
+    case LMB_SEG_STATUS_OUT_OF_ORDER:  return "out of order";
+    case LMB_SEG_STATUS_CONFLICT:      return "conflict";
+    case LMB_SEG_STATUS_EXPIRED:       return "expired";
+    case LMB_SEG_STATUS_BUSY:          return "busy";
+    case LMB_SEG_STATUS_UNSUPPORTED:   return "unsupported";
+    case LMB_SEG_STATUS_QUOTA:         return "quota — the executor has no "
+        "free session slot";
+    case LMB_SEG_STATUS_NEEDS_RESTORE: return "needs restore";
+    case LMB_SEG_STATUS_INTERNAL:      return "internal executor failure — "
+        "look at that peer's log";
+    default:                           return "unknown status";
+    }
+}
+
+/* One message for four causes — a filtered port, a dead executor, a rejected
+ * OPEN and a malformed reply — costs an operator the whole diagnosis, because
+ * the firewall fix and the compatibility fix look identical from here. Say
+ * which one happened. */
 static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
                        const uint8_t model_root[32],
                        const uint8_t tokenizer_root[32], uint32_t context,
-                       uint32_t max_rows) {
+                       uint32_t max_rows, char *why, size_t why_size) {
     const LmbSegAdvert *advert = &remote->route.advert;
     LmbSegOpen *open = &remote->open;
     memset(open, 0, sizeof *open);
@@ -273,25 +301,65 @@ static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
              advert->numeric_class);
     uint8_t *body = NULL;
     uint32_t body_len = 0;
-    if (lmb_seg_open_encode(open, &body, &body_len)) return -1;
+    if (lmb_seg_open_encode(open, &body, &body_len)) {
+        snprintf(why, why_size, "cannot encode the OPEN request");
+        return -1;
+    }
     remote->fd = lmb_connect(advert->addr);
-    if (remote->fd < 0 ||
-        lmb_send(remote->fd, LMB_SEG_OPEN, body, body_len, NULL, 0)) {
+    if (remote->fd < 0) {
+        snprintf(why, why_size, "cannot reach %s at %s: %s",
+                 advert->peer_name, advert->addr, lmb_connect_why());
         free(body);
-        if (remote->fd >= 0) { lmb_close(remote->fd); remote->fd = -1; }
+        return -1;
+    }
+    if (lmb_send(remote->fd, LMB_SEG_OPEN, body, body_len, NULL, 0)) {
+        snprintf(why, why_size, "%s at %s closed the connection before the "
+                 "OPEN request was sent", advert->peer_name, advert->addr);
+        free(body);
+        lmb_close(remote->fd); remote->fd = -1;
         return -1;
     }
     free(body);
     LmbMsg msg = {0};
     LmbSegReply reply;
-    int bad = lmb_recv(remote->fd, &msg) ||
-              reply_ok(&msg, LMB_SEG_OPEN_R, session_id, &open->request_id,
-                       open->owner.route_generation, &reply) || msg.pay_len;
+    if (lmb_recv(remote->fd, &msg)) {
+        snprintf(why, why_size, "%s at %s sent no reply to OPEN",
+                 advert->peer_name, advert->addr);
+        lmb_msg_free(&msg);
+        lmb_close(remote->fd); remote->fd = -1;
+        return -1;
+    }
+    if (msg.op == LMB_ERR) {
+        snprintf(why, why_size, "%s at %s refused OPEN: %.*s",
+                 advert->peer_name, advert->addr, (int)msg.body_len,
+                 msg.body ? (const char *)msg.body : "");
+    } else if (msg.op != LMB_SEG_OPEN_R ||
+               lmb_seg_reply_decode(msg.body, msg.body_len, &reply)) {
+        snprintf(why, why_size, "%s at %s answered OPEN with an "
+                 "unreadable message (op %u)", advert->peer_name,
+                 advert->addr, msg.op);
+    } else if (reply.status != LMB_SEG_STATUS_OK &&
+               reply.status != LMB_SEG_STATUS_DUPLICATE) {
+        snprintf(why, why_size, "%s at %s rejected OPEN [%u:%u]: %s",
+                 advert->peer_name, advert->addr, advert->layer_begin,
+                 advert->layer_end, segment_status_name(reply.status));
+    } else if (reply_ok(&msg, LMB_SEG_OPEN_R, session_id, &open->request_id,
+                        open->owner.route_generation, &reply) || msg.pay_len) {
+        /* Accepted, but not for this session/request/route: the placement
+         * moved while we were opening, or the peer is answering someone
+         * else's traffic. Either way this chain is not usable as it stands. */
+        snprintf(why, why_size, "%s at %s accepted OPEN for a different "
+                 "session or route generation", advert->peer_name,
+                 advert->addr);
+    } else {
+        lmb_msg_free(&msg);
+        remote->sequence = reply.next_sequence;
+        remote->position = reply.next_position;
+        return 0;
+    }
     lmb_msg_free(&msg);
-    if (bad) { lmb_close(remote->fd); remote->fd = -1; return -1; }
-    remote->sequence = reply.next_sequence;
-    remote->position = reply.next_position;
-    return 0;
+    lmb_close(remote->fd); remote->fd = -1;
+    return -1;
 }
 
 static int remote_run(RemoteSegment *remote, const int32_t *tokens,
@@ -434,6 +502,9 @@ static int segment_generate(ColiEdgeEngine *edge,
                             GenerationResult *result,
                             char *error, size_t error_size) {
     memset(result, 0, sizeof *result);
+    /* Own the reason from here on: a caller's placeholder left in place would
+     * report the previous stage's failure for this one. */
+    if (error && error_size) error[0] = 0;
     double started = monotonic_seconds();
     size_t opened = 0;
     int32_t *prompt_tokens = NULL;
@@ -501,12 +572,9 @@ static int segment_generate(ColiEdgeEngine *edge,
         for (; opened < active_count; opened++) {
             active_chain[opened].fd = -1;
             if (remote_open(&active_chain[opened], &session_id, model_root,
-                            tokenizer_root, context, max_rows)) {
-                snprintf(error, error_size, "cannot open segment %s at %s",
-                         active_chain[opened].route.advert.peer_name,
-                         active_chain[opened].route.advert.addr);
+                            tokenizer_root, context, max_rows,
+                            error, error_size))
                 goto cleanup;
-            }
         }
         if (conversation) conversation->active = 1;
     } else {
@@ -595,13 +663,23 @@ static int segment_generate(ColiEdgeEngine *edge,
         if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
         generated_count++;
     }
+    /* The token that stopped generation is a control marker, not text. The
+     * monolithic engines never put it in the reply and the TUI must not
+     * either — a user was shown a literal end-of-sentence marker at the end
+     * of every Segment answer. The raw IDs still carry it: the oracle gate
+     * compares token IDs, not rendered text. */
+    size_t text_tokens = generated_count;
+    while (text_tokens && generated[text_tokens - 1] == cap->eos_token_id)
+        text_tokens--;
     size_t text_bytes = 0;
-    if (coli_edge_detokenize(edge, generated, generated_count, NULL, 0,
+    if (text_tokens &&
+        coli_edge_detokenize(edge, generated, text_tokens, NULL, 0,
                              &text_bytes, error, error_size)) goto cleanup;
     char *text = malloc(text_bytes + 1);
-    if (!text || coli_edge_detokenize(edge, generated, generated_count,
-                                      text, text_bytes + 1, &text_bytes,
-                                      error, error_size)) {
+    if (!text || (text_tokens &&
+                  coli_edge_detokenize(edge, generated, text_tokens,
+                                       text, text_bytes + 1, &text_bytes,
+                                       error, error_size))) {
         free(text);
         goto cleanup;
     }
@@ -637,6 +715,9 @@ static int segment_generate(ColiEdgeEngine *edge,
     rc = 0;
 
 cleanup:
+    if (rc && error && error_size && !error[0])
+        snprintf(error, error_size, "Segment generation failed and the engine "
+                 "reported no reason");
     if (conversation) {
         if (rc) conversation_reset(conversation);
     } else {
@@ -825,15 +906,21 @@ int main(int argc, char **argv) {
         .model_dir = model_dir,
     };
     ColiEdgeEngine *edge = NULL;
-    char error[256];
+    /* Never hand an uninitialised buffer to the engine ABI: a failure that
+     * writes nothing would otherwise be reported as whatever was on the
+     * stack. */
+    char error[256] = "";
     if (coli_edge_engine_open(engine_id, &edge_options, &edge,
                               error, sizeof error)) {
-        fprintf(stderr, "cannot open Colibri Edge engine: %s\n", error);
+        fprintf(stderr, "cannot open Colibri Edge engine: %s\n",
+                engine_error(error));
         return 1;
     }
     ColiEdgeCapabilities cap = { .struct_size = sizeof cap };
+    error[0] = 0;
     if (coli_edge_engine_capabilities(edge, &cap, error, sizeof error)) {
-        fprintf(stderr, "cannot read Edge capabilities: %s\n", error);
+        fprintf(stderr, "cannot read Edge capabilities: %s\n",
+                engine_error(error));
         return 1;
     }
     uint32_t context = cap.max_context_tokens < 4096 ? cap.max_context_tokens : 4096;

--- a/segment_colibri.h
+++ b/segment_colibri.h
@@ -28,6 +28,15 @@ static int lmb_colibri_register_all(void) {
            coli_deepseek_v4_edge_adapter_register();
 }
 
+/* Colibri's ABI is allowed to return a failure without writing the caller's
+ * error buffer. A buffer that starts as uninitialised stack is then printed
+ * as one: an operator chasing a real MoE failure was shown
+ * "[segment-node] run: q<garbage>v" instead of a reason. Every error buffer
+ * in the Segment binaries starts empty and is read back through here. */
+static const char *engine_error(const char *error) {
+    return error && error[0] ? error : "the engine reported no reason";
+}
+
 static int lmb_hex_root(const char *hex, uint8_t out[32]) {
     if (!hex || strlen(hex) != 64) return -1;
     unsigned any = 0;

--- a/segment_node.c
+++ b/segment_node.c
@@ -282,10 +282,11 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
                 .context_tokens = open.context_tokens,
             };
             ColiSegmentSession *session = NULL;
-            char error[256];
+            char error[256] = "";
             if (coli_segment_session_create(node->engine, &options, &session,
                                             error, sizeof error)) {
-                fprintf(stderr, "[segment-node] session create: %s\n", error);
+                fprintf(stderr, "[segment-node] session create: %s\n",
+                        engine_error(error));
                 status = LMB_SEG_STATUS_INTERNAL;
             } else {
                 status = lmb_seg_table_open(node->table, &open, now_ms());
@@ -378,9 +379,17 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                 .output = output,
                 .output_bytes = bytes,
             };
-            char error[256];
+            char error[256] = "";
             if (coli_segment_run(session, &request, error, sizeof error)) {
-                fprintf(stderr, "[segment-node] run: %s\n", error);
+                /* Name the slice: an origin runs several of these at once and
+                 * an unlabelled line cannot be attributed to a layer range. */
+                fprintf(stderr, "[segment-node %s %u:%u] run failed on %u row%s "
+                        "at position %llu: %s\n",
+                        node->advert.peer_name, node->advert.layer_begin,
+                        node->advert.layer_end, run.rows,
+                        run.rows == 1 ? "" : "s",
+                        (unsigned long long)run.position,
+                        engine_error(error));
                 status = LMB_SEG_STATUS_INTERNAL;
             }
             pthread_mutex_lock(&node->registration.lock);
@@ -651,16 +660,19 @@ int main(int argc, char **argv) {
         .layer_end = end,
         .context_tokens = context,
     };
-    char error[256];
+    char error[256] = "";
     if (coli_segment_engine_open(engine_id, &options, &node.engine,
                                  error, sizeof error)) {
-        fprintf(stderr, "cannot open Colibri Segment engine: %s\n", error);
+        fprintf(stderr, "cannot open Colibri Segment engine: %s\n",
+                engine_error(error));
         return 1;
     }
     node.cap.struct_size = sizeof node.cap;
+    error[0] = 0;
     if (coli_segment_engine_capabilities(node.engine, &node.cap,
                                          error, sizeof error)) {
-        fprintf(stderr, "cannot read Segment capabilities: %s\n", error);
+        fprintf(stderr, "cannot read Segment capabilities: %s\n",
+                engine_error(error));
         return 1;
     }
     if (end > node.cap.num_layers || context > node.cap.max_context_tokens ||
@@ -756,8 +768,10 @@ int main(int argc, char **argv) {
     }
     pthread_mutex_unlock(&node.sessions_lock);
     lmb_seg_table_destroy(node.table);
+    error[0] = 0;
     if (coli_segment_engine_close(node.engine, error, sizeof error))
-        fprintf(stderr, "[segment-node] engine close: %s\n", error);
+        fprintf(stderr, "[segment-node] engine close: %s\n",
+                engine_error(error));
     memset(registration->sk, 0, sizeof registration->sk);
     pthread_cond_destroy(&node.connections_drained);
     pthread_mutex_destroy(&node.connections_lock);


### PR DESCRIPTION
## Why

Four defects found while debugging a live DeepSeek-V4-Flash swarm. None of
them changes the data plane; all of them cost real time on the terminal.

## What

**1. One message for four causes.** `cannot open segment NAME at ADDR` was
printed for a filtered port, a dead executor, a rejected OPEN and a
malformed reply alike. The actual diagnosis had to come from timing the
failure against `lmb_connect`'s 5 s budget. `lmb_connect_ms` now keeps the
reason the kernel gave (`lmb_connect_errno` / `lmb_connect_why`), and
`remote_open` reports the peer, the address and what happened:

```
cannot reach segment-origin-7300-0 at 148.251.4.122:7303: no reply before
  the timeout — the port is filtered or the host is unreachable (firewall?)
segment-origin-7300-0 at 148.251.4.122:7303 rejected OPEN [0:10]: bad
  request — the executor's model identity, layer range, context, rows or
  numeric class does not match what the tracker advertised
```

**2. Uninitialised error buffers.** Colibri's ABI may return a failure
without writing the caller's buffer. Those buffers were uninitialised
stack, so a real MoE failure reached an operator as
`[segment-node] run: q<garbage>v`. Every buffer starts empty and is read
back through `engine_error()`; a failed run also names its slice, rows and
position, because one origin runs several slices and an unlabelled line
cannot be attributed to a layer range.

**3. Origin slices shared the operator's terminal.** N unbuffered writers
shred each other's lines exactly when something has gone wrong —
`run: hybrid b` was one such fragment. Each slice now logs under
`~/.lumabri/logs/segment-{origin,peer}-PORT-N.log`, kept across a
supervised restart, and `serve` prints where they are plus a reminder that
the Segment ports must be open.

**4. The EOS token was rendered as text.** The token that stops generation
is a control marker; `segment_chat` detokenized it, so every Segment reply
from a model with a real EOS ended in a literal marker (`...aiutarti
oggi?<|end of sentence|>` on DeepSeek V4). The text now stops before it.
The returned token IDs still carry it, so the oracle gate is unaffected.

## Verification

- `make check-warnings ENGINE=<colibri+#1245>`: PASS (covers `segment_node`
  and `segment_chat` under `-Werror`).
- `make test`: PASS. `segment_native_test.sh` (real `serve` + TUI `chat`):
  PASS.
- Two-peer OLMoE oracle chain still byte-identical (`token-ids: 99,35`).
- Executor killed mid-swarm → the chat names the peer, the address and the
  cause instead of `cannot open segment`.
- Executor with `--sessions 1` and a session already held → the chat reports
  `rejected OPEN [0:2]: quota — the executor has no free session slot`.
- `serve` with two slices → both logs land in `~/.lumabri/logs/`, zero
  `[segment-node]` lines on the terminal, tracker still confirms each slice.
- EOS trim, before/after with the same forced EOS id and the same token IDs
  `99,35`: `origin/main` renders `c#`, this branch renders `c`.

Note on coverage: this box is WSL2, whose loopback does not deliver the RST
for a closed port, so every local failure surfaces as a timeout. The
`ECONNREFUSED` wording is therefore verified by construction, not by a local
run; the timeout wording is deliberately hedged for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)