### PR TITLE
feat: make Segment serving resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ a tag stay under Unreleased until a new tag is created.
 
 ## Unreleased
 
+- Segment temperature/top-p sampling through Colibri Edge logits, while
+  preserving the exact greedy path at temperature zero.
+- Stateful Segment relay over signed outbound tracker tunnels, including
+  relay-only NAT executors and automatic direct-to-relay retry.
+- Chunked opaque snapshots, transactional restore and exact-range replica
+  replay after peer failure; checkpoint copies are skipped without a replica.
+- End-to-end gates for all six Colibri families, relay-only serving, failover
+  replay and the ordinary `lumabri serve` + `lumabri chat` path.
 - Persistent endpoint TOFU and strict `LUMABRI_PEER_PINS` verification.
 - Fail-closed encrypted startup, X25519 low-order rejection, bounded aggregate
   receive memory, one-buffer AEAD frames and encrypted-fd lifecycle cleanup.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -43,20 +43,22 @@ apt update && apt install -y build-essential git python3-numpy ufw
 adduser --disabled-password --gecos "" lumabri
 ```
 
-Open only what the swarm needs. Ports: **7300** tracker, **7301**
-maintainer (byte serving), **7302** classic expert executor and, by default,
-**7303-7306** four layer-aligned Segment origin ranges. Allow through 7309 if
-you intentionally set up to seven ranges.
+Open only what the swarm needs. **7300** is the required tracker/control port.
+The signed relay makes every data path work with only that inbound port. For
+the lower-latency direct path also open **7301** (bytes), **7302** (classic
+experts) and, by default, **7303-7306** (four Segment ranges). Allow through
+7309 only when intentionally using up to seven public ranges.
 
 ```sh
 ufw allow OpenSSH
-ufw allow 7300:7309/tcp
+ufw allow 7300/tcp
+# fastest public-server path (optional): ufw allow 7301:7309/tcp
 ufw --force enable
 ```
 
-In the Hetzner Cloud console, apply the same rule in the **Firewall**
-section (inbound TCP 22, 7300-7309) — the cloud firewall sits in front of
-the machine and a ufw rule alone will not open it.
+In the Hetzner Cloud console, apply the same selected rule in the **Firewall**
+section — the cloud firewall sits in front of the machine and a ufw rule alone
+will not open it.
 
 ---
 
@@ -288,13 +290,14 @@ journalctl -u lumabri -f
 **A reachable address gives the swarm its fastest path.** `serve` detects a
 public IPv4 attached to the machine and publishes it automatically. If the
 host sits behind NAT, pass `--advertise` only after forwarding the advertised
-ports. Lumabri deliberately does not publish an unreachable Segment chain;
-bytes and classic experts continue through their outbound tracker relay.
+ports. Otherwise Lumabri publishes Segment as relay-only and carries bytes,
+experts and stateful layer runs through signed outbound tracker tunnels.
 
 You should see, in order: the maintainer announcing how much it holds, the
 line `ORIGIN: signed the truth of N files with <pubkey>`, the classic executor
-on 7302 and the Segment origin ranges on 7303-7306. The tracker should accept
-all direct endpoints under `YOUR_SERVER_IP`, not `127.0.0.1`.
+and the Segment origin ranges. A public deployment should advertise direct
+endpoints under `YOUR_SERVER_IP`; a NAT deployment explicitly reports
+`data plane relay` and needs no public Segment endpoint.
 
 `--exec-cache 256` is the RAM/SSD trade: 256 expert slots resident, the
 rest streamed from disk on demand. Raise it if the box has spare RAM (the
@@ -398,10 +401,10 @@ the donor pulls it — verifying every byte against the signed truth — and
 then serves it.
 
 **Donate compute** — choose `compute` in the normal TUI. If the current chat
-uses Segment, the machine is directly reachable and a range fits after the
-RAM reserve, the tracker assigns its rarest origin range automatically.
-Otherwise Lumabri starts the finer-grained expert donor, including its NAT
-relay. Manual expert commands remain useful diagnostics:
+uses Segment and a range fits after the RAM reserve, the tracker assigns its
+rarest origin range automatically. A reachable machine uses direct P2P; a NAT
+machine uses Segment relay. If the range does not fit, Lumabri starts the
+finer-grained expert donor. Manual expert commands remain useful diagnostics:
 
 ```sh
 expert_node_glm --model /path/to/model --tracker YOUR_SERVER_IP:7300 \
@@ -417,8 +420,10 @@ no dense weights at all.
 Chatters discover it automatically. Ordinary Segment ranges replace matching
 fallback origin ranges on the next route generation, so the original server
 does progressively less work while retaining full coverage. Expert requests
-can fail over to replicas; a selected Segment dying mid-conversation still
-ends that run until checkpoint/replay lands.
+fail over to replicas. Stateful Segment checkpoints at completed turns when a
+compatible replica exists; a dead selected peer is replaced by an exact-range
+replica, restored and replayed. If no compatible replica exists the run fails
+explicitly.
 
 ---
 
@@ -468,7 +473,7 @@ Two things worth knowing:
 
 | symptom | cause |
 |---|---|
-| `no swarm at HOST:7300` | cloud firewall: open 7300-7309 in the Hetzner console too |
+| `no swarm at HOST:7300` | cloud firewall: open tracker TCP 7300 in the provider console too |
 | the server logs nothing for minutes on first start | it is hashing the model; the progress lines say how far along |
 | `il motore non è arrivato a essere pronto` | the engine's own last 25 lines are printed underneath — read those |
 | engine killed by signal 9 | out of memory: lower `--ctx` and `--cap`, or take a bigger box |

--- a/Makefile
+++ b/Makefile
@@ -411,16 +411,31 @@ segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
 		lumabri_segment_discovery.c $(COLIBRI_SEGMENT_LIB) -o $@ -lm
 
-segment_chat: segment_chat.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
+segment_chat: segment_chat.c lumabri_sampling.c lumabri_sampling.h \
+		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(SEGMENT_CFLAGS) -pthread segment_chat.c lumabri_segment.c \
-		lumabri_segment_discovery.c $(COLIBRI_SEGMENT_LIB) -o $@ -lm
+		lumabri_segment_discovery.c lumabri_sampling.c \
+		$(COLIBRI_SEGMENT_LIB) -o $@ -lm
+
+test_sampling: test_sampling.c lumabri_sampling.c lumabri_sampling.h
+	$(CC) $(CFLAGS) test_sampling.c lumabri_sampling.c -o $@ -lm
 
 .PHONY: segment-direct
 segment-direct: segment_node segment_chat
 
-test-segment-direct-real: tracker maintainer liblumabri.so lumabri segment-direct
+test-segment-direct-real: tracker maintainer liblumabri.so lumabri \
+		segment-direct test_sampling
+	./test_sampling
 	bash ./segment_direct_test.sh
+	bash ./segment_relay_test.sh
+	bash ./segment_failover_test.sh
 	bash ./segment_native_test.sh
+
+test-segment-relay-real: tracker segment-direct
+	bash ./segment_relay_test.sh
+
+test-segment-failover-real: tracker segment-direct
+	bash ./segment_failover_test.sh
 
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	./relay_exec_test.sh
@@ -501,8 +516,10 @@ install: all
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
-	      test_verify_failover test_segment_v2 test_segment_discovery \
-	      segment_node segment_chat \
+	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
+	      test_segment_v2_tsan tracker_tsan \
+	      segment_node segment_chat segment_node_asan segment_chat_asan \
+	      segment_node_tsan segment_chat_tsan \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p qwen36_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	      expert_node_deepseek expert_node_qwen36
@@ -514,4 +531,5 @@ clean:
         test-phase2-deepseek test-engines \
         patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 test-elastic \
         test-cas test-key-rotation test-hedge test-segment-v2 \
-        test-segment-discovery segment-direct test-segment-direct-real
+        test-segment-discovery segment-direct test-segment-direct-real \
+        test-segment-relay-real test-segment-failover-real

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ them, so a script never inherits somebody's saved answers.
 When you join it also asks how you want to take part — just chat, or **lend your
 machine too**. `disk` receives complete rarest-first files up to the chosen GB
 budget (transferred and verified in MiB blocks). `compute` takes the rarest
-tracker-assigned Segment slice when a direct endpoint and enough spare RAM are
-available; otherwise it uses the finer-grained expert donor and its NAT relay.
+tracker-assigned Segment slice when enough spare RAM is available. It publishes
+direct P2P when reachable and otherwise uses the signed outbound Segment relay;
+the finer-grained expert donor remains the lower-memory fallback.
 Both run at low priority and die with the TUI. Nothing to configure — Enter
 picks "just chat".
 
@@ -104,9 +105,17 @@ kept in an isolated remote session.
 The local Edge opens through `liblumabri.so`, so a user supplies neither a model
 directory nor roots: the signed aggregate model identity comes from the tracker
 and only blocks actually read by tokenizer/embedding/head enter the CAS. Four
-origin ranges is the current latency/replacement compromise. Segment endpoints
-are direct TCP today; a server auto-publishes a real public IPv4, refuses to
-guess private/NAT addresses, and retains READ/EXEC relay fallback there.
+origin ranges is the current latency/replacement compromise. Segment prefers
+persistent direct TCP and falls back request-for-request to the exact peer's
+signed tracker tunnel. A machine behind NAT therefore contributes without
+publishing an unreachable address or opening a data port.
+
+The TUI's temperature and top-p are applied to logits returned by Colibri Edge;
+temperature zero retains the exact greedy selector. When a compatible replica
+exists, a completed turn checkpoints every opaque remote state. If a peer dies,
+it opens an exact-range compatible replica, restores the common checkpoint,
+replays only the token delta and retries the interrupted batch with the same
+conversation.
 
 **Experts run on peers.** For a mixture-of-experts model the chatter keeps only
 the dense weights, the router and the KV cache, and sends the 4 KB activation to
@@ -175,8 +184,8 @@ resident on peers, reducing the network boundary from one request per
 layer/expert to one request per segment. It is the preferred path of ordinary
 `lumabri chat` when the matching Colibri ABI and a complete compatible route
 exist. GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4 are all release
-gates; OLMoE is not a special-case definition of complete. Build details and
-the explicit greedy/direct/no-replay limitations are in
+gates; OLMoE is not a special-case definition of complete. Build details,
+relay/failover semantics and the remaining operational boundaries are in
 **[SEGMENT_DIRECT.md](SEGMENT_DIRECT.md)**.
 
 ## Running a swarm
@@ -191,12 +200,12 @@ sudo make install                                    # or PREFIX=$HOME/.local
 ```
 
 On the server, `lumabri serve --model /srv/model` starts tracker, maintainer,
-classic expert executor and the automatic Segment origin. With the default four
-ranges it opens TCP 7300 through 7306; allow 7300:7309 if deployments may use up
-to seven. A public IPv4 attached to the machine is detected automatically;
-otherwise add `--advertise <reachable-ip>` or Lumabri deliberately withholds
-Segment and uses the proven READ/EXEC relay. Add `--key swarm.key` to sign the
-model.
+classic expert executor and the automatic Segment origin. TCP 7300 must be
+reachable. A public IPv4 attached to the machine is detected automatically and
+enables the fastest direct paths on 7301 onward; allow 7300:7309 when using up
+to seven public Segment ranges. Without a reachable address, Segment, READ and
+EXEC use signed outbound tracker tunnels, so no data port is required. Add
+`--key swarm.key` to sign the model.
 
 On every other machine, pick a role:
 
@@ -209,25 +218,26 @@ On every other machine, pick a role:
 
 A disk donor is told which complete files to hold, rarest first, by the tracker;
 the GB budget is a hard placement input, not permission to fill the disk. A
-compute donor needs no model: when Segment is active, directly reachable and a
-quarter-range fits after the system reserve, it receives the least-replicated
-origin range. Otherwise `--hold auto` sizes an expert slice to free RAM and the
+compute donor needs no model: when Segment is active and a quarter-range fits
+after the system reserve, it receives the least-replicated origin range. Direct
+P2P is preferred; NAT donors use Segment relay automatically. If the range does
+not fit, `--hold auto` sizes an expert slice to free RAM and the
 tracker gives it what nobody else covers through direct EXEC or relay. Both
 load through the verified swarm mirror, so the whole model never lands on the
 donor.
 Donors register under `donor-<hostname>-…` (pick one with `--donor-name`);
 a name already owned by another peer key is retried with a numbered suffix
 instead of being silently rejected forever. So several
-compute donors **split the model into disjoint slices automatically**, and one
-token's experts then run across them in parallel: more machines, faster
-tokens. (`--hold N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or
+compute donors **split the model into disjoint slices automatically**. (`--hold
+N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or
 `--layers …` split it explicitly if you want to size each machine yourself.)
 When two donors happen to hold the *same* expert, add `LUMABRI_SPREAD=1` on the
 chatter to balance the load between them too. Neither donor needs to know the
-others exist. Expert requests can fail over to another replica. A selected
-stateful Segment dying mid-conversation is different: checkpoint/replay is not
-on the wire yet, so the run stops with that explicit error instead of silently
-restarting from divergent state.
+others exist. Expert requests can fail over to another replica. Stateful
+Segment sessions with compatible replicas checkpoint at turn boundaries; on
+failure the gateway restores an exact-range replica, replays tokens after the
+common checkpoint and retries the interrupted batch. If no compatible replica
+exists, it still fails loudly rather than inventing divergent state.
 
 For a manual signing-key rotation, distribute a keyring containing one public
 key per line. `--pubkey keyring` and `LUMABRI_PUBKEY=keyring` accept every key
@@ -314,8 +324,11 @@ have their own scripts (`assign_test.sh`, `concurrency_test.sh`,
 Segment discovery checks leases, route generations, replicas, draining,
 compatibility and the asynchronous snapshot. The direct gate runs all six tiny
 families through real TCP executors, matches independent Colibri token oracles,
-drives the persistent TUI codec, overlaps sessions, and proves rarest-first
-automatic range replacement. Relay EXEC needs
+drives sampled persistent TUI turns, overlaps sessions, and proves rarest-first
+automatic range replacement. The same target also forces Segment through a
+relay-only NAT topology, kills a selected executor to require checkpoint
+restore/replay, and launches the ordinary `serve` + `chat` UX without a public
+data address. Relay EXEC needs
 an OLMoE engine source under `ENGINE`; its script reports `SKIP` explicitly
 when that external checkout is absent. Every claim in this README has a script
 behind it.

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -40,9 +40,11 @@ The model owner runs:
 lumabri serve --model /models/olmoe --advertise PUBLIC_IP
 ```
 
-Lumabri detects the family, layer/context shape, CPU/RAM and public IPv4, then
-starts four disjoint fallback executors. A public interface address removes the
-need for `--advertise`; private/NAT addresses are never guessed.
+Lumabri detects the family, layer/context shape, CPU/RAM and network capability,
+then starts four disjoint fallback executors. A public interface enables the
+preferred direct path. Behind NAT the same executors register as relay-only and
+remain reachable through their signed outbound tracker tunnels; Lumabri never
+publishes a guessed private address as direct.
 
 Every client runs the unchanged TUI:
 
@@ -57,7 +59,7 @@ user-facing model roots, tokenizer roots, ranges or `segment_chat` command.
 
 Choosing `compute` in the TUI asks the tracker for the least-replicated exact
 origin range. The node loads that slice from CAS at low priority if it fits
-after the machine reserve and has a reachable direct address; otherwise
+after the machine reserve, using direct P2P or automatic NAT relay. Otherwise
 Lumabri donates auto-sized experts over the relay-capable classic path.
 
 ## Low-level two-peer diagnostic
@@ -108,8 +110,31 @@ isolated fixtures and protocol diagnosis. A donor may use `--auto-range` in
 place of `--range`: the tracker keeps a short loading promise so concurrent
 donors do not all choose the same rare slice.
 
-Open the Segment port on each executor's firewall. The current transport is
-direct TCP, so an executor behind an unforwarded NAT is not reachable yet.
+Open the Segment port on each executor's firewall only when publishing a direct
+address. Without `--advertise`, `lumabri serve` and compute donors use the exact
+peer's outbound tracker connection for `OPEN`, `RUN`, `SNAPSHOT`, `RESTORE` and
+`CLOSE`; tracker TCP 7300 is the only required inbound port. Direct is preferred
+when both transports are available and a failed direct request is retried by
+relay with the same idempotent request ID.
+
+## Sampling and recovery
+
+Colibri Edge ABI v2 exposes the full logits for all six adapters. The ordinary
+TUI's temperature and top-p are therefore honored on the Segment path. A zero
+temperature calls Colibri's original greedy selector unchanged; a positive
+temperature uses deterministic-seedable nucleus sampling (`--seed` or
+`LUMABRI_SAMPLE_SEED` for diagnostics).
+
+Persistent chats with at least one compatible replica take a transactional
+opaque checkpoint of every selected range at a completed turn. Origin-only
+swarms avoid that copy because there is nowhere to restore it. When one peer
+fails, the gateway selects a compatible replica with exactly the same layer
+boundaries/schema/numeric class, creates a new fenced session across the whole
+chain, restores the common checkpoint,
+replays the token delta and retries the failed batch. No model-specific KV
+layout enters Lumabri. If any exact-range replica or checkpoint is unavailable,
+the error is explicit and the conversation is never continued from partial
+state.
 
 ## Encryption
 
@@ -134,26 +159,24 @@ make test-segment-direct-real ENGINE=/path/to/colibri/c \
 ```
 
 Run the same command with `LUMABRI_ENCRYPT=1` to gate encrypted control and
-data planes.
+data planes. The target also runs the sampler unit gate, a relay-only real
+session, checkpoint/replay after a killed executor, and ordinary
+`lumabri serve` + `lumabri chat` with context negotiation.
 
-## Deliberate current limits
+## Remaining operational scope
 
-- Edge v1 selects greedy tokens only. Temperature, top-p and top-k are not
-  silently approximated outside Colibri.
-- Segment relay and NAT hole punching are not implemented; only tracker
-  discovery and direct peer connections are used.
-- Snapshot bytes are not transported yet. If a selected peer dies, the chat
-  stops with an explicit checkpoint/replay error rather than producing a
-  divergent continuation.
 - The archive advertises CPU only. GPU Segment adapters must expose a real
   Colibri backend before Lumabri may publish CUDA/HIP/Metal/Vulkan capability.
 - The current governor is conservative rather than complete: CPU/RAM/context
   choose chunk/session limits, desktop donors are niced and Segment donation
   is refused when its estimated range would consume the system reserve. Live
-  pressure migration and state replay are still pending.
+  pressure-triggered migration is still pending.
+- Relay is a reachability floor, not the fastest topology: it adds a tracker hop
+  and currently serializes requests per executor tunnel. Reachable peers should
+  publish direct P2P; decentralized relay/hole punching remains future work.
 - One chatter process hosts one active Edge model. This also respects Qwen's
   currently process-global tokenizer state.
 
 These are roadmap items, not hidden fallbacks. The completed milestone proves
-one RTT per segment, exact multi-session state ownership and real token
-generation over the network for every current model family.
+one RTT per segment, sampled multi-session generation, NAT reachability and
+checkpoint/replay over the network for every current model family.

--- a/SEGMENT_V2.md
+++ b/SEGMENT_V2.md
@@ -6,13 +6,14 @@ particular model's KV layout. Colibri owns the model math, weights, accelerator
 and opaque state; Lumabri owns transport, session identity, ordering, leases,
 fencing and route lifecycle.
 
-The wire/session contract, tracker discovery and opt-in direct executor are
-implemented. `segment_node` dispatches `SEG_OPEN`, `SEG_RUN`, `SEG_CLOSE` and
-`SEG_HEALTH` through Colibri's public ABI; `segment_chat` keeps Edge math local
-and freezes an immutable complete route before inference. The normal
-interactive CLI does not advertise Segment capability automatically yet.
-Snapshot/restore wire envelopes exist, but snapshot transport and replay are
-still deliberately unadvertised. See [SEGMENT_DIRECT.md](SEGMENT_DIRECT.md).
+The wire/session contract, tracker discovery, direct/relay executor and native
+interactive path are implemented. `segment_node` dispatches `SEG_OPEN`,
+`SEG_RUN`, `SEG_SNAPSHOT`, `SEG_RESTORE`, `SEG_CLOSE` and `SEG_HEALTH` through
+Colibri's public ABI; `segment_chat` keeps Edge math local and binds a complete
+route before inference. Snapshot bytes are chunked without a whole-checkpoint
+frame limit, and persistent chats restore a compatible chain plus replay token
+deltas after a selected peer fails. See
+[SEGMENT_DIRECT.md](SEGMENT_DIRECT.md).
 
 ## Tracker discovery
 
@@ -28,8 +29,9 @@ plus:
 
 - a random lease ID and monotonic fencing epoch per executor;
 - a monotonic route generation for the complete placement;
-- data-plane transport capability (`DIRECT` today; `RELAY` remains reserved
-  until Segment forwarding is implemented rather than inferred from SREG);
+- data-plane transport capability (`DIRECT`, `RELAY`, or both). Relay is
+  published only for a live signed SREG control tunnel; relay-only peers never
+  leak their loopback listener as a direct endpoint;
 - whether the returned ranges contain an exact executable chain. Interval
   union alone is insufficient because overlapping executors would run a layer
   twice; replicas may overlap, but the selected boundaries must join exactly.
@@ -119,10 +121,11 @@ outside the table lock, then calls `run_commit` or `run_abort`. Commit alone
 advances sequence and position.
 
 The table records the last 16 committed request identities and digests. A
-duplicate is never executed twice. The direct executor retains the most recent
+duplicate is never executed twice. The executor retains the most recent
 committed activation response for a safe immediate retry. An older recognized
-duplicate returns `NEEDS_RESTORE`; once replay lands, that status will restore
-from a checkpoint rather than ever calling the model twice.
+duplicate returns `NEEDS_RESTORE`; the gateway restores the common checkpoint
+and replays the missing token suffix rather than ever calling the model twice
+on ambiguous state.
 
 ## Fencing
 
@@ -162,6 +165,8 @@ The real-tracker discovery gate additionally covers signed registration,
 compatibility filtering, replicas, complete chains, telemetry stability,
 draining, lease rotation and asynchronous snapshots. These are protocol and
 control-plane fixtures. `segment_direct_test.sh` adds the real data plane: two
-peers per family, real prefill/decode, persistent sessions and three oracle
-tokens for all six models, plus overlapping real sessions, in plaintext and
-encrypted modes.
+peers per family, real prefill/decode, persistent sampled sessions and three
+greedy oracle tokens for all six models, plus overlapping real sessions. The
+relay gate forces every stateful operation through tracker tunnels; the
+failover gate kills a selected peer between turns and requires checkpoint
+restore plus replay before generation can continue.

--- a/lumabri.c
+++ b/lumabri.c
@@ -598,7 +598,7 @@ static int cmd_serve(int argc, char **argv) {
         model, mname, segment_model_storage, sizeof segment_model_storage);
     uint32_t segment_layers = 0;
     int with_segment = 0;
-    if (!disk_donor && !no_exec && advertise && segment_engine && segment_model &&
+    if (!disk_donor && !no_exec && segment_engine && segment_model &&
         access(segment_bin, X_OK) == 0 &&
         local_model_layers(model, &segment_layers) == 0) {
         long cores = sysconf(_SC_NPROCESSORS_ONLN);
@@ -646,6 +646,7 @@ static int cmd_serve(int argc, char **argv) {
             sargv[a++] = "--name";         sargv[a++] = sname;
             sargv[a++] = "--auto-identity";
             if (!join) sargv[a++] = "--fallback";
+            if (!advertise) sargv[a++] = "--relay-only";
             sargv[a++] = "--context";      sargv[a++] = context;
             sargv[a++] = "--max-rows";     sargv[a++] = "16";
             sargv[a++] = "--sessions";     sargv[a++] = session_text;
@@ -661,24 +662,22 @@ static int cmd_serve(int argc, char **argv) {
         const char *home = getenv("HOME") ? getenv("HOME") : ".";
         printf("  %sSegment prepara %d fette layer-aligned sulle porte %d-%d "
                "(%ld CPU, %.1f GB RAM disponibili, %d sessioni/fetta). "
-               "%s%s\n",
+               "%s%s%s\n",
                C_DIM, chunks, port + 3, port + 2 + chunks, cores, ram_gb,
                sessions, join ? "Sono peer ordinari; " :
-               "Sono il fallback sostituibile; ", C_R);
+               "Sono il fallback sostituibile; ",
+               advertise ? "data plane diretto con relay di sicurezza. " :
+                           "data plane relay (nessuna porta pubblica richiesta). ",
+               C_R);
         /* Their diagnostics belong in one file per slice: N unbuffered
          * writers on one terminal shred each other's lines exactly when
          * something has gone wrong and the line matters most. */
         printf("  %slog delle fette: %s/.lumabri/logs/segment-%s-%d-*.log · "
-               "apri le porte %d-%d sul firewall, altrimenti pubblichi una "
-               "catena che i chatter non riescono ad aprire%s\n",
+               "%s%s\n",
                C_DIM, home, join ? "peer" : "origin", port,
-               port + 3, port + 2 + chunks, C_R);
-    } else if (!disk_donor && !no_exec && !advertise && segment_engine &&
-               access(segment_bin, X_OK) == 0) {
-        printf("  %sSegment non viene pubblicato: questa macchina non espone "
-               "un IPv4 pubblico. READ/EXEC continuano via relay; usa "
-               "--advertise IP solo quando le porte sono raggiungibili.%s\n",
-               C_DIM, C_R);
+               advertise ? "apri le porte Segment sul firewall per il P2P diretto"
+                         : "relay NAT attivo: non serve aprire le porte Segment",
+               C_R);
     }
     signal(SIGINT, on_sigint);
     signal(SIGTERM, on_sigint);
@@ -686,14 +685,12 @@ static int cmd_serve(int argc, char **argv) {
     printf("\n%sserving%s %s %s(tracker %s%s)%s\n", C_GRN, C_R, model, C_DIM, taddr,
            with_segment ? " · Segment origin attivo" :
            (with_exec ? " · executing experts for the swarm" : ""), C_R);
-    /* Without --advertise every local peer registers as 127.0.0.1, and the
-     * tracker's correction cannot help because these registrations arrive
-     * over loopback. A remote chatter then uses the READ/EXEC tracker relay.
-     * That works through NAT but adds an extra hop and centralises traffic,
-     * so say plainly that --advertise is required for the direct P2P path. */
+    /* Without --advertise every local peer uses its signed outbound tracker
+     * tunnel for READ/EXEC/Segment. It works through NAT with no open data
+     * ports, while --advertise retains the lower-latency direct preference. */
     if (!advertise && !join)
         printf("%s⚠ nessun --advertise: i chatter remoti useranno il relay del "
-               "tracker per READ ed EXEC.%s\n"
+               "tracker per READ, EXEC e Segment.%s\n"
                "%s  Funziona anche dietro NAT, ma aggiunge un hop e carica il "
                "tracker; --advertise abilita il P2P diretto.%s\n"
                "%s  Per il percorso diretto: lumabri serve --model %s --advertise <ip-pubblico>%s\n",
@@ -2374,9 +2371,8 @@ static int free_port(int from) {
 }
 
 /* Prefer one tracker-assigned Segment slice when this chat is already using
- * Segment and the machine can publish a genuinely reachable address. Home
- * NAT peers keep donating through the mature EXEC relay instead of poisoning
- * discovery with an endpoint that only looks public from the tracker. */
+ * Segment. Public machines advertise direct TCP; NAT peers expose the same
+ * local listener only through their signed outbound tracker tunnel. */
 static int role_start_segment(const Role *r, const char *tracker,
                               const char *model, const char *model_type,
                               int context, uint64_t model_bytes) {
@@ -2391,6 +2387,7 @@ static int role_start_segment(const Role *r, const char *tracker,
         snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
 
     char host[INET_ADDRSTRLEN] = "";
+    int relay_only = 0;
     const char *forced = getenv("LUMABRI_ADVERTISE");
     struct in_addr forced_address;
     if (forced && forced[0]) {
@@ -2402,8 +2399,10 @@ static int role_start_segment(const Role *r, const char *tracker,
     else if (!strncmp(tracker, "127.0.0.1:", 10) ||
              !strncmp(tracker, "localhost:", 10))
         snprintf(host, sizeof host, "127.0.0.1");
-    else if (machine_public_ipv4(host, sizeof host))
-        return 0;
+    else if (machine_public_ipv4(host, sizeof host)) {
+        snprintf(host, sizeof host, "127.0.0.1");
+        relay_only = 1;
+    }
 
     /* The origin's default four-way partition makes one slice roughly a
      * quarter of the checkpoint. Keep both a fixed OS reserve and 25% of the
@@ -2474,6 +2473,7 @@ static int role_start_segment(const Role *r, const char *tracker,
     argv[a++] = "--advertise";     argv[a++] = address;
     argv[a++] = "--name";          argv[a++] = name;
     argv[a++] = "--auto-identity";
+    if (relay_only) argv[a++] = "--relay-only";
     argv[a++] = "--context";       argv[a++] = context_text;
     argv[a++] = "--max-rows";      argv[a++] = "16";
     argv[a++] = "--sessions";      argv[a++] = sessions_text;
@@ -2486,8 +2486,10 @@ static int role_start_segment(const Role *r, const char *tracker,
     if (pid <= 0) return 0;
     child_publish(g_nchildren++, pid);
     printf("  %s\xe2\x9c\xa6 eseguo una fetta Segment assegnata dal tracker "
-           "per lo sciame%s %s(priorita' bassa, %d sessioni massime)%s\n",
-           C_GRN, C_R, C_DIM, sessions, C_R);
+           "per lo sciame%s %s(priorita' bassa, %d sessioni massime%s)%s\n",
+           C_GRN, C_R, C_DIM, sessions,
+           relay_only ? ", relay NAT automatico" : ", P2P diretto + relay",
+           C_R);
     return 1;
 }
 

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -233,6 +233,11 @@ enum {
      * origin's exact layer-aligned ranges, rarest first.  The subsequent
      * signed SEG_REGISTER remains the authority; this is only placement. */
     LMB_SEG_ASSIGN = 55, LMB_SEG_ASSIGN_R = 56,
+    /* Stateful Segment relay. The caller names one exact registered peer and
+     * wraps an ordinary Segment request. The tracker only forwards bytes over
+     * that peer's signed outbound control connection; the executor remains
+     * the sole authority for session, lease and request-id validation. */
+    LMB_RSEG = 57, LMB_RSEG_FWD = 58, LMB_RSEG_R = 59,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -327,7 +332,12 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
     case LMB_SEG_RUN_R:
     case LMB_SEG_SNAPSHOT_R:
     case LMB_SEG_RESTORE:
+    case LMB_RSEG:
+    case LMB_RSEG_FWD:
+    case LMB_RSEG_R:
         *pay_cap = LMB_MAX_PAY;
+        if (op == LMB_RSEG || op == LMB_RSEG_FWD || op == LMB_RSEG_R)
+            *body_cap = LMB_MAX_CONTROL_BODY;
         break;
     case LMB_RREAD_FWD:
     case LMB_EXEC:

--- a/lumabri_sampling.c
+++ b/lumabri_sampling.c
@@ -1,0 +1,107 @@
+#include "lumabri_sampling.h"
+
+#include <math.h>
+#include <stdlib.h>
+
+typedef struct {
+    double weight;
+    uint32_t token;
+} LmbSampleCandidate;
+
+static uint64_t splitmix64(uint64_t *state) {
+    uint64_t value = (*state += UINT64_C(0x9e3779b97f4a7c15));
+    value = (value ^ (value >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    value = (value ^ (value >> 27)) * UINT64_C(0x94d049bb133111eb);
+    return value ^ (value >> 31);
+}
+
+static double uniform_open(LmbSampler *sampler) {
+    /* The midpoint keeps the draw strictly inside (0, 1). */
+    return ((double)(splitmix64(&sampler->state) >> 11) + 0.5) *
+           (1.0 / 9007199254740992.0);
+}
+
+void lmb_sampler_init(LmbSampler *sampler, uint64_t seed) {
+    if (sampler)
+        sampler->state = seed ^ UINT64_C(0x6a09e667f3bcc909);
+}
+
+static int candidate_desc(const void *left, const void *right) {
+    const LmbSampleCandidate *a = left;
+    const LmbSampleCandidate *b = right;
+    if (a->weight > b->weight) return -1;
+    if (a->weight < b->weight) return 1;
+    return a->token < b->token ? -1 : a->token != b->token;
+}
+
+int lmb_sample_logits(LmbSampler *sampler, const float *logits,
+                      uint32_t vocab_size, double temperature, double top_p,
+                      int32_t *token) {
+    if (!sampler || !logits || !vocab_size || !token ||
+        !isfinite(temperature) || temperature <= 0.0 ||
+        !isfinite(top_p) || top_p <= 0.0 || top_p > 1.0)
+        return -1;
+
+    uint32_t positive_infinities = 0;
+    for (uint32_t i = 0; i < vocab_size; i++)
+        if (isinf(logits[i]) && logits[i] > 0.0f) positive_infinities++;
+    if (positive_infinities) {
+        uint32_t wanted = (uint32_t)(uniform_open(sampler) *
+                                     positive_infinities);
+        if (wanted >= positive_infinities) wanted = positive_infinities - 1;
+        for (uint32_t i = 0; i < vocab_size; i++)
+            if (isinf(logits[i]) && logits[i] > 0.0f && !wanted--) {
+                *token = (int32_t)i;
+                return 0;
+            }
+        return -1;
+    }
+
+    float maximum = -INFINITY;
+    for (uint32_t i = 0; i < vocab_size; i++)
+        if (isfinite(logits[i]) && logits[i] > maximum) maximum = logits[i];
+    if (!isfinite(maximum)) return -1;
+
+    LmbSampleCandidate *candidates =
+        malloc((size_t)vocab_size * sizeof(*candidates));
+    if (!candidates) return -1;
+    size_t count = 0;
+    double total = 0.0;
+    for (uint32_t i = 0; i < vocab_size; i++) {
+        if (!isfinite(logits[i])) continue;
+        double weight = exp(((double)logits[i] - maximum) / temperature);
+        if (!(weight > 0.0) || !isfinite(weight)) continue;
+        candidates[count++] = (LmbSampleCandidate){weight, i};
+        total += weight;
+    }
+    if (!count || !(total > 0.0) || !isfinite(total)) {
+        free(candidates);
+        return -1;
+    }
+
+    size_t kept = count;
+    double kept_total = total;
+    if (top_p < 1.0) {
+        qsort(candidates, count, sizeof(*candidates), candidate_desc);
+        double target = top_p * total;
+        kept_total = 0.0;
+        kept = 0;
+        do {
+            kept_total += candidates[kept].weight;
+            kept++;
+        } while (kept < count && kept_total < target);
+    }
+
+    double draw = uniform_open(sampler) * kept_total;
+    for (size_t i = 0; i < kept; i++) {
+        if (draw < candidates[i].weight) {
+            *token = (int32_t)candidates[i].token;
+            free(candidates);
+            return 0;
+        }
+        draw -= candidates[i].weight;
+    }
+    *token = (int32_t)candidates[kept - 1].token;
+    free(candidates);
+    return 0;
+}

--- a/lumabri_sampling.h
+++ b/lumabri_sampling.h
@@ -1,0 +1,20 @@
+#ifndef LUMABRI_SAMPLING_H
+#define LUMABRI_SAMPLING_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    uint64_t state;
+} LmbSampler;
+
+/* A zero seed is accepted and expanded to a non-zero deterministic state. */
+void lmb_sampler_init(LmbSampler *sampler, uint64_t seed);
+
+/* Exact categorical sampling after temperature scaling and nucleus cutoff.
+ * temperature must be positive and top_p must be in (0, 1]. */
+int lmb_sample_logits(LmbSampler *sampler, const float *logits,
+                      uint32_t vocab_size, double temperature, double top_p,
+                      int32_t *token);
+
+#endif

--- a/lumabri_segment.c
+++ b/lumabri_segment.c
@@ -536,6 +536,7 @@ typedef struct {
     uint64_t next_position;
     uint64_t expires_at_ms;
     LmbSegRun pending;
+    LmbSegTransfer pending_restore;
     uint8_t pending_digest[32];
     SegHistory history[LMB_SEG_HISTORY_SLOTS];
     size_t history_next;
@@ -891,6 +892,77 @@ LmbSegStatus lmb_seg_table_restore_commit(LmbSegTable *table,
             slot->history_next = 0;
             seg_touch(slot, now_ms);
         }
+    }
+    pthread_mutex_unlock(&table->lock);
+    return status;
+}
+
+LmbSegStatus lmb_seg_table_restore_begin(LmbSegTable *table,
+                                         const LmbSegTransfer *transfer,
+                                         uint64_t now_ms) {
+    if (!table || !seg_transfer_valid(transfer) ||
+        !(transfer->flags & LMB_SEG_XFER_BEGIN))
+        return LMB_SEG_STATUS_BAD_REQUEST;
+    pthread_mutex_lock(&table->lock);
+    SegSlot *slot = seg_find(table, &transfer->session_id);
+    LmbSegStatus status = LMB_SEG_STATUS_OK;
+    if (!slot) status = LMB_SEG_STATUS_NOT_FOUND;
+    else if (seg_expired(slot, now_ms)) status = LMB_SEG_STATUS_EXPIRED;
+    else if (!(slot->open.capabilities & LMB_SEG_CAP_SNAPSHOT))
+        status = LMB_SEG_STATUS_UNSUPPORTED;
+    else if (slot->busy) status = LMB_SEG_STATUS_BUSY;
+    else if (transfer->position > slot->open.context_tokens ||
+             transfer->sequence == UINT64_MAX)
+        status = LMB_SEG_STATUS_BAD_REQUEST;
+    else {
+        int relation = seg_owner_relation(&transfer->owner, &slot->open.owner);
+        if (relation < 0) status = LMB_SEG_STATUS_STALE_OWNER;
+        else if (relation == 2) status = LMB_SEG_STATUS_CONFLICT;
+        else if (relation == 0 &&
+                 (transfer->sequence < slot->next_sequence ||
+                  transfer->position < slot->next_position))
+            status = LMB_SEG_STATUS_OUT_OF_ORDER;
+        else {
+            slot->busy = 1;
+            slot->pending_restore = *transfer;
+            seg_touch(slot, now_ms);
+        }
+    }
+    pthread_mutex_unlock(&table->lock);
+    return status;
+}
+
+LmbSegStatus lmb_seg_table_restore_finish(LmbSegTable *table,
+                                          const LmbSegTransfer *transfer,
+                                          int commit, uint64_t now_ms) {
+    if (!table || !transfer || lmb_seg_id_is_zero(&transfer->session_id) ||
+        lmb_seg_id_is_zero(&transfer->request_id))
+        return LMB_SEG_STATUS_BAD_REQUEST;
+    pthread_mutex_lock(&table->lock);
+    SegSlot *slot = seg_find(table, &transfer->session_id);
+    LmbSegStatus status = LMB_SEG_STATUS_OK;
+    if (!slot) status = LMB_SEG_STATUS_NOT_FOUND;
+    else if (!slot->busy ||
+             !lmb_seg_id_equal(&slot->pending_restore.request_id,
+                               &transfer->request_id) ||
+             slot->pending_restore.sequence != transfer->sequence ||
+             slot->pending_restore.position != transfer->position ||
+             slot->pending_restore.snapshot_size != transfer->snapshot_size ||
+             seg_owner_relation(&transfer->owner,
+                                &slot->pending_restore.owner) != 0)
+        status = LMB_SEG_STATUS_CONFLICT;
+    else {
+        slot->busy = 0;
+        memset(&slot->pending_restore, 0, sizeof slot->pending_restore);
+        if (commit) {
+            slot->open.owner = transfer->owner;
+            slot->next_sequence = transfer->sequence;
+            slot->next_position = transfer->position;
+            slot->needs_restore = 0;
+            memset(slot->history, 0, sizeof slot->history);
+            slot->history_next = 0;
+        }
+        seg_touch(slot, now_ms);
     }
     pthread_mutex_unlock(&table->lock);
     return status;

--- a/lumabri_segment.h
+++ b/lumabri_segment.h
@@ -209,6 +209,16 @@ LmbSegStatus lmb_seg_table_snapshot_check(LmbSegTable *table,
 LmbSegStatus lmb_seg_table_restore_commit(LmbSegTable *table,
                                           const LmbSegTransfer *transfer,
                                           uint64_t now_ms);
+/* Multi-frame restore transaction. begin marks the session busy before any
+ * adapter state changes; finish either publishes the new sequence/position or
+ * releases the reservation. Unlike restore_commit, snapshot_size may exceed
+ * the size of one wire frame. */
+LmbSegStatus lmb_seg_table_restore_begin(LmbSegTable *table,
+                                         const LmbSegTransfer *transfer,
+                                         uint64_t now_ms);
+LmbSegStatus lmb_seg_table_restore_finish(LmbSegTable *table,
+                                          const LmbSegTransfer *transfer,
+                                          int commit, uint64_t now_ms);
 LmbSegStatus lmb_seg_table_fence(LmbSegTable *table,
                                  const LmbSegId *session_id,
                                  const LmbSegOwner *new_owner,

--- a/lumabri_segment_discovery.c
+++ b/lumabri_segment_discovery.c
@@ -54,7 +54,8 @@ int lmb_seg_advert_valid(const LmbSegAdvert *a) {
         !a->state_width || a->state_width > LMB_SEG_MAX_STATE_WIDTH ||
         !a->max_sessions || a->active_sessions > a->max_sessions ||
         (a->flags & ~(LMB_SEG_ADVERT_DRAINING |
-                      LMB_SEG_ADVERT_FALLBACK)) ||
+                      LMB_SEG_ADVERT_FALLBACK |
+                      LMB_SEG_ADVERT_RELAY_ONLY)) ||
         (a->capabilities & ~LMB_SEG_CAP_KNOWN_MASK) ||
         !(a->capabilities & LMB_SEG_CAP_RANGE_NATIVE) ||
         !(a->capabilities & LMB_SEG_CAP_MULTI_SESSION) ||

--- a/lumabri_segment_discovery.h
+++ b/lumabri_segment_discovery.h
@@ -26,6 +26,10 @@ enum {
      * minute zero.  Placement prefers ordinary donated ranges and consumes a
      * fallback range only where no non-fallback exact chain is available. */
     LMB_SEG_ADVERT_FALLBACK = 1u << 1,
+    /* The listener is reachable locally by the node, but must not be offered
+     * as an Internet-routable endpoint. The signed tracker tunnel is its data
+     * plane until direct connectivity is available. */
+    LMB_SEG_ADVERT_RELAY_ONLY = 1u << 2,
 };
 
 enum {

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -6,8 +6,10 @@
 #include "lumabri_segment_discovery.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
+#include "lumabri_sampling.h"
 #include "segment_colibri.h"
 
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,9 +18,16 @@
 typedef struct {
     LmbSegRouteEntry route;
     int fd;
+    int direct_failed;
+    int opened;
+    char transport_error[256];
     LmbSegOpen open;
     uint64_t sequence;
     uint64_t position;
+    uint8_t *snapshot;
+    size_t snapshot_bytes;
+    uint64_t snapshot_sequence;
+    uint64_t snapshot_position;
 } RemoteSegment;
 
 typedef struct {
@@ -31,6 +40,7 @@ typedef struct {
      * it through the chain. */
     int32_t *committed_tokens;
     size_t committed_count;
+    size_t checkpoint_count;
 } SegmentConversation;
 
 typedef struct {
@@ -43,8 +53,10 @@ typedef struct {
 } GenerationResult;
 
 static int retry_first_run;
+static const char *segment_tracker;
 
 #define SEGMENT_FRAME_READY "\x01\x01" "READY" "\x01\x01"
+#define REMOTE_SNAPSHOT_CHUNK (1u << 20)
 
 static void sleep_ms(unsigned ms) {
     struct timespec ts = { (time_t)(ms / 1000u),
@@ -68,8 +80,39 @@ static void usage(const char *program) {
         "--tracker HOST:PORT [--model-root HEX64 --tokenizer-root HEX64] "
         "((--prompt TEXT | --prompt-ids CSV) | --serve) "
         "[--expect-ids CSV] [--tokens N] [--context N] [--max-rows N] "
+        "[--temperature F --top-p F --seed N] "
         "[--discovery-timeout-ms N] [--retry-first-run]\n",
         program);
+}
+
+static int parse_double(const char *text, double minimum, double maximum,
+                        double *value) {
+    if (!text || !*text || !value || minimum > maximum) return -1;
+    char *end = NULL;
+    errno = 0;
+    double parsed = strtod(text, &end);
+    if (errno || end == text || *end || !isfinite(parsed) ||
+        parsed < minimum || parsed > maximum) return -1;
+    *value = parsed;
+    return 0;
+}
+
+static int parse_u64(const char *text, uint64_t *value) {
+    if (!text || !*text || !value || text[0] == '-') return -1;
+    char *end = NULL;
+    errno = 0;
+    unsigned long long parsed = strtoull(text, &end, 10);
+    if (errno || end == text || *end) return -1;
+    *value = (uint64_t)parsed;
+    return 0;
+}
+
+static uint64_t sampler_seed(const char *requested) {
+    uint64_t seed = 0;
+    const char *text = requested ? requested : getenv("LUMABRI_SAMPLE_SEED");
+    if (text && !parse_u64(text, &seed)) return seed;
+    lmb_random((uint8_t *)&seed, sizeof seed);
+    return seed;
 }
 
 static int model_identity_resolve(const char *tracker, const char *model,
@@ -138,7 +181,8 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
         int changed = 0;
         for (uint32_t i = 0; i < snapshot->count; i++) {
             const LmbSegRouteEntry *entry = &snapshot->entries[i];
-            if (!(entry->transport & LMB_SEG_TRANSPORT_DIRECT) ||
+            if (!(entry->transport & (LMB_SEG_TRANSPORT_DIRECT |
+                                      LMB_SEG_TRANSPORT_RELAY)) ||
                 entry->advert.layer_begin >= entry->advert.layer_end ||
                 entry->advert.layer_end > layers ||
                 entry->advert.max_context < required_context ||
@@ -218,6 +262,13 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 (fallback_layers[i] == fallback_layers[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] == load_cost[best_index] &&
+                 (candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
+                 !(best->transport & LMB_SEG_TRANSPORT_DIRECT)) ||
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 hops[i] == hops[best_index] &&
+                 load_cost[i] == load_cost[best_index] &&
+                 !!(candidate->transport & LMB_SEG_TRANSPORT_DIRECT) ==
+                    !!(best->transport & LMB_SEG_TRANSPORT_DIRECT) &&
                  candidate->advert.layer_end > best->advert.layer_end))
                 best = candidate;
         }
@@ -270,6 +321,96 @@ static const char *segment_status_name(uint32_t status) {
     }
 }
 
+static int remote_relay_request(RemoteSegment *remote, uint32_t op,
+                                const void *body, uint32_t body_len,
+                                const void *pay, uint32_t pay_len,
+                                LmbMsg *response) {
+    if (!segment_tracker ||
+        !(remote->route.transport & LMB_SEG_TRANSPORT_RELAY)) return -1;
+    LmbBuf envelope = {0};
+    if (lmb_buf_str(&envelope, remote->route.advert.peer_name) ||
+        lmb_buf_u32(&envelope, op) || lmb_buf_u32(&envelope, body_len) ||
+        lmb_buf_bytes(&envelope, body, body_len)) {
+        free(envelope.p); return -1;
+    }
+    LmbMsg outer = {0};
+    int bad = lmb_request_pay(segment_tracker, LMB_RSEG,
+                              envelope.p, (uint32_t)envelope.len,
+                              pay, pay_len, &outer);
+    free(envelope.p);
+    if (bad || outer.op != LMB_RSEG_R) {
+        lmb_msg_free(&outer); return -1;
+    }
+    LmbCur cursor = { outer.body, outer.body_len, 0 };
+    uint32_t inner_op = 0, inner_body_len = 0;
+    if (lmb_cur_u32(&cursor, &inner_op) ||
+        lmb_cur_u32(&cursor, &inner_body_len) ||
+        inner_body_len != cursor.len - cursor.off || inner_op != op + 1u ||
+        !lmb_frame_shape_ok(inner_op, inner_body_len, outer.pay_len)) {
+        lmb_msg_free(&outer); return -1;
+    }
+    response->op = inner_op;
+    response->body_len = inner_body_len;
+    response->pay_len = outer.pay_len;
+    response->body = malloc(inner_body_len ? inner_body_len : 1u);
+    response->pay = malloc(outer.pay_len ? outer.pay_len : 1u);
+    if (!response->body || !response->pay) {
+        lmb_msg_free(response); lmb_msg_free(&outer); return -1;
+    }
+    if (inner_body_len)
+        memcpy(response->body, cursor.p + cursor.off, inner_body_len);
+    if (outer.pay_len) memcpy(response->pay, outer.pay, outer.pay_len);
+    lmb_msg_free(&outer);
+    return 0;
+}
+
+static int remote_request(RemoteSegment *remote, uint32_t op,
+                          const void *body, uint32_t body_len,
+                          const void *pay, uint32_t pay_len,
+                          LmbMsg *response) {
+    if (!remote->direct_failed &&
+        (remote->route.transport & LMB_SEG_TRANSPORT_DIRECT)) {
+        remote->transport_error[0] = 0;
+        if (remote->fd < 0) {
+            remote->fd = lmb_connect(remote->route.advert.addr);
+            if (remote->fd < 0)
+                snprintf(remote->transport_error,
+                         sizeof remote->transport_error,
+                         "cannot reach %s at %s: %s",
+                         remote->route.advert.peer_name,
+                         remote->route.advert.addr, lmb_connect_why());
+        }
+        if (remote->fd >= 0) {
+            if (lmb_send(remote->fd, op, body, body_len, pay, pay_len))
+                snprintf(remote->transport_error,
+                         sizeof remote->transport_error,
+                         "%s at %s closed the connection while sending op %u",
+                         remote->route.advert.peer_name,
+                         remote->route.advert.addr, op);
+            else if (lmb_recv(remote->fd, response))
+                snprintf(remote->transport_error,
+                         sizeof remote->transport_error,
+                         "%s at %s sent no reply to op %u",
+                         remote->route.advert.peer_name,
+                         remote->route.advert.addr, op);
+            else return 0;
+        }
+        lmb_msg_free(response);
+        if (remote->fd >= 0) lmb_close(remote->fd);
+        remote->fd = -1;
+        remote->direct_failed = 1;
+    }
+    if (!(remote->route.transport & LMB_SEG_TRANSPORT_RELAY)) return -1;
+    if (!remote_relay_request(remote, op, body, body_len,
+                              pay, pay_len, response)) return 0;
+    size_t used = strlen(remote->transport_error);
+    snprintf(remote->transport_error + used,
+             sizeof remote->transport_error - used,
+             "%stracker relay for %s is unavailable",
+             used ? "; " : "", remote->route.advert.peer_name);
+    return -1;
+}
+
 /* One message for four causes — a filtered port, a dead executor, a rejected
  * OPEN and a malformed reply — costs an operator the whole diagnosis, because
  * the firewall fix and the compatibility fix look identical from here. Say
@@ -305,44 +446,30 @@ static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
         snprintf(why, why_size, "cannot encode the OPEN request");
         return -1;
     }
-    remote->fd = lmb_connect(advert->addr);
-    if (remote->fd < 0) {
-        snprintf(why, why_size, "cannot reach %s at %s: %s",
-                 advert->peer_name, advert->addr, lmb_connect_why());
+    LmbMsg msg = {0};
+    LmbSegReply reply;
+    if (remote_request(remote, LMB_SEG_OPEN, body, body_len,
+                       NULL, 0, &msg)) {
+        snprintf(why, why_size, "%s", remote->transport_error[0]
+                 ? remote->transport_error : "no usable Segment transport");
         free(body);
-        return -1;
-    }
-    if (lmb_send(remote->fd, LMB_SEG_OPEN, body, body_len, NULL, 0)) {
-        snprintf(why, why_size, "%s at %s closed the connection before the "
-                 "OPEN request was sent", advert->peer_name, advert->addr);
-        free(body);
-        lmb_close(remote->fd); remote->fd = -1;
+        lmb_msg_free(&msg);
         return -1;
     }
     free(body);
-    LmbMsg msg = {0};
-    LmbSegReply reply;
-    if (lmb_recv(remote->fd, &msg)) {
-        snprintf(why, why_size, "%s at %s sent no reply to OPEN",
-                 advert->peer_name, advert->addr);
-        lmb_msg_free(&msg);
-        lmb_close(remote->fd); remote->fd = -1;
-        return -1;
-    }
     if (msg.op == LMB_ERR) {
-        snprintf(why, why_size, "%s at %s refused OPEN: %.*s",
-                 advert->peer_name, advert->addr, (int)msg.body_len,
+        snprintf(why, why_size, "%s refused OPEN: %.*s",
+                 advert->peer_name, (int)msg.body_len,
                  msg.body ? (const char *)msg.body : "");
     } else if (msg.op != LMB_SEG_OPEN_R ||
                lmb_seg_reply_decode(msg.body, msg.body_len, &reply)) {
-        snprintf(why, why_size, "%s at %s answered OPEN with an "
-                 "unreadable message (op %u)", advert->peer_name,
-                 advert->addr, msg.op);
+        snprintf(why, why_size, "%s answered OPEN with an unreadable "
+                 "message (op %u)", advert->peer_name, msg.op);
     } else if (reply.status != LMB_SEG_STATUS_OK &&
                reply.status != LMB_SEG_STATUS_DUPLICATE) {
-        snprintf(why, why_size, "%s at %s rejected OPEN [%u:%u]: %s",
-                 advert->peer_name, advert->addr, advert->layer_begin,
-                 advert->layer_end, segment_status_name(reply.status));
+        snprintf(why, why_size, "%s rejected OPEN [%u:%u]: %s",
+                 advert->peer_name, advert->layer_begin, advert->layer_end,
+                 segment_status_name(reply.status));
     } else if (reply_ok(&msg, LMB_SEG_OPEN_R, session_id, &open->request_id,
                         open->owner.route_generation, &reply) || msg.pay_len) {
         /* Accepted, but not for this session/request/route: the placement
@@ -355,10 +482,12 @@ static int remote_open(RemoteSegment *remote, const LmbSegId *session_id,
         lmb_msg_free(&msg);
         remote->sequence = reply.next_sequence;
         remote->position = reply.next_position;
+        remote->opened = 1;
         return 0;
     }
     lmb_msg_free(&msg);
-    lmb_close(remote->fd); remote->fd = -1;
+    if (remote->fd >= 0) lmb_close(remote->fd);
+    remote->fd = -1;
     return -1;
 }
 
@@ -379,12 +508,10 @@ static int remote_run(RemoteSegment *remote, const int32_t *tokens,
     uint32_t body_len = 0;
     if (lmb_seg_run_encode(&run, &body, &body_len) || bytes > UINT32_MAX)
         return -1;
-    int bad = lmb_send(remote->fd, LMB_SEG_RUN, body, body_len,
-                       input, (uint32_t)bytes);
-    if (bad) { free(body); return -1; }
     LmbMsg msg = {0};
     LmbSegReply reply;
-    bad = lmb_recv(remote->fd, &msg) ||
+    int bad = remote_request(remote, LMB_SEG_RUN, body, body_len,
+                             input, (uint32_t)bytes, &msg) ||
           reply_ok(&msg, LMB_SEG_RUN_R, &run.session_id, &run.request_id,
                    run.owner.route_generation, &reply) ||
           msg.pay_len != bytes;
@@ -400,11 +527,11 @@ static int remote_run(RemoteSegment *remote, const int32_t *tokens,
     lmb_msg_free(&msg);
     if (!bad && retry_first_run) {
         retry_first_run = 0;
-        bad = lmb_send(remote->fd, LMB_SEG_RUN, body, body_len,
-                       input, (uint32_t)bytes);
         memset(&msg, 0, sizeof msg);
+        bad = remote_request(remote, LMB_SEG_RUN, body, body_len,
+                             input, (uint32_t)bytes, &msg);
         LmbSegReply duplicate;
-        if (!bad) bad = lmb_recv(remote->fd, &msg) ||
+        if (!bad) bad =
             reply_ok(&msg, LMB_SEG_RUN_R, &run.session_id, &run.request_id,
                      run.owner.route_generation, &duplicate) ||
             duplicate.status != LMB_SEG_STATUS_DUPLICATE ||
@@ -417,8 +544,136 @@ static int remote_run(RemoteSegment *remote, const int32_t *tokens,
     return bad ? -1 : 0;
 }
 
+typedef struct {
+    uint8_t *data;
+    size_t bytes;
+    uint64_t sequence;
+    uint64_t position;
+} RemoteCheckpoint;
+
+static int remote_snapshot(RemoteSegment *remote, RemoteCheckpoint *checkpoint) {
+    memset(checkpoint, 0, sizeof *checkpoint);
+    LmbSegTransfer transfer;
+    memset(&transfer, 0, sizeof transfer);
+    transfer.session_id = remote->open.session_id;
+    lmb_random(transfer.request_id.bytes, sizeof transfer.request_id.bytes);
+    transfer.owner = remote->open.owner;
+    transfer.sequence = remote->sequence;
+    transfer.position = remote->position;
+    transfer.flags = LMB_SEG_XFER_BEGIN | LMB_SEG_XFER_END;
+    uint64_t offset = 0, snapshot_size = 0;
+    uint8_t *data = NULL;
+    for (;;) {
+        uint8_t *body = NULL;
+        uint32_t body_len = 0;
+        if (lmb_seg_transfer_encode(&transfer, &body, &body_len)) {
+            free(data); return -1;
+        }
+        LmbMsg message = {0};
+        int bad = remote_request(remote, LMB_SEG_SNAPSHOT, body, body_len,
+                                 NULL, 0, &message);
+        free(body);
+        LmbSegTransferReply reply;
+        if (!bad)
+            bad = message.op != LMB_SEG_SNAPSHOT_R ||
+                  lmb_seg_transfer_reply_decode(message.body,
+                                                message.body_len, &reply) ||
+                  !lmb_seg_id_equal(&reply.reply.session_id,
+                                    &transfer.session_id) ||
+                  !lmb_seg_id_equal(&reply.reply.request_id,
+                                    &transfer.request_id) ||
+                  reply.reply.status != LMB_SEG_STATUS_OK ||
+                  reply.reply.route_generation !=
+                      transfer.owner.route_generation ||
+                  reply.offset != offset || reply.chunk_len != message.pay_len;
+        if (!bad && !data) {
+            size_t limit = (size_t)lmb_env_int(
+                "LUMABRI_SEGMENT_MAX_SNAPSHOT_MB", 2048, 1, 32768) << 20;
+            if (!reply.snapshot_size || reply.snapshot_size > limit)
+                bad = 1;
+            else {
+                snapshot_size = reply.snapshot_size;
+                data = malloc((size_t)snapshot_size);
+                if (!data) bad = 1;
+            }
+        }
+        if (!bad && (reply.snapshot_size != snapshot_size ||
+                     reply.offset > snapshot_size ||
+                     reply.chunk_len > snapshot_size - reply.offset)) bad = 1;
+        /* A non-final empty chunk would never advance offset and could keep a
+         * broken or malicious executor in this loop forever. */
+        if (!bad && !reply.chunk_len &&
+            !(reply.transfer_flags & LMB_SEG_XFER_END)) bad = 1;
+        if (!bad && reply.chunk_len)
+            memcpy(data + reply.offset, message.pay, reply.chunk_len);
+        if (!bad) offset += reply.chunk_len;
+        int complete = !bad && (reply.transfer_flags & LMB_SEG_XFER_END);
+        lmb_msg_free(&message);
+        if (bad || (complete && offset != snapshot_size)) {
+            free(data); return -1;
+        }
+        if (complete) break;
+        transfer.snapshot_size = snapshot_size;
+        transfer.offset = offset;
+        uint64_t remaining = snapshot_size - offset;
+        transfer.chunk_len = (uint32_t)(remaining < REMOTE_SNAPSHOT_CHUNK
+                                      ? remaining : REMOTE_SNAPSHOT_CHUNK);
+        transfer.flags = transfer.chunk_len == remaining ? LMB_SEG_XFER_END : 0;
+    }
+    checkpoint->data = data;
+    checkpoint->bytes = (size_t)snapshot_size;
+    checkpoint->sequence = remote->sequence;
+    checkpoint->position = remote->position;
+    return 0;
+}
+
+static int remote_restore(RemoteSegment *remote, const RemoteCheckpoint *source) {
+    if (!source || !source->data || !source->bytes) return -1;
+    LmbSegTransfer transfer;
+    memset(&transfer, 0, sizeof transfer);
+    transfer.session_id = remote->open.session_id;
+    lmb_random(transfer.request_id.bytes, sizeof transfer.request_id.bytes);
+    transfer.owner = remote->open.owner;
+    transfer.sequence = source->sequence;
+    transfer.position = source->position;
+    transfer.snapshot_size = source->bytes;
+    for (size_t offset = 0; offset < source->bytes; ) {
+        size_t remaining = source->bytes - offset;
+        size_t chunk = remaining < REMOTE_SNAPSHOT_CHUNK
+                     ? remaining : REMOTE_SNAPSHOT_CHUNK;
+        transfer.offset = offset;
+        transfer.chunk_len = (uint32_t)chunk;
+        transfer.flags = (!offset ? LMB_SEG_XFER_BEGIN : 0) |
+                         (chunk == remaining ? LMB_SEG_XFER_END : 0);
+        uint8_t *body = NULL;
+        uint32_t body_len = 0;
+        if (lmb_seg_transfer_encode(&transfer, &body, &body_len)) return -1;
+        LmbMsg message = {0};
+        int bad = remote_request(remote, LMB_SEG_RESTORE, body, body_len,
+                                 source->data + offset, (uint32_t)chunk,
+                                 &message);
+        free(body);
+        LmbSegReply reply;
+        if (!bad)
+            bad = reply_ok(&message, LMB_SEG_RESTORE_R,
+                           &transfer.session_id, &transfer.request_id,
+                           transfer.owner.route_generation, &reply) ||
+                  message.pay_len;
+        lmb_msg_free(&message);
+        if (bad) return -1;
+        offset += chunk;
+        if (offset == source->bytes) {
+            if (reply.next_sequence != source->sequence ||
+                reply.next_position != source->position) return -1;
+            remote->sequence = reply.next_sequence;
+            remote->position = reply.next_position;
+        }
+    }
+    return 0;
+}
+
 static void remote_close(RemoteSegment *remote) {
-    if (remote->fd < 0) return;
+    if (!remote->opened) return;
     LmbSegControl control;
     memset(&control, 0, sizeof control);
     control.session_id = remote->open.session_id;
@@ -428,19 +683,28 @@ static void remote_close(RemoteSegment *remote) {
     uint8_t *body = NULL;
     uint32_t body_len = 0;
     if (!lmb_seg_control_encode(&control, &body, &body_len)) {
-        (void)lmb_send(remote->fd, LMB_SEG_CLOSE, body, body_len, NULL, 0);
         LmbMsg reply = {0};
-        if (!lmb_recv(remote->fd, &reply)) lmb_msg_free(&reply);
+        if (!remote_request(remote, LMB_SEG_CLOSE, body, body_len,
+                            NULL, 0, &reply))
+            lmb_msg_free(&reply);
     }
     free(body);
-    lmb_close(remote->fd);
+    if (remote->fd >= 0) lmb_close(remote->fd);
     remote->fd = -1;
+    remote->opened = 0;
+}
+
+static void remote_dispose(RemoteSegment *remote) {
+    remote_close(remote);
+    free(remote->snapshot);
+    remote->snapshot = NULL;
+    remote->snapshot_bytes = 0;
 }
 
 static void conversation_reset(SegmentConversation *conversation) {
     if (!conversation) return;
     for (size_t i = 0; i < conversation->chain_count; i++)
-        remote_close(&conversation->chain[i]);
+        remote_dispose(&conversation->chain[i]);
     free(conversation->committed_tokens);
     memset(conversation, 0, sizeof *conversation);
 }
@@ -467,12 +731,201 @@ static int chain_run(RemoteSegment *chain, size_t count,
                      uint8_t **first, uint8_t **second, size_t bytes) {
     uint8_t *input = *first, *output = *second;
     for (size_t i = 0; i < count; i++) {
-        if (remote_run(&chain[i], tokens, rows, input, bytes, output)) return -1;
+        if (remote_run(&chain[i], tokens, rows, input, bytes, output))
+            return -(int)i - 1;
         uint8_t *swap = input; input = output; output = swap;
     }
     *first = input;
     *second = output;
     return 0;
+}
+
+static int conversation_checkpoint(SegmentConversation *conversation,
+                                   size_t token_count) {
+    if (!conversation || !conversation->active) return -1;
+    RemoteCheckpoint checkpoints[LMB_SEG_ROUTE_MAX];
+    memset(checkpoints, 0, sizeof checkpoints);
+    size_t completed = 0;
+    for (; completed < conversation->chain_count; completed++)
+        if (remote_snapshot(&conversation->chain[completed],
+                            &checkpoints[completed])) break;
+    if (completed != conversation->chain_count) {
+        for (size_t i = 0; i < completed; i++) free(checkpoints[i].data);
+        return -1;
+    }
+    for (size_t i = 0; i < conversation->chain_count; i++) {
+        RemoteSegment *remote = &conversation->chain[i];
+        free(remote->snapshot);
+        remote->snapshot = checkpoints[i].data;
+        remote->snapshot_bytes = checkpoints[i].bytes;
+        remote->snapshot_sequence = checkpoints[i].sequence;
+        remote->snapshot_position = checkpoints[i].position;
+    }
+    conversation->checkpoint_count = token_count;
+    return 0;
+}
+
+static int route_same_range(const LmbSegRouteEntry *a,
+                            const LmbSegRouteEntry *b,
+                            uint32_t context, uint32_t max_rows) {
+    return a->advert.layer_begin == b->advert.layer_begin &&
+           a->advert.layer_end == b->advert.layer_end &&
+           a->advert.max_context >= context &&
+           a->advert.max_rows >= max_rows &&
+           a->advert.state_dtype == b->advert.state_dtype &&
+           a->advert.state_width == b->advert.state_width &&
+           !strcmp(a->advert.engine_id, b->advert.engine_id) &&
+           !strcmp(a->advert.state_schema, b->advert.state_schema) &&
+           !strcmp(a->advert.numeric_class, b->advert.numeric_class) &&
+           (a->transport & (LMB_SEG_TRANSPORT_DIRECT |
+                            LMB_SEG_TRANSPORT_RELAY));
+}
+
+/* Serializing opaque KV/recurrent state is useful only when the immutable
+ * route snapshot contains somewhere to restore it. Avoid copying and sending
+ * a potentially large checkpoint on an origin-only swarm where failover is
+ * impossible anyway. When any selected range has a replica, all ranges are
+ * snapshotted so a replacement chain can be restored at one common token. */
+static int conversation_has_replica(
+    const SegmentConversation *conversation,
+    const LmbSegRouteSnapshot *snapshot,
+    uint32_t context, uint32_t max_rows) {
+    if (!conversation || !snapshot) return 0;
+    for (size_t i = 0; i < conversation->chain_count; i++)
+        for (uint32_t j = 0; j < snapshot->count; j++) {
+            const LmbSegRouteEntry *current = &conversation->chain[i].route;
+            const LmbSegRouteEntry *candidate = &snapshot->entries[j];
+            if (strcmp(candidate->advert.peer_name,
+                       current->advert.peer_name) &&
+                route_same_range(candidate, current, context, max_rows))
+                return 1;
+        }
+    return 0;
+}
+
+static int conversation_recover(
+    SegmentConversation *conversation,
+    const LmbSegRouteSnapshot *snapshot, size_t failed_index,
+    ColiEdgeEngine *edge, const ColiEdgeCapabilities *cap,
+    const uint8_t model_root[32], const uint8_t tokenizer_root[32],
+    uint32_t context, uint32_t max_rows,
+    const int32_t *prompt_tokens, size_t prompt_replayed,
+    const int32_t *generated, size_t generated_replayed,
+    uint8_t *buffer_a, uint8_t *buffer_b,
+    char *error, size_t error_size) {
+    if (!conversation || !conversation->active || !snapshot ||
+        failed_index >= conversation->chain_count) return -1;
+    RemoteSegment replacement[LMB_SEG_ROUTE_MAX];
+    memset(replacement, 0, sizeof replacement);
+    for (size_t i = 0; i < conversation->chain_count; i++) {
+        const LmbSegRouteEntry *current = &conversation->chain[i].route;
+        const LmbSegRouteEntry *chosen = current;
+        if (i == failed_index) {
+            chosen = NULL;
+            for (uint32_t j = 0; j < snapshot->count; j++) {
+                const LmbSegRouteEntry *candidate = &snapshot->entries[j];
+                if (!strcmp(candidate->advert.peer_name,
+                            current->advert.peer_name) ||
+                    !route_same_range(candidate, current,
+                                      context, max_rows)) continue;
+                if (!chosen ||
+                    ((candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
+                     !(chosen->transport & LMB_SEG_TRANSPORT_DIRECT)) ||
+                    ((candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK) == 0 &&
+                     (chosen->advert.flags & LMB_SEG_ADVERT_FALLBACK)))
+                    chosen = candidate;
+            }
+            if (!chosen) {
+                snprintf(error, error_size,
+                         "Segment peer failed and no compatible replica exists");
+                return -1;
+            }
+        }
+        replacement[i].route = *chosen;
+        replacement[i].fd = -1;
+    }
+
+    LmbSegId session_id;
+    lmb_random(session_id.bytes, sizeof session_id.bytes);
+    size_t opened = 0;
+    for (; opened < conversation->chain_count; opened++) {
+        if (remote_open(&replacement[opened], &session_id,
+                        model_root, tokenizer_root, context, max_rows,
+                        error, error_size)) break;
+        if (conversation->checkpoint_count) {
+            RemoteSegment *old = &conversation->chain[opened];
+            RemoteCheckpoint checkpoint = {
+                old->snapshot, old->snapshot_bytes,
+                old->snapshot_sequence, old->snapshot_position,
+            };
+            if (!checkpoint.data ||
+                checkpoint.position != conversation->checkpoint_count ||
+                remote_restore(&replacement[opened], &checkpoint)) break;
+        }
+    }
+    if (opened != conversation->chain_count) {
+        for (size_t i = 0; i <= opened && i < conversation->chain_count; i++)
+            remote_dispose(&replacement[i]);
+        snprintf(error, error_size,
+                 "Segment replica could not restore the last checkpoint");
+        return -1;
+    }
+
+    size_t total = prompt_replayed + generated_replayed;
+    int32_t *history = total ? malloc(total * sizeof *history) : NULL;
+    if (total && !history) goto recovery_failed;
+    if (prompt_replayed)
+        memcpy(history, prompt_tokens, prompt_replayed * sizeof *history);
+    if (generated_replayed)
+        memcpy(history + prompt_replayed, generated,
+               generated_replayed * sizeof *history);
+    if (conversation->checkpoint_count > total) {
+        free(history); goto recovery_failed;
+    }
+    for (size_t offset = conversation->checkpoint_count;
+         offset < total; offset += max_rows) {
+        uint32_t rows = (uint32_t)(total - offset);
+        if (rows > max_rows) rows = max_rows;
+        size_t bytes = lmb_state_bytes(rows, cap->state_width, cap->state_dtype);
+        ColiEdgeEmbedRequest embed = {
+            .struct_size = sizeof embed, .rows = rows,
+            .token_ids = history + offset, .token_count = rows,
+            .output = buffer_a, .output_bytes = bytes,
+        };
+        if (coli_edge_embed(edge, &embed, error, error_size)) {
+            free(history); goto recovery_failed;
+        }
+        uint8_t *first = buffer_a, *second = buffer_b;
+        if (chain_run(replacement, conversation->chain_count,
+                      history + offset, rows, &first, &second, bytes)) {
+            free(history); goto recovery_failed;
+        }
+    }
+    free(history);
+    for (size_t i = 0; i < conversation->chain_count; i++) {
+        RemoteSegment *old = &conversation->chain[i];
+        replacement[i].snapshot = old->snapshot;
+        replacement[i].snapshot_bytes = old->snapshot_bytes;
+        replacement[i].snapshot_sequence = old->snapshot_sequence;
+        replacement[i].snapshot_position = old->snapshot_position;
+        old->snapshot = NULL; old->snapshot_bytes = 0;
+        remote_dispose(old);
+        *old = replacement[i];
+    }
+    conversation->route_generation = snapshot->route_generation;
+    fprintf(stderr, "[lumabri] Segment failover: restored checkpoint at token "
+                    "%zu and replayed %zu token%s\n",
+            conversation->checkpoint_count,
+            total - conversation->checkpoint_count,
+            total - conversation->checkpoint_count == 1 ? "" : "s");
+    return 0;
+
+recovery_failed:
+    for (size_t i = 0; i < conversation->chain_count; i++)
+        remote_dispose(&replacement[i]);
+    snprintf(error, error_size,
+             "Segment checkpoint replay failed on the replacement chain");
+    return -1;
 }
 
 static double monotonic_seconds(void) {
@@ -497,7 +950,10 @@ static int segment_generate(ColiEdgeEngine *edge,
                             const char *prompt, size_t prompt_bytes,
                             const int32_t *provided_tokens,
                             size_t provided_count, uint32_t wanted_tokens,
+                            double temperature, double top_p,
+                            LmbSampler *sampler,
                             SegmentConversation *conversation,
+                            const LmbSegRouteSnapshot *route_snapshot,
                             uint64_t route_generation,
                             GenerationResult *result,
                             char *error, size_t error_size) {
@@ -510,6 +966,7 @@ static int segment_generate(ColiEdgeEngine *edge,
     int32_t *prompt_tokens = NULL;
     int32_t *generated = NULL;
     uint8_t *buffer_a = NULL, *buffer_b = NULL;
+    float *logits = NULL;
     RemoteSegment *active_chain = chain;
     size_t active_count = chain_count;
     size_t prefilled = 0;
@@ -597,11 +1054,20 @@ static int segment_generate(ColiEdgeEngine *edge,
         goto cleanup;
     }
     generated = malloc((size_t)wanted_tokens * sizeof *generated);
+    if (temperature > 0.0) {
+        if (!(cap->flags & COLI_EDGE_CAP_LOGITS) || !sampler) {
+            snprintf(error, error_size,
+                     "Colibri Edge logits are unavailable for sampling");
+            goto cleanup;
+        }
+        logits = malloc((size_t)cap->vocab_size * sizeof *logits);
+    }
     size_t max_bytes = lmb_state_bytes(max_rows, cap->state_width,
                                        cap->state_dtype);
     buffer_a = max_bytes ? malloc(max_bytes) : NULL;
     buffer_b = max_bytes ? malloc(max_bytes) : NULL;
-    if (!generated || !buffer_a || !buffer_b) {
+    if (!generated || !buffer_a || !buffer_b ||
+        (temperature > 0.0 && !logits)) {
         snprintf(error, error_size, "out of memory preparing Segment run");
         goto cleanup;
     }
@@ -619,11 +1085,26 @@ static int segment_generate(ColiEdgeEngine *edge,
         };
         if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
         uint8_t *first = buffer_a, *second = buffer_b;
-        if (chain_run(active_chain, active_count, prompt_tokens + offset, rows,
-                      &first, &second, bytes)) {
-            snprintf(error, error_size, "Segment peer failed; checkpoint/replay "
-                     "is not available yet");
+        int failed = chain_run(active_chain, active_count,
+                               prompt_tokens + offset, rows,
+                               &first, &second, bytes);
+        if (failed && (!conversation || !route_snapshot ||
+            conversation_recover(conversation, route_snapshot,
+                                 (size_t)(-failed - 1), edge, cap,
+                                 model_root, tokenizer_root, context, max_rows,
+                                 prompt_tokens, offset, NULL, 0,
+                                 buffer_a, buffer_b, error, error_size))) {
+            if (!error[0])
+                snprintf(error, error_size,
+                         "Segment peer failed and recovery was unavailable");
             goto cleanup;
+        }
+        if (failed) {
+            if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
+            first = buffer_a; second = buffer_b;
+            if (chain_run(active_chain, active_count,
+                          prompt_tokens + offset, rows,
+                          &first, &second, bytes)) goto cleanup;
         }
         final_state = first;
         final_rows = rows;
@@ -634,12 +1115,25 @@ static int segment_generate(ColiEdgeEngine *edge,
     size_t element = cap->state_dtype == COLI_EDGE_DTYPE_F32 ? 4u : 2u;
     const uint8_t *last = final_state +
         (size_t)(final_rows - 1) * cap->state_width * element;
+    size_t state_row_bytes = (size_t)cap->state_width * element;
     ColiEdgeSelectRequest select = {
         .struct_size = sizeof select, .rows = 1,
-        .input = last, .input_bytes = (size_t)cap->state_width * element,
+        .input = last, .input_bytes = state_row_bytes,
         .token_ids = generated, .token_capacity = 1,
     };
-    if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
+    ColiEdgeLogitsRequest logits_request = {
+        .struct_size = sizeof logits_request, .rows = 1,
+        .input = last, .input_bytes = state_row_bytes,
+        .logits = logits, .logits_capacity = cap->vocab_size,
+    };
+    if (temperature > 0.0) {
+        if (coli_edge_logits(edge, &logits_request, error, error_size) ||
+            lmb_sample_logits(sampler, logits, cap->vocab_size,
+                              temperature, top_p, generated)) {
+            if (!error[0]) snprintf(error, error_size, "sampling failed");
+            goto cleanup;
+        }
+    } else if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
     size_t generated_count = 1;
     while (generated_count < wanted_tokens &&
            generated[generated_count - 1] != cap->eos_token_id) {
@@ -652,15 +1146,39 @@ static int segment_generate(ColiEdgeEngine *edge,
         };
         if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
         uint8_t *first = buffer_a, *second = buffer_b;
-        if (chain_run(active_chain, active_count, &token, 1,
-                      &first, &second, bytes)) {
-            snprintf(error, error_size, "Segment peer failed; checkpoint/replay "
-                     "is not available yet");
+        int failed = chain_run(active_chain, active_count, &token, 1,
+                               &first, &second, bytes);
+        if (failed && (!conversation || !route_snapshot ||
+            conversation_recover(conversation, route_snapshot,
+                                 (size_t)(-failed - 1), edge, cap,
+                                 model_root, tokenizer_root, context, max_rows,
+                                 prompt_tokens, prompt_count,
+                                 generated, generated_count - 1,
+                                 buffer_a, buffer_b, error, error_size))) {
+            if (!error[0])
+                snprintf(error, error_size,
+                         "Segment peer failed and recovery was unavailable");
             goto cleanup;
+        }
+        if (failed) {
+            if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
+            first = buffer_a; second = buffer_b;
+            if (chain_run(active_chain, active_count, &token, 1,
+                          &first, &second, bytes)) goto cleanup;
         }
         select.input = first;
         select.token_ids = generated + generated_count;
-        if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
+        logits_request.input = first;
+        if (temperature > 0.0) {
+            if (coli_edge_logits(edge, &logits_request, error, error_size) ||
+                lmb_sample_logits(sampler, logits, cap->vocab_size,
+                                  temperature, top_p,
+                                  generated + generated_count)) {
+                if (!error[0]) snprintf(error, error_size, "sampling failed");
+                goto cleanup;
+            }
+        } else if (coli_edge_select(edge, &select, error, error_size))
+            goto cleanup;
         generated_count++;
     }
     /* The token that stopped generation is a control marker, not text. The
@@ -687,6 +1205,12 @@ static int segment_generate(ColiEdgeEngine *edge,
     if (conversation) {
         size_t generated_committed = generated_count ? generated_count - 1 : 0;
         size_t committed_count = prompt_count + generated_committed;
+        if (conversation_has_replica(conversation, route_snapshot,
+                                     context, max_rows) &&
+            conversation_checkpoint(conversation, committed_count))
+            fprintf(stderr, "[lumabri] Segment checkpoint unavailable; "
+                            "failover will replay from token %zu\n",
+                    conversation->checkpoint_count);
         if (committed_count > SIZE_MAX / sizeof *prompt_tokens) {
             free(text); goto cleanup;
         }
@@ -726,6 +1250,7 @@ cleanup:
     }
     free(prompt_tokens);
     free(generated);
+    free(logits);
     free(buffer_a);
     free(buffer_b);
     return rc;
@@ -775,11 +1300,12 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
                               LmbSegDiscovery *discovery,
                               const uint8_t model_root[32],
                               const uint8_t tokenizer_root[32],
-                              uint32_t context, uint32_t max_rows) {
+                              uint32_t context, uint32_t max_rows,
+                              uint64_t seed) {
     printf(SEGMENT_FRAME_READY "\nSTAT 0 0 0 0\n");
     fflush(stdout);
-    fprintf(stderr, "[lumabri] Segment Edge v1 is greedy; temperature/top-p "
-            "remain on the classic path\n");
+    LmbSampler sampler;
+    lmb_sampler_init(&sampler, seed);
     SegmentConversation conversation;
     memset(&conversation, 0, sizeof conversation);
     char header[512];
@@ -791,12 +1317,14 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
         if (sscanf(header, "SUBMIT %u %u %zu %u %lf %lf %c",
                    &request_id, &slot, &prompt_bytes, &max_tokens,
                    &temperature, &top_p, &trailing) != 6 ||
-            !max_tokens || max_tokens > 4096 || prompt_bytes > (64u << 20)) {
+            !max_tokens || max_tokens > 4096 || prompt_bytes > (64u << 20) ||
+            !isfinite(temperature) || temperature < 0.0 || temperature > 100.0 ||
+            !isfinite(top_p) || top_p <= 0.0 || top_p > 1.0) {
             printf("ERROR %u invalid Segment SUBMIT\n", request_id);
             fflush(stdout);
             continue;
         }
-        (void)slot; (void)temperature; (void)top_p;
+        (void)slot;
         char *prompt = malloc(prompt_bytes + 1);
         if (!prompt || read_exact_stdin(prompt, prompt_bytes)) {
             free(prompt); conversation_reset(&conversation); return 1;
@@ -813,11 +1341,14 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
         int have = lmb_seg_discovery_snapshot(discovery, &snapshot);
         RemoteSegment chain[LMB_SEG_ROUTE_MAX];
         size_t chain_count = 0;
-        char error[256] = "no complete compatible Segment chain";
+        char error[256] = {0};
         GenerationResult result;
         int bad = have <= 0 || !snapshot.complete ||
                   select_chain(&snapshot, cap->num_layers, context, max_rows,
                                chain, &chain_count);
+        if (bad)
+            snprintf(error, sizeof error,
+                     "no complete compatible Segment chain");
         if (!bad) {
             if (conversation.active && conversation.route_generation !=
                                        snapshot.route_generation)
@@ -826,7 +1357,9 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
             bad = segment_generate(edge, cap, chain, chain_count,
                                    model_root, tokenizer_root,
                                    context, max_rows, prompt, prompt_bytes,
-                                   NULL, 0, max_tokens, &conversation,
+                                   NULL, 0, max_tokens,
+                                   temperature, top_p, &sampler, &conversation,
+                                   &snapshot,
                                    snapshot.route_generation, &result,
                                    error, sizeof error);
         }
@@ -865,6 +1398,7 @@ int main(int argc, char **argv) {
     const char *prompt_ids_text = arg_value(argc, argv, "--prompt-ids");
     const char *expect_ids_text = arg_value(argc, argv, "--expect-ids");
     int serve_mode = has_arg(argc, argv, "--serve");
+    segment_tracker = tracker;
     for (int i = 1; i < argc; i++)
         if (!strcmp(argv[i], "--retry-first-run")) retry_first_run = 1;
     if (!engine_id || !model_dir || !model || !tracker ||
@@ -882,6 +1416,18 @@ int main(int argc, char **argv) {
     if (value && lmb_parse_u32(value, 1, 4096, &wanted_tokens)) {
         usage(argv[0]); return 2;
     }
+    double temperature = 0.0, top_p = 0.95;
+    if (((value = arg_value(argc, argv, "--temperature")) &&
+         parse_double(value, 0.0, 100.0, &temperature)) ||
+        ((value = arg_value(argc, argv, "--top-p")) &&
+         parse_double(value, 0.000001, 1.0, &top_p)) ||
+        (arg_value(argc, argv, "--seed") &&
+         parse_u64(arg_value(argc, argv, "--seed"), &(uint64_t){0}))) {
+        usage(argv[0]); return 2;
+    }
+    uint64_t seed = sampler_seed(arg_value(argc, argv, "--seed"));
+    LmbSampler sampler;
+    lmb_sampler_init(&sampler, seed);
     int32_t *expected = NULL;
     size_t expected_count = 0;
     if (expect_ids_text &&
@@ -948,7 +1494,8 @@ int main(int argc, char **argv) {
     query.state_dtype = cap.state_dtype;
     query.state_width = cap.state_width;
     query.required_capabilities = LMB_SEG_CAP_RANGE_NATIVE |
-                                  LMB_SEG_CAP_MULTI_SESSION;
+                                  LMB_SEG_CAP_MULTI_SESSION |
+                                  LMB_SEG_CAP_SNAPSHOT;
     snprintf(query.engine_id, sizeof query.engine_id, "%s", cap.engine_id);
     snprintf(query.state_schema, sizeof query.state_schema, "%s", cap.state_schema);
     snprintf(query.numeric_class, sizeof query.numeric_class, "%s", cap.numeric_class);
@@ -1017,7 +1564,7 @@ int main(int argc, char **argv) {
     if (serve_mode) {
         int result = segment_serve_loop(edge, &cap, discovery,
                                         model_root, tokenizer_root,
-                                        context, max_rows);
+                                        context, max_rows, seed);
         lmb_seg_discovery_stop(discovery);
         coli_edge_engine_close(edge);
         free(expected);
@@ -1040,7 +1587,7 @@ int main(int argc, char **argv) {
                                context, max_rows,
                                prompt, prompt ? strlen(prompt) : 0,
                                prompt_tokens, prompt_count, wanted_tokens,
-                               NULL, 0,
+                               temperature, top_p, &sampler, NULL, &snapshot, 0,
                                &generated, error, sizeof error);
     free(prompt_tokens);
     if (bad) {

--- a/segment_direct_test.sh
+++ b/segment_direct_test.sh
@@ -7,6 +7,7 @@ cd "$(dirname "$0")"
 
 SEGMENT_NODE_BIN=${SEGMENT_NODE_BIN:-./segment_node}
 SEGMENT_CHAT_BIN=${SEGMENT_CHAT_BIN:-./segment_chat}
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
 
 : "${GLM_EDGE_MODEL:?set GLM_EDGE_MODEL}"
 : "${GLM_EDGE_REF:?set GLM_EDGE_REF}"
@@ -48,7 +49,7 @@ wait_port() {
 
 env LUMABRI_PEER_KEY="$TMP/tracker.peer.key" \
     LUMABRI_KNOWN_HOSTS="$TMP/tracker.known_hosts" \
-    ./tracker --port 7868 --peer-bindings "$TMP/bindings" \
+    "$TRACKER_BIN" --port 7868 --peer-bindings "$TMP/bindings" \
     >"$TMP/tracker.log" 2>&1 &
 TRACKER_PID=$!
 wait_port 7868

--- a/segment_failover_test.sh
+++ b/segment_failover_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Kill the selected non-fallback executor after turn one. Turn two must restore
+# every range at the common checkpoint, replace the dead range with its exact
+# origin replica and replay the token delta without ending the conversation.
+set -euo pipefail
+cd "$(dirname "$0")"
+: "${OLMOE_EDGE_MODEL:?set OLMOE_EDGE_MODEL}"
+SEGMENT_NODE_BIN=${SEGMENT_NODE_BIN:-./segment_node}
+SEGMENT_CHAT_BIN=${SEGMENT_CHAT_BIN:-./segment_chat}
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
+TMP=$(mktemp -d /tmp/lumabri-segment-failover.XXXXXX)
+PIDS=()
+cleanup() {
+    for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+    for pid in "${PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+wait_port() {
+    local port=$1
+    for _ in $(seq 1 200); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            exec 3<&-; exec 3>&-; return 0
+        fi
+        sleep 0.025
+    done
+    return 1
+}
+env LUMABRI_PEER_KEY="$TMP/tracker.key" LUMABRI_KNOWN_HOSTS="$TMP/known" \
+    "$TRACKER_BIN" --port 8068 --peer-bindings "$TMP/bindings" \
+    >"$TMP/tracker.log" 2>&1 &
+PIDS+=("$!"); wait_port 8068
+root=$(printf '%064x' 101); tok=$(printf '%064x' 102)
+common=(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/node.key"
+        LUMABRI_KNOWN_HOSTS="$TMP/known")
+start_node() {
+    local range=$1 port=$2 name=$3 fallback=$4
+    "${common[@]}" "$SEGMENT_NODE_BIN" --engine olmoe \
+        --model-dir "$OLMOE_EDGE_MODEL" --model tiny-failover \
+        --range "$range" --port "$port" --tracker 127.0.0.1:8068 \
+        --advertise "127.0.0.1:$port" --name "$name" \
+        --model-root "$root" --tokenizer-root "$tok" --context 64 \
+        --max-rows 16 --sessions 4 $fallback >"$TMP/$name.log" 2>&1 &
+    LAST_PID=$!; PIDS+=("$LAST_PID"); wait_port "$port"
+}
+start_node 0:2 8069 origin-left --fallback
+start_node 2:4 8070 origin-right --fallback
+start_node 0:2 8071 donor-left ""
+DONOR_PID=$LAST_PID
+sleep 1
+
+env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
+    LUMABRI_KNOWN_HOSTS="$TMP/known" LUMABRI_SAMPLE_SEED=11 \
+    python3 - "$DONOR_PID" "$SEGMENT_CHAT_BIN" "$OLMOE_EDGE_MODEL" "$root" "$tok" <<'PY'
+import os, subprocess, sys, time
+donor, binary, model_dir, root, tok = sys.argv[1:]
+p = subprocess.Popen([
+    binary, "--serve", "--engine", "olmoe",
+    "--model-dir", model_dir, "--model", "tiny-failover",
+    "--tracker", "127.0.0.1:8068", "--model-root", root,
+    "--tokenizer-root", tok, "--context", "64", "--max-rows", "16",
+], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+def line():
+    value = p.stdout.readline()
+    if not value: raise RuntimeError("Segment gateway closed")
+    return value
+if b"READY" not in line() or not line().startswith(b"STAT "):
+    raise RuntimeError("gateway not ready")
+def turn(rid, prompt):
+    p.stdin.write(f"SUBMIT {rid} 0 {len(prompt)} 1 0.7 0.95\n".encode()+prompt+b"\n")
+    p.stdin.flush()
+    if line() != f"ACCEPT {rid}\n".encode(): raise RuntimeError("not accepted")
+    head=line().split(); size=int(head[2]); p.stdout.read(size)
+    if p.stdout.read(1) != b"\n": raise RuntimeError("truncated data")
+    if not line().startswith(f"DONE {rid} STAT ".encode()): raise RuntimeError("no done")
+turn(1, b"hi\n")
+os.kill(int(donor), 15)
+time.sleep(.3)
+turn(2, b"hi\nthere\n")
+p.stdin.close()
+if p.wait(timeout=30): raise RuntimeError("gateway failed")
+diagnostics=p.stderr.read().decode("utf-8", "replace")
+if "Segment failover: restored checkpoint" not in diagnostics:
+    raise RuntimeError("checkpoint failover did not run:\n"+diagnostics)
+PY
+echo "SEGMENT FAILOVER: PASS (checkpoint restore + replay after peer death)"

--- a/segment_native_test.sh
+++ b/segment_native_test.sh
@@ -33,8 +33,8 @@ mkdir -p "$TMP/server-home" "$TMP/client-home"
 HOME="$TMP/server-home" ./lumabri key --out "$TMP/swarm" >/dev/null
 
 HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 OMP_NUM_THREADS=2 \
-    ./lumabri serve --model "$OLMOE_EDGE_MODEL" --port 7880 \
-    --advertise 127.0.0.1 --key "$TMP/swarm.key" \
+    stdbuf -oL -eL ./lumabri serve --model "$OLMOE_EDGE_MODEL" --port 7880 \
+    --key "$TMP/swarm.key" \
     >"$TMP/server.log" 2>&1 &
 SERVER_PID=$!
 
@@ -53,6 +53,7 @@ status=$?
 set -e
 if (( status != 0 )) || ! grep -q 'pronto via Segment' "$TMP/chat.log" ||
    ! grep -q 'Segment context negotiated to' "$TMP/chat.log" ||
+   ! grep -q 'data plane relay (nessuna porta pubblica richiesta)' "$TMP/server.log" ||
    grep -q 'continuo con il percorso expert/CAS' "$TMP/chat.log" ||
    grep -q 'Segment route generation' "$TMP/chat.log"; then
     cat "$TMP/server.log" "$TMP/chat.log"
@@ -60,4 +61,4 @@ if (( status != 0 )) || ! grep -q 'pronto via Segment' "$TMP/chat.log" ||
     exit 1
 fi
 
-echo "SEGMENT NATIVE: PASS (serve + TUI chat, automatic context negotiation)"
+echo "SEGMENT NATIVE: PASS (serve + TUI chat, NAT relay + context negotiation)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -17,6 +17,7 @@
 
 #define NODE_SESSIONS_MAX 256u
 #define NODE_CONNECTIONS_MAX 256u
+#define NODE_SNAPSHOT_CHUNK (1u << 20)
 
 typedef struct {
     int used;
@@ -26,11 +27,26 @@ typedef struct {
     LmbSegId cached_request;
     uint8_t *cached_output;
     size_t cached_bytes;
+    uint8_t *snapshot;
+    size_t snapshot_bytes;
+    uint64_t snapshot_sequence;
+    uint64_t snapshot_position;
+    uint8_t *restore;
+    size_t restore_bytes;
+    size_t restore_received;
+    LmbSegTransfer restore_transfer;
+    uint64_t restore_updated_ms;
+    int restore_active;
+    LmbSegId restored_request;
+    uint64_t restored_sequence;
+    uint64_t restored_position;
+    int restored_valid;
 } NodeSession;
 
 typedef struct {
     pthread_mutex_t lock;
     char tracker[256];
+    char local_addr[64];
     LmbSegAdvert advert;
     uint8_t pk[32], sk[64];
     LmbSegOwner owner;
@@ -85,8 +101,8 @@ static int registration_owner(TrackerRegistration *r,
     return ok;
 }
 
-static int tracker_heartbeat(int fd, const uint8_t nonce[32],
-                             TrackerRegistration *r) {
+static int tracker_register_send(int fd, const uint8_t nonce[32],
+                                 TrackerRegistration *r) {
     LmbSegAdvert advert;
     pthread_mutex_lock(&r->lock);
     advert = r->advert;
@@ -106,22 +122,63 @@ static int tracker_heartbeat(int fd, const uint8_t nonce[32],
         return -1;
     }
     free(body.p);
-    LmbMsg reply = {0};
+    return 0;
+}
+
+static int tracker_registration_reply(TrackerRegistration *r,
+                                      const LmbMsg *reply) {
     LmbSegOwner owner;
-    int received = !lmb_recv(fd, &reply);
-    if (received && reply.op == LMB_ERR)
-        fprintf(stderr, "[segment-node] tracker rejected registration: %.*s\n",
-                (int)reply.body_len, reply.body ? (char *)reply.body : "");
-    int bad = !received || reply.op != LMB_SEG_REGISTER_R || reply.pay_len ||
-              lmb_seg_registration_reply_decode(reply.body, reply.body_len,
-                                                 &owner);
-    lmb_msg_free(&reply);
-    if (bad) return -1;
+    if (reply->op != LMB_SEG_REGISTER_R || reply->pay_len ||
+        lmb_seg_registration_reply_decode(reply->body, reply->body_len, &owner))
+        return -1;
     pthread_mutex_lock(&r->lock);
     r->owner = owner;
     r->ready = 1;
     pthread_mutex_unlock(&r->lock);
     return 0;
+}
+
+static int segment_request_op(uint32_t op) {
+    return op == LMB_SEG_OPEN || op == LMB_SEG_RUN ||
+           op == LMB_SEG_SNAPSHOT || op == LMB_SEG_RESTORE ||
+           op == LMB_SEG_CLOSE || op == LMB_SEG_HEALTH;
+}
+
+static int handle_rseg_fwd(TrackerRegistration *r, int tracker_fd,
+                           const LmbMsg *forward) {
+    LmbCur cursor = { forward->body, forward->body_len, 0 };
+    uint32_t relay_id = 0, inner_op = 0, inner_body_len = 0;
+    if (lmb_cur_u32(&cursor, &relay_id) ||
+        lmb_cur_u32(&cursor, &inner_op) ||
+        lmb_cur_u32(&cursor, &inner_body_len) ||
+        !segment_request_op(inner_op) ||
+        inner_body_len != cursor.len - cursor.off ||
+        !lmb_frame_shape_ok(inner_op, inner_body_len, forward->pay_len))
+        return -1;
+
+    LmbMsg response = {0};
+    int local_fd = lmb_connect(r->local_addr);
+    int ok = local_fd >= 0 &&
+             !lmb_send(local_fd, inner_op, cursor.p + cursor.off,
+                       inner_body_len, forward->pay, forward->pay_len) &&
+             !lmb_recv(local_fd, &response) &&
+             response.op == inner_op + 1u &&
+             lmb_frame_shape_ok(response.op, response.body_len,
+                                response.pay_len);
+    if (local_fd >= 0) lmb_close(local_fd);
+    LmbBuf body = {0};
+    int bad = lmb_buf_u32(&body, relay_id) ||
+              lmb_buf_u32(&body, ok ? 1u : 0u) ||
+              lmb_buf_u32(&body, ok ? response.op : 0u) ||
+              lmb_buf_u32(&body, ok ? response.body_len : 0u) ||
+              (ok && lmb_buf_bytes(&body, response.body, response.body_len));
+    if (!bad)
+        bad = lmb_send(tracker_fd, LMB_RSEG_R, body.p, (uint32_t)body.len,
+                       ok ? response.pay : NULL,
+                       ok ? response.pay_len : 0u);
+    free(body.p);
+    lmb_msg_free(&response);
+    return bad;
 }
 
 static void *registration_worker(void *opaque) {
@@ -134,8 +191,47 @@ static void *registration_worker(void *opaque) {
             sleep(1);
             continue;
         }
-        while (!r->stop && !tracker_heartbeat(fd, nonce, r)) {
-            for (int i = 0; i < 20 && !r->stop; i++) usleep(100000);
+        /* Poll provides the short heartbeat cadence; once a frame starts,
+         * allow a slow WAN relay enough time to receive the complete bounded
+         * activation/snapshot instead of treating a 200 ms partial read as a
+         * broken control tunnel. */
+        struct timeval timeout = {60, 0};
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof timeout);
+        uint64_t last_heartbeat = now_ms();
+        if (tracker_register_send(fd, nonce, r)) {
+            lmb_close(fd); sleep(1); continue;
+        }
+        while (!r->stop) {
+            struct pollfd input = { .fd = fd, .events = POLLIN };
+            int ready = poll(&input, 1, 200);
+            if (ready < 0) {
+                if (errno == EINTR) continue;
+                break;
+            }
+            if (!ready) {
+                if (now_ms() - last_heartbeat >= 2000u) {
+                    if (tracker_register_send(fd, nonce, r)) break;
+                    last_heartbeat = now_ms();
+                }
+                continue;
+            }
+            if (input.revents & (POLLERR | POLLHUP | POLLNVAL)) break;
+            LmbMsg message = {0};
+            if (lmb_recv(fd, &message)) {
+                break;
+            }
+            int bad = 0;
+            if (message.op == LMB_SEG_REGISTER_R)
+                bad = tracker_registration_reply(r, &message);
+            else if (message.op == LMB_RSEG_FWD)
+                bad = handle_rseg_fwd(r, fd, &message);
+            else if (message.op == LMB_ERR) {
+                fprintf(stderr,
+                        "[segment-node] tracker rejected control message\n");
+                bad = 1;
+            }
+            lmb_msg_free(&message);
+            if (bad) break;
         }
         lmb_close(fd);
         pthread_mutex_lock(&r->lock);
@@ -180,6 +276,8 @@ static void session_release(Node *node, NodeSession *slot) {
     pthread_mutex_lock(&slot->lock);
     coli_segment_session_destroy(slot->session);
     free(slot->cached_output);
+    free(slot->snapshot);
+    free(slot->restore);
     pthread_mutex_unlock(&slot->lock);
     pthread_mutex_destroy(&slot->lock);
     memset(slot, 0, sizeof *slot);
@@ -193,6 +291,20 @@ static void *session_reaper(void *opaque) {
     Node *node = (Node *)opaque;
     while (!g_stop) {
         pthread_mutex_lock(&node->sessions_lock);
+        for (size_t i = 0; i < NODE_SESSIONS_MAX; i++) {
+            NodeSession *slot = &node->sessions[i];
+            if (!slot->used) continue;
+            pthread_mutex_lock(&slot->lock);
+            if (slot->restore_active &&
+                now_ms() - slot->restore_updated_ms >= 60000u) {
+                (void)lmb_seg_table_restore_finish(
+                    node->table, &slot->restore_transfer, 0, now_ms());
+                free(slot->restore); slot->restore = NULL;
+                slot->restore_bytes = slot->restore_received = 0;
+                slot->restore_active = 0;
+            }
+            pthread_mutex_unlock(&slot->lock);
+        }
         LmbSegId expired;
         while (lmb_seg_table_reap_expired(node->table, now_ms(), &expired)) {
             NodeSession *slot = session_find(node, &expired);
@@ -262,6 +374,58 @@ static int send_reply(int fd, uint32_t op, LmbSegReply *reply,
     int rc = lmb_send(fd, op, body, body_len, pay, (uint32_t)pay_len);
     free(body);
     return rc;
+}
+
+static int send_transfer_reply(int fd, uint32_t op,
+                               LmbSegTransferReply *reply,
+                               const void *pay, size_t pay_len) {
+    uint8_t *body = NULL;
+    uint32_t body_len = 0;
+    if (pay_len > UINT32_MAX ||
+        lmb_seg_transfer_reply_encode(reply, &body, &body_len)) return -1;
+    int rc = lmb_send(fd, op, body, body_len, pay, (uint32_t)pay_len);
+    free(body);
+    return rc;
+}
+
+typedef struct {
+    uint8_t *data;
+    size_t length;
+    size_t capacity;
+    size_t limit;
+} SnapshotBuffer;
+
+static int snapshot_write(void *opaque, const void *data, size_t size) {
+    SnapshotBuffer *buffer = opaque;
+    if (size > buffer->limit - buffer->length) return -1;
+    size_t needed = buffer->length + size;
+    if (needed > buffer->capacity) {
+        size_t capacity = buffer->capacity ? buffer->capacity : 4096u;
+        while (capacity < needed) {
+            if (capacity > buffer->limit / 2u) { capacity = buffer->limit; break; }
+            capacity *= 2u;
+        }
+        uint8_t *grown = realloc(buffer->data, capacity);
+        if (!grown) return -1;
+        buffer->data = grown; buffer->capacity = capacity;
+    }
+    if (size) memcpy(buffer->data + buffer->length, data, size);
+    buffer->length = needed;
+    return 0;
+}
+
+typedef struct {
+    const uint8_t *data;
+    size_t length;
+    size_t offset;
+} SnapshotReader;
+
+static int snapshot_read(void *opaque, void *data, size_t size) {
+    SnapshotReader *reader = opaque;
+    if (size > reader->length - reader->offset) return -1;
+    if (size) memcpy(data, reader->data + reader->offset, size);
+    reader->offset += size;
+    return 0;
 }
 
 static int handle_open(Node *node, int fd, const LmbMsg *msg) {
@@ -411,6 +575,9 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                 slot->cached_output = output;
                 slot->cached_bytes = bytes;
                 slot->cached_request = run.request_id;
+                free(slot->snapshot);
+                slot->snapshot = NULL;
+                slot->snapshot_bytes = 0;
                 reply.status = status;
                 reply_state(node, &reply);
                 int rc = send_reply(fd, LMB_SEG_RUN_R, &reply, output, bytes);
@@ -426,6 +593,197 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
     reply_state(node, &reply);
     free(tokens);
     return send_reply(fd, LMB_SEG_RUN_R, &reply, NULL, 0);
+}
+
+static int handle_snapshot(Node *node, int fd, const LmbMsg *msg) {
+    LmbSegTransfer transfer;
+    if (msg->pay_len ||
+        lmb_seg_transfer_decode(msg->body, msg->body_len, &transfer)) return -1;
+    LmbSegStatus status = lmb_seg_table_snapshot_check(
+        node->table, &transfer, now_ms());
+    LmbSegTransferReply response;
+    memset(&response, 0, sizeof response);
+    response.reply = make_reply(&transfer.session_id, &transfer.request_id,
+                                &transfer.owner, status);
+    uint8_t *payload = NULL;
+    size_t payload_bytes = 0;
+    if (status == LMB_SEG_STATUS_OK) {
+        pthread_mutex_lock(&node->sessions_lock);
+        NodeSession *slot = session_find(node, &transfer.session_id);
+        if (slot) pthread_mutex_lock(&slot->lock);
+        pthread_mutex_unlock(&node->sessions_lock);
+        if (!slot) status = LMB_SEG_STATUS_NOT_FOUND;
+        else {
+            int initial = transfer.snapshot_size == 0 && transfer.offset == 0 &&
+                          transfer.chunk_len == 0;
+            if (initial) {
+                SnapshotBuffer writer = {
+                    .limit = (size_t)lmb_env_int(
+                        "LUMABRI_SEGMENT_MAX_SNAPSHOT_MB", 2048, 1, 32768) << 20,
+                };
+                char error[256] = {0};
+                if (coli_segment_snapshot(slot->session, snapshot_write, &writer,
+                                          error, sizeof error) ||
+                    !writer.length) {
+                    fprintf(stderr, "[segment-node] snapshot: %s\n",
+                            error[0] ? error : "empty or oversized snapshot");
+                    free(writer.data);
+                    status = LMB_SEG_STATUS_INTERNAL;
+                } else {
+                    free(slot->snapshot);
+                    slot->snapshot = writer.data;
+                    slot->snapshot_bytes = writer.length;
+                    slot->snapshot_sequence = transfer.sequence;
+                    slot->snapshot_position = transfer.position;
+                }
+            } else if (!slot->snapshot ||
+                       transfer.snapshot_size != slot->snapshot_bytes ||
+                       transfer.sequence != slot->snapshot_sequence ||
+                       transfer.position != slot->snapshot_position) {
+                status = LMB_SEG_STATUS_CONFLICT;
+            }
+            if (status == LMB_SEG_STATUS_OK) {
+                uint64_t offset = initial ? 0 : transfer.offset;
+                size_t requested = initial ? NODE_SNAPSHOT_CHUNK
+                                           : transfer.chunk_len;
+                if (!requested || offset > slot->snapshot_bytes) {
+                    status = LMB_SEG_STATUS_BAD_REQUEST;
+                } else {
+                    size_t remaining = slot->snapshot_bytes - (size_t)offset;
+                    payload_bytes = remaining < requested ? remaining : requested;
+                    payload = malloc(payload_bytes ? payload_bytes : 1u);
+                    if (!payload) {
+                        status = LMB_SEG_STATUS_INTERNAL;
+                        payload_bytes = 0;
+                    } else if (payload_bytes) {
+                        memcpy(payload, slot->snapshot + offset, payload_bytes);
+                    }
+                    response.snapshot_size = slot->snapshot_bytes;
+                    response.offset = offset;
+                    response.chunk_len = (uint32_t)payload_bytes;
+                    if (!offset) response.transfer_flags |= LMB_SEG_XFER_BEGIN;
+                    if (payload_bytes == remaining)
+                        response.transfer_flags |= LMB_SEG_XFER_END;
+                }
+            }
+            pthread_mutex_unlock(&slot->lock);
+        }
+    }
+    response.reply.status = status;
+    if (status == LMB_SEG_STATUS_OK) reply_state(node, &response.reply);
+    else {
+        response.snapshot_size = response.offset = 0;
+        response.chunk_len = response.transfer_flags = 0;
+        free(payload); payload = NULL; payload_bytes = 0;
+    }
+    int rc = send_transfer_reply(fd, LMB_SEG_SNAPSHOT_R, &response,
+                                 payload, payload_bytes);
+    free(payload);
+    return rc;
+}
+
+static int handle_restore(Node *node, int fd, const LmbMsg *msg) {
+    LmbSegTransfer transfer;
+    if (lmb_seg_transfer_decode(msg->body, msg->body_len, &transfer) ||
+        msg->pay_len != transfer.chunk_len) return -1;
+    LmbSegStatus status = LMB_SEG_STATUS_OK;
+    pthread_mutex_lock(&node->sessions_lock);
+    NodeSession *slot = session_find(node, &transfer.session_id);
+    if (slot) pthread_mutex_lock(&slot->lock);
+    pthread_mutex_unlock(&node->sessions_lock);
+    if (!slot) status = LMB_SEG_STATUS_NOT_FOUND;
+    else if (slot->restored_valid &&
+             lmb_seg_id_equal(&slot->restored_request, &transfer.request_id) &&
+             slot->restored_sequence == transfer.sequence &&
+             slot->restored_position == transfer.position) {
+        status = LMB_SEG_STATUS_DUPLICATE;
+    } else {
+        int same = slot->restore_active &&
+                   lmb_seg_id_equal(&slot->restore_transfer.request_id,
+                                    &transfer.request_id) &&
+                   slot->restore_transfer.snapshot_size == transfer.snapshot_size &&
+                   slot->restore_transfer.sequence == transfer.sequence &&
+                   slot->restore_transfer.position == transfer.position;
+        if (transfer.flags & LMB_SEG_XFER_BEGIN) {
+            if (!same) {
+                status = lmb_seg_table_restore_begin(
+                    node->table, &transfer, now_ms());
+                size_t limit = (size_t)lmb_env_int(
+                    "LUMABRI_SEGMENT_MAX_SNAPSHOT_MB", 2048, 1, 32768) << 20;
+                if (status == LMB_SEG_STATUS_OK &&
+                    transfer.snapshot_size > limit)
+                    status = LMB_SEG_STATUS_QUOTA;
+                if (status == LMB_SEG_STATUS_OK) {
+                    free(slot->restore);
+                    slot->restore = malloc((size_t)transfer.snapshot_size);
+                    if (!slot->restore) status = LMB_SEG_STATUS_INTERNAL;
+                }
+                if (status == LMB_SEG_STATUS_OK) {
+                    slot->restore_bytes = (size_t)transfer.snapshot_size;
+                    slot->restore_received = 0;
+                    slot->restore_transfer = transfer;
+                    slot->restore_active = 1;
+                } else if (status != LMB_SEG_STATUS_BUSY) {
+                    (void)lmb_seg_table_restore_finish(
+                        node->table, &transfer, 0, now_ms());
+                }
+            }
+        } else if (!same) {
+            status = LMB_SEG_STATUS_CONFLICT;
+        }
+        if (status == LMB_SEG_STATUS_OK && slot->restore_active) {
+            if (transfer.offset < slot->restore_received &&
+                transfer.chunk_len <= slot->restore_received - transfer.offset &&
+                !memcmp(slot->restore + transfer.offset,
+                        msg->pay, transfer.chunk_len)) {
+                status = LMB_SEG_STATUS_DUPLICATE;
+            } else if (transfer.offset != slot->restore_received ||
+                       transfer.chunk_len >
+                           slot->restore_bytes - slot->restore_received) {
+                status = LMB_SEG_STATUS_OUT_OF_ORDER;
+            } else {
+                if (transfer.chunk_len)
+                    memcpy(slot->restore + slot->restore_received,
+                           msg->pay, transfer.chunk_len);
+                slot->restore_received += transfer.chunk_len;
+                slot->restore_updated_ms = now_ms();
+                if (transfer.flags & LMB_SEG_XFER_END) {
+                    SnapshotReader reader = {
+                        slot->restore, slot->restore_bytes, 0
+                    };
+                    char error[256] = {0};
+                    int restored = slot->restore_received == slot->restore_bytes &&
+                        !coli_segment_restore(slot->session, snapshot_read,
+                                              &reader, error, sizeof error) &&
+                        reader.offset == reader.length;
+                    if (!restored)
+                        fprintf(stderr, "[segment-node] restore: %s\n",
+                                error[0] ? error : "truncated snapshot");
+                    status = lmb_seg_table_restore_finish(
+                        node->table, &transfer, restored, now_ms());
+                    if (!restored && status == LMB_SEG_STATUS_OK)
+                        status = LMB_SEG_STATUS_INTERNAL;
+                    if (restored && status == LMB_SEG_STATUS_OK) {
+                        slot->restored_request = transfer.request_id;
+                        slot->restored_sequence = transfer.sequence;
+                        slot->restored_position = transfer.position;
+                        slot->restored_valid = 1;
+                        free(slot->cached_output);
+                        slot->cached_output = NULL; slot->cached_bytes = 0;
+                    }
+                    free(slot->restore); slot->restore = NULL;
+                    slot->restore_bytes = slot->restore_received = 0;
+                    slot->restore_active = 0;
+                }
+            }
+        }
+    }
+    if (slot) pthread_mutex_unlock(&slot->lock);
+    LmbSegReply reply = make_reply(&transfer.session_id, &transfer.request_id,
+                                   &transfer.owner, status);
+    if (status == LMB_SEG_STATUS_OK || status == LMB_SEG_STATUS_DUPLICATE)
+        reply_state(node, &reply);
+    return send_reply(fd, LMB_SEG_RESTORE_R, &reply, NULL, 0);
 }
 
 static int handle_control(Node *node, int fd, const LmbMsg *msg) {
@@ -471,6 +829,8 @@ static void *connection_worker(void *opaque) {
         int rc;
         if (msg.op == LMB_SEG_OPEN) rc = handle_open(node, fd, &msg);
         else if (msg.op == LMB_SEG_RUN) rc = handle_run(node, fd, &msg);
+        else if (msg.op == LMB_SEG_SNAPSHOT) rc = handle_snapshot(node, fd, &msg);
+        else if (msg.op == LMB_SEG_RESTORE) rc = handle_restore(node, fd, &msg);
         else if (msg.op == LMB_SEG_CLOSE || msg.op == LMB_SEG_HEALTH)
             rc = handle_control(node, fd, &msg);
         else rc = lmb_send(fd, LMB_ERR, "unsupported Segment operation", 29,
@@ -489,7 +849,8 @@ static void usage(const char *program) {
         "(--range A:B | --auto-range) --port N --tracker HOST:PORT "
         "--advertise HOST:PORT --name PEER "
         "(--auto-identity | --model-root HEX64 --tokenizer-root HEX64) "
-        "[--fallback] [--context N] [--max-rows N] [--sessions N]\n",
+        "[--fallback] [--relay-only] [--context N] [--max-rows N] "
+        "[--sessions N]\n",
         program);
 }
 
@@ -549,6 +910,7 @@ int main(int argc, char **argv) {
     int auto_identity = has_arg(argc, argv, "--auto-identity");
     int auto_range = has_arg(argc, argv, "--auto-range");
     int fallback = has_arg(argc, argv, "--fallback");
+    int relay_only = has_arg(argc, argv, "--relay-only");
     if (!engine_id || !model_dir || !model || ((range != NULL) == auto_range) ||
         !port_text || !tracker ||
         !advertise || !name ||
@@ -692,9 +1054,8 @@ int main(int argc, char **argv) {
     a->state_dtype = node.cap.state_dtype; a->state_width = node.cap.state_width;
     a->max_sessions = max_sessions;
     if (fallback) a->flags |= LMB_SEG_ADVERT_FALLBACK;
+    if (relay_only) a->flags |= LMB_SEG_ADVERT_RELAY_ONLY;
     a->capabilities = node.cap.flags & LMB_SEG_CAP_KNOWN_MASK;
-    /* Snapshot/replay is intentionally not on the network data plane yet. */
-    a->capabilities &= ~LMB_SEG_CAP_SNAPSHOT;
     snprintf(a->engine_id, sizeof a->engine_id, "%s", node.cap.engine_id);
     snprintf(a->state_schema, sizeof a->state_schema, "%s", node.cap.state_schema);
     snprintf(a->numeric_class, sizeof a->numeric_class, "%s", node.cap.numeric_class);
@@ -706,6 +1067,8 @@ int main(int argc, char **argv) {
     TrackerRegistration *registration = &node.registration;
     pthread_mutex_init(&registration->lock, NULL);
     snprintf(registration->tracker, sizeof registration->tracker, "%s", tracker);
+    snprintf(registration->local_addr, sizeof registration->local_addr,
+             "127.0.0.1:%u", port);
     registration->advert = *a;
     char peer_key_path[512];
     if (lmb_peer_identity(lmb_peer_key_path(peer_key_path,

--- a/segment_relay_test.sh
+++ b/segment_relay_test.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Real stateful Segment relay gate. Both executors deliberately suppress their
+# direct transport, so OPEN/RUN/SNAPSHOT/CLOSE must traverse the signed tracker
+# tunnel. A same-range replica makes the persistent turn take real snapshots;
+# greedy output is still compared with the independent OLMoE oracle.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+: "${OLMOE_EDGE_MODEL:?set OLMOE_EDGE_MODEL}"
+: "${OLMOE_EDGE_REF:?set OLMOE_EDGE_REF}"
+SEGMENT_NODE_BIN=${SEGMENT_NODE_BIN:-./segment_node}
+SEGMENT_CHAT_BIN=${SEGMENT_CHAT_BIN:-./segment_chat}
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
+TMP=$(mktemp -d /tmp/lumabri-segment-relay.XXXXXX)
+PIDS=()
+cleanup() {
+    for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+    for pid in "${PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+wait_port() {
+    local port=$1
+    for _ in $(seq 1 200); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            exec 3<&-; exec 3>&-; return 0
+        fi
+        sleep 0.025
+    done
+    return 1
+}
+
+env LUMABRI_PEER_KEY="$TMP/tracker.key" \
+    LUMABRI_KNOWN_HOSTS="$TMP/known" \
+    "$TRACKER_BIN" --port 7968 --peer-bindings "$TMP/bindings" \
+    >"$TMP/tracker.log" 2>&1 &
+PIDS+=("$!")
+wait_port 7968
+
+model_root=$(printf '%064x' 91)
+tokenizer_root=$(printf '%064x' 92)
+common=(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/node.key"
+        LUMABRI_KNOWN_HOSTS="$TMP/known")
+for spec in "0:2 7969 relay-left" "2:4 7970 relay-right" \
+            "0:2 7971 relay-left-replica"; do
+    read -r range port name <<<"$spec"
+    "${common[@]}" "$SEGMENT_NODE_BIN" --engine olmoe \
+        --model-dir "$OLMOE_EDGE_MODEL" --model tiny-relay \
+        --range "$range" --port "$port" --tracker 127.0.0.1:7968 \
+        --advertise "127.0.0.1:$port" --name "$name" \
+        --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
+        --context 64 --max-rows 16 --sessions 4 --relay-only --fallback \
+        >"$TMP/$name.log" 2>&1 &
+    PIDS+=("$!")
+    wait_port "$port"
+done
+sleep 1
+
+oracle=$(python3 -c '
+import json,sys
+r=json.load(open(sys.argv[1], encoding="utf-8"))
+p=r["prompt_ids"]; f=r["full_ids"]
+print(",".join(map(str,p))+"|"+",".join(map(str,f[len(p):len(p)+3])))
+' "$OLMOE_EDGE_REF")
+prompt_ids=${oracle%%|*}
+expected=${oracle#*|}
+output=$(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
+    LUMABRI_KNOWN_HOSTS="$TMP/known" LUMABRI_SEGMENT_DEBUG_ROUTES=1 \
+    "$SEGMENT_CHAT_BIN" --engine olmoe --model-dir "$OLMOE_EDGE_MODEL" \
+    --model tiny-relay --tracker 127.0.0.1:7968 \
+    --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
+    --prompt-ids "$prompt_ids" --tokens 3 --expect-ids "$expected" \
+    --context 64 --max-rows 16 2>&1)
+grep -q 'relay-left.*transport=2' <<<"$output"
+grep -q 'relay-right.*transport=2' <<<"$output"
+
+# Persistent mode forces a real checkpoint through the relay after generation.
+serve=$(printf 'SUBMIT 1 0 2 2 0.7 0.95\nhi\n' | \
+    env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client2.key" \
+        LUMABRI_KNOWN_HOSTS="$TMP/known" LUMABRI_SAMPLE_SEED=7 \
+        "$SEGMENT_CHAT_BIN" --serve --engine olmoe \
+        --model-dir "$OLMOE_EDGE_MODEL" --model tiny-relay \
+        --tracker 127.0.0.1:7968 --model-root "$model_root" \
+        --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16)
+grep -q '^DATA 1 ' <<<"$serve"
+grep -q '^DONE 1 STAT ' <<<"$serve"
+echo "SEGMENT RELAY: PASS (relay-only OPEN/RUN/SNAPSHOT/CLOSE)"

--- a/test_sampling.c
+++ b/test_sampling.c
@@ -1,0 +1,46 @@
+#include "lumabri_sampling.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+int main(void) {
+    LmbSampler first, second;
+    lmb_sampler_init(&first, 42);
+    lmb_sampler_init(&second, 42);
+    const float logits[] = {0.0f, 1.0f, 4.0f, 2.0f};
+    for (int i = 0; i < 100; i++) {
+        int32_t a = -1, b = -1;
+        assert(!lmb_sample_logits(&first, logits, 4, 0.7, 0.95, &a));
+        assert(!lmb_sample_logits(&second, logits, 4, 0.7, 0.95, &b));
+        assert(a == b && a >= 0 && a < 4);
+    }
+
+    /* A sufficiently tight nucleus contains only the maximum token. */
+    lmb_sampler_init(&first, 7);
+    for (int i = 0; i < 100; i++) {
+        int32_t selected = -1;
+        assert(!lmb_sample_logits(&first, logits, 4, 1.0, 0.5, &selected));
+        assert(selected == 2);
+    }
+
+    float infinities[] = {-INFINITY, INFINITY, 1.0f, INFINITY};
+    int seen_one = 0, seen_three = 0;
+    lmb_sampler_init(&first, 99);
+    for (int i = 0; i < 100; i++) {
+        int32_t selected = -1;
+        assert(!lmb_sample_logits(&first, infinities, 4, 1.0, 1.0,
+                                  &selected));
+        assert(selected == 1 || selected == 3);
+        seen_one |= selected == 1;
+        seen_three |= selected == 3;
+    }
+    assert(seen_one && seen_three);
+
+    int32_t selected = -1;
+    assert(lmb_sample_logits(&first, logits, 4, 0.0, 1.0, &selected));
+    assert(lmb_sample_logits(&first, logits, 4, 1.0, 0.0, &selected));
+    puts("sampling tests: ok");
+    return 0;
+}

--- a/test_segment_discovery.c
+++ b/test_segment_discovery.c
@@ -208,7 +208,10 @@ static void test_tracker(const char *tracker) {
         assert(!lmb_seg_routes_fetch(tracker, &q, &s));
         assert(s.complete && s.count == 1);
         assert(s.entries[0].owner.route_generation == s.route_generation);
-        assert(s.entries[0].transport == LMB_SEG_TRANSPORT_DIRECT);
+        /* A reachable executor advertises the preferred direct endpoint and
+         * the live signed control tunnel as an exact-peer fallback. */
+        assert(s.entries[0].transport ==
+               (LMB_SEG_TRANSPORT_DIRECT | LMB_SEG_TRANSPORT_RELAY));
     }
 
     /* Telemetry may refresh at heartbeat frequency without fencing sessions

--- a/test_segment_v2.c
+++ b/test_segment_v2.c
@@ -267,6 +267,11 @@ static void test_control_wire(void) {
     assert(lmb_frame_shape_ok(LMB_SEG_RUN, 32, LMB_MAX_PAY));
     assert(lmb_frame_shape_ok(LMB_SEG_SNAPSHOT_R, 32, LMB_MAX_PAY));
     assert(lmb_frame_shape_ok(LMB_SEG_RESTORE, 32, LMB_MAX_PAY));
+    assert(lmb_frame_shape_ok(LMB_RSEG, LMB_MAX_CONTROL_BODY, LMB_MAX_PAY));
+    assert(lmb_frame_shape_ok(LMB_RSEG_FWD,
+                              LMB_MAX_CONTROL_BODY, LMB_MAX_PAY));
+    assert(lmb_frame_shape_ok(LMB_RSEG_R,
+                              LMB_MAX_CONTROL_BODY, LMB_MAX_PAY));
 }
 
 static void test_session_table(void) {
@@ -368,6 +373,28 @@ static void test_session_table(void) {
     snapshot.chunk_len = 10;
     snapshot.flags = LMB_SEG_XFER_BEGIN;
     assert(lmb_seg_table_snapshot_check(table, &snapshot, 122) ==
+           LMB_SEG_STATUS_OK);
+
+    /* A restore larger than one frame reserves the session until the final
+     * chunk, then commits sequence/position independently of chunk_len. */
+    LmbSegTransfer large_restore = snapshot;
+    fill_id(&large_restore.request_id, 186);
+    large_restore.snapshot_size = (uint64_t)LMB_MAX_PAY + 1u;
+    large_restore.offset = 0;
+    large_restore.chunk_len = LMB_MAX_PAY;
+    large_restore.flags = LMB_SEG_XFER_BEGIN;
+    assert(lmb_seg_table_restore_begin(table, &large_restore, 123) ==
+           LMB_SEG_STATUS_OK);
+    assert(lmb_seg_table_snapshot_check(table, &snapshot, 123) ==
+           LMB_SEG_STATUS_BUSY);
+    assert(lmb_seg_table_restore_finish(table, &large_restore, 0, 124) ==
+           LMB_SEG_STATUS_OK);
+    assert(lmb_seg_table_restore_begin(table, &large_restore, 125) ==
+           LMB_SEG_STATUS_OK);
+    large_restore.offset = LMB_MAX_PAY;
+    large_restore.chunk_len = 1;
+    large_restore.flags = LMB_SEG_XFER_END;
+    assert(lmb_seg_table_restore_finish(table, &large_restore, 1, 126) ==
            LMB_SEG_STATUS_OK);
 
     LmbSegControl close = {

--- a/tracker.c
+++ b/tracker.c
@@ -72,12 +72,14 @@ typedef struct {
     pthread_mutex_t rq_lk;
     pthread_cond_t rq_cv;
     int rq_busy, rq_sent, rq_done, rq_ok;
-    uint32_t rq_id, rq_next, rq_op;
+    uint32_t rq_id, rq_next, rq_op, rq_inner_op;
     char rq_path[LMB_PATH_MAX];
     uint64_t rq_off; uint32_t rq_len;
     uint8_t *rq_body; uint32_t rq_body_len;
     uint8_t *rq_pay; uint32_t rq_pay_len;
     uint8_t *rq_resp; uint32_t rq_resp_len;
+    uint8_t *rq_resp_pay; uint32_t rq_resp_pay_len;
+    uint32_t rq_resp_op;
 } Peer;
 
 static Peer g_peers[MAX_PEERS];
@@ -464,7 +466,7 @@ static Peer *peer_slot_new(int is_expert, int *idx) {
     Peer *p = &g_peers[pick];
     if (p->used) {
         free(p->files); free(p->ebits); free(p->rq_body); free(p->rq_pay);
-        free(p->rq_resp);
+        free(p->rq_resp); free(p->rq_resp_pay);
         if (p->evfd >= 0) close(p->evfd);
         pthread_mutex_destroy(&p->rq_lk);
         pthread_cond_destroy(&p->rq_cv);
@@ -1184,11 +1186,11 @@ static int handle_segment_routes(int fd, LmbMsg *m) {
         entry->advert = p->segment;
         entry->owner = p->segment_owner;
         entry->owner.route_generation = snapshot.route_generation;
-        if (entry->advert.addr[0]) entry->transport |= LMB_SEG_TRANSPORT_DIRECT;
-        /* Do not infer Segment relay from the persistent SREG connection.
-         * This tracker can relay READ/EXEC today, but it does not forward the
-         * stateful Segment operations yet. The reserved bit is published only
-         * when that data-plane handler exists. */
+        if (entry->advert.addr[0] &&
+            !(entry->advert.flags & LMB_SEG_ADVERT_RELAY_ONLY))
+            entry->transport |= LMB_SEG_TRANSPORT_DIRECT;
+        if (p->ctrl_fd >= 0 && p->evfd >= 0)
+            entry->transport |= LMB_SEG_TRANSPORT_RELAY;
     }
     snapshot.complete = (uint32_t)lmb_seg_route_complete(&snapshot, &query);
     pthread_mutex_unlock(&g_lk);
@@ -1817,6 +1819,7 @@ static int handle_rread(int fd, LmbMsg *m) {
     free(p->rq_body); p->rq_body = NULL; p->rq_body_len = 0;
     free(p->rq_pay); p->rq_pay = NULL; p->rq_pay_len = 0;
     free(p->rq_resp); p->rq_resp = NULL; p->rq_resp_len = 0;
+    free(p->rq_resp_pay); p->rq_resp_pay = NULL; p->rq_resp_pay_len = 0;
     pthread_mutex_unlock(&p->rq_lk);
 
     uint64_t one = 1;
@@ -1916,6 +1919,7 @@ static int handle_rexec(int fd, LmbMsg *m) {
     free(p->rq_body); p->rq_body = body; p->rq_body_len = body_len;
     free(p->rq_pay); p->rq_pay = pay; p->rq_pay_len = m->pay_len;
     free(p->rq_resp); p->rq_resp = NULL; p->rq_resp_len = 0;
+    free(p->rq_resp_pay); p->rq_resp_pay = NULL; p->rq_resp_pay_len = 0;
     pthread_mutex_unlock(&p->rq_lk);
     uint64_t one = 1; if (write(p->evfd, &one, 8) != 8) {}
     if (getenv("LUMABRI_RELAY_TRACE"))
@@ -1941,6 +1945,102 @@ static int handle_rexec(int fd, LmbMsg *m) {
         rc = lmb_send(fd, LMB_REXEC_R, b.p, (uint32_t)b.len, resp, resp_len);
         free(b.p); free(resp);
     }
+    pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
+    return rc;
+}
+
+static int segment_request_op(uint32_t op) {
+    return op == LMB_SEG_OPEN || op == LMB_SEG_RUN ||
+           op == LMB_SEG_SNAPSHOT || op == LMB_SEG_RESTORE ||
+           op == LMB_SEG_CLOSE || op == LMB_SEG_HEALTH;
+}
+
+/* Relay one ordinary Segment frame to one exact signed Segment registrant.
+ * Selection is by peer identity, never "any peer with this range": stateful
+ * placement belongs to the session and failover is an explicit client act. */
+static int handle_rseg(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    char peer_name[LMB_SEG_PEER_NAME_MAX];
+    uint32_t inner_op = 0, inner_body_len = 0;
+    if (lmb_cur_str(&c, peer_name, sizeof peer_name) ||
+        lmb_cur_u32(&c, &inner_op) ||
+        lmb_cur_u32(&c, &inner_body_len) ||
+        !segment_request_op(inner_op) ||
+        inner_body_len != c.len - c.off ||
+        !lmb_frame_shape_ok(inner_op, inner_body_len, m->pay_len)) {
+        send_err(fd, "bad Segment relay frame"); return -1;
+    }
+
+    Peer *p = NULL;
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *q = &g_peers[i];
+        if (!q->used || !q->is_expert || !q->has_segment ||
+            !q->segment_live || now - q->segment_ts > g_stale_s ||
+            q->ctrl_fd < 0 || q->evfd < 0 ||
+            strcmp(q->segment.peer_name, peer_name)) continue;
+        p = q; p->refs++; break;
+    }
+    pthread_mutex_unlock(&g_lk);
+    if (!p) { send_err(fd, "Segment relay peer is unavailable"); return 0; }
+
+    uint8_t *body = malloc(inner_body_len ? inner_body_len : 1u);
+    uint8_t *pay = malloc(m->pay_len ? m->pay_len : 1u);
+    if (!body || !pay) {
+        free(body); free(pay);
+        pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
+        send_err(fd, "oom"); return -1;
+    }
+    if (inner_body_len) memcpy(body, c.p + c.off, inner_body_len);
+    if (m->pay_len) memcpy(pay, m->pay, m->pay_len);
+
+    pthread_mutex_lock(&p->rq_lk);
+    while (p->rq_busy) pthread_cond_wait(&p->rq_cv, &p->rq_lk);
+    p->rq_busy = 1; p->rq_sent = 0; p->rq_done = 0; p->rq_ok = 0;
+    p->rq_id = ++p->rq_next; p->rq_op = LMB_RSEG_FWD;
+    p->rq_inner_op = inner_op;
+    free(p->rq_body); p->rq_body = body; p->rq_body_len = inner_body_len;
+    free(p->rq_pay); p->rq_pay = pay; p->rq_pay_len = m->pay_len;
+    free(p->rq_resp); p->rq_resp = NULL; p->rq_resp_len = 0;
+    free(p->rq_resp_pay); p->rq_resp_pay = NULL; p->rq_resp_pay_len = 0;
+    p->rq_resp_op = 0;
+    pthread_mutex_unlock(&p->rq_lk);
+    uint64_t one = 1; if (write(p->evfd, &one, sizeof one) != sizeof one) {}
+
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline); deadline.tv_sec += RELAY_WAIT_S;
+    pthread_mutex_lock(&p->rq_lk);
+    while (!p->rq_done)
+        if (pthread_cond_timedwait(&p->rq_cv, &p->rq_lk, &deadline)) break;
+    int ok = p->rq_done && p->rq_ok;
+    uint32_t response_op = p->rq_resp_op;
+    uint8_t *response_body = p->rq_resp;
+    uint32_t response_body_len = p->rq_resp_len;
+    uint8_t *response_pay = p->rq_resp_pay;
+    uint32_t response_pay_len = p->rq_resp_pay_len;
+    p->rq_resp = NULL; p->rq_resp_len = 0;
+    p->rq_resp_pay = NULL; p->rq_resp_pay_len = 0;
+    free(p->rq_body); p->rq_body = NULL; p->rq_body_len = 0;
+    free(p->rq_pay); p->rq_pay = NULL; p->rq_pay_len = 0;
+    p->rq_busy = 0; pthread_cond_broadcast(&p->rq_cv);
+    pthread_mutex_unlock(&p->rq_lk);
+
+    int rc = 0;
+    if (!ok) {
+        send_err(fd, "Segment relay timeout or peer failure");
+    } else {
+        LmbBuf reply = {0};
+        if (lmb_buf_u32(&reply, response_op) ||
+            lmb_buf_u32(&reply, response_body_len) ||
+            lmb_buf_bytes(&reply, response_body, response_body_len))
+            rc = -1;
+        else
+            rc = lmb_send(fd, LMB_RSEG_R, reply.p, (uint32_t)reply.len,
+                          response_pay, response_pay_len);
+        free(reply.p);
+    }
+    free(response_body); free(response_pay);
     pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
     return rc;
 }
@@ -2034,11 +2134,32 @@ static void relay_complete(Peer *p, LmbMsg *m) {
         fprintf(stderr, "[tracker] relay complete op=%u id=%u ok=%u pay=%u\n",
                 m->op, id, ok, m->pay_len);
     pthread_mutex_lock(&p->rq_lk);
-    uint32_t expect = p->rq_op == LMB_RREAD_FWD ? LMB_RREAD_R : LMB_REXEC_R;
+    uint32_t expect = p->rq_op == LMB_RREAD_FWD ? LMB_RREAD_R :
+                      p->rq_op == LMB_REXEC_FWD ? LMB_REXEC_R : LMB_RSEG_R;
     if (p->rq_busy && p->rq_sent && id == p->rq_id && m->op == expect &&
         !p->rq_done) {
-        p->rq_ok = ok && m->pay_len > 0;
-        p->rq_resp = lmb_msg_take_pay(m); p->rq_resp_len = m->pay_len;
+        if (expect == LMB_RSEG_R) {
+            uint32_t response_op = 0, body_len = 0;
+            int valid = ok && !lmb_cur_u32(&c, &response_op) &&
+                        !lmb_cur_u32(&c, &body_len) &&
+                        body_len == c.len - c.off &&
+                        response_op == p->rq_inner_op + 1u &&
+                        lmb_frame_shape_ok(response_op, body_len, m->pay_len);
+            if (valid) {
+                p->rq_resp = malloc(body_len ? body_len : 1u);
+                if (p->rq_resp) {
+                    if (body_len) memcpy(p->rq_resp, c.p + c.off, body_len);
+                    p->rq_resp_len = body_len;
+                    p->rq_resp_pay = lmb_msg_take_pay(m);
+                    p->rq_resp_pay_len = m->pay_len;
+                    p->rq_resp_op = response_op;
+                    p->rq_ok = 1;
+                }
+            }
+        } else {
+            p->rq_ok = ok && m->pay_len > 0;
+            p->rq_resp = lmb_msg_take_pay(m); p->rq_resp_len = m->pay_len;
+        }
         p->rq_done = 1;
         pthread_cond_broadcast(&p->rq_cv);
     }
@@ -2090,6 +2211,19 @@ static void *conn_thread(void *arg) {
                         pay_len = ctrl->rq_pay_len;
                         if (pay_len) {
                             pay = (uint8_t *)malloc(pay_len);
+                            if (pay) memcpy(pay, ctrl->rq_pay, pay_len);
+                            else {
+                                have = 0; ctrl->rq_done = 1; ctrl->rq_ok = 0;
+                                pthread_cond_broadcast(&ctrl->rq_cv);
+                            }
+                        }
+                    } else if (op == LMB_RSEG_FWD) {
+                        lmb_buf_u32(&b, ctrl->rq_inner_op);
+                        lmb_buf_u32(&b, ctrl->rq_body_len);
+                        lmb_buf_bytes(&b, ctrl->rq_body, ctrl->rq_body_len);
+                        pay_len = ctrl->rq_pay_len;
+                        if (pay_len) {
+                            pay = malloc(pay_len);
                             if (pay) memcpy(pay, ctrl->rq_pay, pay_len);
                             else {
                                 have = 0; ctrl->rq_done = 1; ctrl->rq_ok = 0;
@@ -2154,7 +2288,8 @@ static void *conn_thread(void *arg) {
             break;
         }
         case LMB_RREAD_R:
-        case LMB_REXEC_R:   if (ctrl) relay_complete(ctrl, &m); break;
+        case LMB_REXEC_R:
+        case LMB_RSEG_R:    if (ctrl) relay_complete(ctrl, &m); break;
         case LMB_EREG: {
             Peer *p = handle_ereg(fd, &m, have_nonce ? nonce : NULL);
             if (p) {
@@ -2199,6 +2334,7 @@ static void *conn_thread(void *arg) {
         case LMB_SWARM:     rc = handle_swarm(fd); break;
         case LMB_RREAD:     rc = handle_rread(fd, &m); break;
         case LMB_REXEC:     rc = handle_rexec(fd, &m); break;
+        case LMB_RSEG:      rc = handle_rseg(fd, &m); break;
         case LMB_ASSIGN:    rc = handle_assign(fd, &m); break;
         default:            send_err(fd, "unknown op"); rc = -1; break;
         }


### PR DESCRIPTION
## Summary

- add temperature and top-p sampling to Segment chat through the universal Colibri Edge logits ABI
- add stateful Segment relay through the tracker so NAT peers need only the tracker port, while preserving direct-first routing
- add transactional chunked snapshots, checkpoint restore, token replay, and exact-range replica failover
- keep serve/chat native behavior and diagnostics aligned with main
- gate direct execution, TUI codec, relay, failover, and native serve/chat across GLM, Inkling, Kimi K3, OLMoE, Qwen3.6, and DeepSeek V4

## Dependency

Depends on Colibri #1257 (universal Edge logits ABI), currently open and clean against dev:
https://github.com/JustVugg/colibri/pull/1257

## Validation

- make check-warnings ENGINE=/tmp/colibri-edge-runtime/c
- make test-segment-v2 test-segment-discovery ENGINE=/tmp/colibri-edge-runtime/c
- make test-segment-direct-real ENGINE=/tmp/colibri-edge-runtime/c with all six tiny fixtures
- make test ENGINE=/tmp/colibri-edge-runtime/c (complete green rerun)
- ASan/UBSan: protocol, discovery, relay, failover, and six-family direct gates pass with leak detection disabled; LeakSanitizer reports retained allocations in the existing Colibri JSON parser
- TSan: state-machine gate passes; full tracker TSan is unavailable on this WSL runtime because ThreadSanitizer aborts on its memory mapping

## Deliberate boundaries

- the relay tunnel is serialized per executor; direct transport remains the fast path
- checkpoints are created only when a compatible replica exists; otherwise failover replays from token zero
- no merge is requested until Colibri #1257 and this PR have been reviewed