### PR TITLE
feat: live swarm chat UX and executor safeguards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ a tag stay under Unreleased until a new tag is created.
 - Streaming Segment replies with live routing/prefill/decode/checkpoint/failover
   status, a fixed non-blocking input dock, slash-command autocomplete and menus
   usable during inference.
+- Immediate live-turn interruption: `Ctrl-C`/`Ctrl-\\` stop the engine instead
+  of queueing an exit behind inference, `Ctrl-Z` restores and reconstructs the
+  dock across suspend/resume, and an exit guard restores termios after normal
+  shutdown signals. Terminal recovery happens before waiting on the engine; a
+  second shutdown signal provides an async-safe forced exit.
+- Clean Segment gateway EOF on ordinary `/quit`, so remote sessions are closed
+  instead of occupying executor slots until their lease expires; per-slice
+  session capacity also has a bounded operator override.
 - Stable machine names, named `/swarm`/`/hosts` topology, `/experts` call
   counters and periodic server-side host/executor/session telemetry.
 - Per-source Segment-relay token bucket, concurrency cap and bounded serialized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ a tag stay under Unreleased until a new tag is created.
 
 ## Unreleased
 
+- Streaming Segment replies with live routing/prefill/decode/checkpoint/failover
+  status, a fixed non-blocking input dock, slash-command autocomplete and menus
+  usable during inference.
+- Stable machine names, named `/swarm`/`/hosts` topology, `/experts` call
+  counters and periodic server-side host/executor/session telemetry.
+- Per-source Segment-relay token bucket, concurrency cap and bounded serialized
+  executor queue while caller-signed `LMB_RSEG` identities remain future work.
+- Restore isolation: multi-GB restores no longer hold the node-wide session
+  lock, and same-session `CLOSE` returns busy without blocking other chats.
+- Automatic Segment resource governor: CPU teams are bounded per slice,
+  fallback work is low priority, relay-only origins have lower session caps,
+  new sessions preserve a RAM reserve and automatic startup requires spare RAM.
+  **Release note:** NAT servers now start Segment slices too; they therefore use
+  additional CPU/RAM unless `--no-exec` is passed.
 - Segment temperature/top-p sampling through Colibri Edge logits, while
   preserving the exact greedy path at temperature zero.
 - Stateful Segment relay over signed outbound tracker tunnels, including

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -358,8 +358,12 @@ unsigned. Without it the client still works, but it is trusting the server.
 With Segment, the first answer fetches only the local Edge working set
 (tokenizer, embedding, final transform/head) into `~/.lumabri`; layer weights
 and state remain on peers. If Segment is unavailable, the same TUI starts the
-classic expert/CAS path and its dense working set automatically. `/swarm`
-shows the network, `/model` switches model.
+classic expert/CAS path and its dense working set automatically. `/swarm` and
+`/hosts` show named machines and their live roles, `/experts` shows executor
+call counts and Segment activity, and `/model` switches model. Slash commands
+autocomplete with Tab. During generation the fixed input dock remains usable:
+status shows routing/prefill/decode/failover and read-only menus open without
+waiting for the answer to finish.
 
 Verified chunks are shared across models in `~/.lumabri/cas`; override it
 with `LUMABRI_CAS=/fast/local/path`. To enable the basic straggler hedge, set
@@ -441,6 +445,38 @@ journalctl -u lumabri -f
 rm -rf /home/lumabri/models/mymodel/.lumabri_hashes
 systemctl restart lumabri
 ```
+
+Use `--host-name NAME` on `lumabri serve` when the automatic hostname is not
+recognizable. The storage, expert and Segment children inherit that prefix,
+and the server prints a periodic aggregate whenever hosts, calls or active
+sessions change.
+
+The Segment relay is deliberately bounded even though its end-user `LMB_RSEG`
+request does not yet contain a caller signature. The tracker applies a token
+bucket and concurrency cap per observed source, and waits only a bounded time
+for the serialized executor tunnel. Defaults and overrides are:
+
+```sh
+LUMABRI_RSEG_RATE=2048                 # weighted requests/second/source
+LUMABRI_RSEG_BURST=4096
+LUMABRI_RSEG_SOURCE_CONCURRENCY=32
+LUMABRI_RSEG_QUEUE_MS=2000
+```
+
+Private swarms should still set `LUMABRI_TOKEN`; source rate limiting is abuse
+containment, not a cryptographic end-user identity. Direct Segment remains the
+preferred data plane.
+
+Resource defaults for automatic origin slices are conservative:
+
+```sh
+LUMABRI_SEGMENT_MIN_FREE_MB=8192       # do not auto-start below this
+LUMABRI_SEGMENT_RAM_RESERVE_MB=4096    # reject new sessions below this
+```
+
+Threads are divided across layer slices, only one OpenMP team runs per slice,
+and fallback/NAT executors are niced. These ranges consume real RAM and CPU;
+use `--no-exec` when this server must provide storage only.
 
 Two things worth knowing:
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -472,11 +472,14 @@ Resource defaults for automatic origin slices are conservative:
 ```sh
 LUMABRI_SEGMENT_MIN_FREE_MB=8192       # do not auto-start below this
 LUMABRI_SEGMENT_RAM_RESERVE_MB=4096    # reject new sessions below this
+LUMABRI_SEGMENT_SESSIONS=2             # optional per-slice override (1..64)
 ```
 
 Threads are divided across layer slices, only one OpenMP team runs per slice,
-and fallback/NAT executors are niced. These ranges consume real RAM and CPU;
-use `--no-exec` when this server must provide storage only.
+and fallback/NAT executors are niced. Direct origins default to four sessions
+per slice and NAT/relay origins to two; the override above is bounded but can
+increase real KV RAM substantially. These ranges consume real RAM and CPU; use
+`--no-exec` when this server must provide storage only.
 
 Two things worth knowing:
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
-		test_segment_discovery \
+		test_segment_discovery test_swarm_detail test_relay_rate \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -394,6 +394,13 @@ test_segment_discovery: test_segment_discovery.c lumabri_segment_discovery.c \
 	$(CC) $(CFLAGS) -pthread test_segment_discovery.c \
 		lumabri_segment_discovery.c lumabri_segment.c -o $@
 
+test_swarm_detail: test_swarm_detail.c lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_swarm_detail.c -o $@
+
+test_relay_rate: test_relay_rate.c lumabri_segment.c lumabri_segment.h \
+		lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_relay_rate.c lumabri_segment.c -o $@
+
 # ---- Segment direct data plane (requires Colibri's additive Edge ABI) ---
 # `all` includes this only when both additive headers are present. A Lumabri
 # checkout pointed at an older/release Colibri therefore keeps building the
@@ -471,7 +478,7 @@ test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
-		test_segment_discovery
+		test_segment_discovery test_swarm_detail test_relay_rate
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -493,6 +500,8 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_hedge
 	./test_segment_v2
 	bash ./segment_discovery_test.sh
+	bash ./swarm_detail_test.sh
+	bash ./relay_rate_test.sh
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)
@@ -517,6 +526,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
+	      test_swarm_detail test_relay_rate \
 	      test_segment_v2_tsan tracker_tsan \
 	      segment_node segment_chat segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \

--- a/README.md
+++ b/README.md
@@ -74,7 +74,15 @@ Generation streams as soon as decoded text is stable. During inference a small
 dock remains fixed above the input and reports routing, prefill, decode,
 checkpoint or failover without splicing diagnostics into the answer. The input
 remains active: read-only menus open immediately and one next prompt or command
-can be prepared while the current KV transition finishes.
+can be prepared while the current KV transition finishes. `Ctrl-C` interrupts
+the active turn and exits immediately instead of waiting for it to finish;
+`Ctrl-Z` restores the terminal before suspending and rebuilds the dock after
+resume, while `Ctrl-\\` follows the same immediate shutdown path through
+`SIGQUIT`. Normal exit, `SIGINT`, `SIGTERM`, `SIGHUP` and `SIGQUIT` all restore
+the original terminal mode. If a child is genuinely uninterruptible, a second
+Ctrl-C forces the chatter out after the first has already restored the shell.
+As on every Unix program, `SIGKILL` cannot run cleanup; `reset` remains the
+recovery command after an external `kill -9`.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -62,11 +62,19 @@ the finer-grained expert donor remains the lower-memory fallback.
 Both run at low priority and die with the TUI. Nothing to configure — Enter
 picks "just chat".
 
-Inside the chat, `/swarm` shows the network live and anonymous (peers are
-numbered, never named), and `/model` lists the models on the swarm and switches
-between them on the fly. The prompt is a real line editor — arrow keys, Home/End,
-word and line kill, and Up/Down through the session's history — so a typo is one
-keystroke back, not a retyped line.
+Inside the chat, `/swarm` (or `/hosts`) shows stable human-readable machine
+names, storage served, expert calls and live Segment ranges. `/experts` answers
+how often each executor has actually been used; `/model`, `/debug`, `/storage`
+and `/help` expose the other controls. Tab completes slash commands. The prompt
+is a real line editor — arrow keys, Home/End, word and line kill, and Up/Down
+through the session's history — so a typo is one keystroke back, not a retyped
+line.
+
+Generation streams as soon as decoded text is stable. During inference a small
+dock remains fixed above the input and reports routing, prefill, decode,
+checkpoint or failover without splicing diagnostics into the answer. The input
+remains active: read-only menus open immediately and one next prompt or command
+can be prepared while the current KV transition finishes.
 
 ## How it works
 
@@ -206,6 +214,17 @@ enables the fastest direct paths on 7301 onward; allow 7300:7309 when using up
 to seven public Segment ranges. Without a reachable address, Segment, READ and
 EXEC use signed outbound tracker tunnels, so no data port is required. Add
 `--key swarm.key` to sign the model.
+
+`serve` derives names such as `host-gpu-box-7300-storage`, `-experts` and
+`-segment-1`; use `--host-name gpu-box` for an operator-chosen prefix. Its live
+summary reports connected hosts, bytes served, expert calls and active Segment
+runs, so successful swarm work is visible on both sides.
+
+Automatic Segment is a real compute service. It starts only with at least 8 GiB
+available by default (`LUMABRI_SEGMENT_MIN_FREE_MB`), divides CPU threads among
+the slices, runs fallback work at low priority and keeps 4 GiB free before
+accepting a new session (`LUMABRI_SEGMENT_RAM_RESERVE_MB`). A relay-only/NAT
+origin defaults to two sessions per slice; a direct server defaults to four.
 
 On every other machine, pick a role:
 

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -172,8 +172,11 @@ session, checkpoint/replay after a killed executor, and ordinary
   is refused when its estimated range would consume the system reserve. Live
   pressure-triggered migration is still pending.
 - Relay is a reachability floor, not the fastest topology: it adds a tracker hop
-  and currently serializes requests per executor tunnel. Reachable peers should
-  publish direct P2P; decentralized relay/hole punching remains future work.
+  and currently serializes requests per executor tunnel. The queue wait is
+  bounded and unsigned callers are rate/concurrency limited per observed
+  source; this is abuse containment, not caller authentication. Reachable peers
+  should publish direct P2P; multiplexing and decentralized relay/hole punching
+  remain future work.
 - One chatter process hosts one active Edge model. This also respects Qwen's
   currently process-global tokenizer state.
 

--- a/SEGMENT_V2.md
+++ b/SEGMENT_V2.md
@@ -120,6 +120,12 @@ A successful `run_begin` reserves the next transition. The adapter executes
 outside the table lock, then calls `run_commit` or `run_abort`. Commit alone
 advances sequence and position.
 
+The executor keeps one permanent mutex per session slot. A multi-gigabyte
+adapter restore holds only that session mutex: lookup releases the node-wide
+session-table mutex before waiting, and `CLOSE` reports `BUSY` for the one slot
+instead of blocking unrelated `OPEN`, `CLOSE`, snapshot or run traffic. The
+same lock prevents a close from destroying adapter state during a run.
+
 The table records the last 16 committed request identities and digests. A
 duplicate is never executed twice. The executor retains the most recent
 committed activation response for a safe immediate retry. An older recognized

--- a/lumabri.c
+++ b/lumabri.c
@@ -50,6 +50,12 @@
 /* ---- terminal ----------------------------------------------------------- */
 
 static int g_tty = 0;
+/* Snapshot the shell's terminal state once, before either line editor can
+ * touch it.  Taking live_begin's "old" value from the current tty created a
+ * narrow hand-off race where it could inherit the previous editor's cbreak
+ * mode and then faithfully restore a non-canonical terminal on Ctrl-Z. */
+static struct termios g_chat_term;
+static int g_chat_term_valid;
 #define C_DIM   (g_tty ? "\x1b[2m"  : "")
 #define C_BOLD  (g_tty ? "\x1b[1m"  : "")
 #define C_GRN   (g_tty ? "\x1b[32m" : "")
@@ -263,14 +269,42 @@ static void spawn_tracked(char *const argv[], const char *what) {
 }
 
 static volatile sig_atomic_t g_stopping = 0;
+/* The chat engine is not one of the optional donor children above.  Publish
+ * it separately so a shutdown signal can break a blocked read immediately
+ * instead of waiting for a long inference to finish. */
+static volatile sig_atomic_t g_signal_engine_pid = 0;
 
 static void on_sigint(int sig) {
-    (void)sig;
+    if (g_stopping) {
+        /* A second shutdown signal is the escape hatch for an engine stuck in
+         * an uninterruptible path.  The live input thread restored termios
+         * before the first Ctrl-C; _exit is async-signal-safe and cannot
+         * deadlock on a stdio/pthread lock held by another thread. */
+        sig_atomic_t engine = g_signal_engine_pid;
+        if (engine > 0) kill((pid_t)engine, SIGKILL);
+        _exit(128 + (sig > 0 && sig < 128 ? sig : SIGTERM));
+    }
     g_stopping = 1;
+    sig_atomic_t engine = g_signal_engine_pid;
+    if (engine > 0) kill((pid_t)engine, SIGTERM);
     for (int i = 0; i < MAX_CHILDREN; i++) {
         sig_atomic_t p = g_signal_children[i];
         if (p > 0) kill((pid_t)p, SIGTERM);
     }
+}
+
+static void install_chat_signal_handlers(void) {
+    struct sigaction action;
+    memset(&action, 0, sizeof action);
+    action.sa_handler = on_sigint;
+    sigemptyset(&action.sa_mask);
+    /* Do not use SA_RESTART: a signal from another terminal must also wake a
+     * line-editor read.  During inference the engine termination closes the
+     * pipe and wakes every streaming dialect independently of EINTR. */
+    sigaction(SIGINT, &action, NULL);
+    sigaction(SIGTERM, &action, NULL);
+    sigaction(SIGHUP, &action, NULL);
+    sigaction(SIGQUIT, &action, NULL);
 }
 
 /* Which expert-node binary can execute this model's experts, or NULL when
@@ -677,7 +711,8 @@ static int cmd_serve(int argc, char **argv) {
         if ((uint32_t)chunks > segment_layers) chunks = (int)segment_layers;
         int slice_threads = (int)(cores / chunks);
         if (slice_threads < 1) slice_threads = 1;
-        int sessions = advertise ? 4 : 2;
+        int sessions = lmb_env_int("LUMABRI_SEGMENT_SESSIONS",
+                                   advertise ? 4 : 2, 1, 64);
         uint32_t segment_context = 4096, model_context = 0;
         if (!local_model_u32(model, "max_position_embeddings", &model_context) &&
             model_context < segment_context)
@@ -1452,7 +1487,7 @@ typedef struct {
     pthread_mutex_t lock;
     volatile int active;
     int enabled, rows, cols, raw_set;
-    struct termios old_term;
+    struct termios old_term, raw_term;
     pthread_t thread;
     char tracker[80], model[64], phase[160], notice[160];
     char input[4096]; int input_len, input_pos;
@@ -1461,6 +1496,23 @@ typedef struct {
 } LiveUi;
 
 static LiveUi g_live = { .lock = PTHREAD_MUTEX_INITIALIZER };
+static int g_live_atexit_registered;
+
+/* Best-effort last line of defence for normal exit() paths.  Fatal signals
+ * are routed through on_sigint(), which wakes the main loop and reaches
+ * live_end(); SIGKILL is intentionally not claimed because no process can
+ * run cleanup after it. */
+static void live_atexit_restore(void) {
+    if (g_live.raw_set)
+        (void)tcsetattr(STDIN_FILENO, TCSANOW, &g_live.old_term);
+    if (g_live.enabled) {
+        static const char reset_scroll[] = "\x1b[r";
+        ssize_t ignored = write(STDOUT_FILENO, reset_scroll,
+                                sizeof reset_scroll - 1);
+        (void)ignored;
+    }
+    g_live.raw_set = 0;
+}
 
 static void live_draw_locked(void) {
     if (!g_live.enabled) return;
@@ -1567,9 +1619,57 @@ static void live_submit_input_locked(void) {
     live_draw_locked();
 }
 
+/* Called from the input worker before requesting shutdown.  The engine may be
+ * the very thing that is wedged, so terminal recovery cannot depend on the
+ * main thread first escaping its pipe read. */
+static void live_release_terminal_locked(void) {
+    if (g_live.enabled) {
+        printf("\x1b[r\x1b[%d;1H\x1b[2K\x1b[%d;1H\x1b[2K"
+               "\x1b[%d;1H\x1b[2K", g_live.rows - 2, g_live.rows - 1,
+               g_live.rows);
+        fflush(stdout);
+    }
+    if (g_live.raw_set)
+        (void)tcsetattr(STDIN_FILENO, TCSANOW, &g_live.old_term);
+    g_live.raw_set = 0;
+    g_live.enabled = 0;
+}
+
+/* Ctrl-Z is read as a byte while the dock owns raw input.  Restore canonical
+ * mode and the normal scrolling region before stopping, then reconstruct the
+ * dock after SIGCONT.  This is ordinary thread context, not a signal handler,
+ * so tcsetattr and stdio are safe here. */
+static void live_suspend_locked(void) {
+    if (g_live.enabled) {
+        printf("\x1b[r\x1b[%d;1H\x1b[2K\r\n", g_live.rows);
+        fflush(stdout);
+    }
+    if (g_live.raw_set) {
+        struct termios shell_term = g_live.old_term;
+        /* An interactive shell may hand a foreground job a cbreak-flavoured
+         * snapshot during the editor-to-dock transition.  Job control needs
+         * a genuinely usable terminal, not merely that snapshot: guarantee
+         * the conventional signal/canonical/echo controls while stopped. */
+        shell_term.c_lflag |= (tcflag_t)(ICANON | ECHO | ISIG | IEXTEN);
+        shell_term.c_iflag |= (tcflag_t)IXON;
+        shell_term.c_cc[VMIN] = 1; shell_term.c_cc[VTIME] = 0;
+        (void)tcsetattr(STDIN_FILENO, TCSANOW, &shell_term);
+    }
+    g_live.raw_set = 0;
+    raise(SIGTSTP);
+    if (!g_live.active || g_stopping) return;
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &g_live.raw_term)) return;
+    g_live.raw_set = 1;
+    g_live.rows = term_h(); g_live.cols = term_w();
+    g_live.enabled = g_live.rows >= 8;
+    if (g_live.enabled)
+        printf("\x1b[1;%dr", g_live.rows - 3);
+    live_draw_locked();
+}
+
 static void *live_input_thread(void *unused) {
     (void)unused;
-    while (g_live.active) {
+    while (g_live.active && !g_stopping) {
         struct pollfd pollfd = { STDIN_FILENO, POLLIN, 0 };
         int ready = poll(&pollfd, 1, 100);
         if (ready <= 0 || !(pollfd.revents & POLLIN)) continue;
@@ -1581,13 +1681,21 @@ static void *live_input_thread(void *unused) {
         } else if (c == '\t') {
             live_complete_locked(); live_draw_locked();
         } else if (c == 3) {
-            if (!g_live.pending_ready) {
-                snprintf(g_live.pending, sizeof g_live.pending, "/quit");
-                g_live.pending_ready = 1;
-            }
             snprintf(g_live.notice, sizeof g_live.notice,
-                     "uscita dopo la risposta in corso");
+                     "interrompo l'inferenza ed esco");
             live_draw_locked();
+            live_release_terminal_locked();
+            on_sigint(SIGINT);
+        } else if (c == 26) {
+            live_suspend_locked();
+        } else if (c == 28) {
+            snprintf(g_live.notice, sizeof g_live.notice,
+                     "SIGQUIT: interrompo l'inferenza ed esco");
+            live_draw_locked();
+            live_release_terminal_locked();
+            /* ISIG is disabled only while this worker owns the terminal; emit
+             * the conventional signal explicitly instead of swallowing ^\ . */
+            raise(SIGQUIT);
         } else if (c == 21) {
             live_clear_input_locked(); live_draw_locked();
         } else if (c == 127 || c == 8) {
@@ -1635,7 +1743,8 @@ static int live_begin(const char *tracker, const char *model,
                       const char *initial_phase) {
     if (!g_tty || !isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) return 0;
     struct termios raw;
-    if (tcgetattr(STDIN_FILENO, &g_live.old_term)) return 0;
+    if (g_chat_term_valid) g_live.old_term = g_chat_term;
+    else if (tcgetattr(STDIN_FILENO, &g_live.old_term)) return 0;
     raw = g_live.old_term;
     raw.c_lflag &= ~(tcflag_t)(ICANON | ECHO | ISIG | IEXTEN);
     raw.c_iflag &= ~(tcflag_t)IXON;
@@ -1644,6 +1753,7 @@ static int live_begin(const char *tracker, const char *model,
     pthread_mutex_lock(&g_live.lock);
     g_live.rows = term_h(); g_live.cols = term_w();
     g_live.enabled = g_live.rows >= 8;
+    g_live.raw_term = raw;
     g_live.raw_set = 1; g_live.active = 1;
     snprintf(g_live.tracker, sizeof g_live.tracker, "%s", tracker);
     snprintf(g_live.model, sizeof g_live.model, "%s", model);
@@ -1656,7 +1766,16 @@ static int live_begin(const char *tracker, const char *model,
         live_draw_locked();
     }
     pthread_mutex_unlock(&g_live.lock);
+    if (!g_live_atexit_registered) {
+        if (atexit(live_atexit_restore) == 0) g_live_atexit_registered = 1;
+    }
     if (pthread_create(&g_live.thread, NULL, live_input_thread, NULL)) {
+        if (g_live.enabled) {
+            static const char reset_scroll[] = "\x1b[r";
+            ssize_t ignored = write(STDOUT_FILENO, reset_scroll,
+                                    sizeof reset_scroll - 1);
+            (void)ignored;
+        }
         g_live.active = 0; g_live.enabled = 0;
         tcsetattr(STDIN_FILENO, TCSANOW, &g_live.old_term);
         g_live.raw_set = 0;
@@ -2271,6 +2390,7 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
     }
     close(in_pipe[0]); close(out_pipe[1]); close(err_pipe[1]);
     e->pid = pid; e->to = in_pipe[1]; e->from = out_pipe[0];
+    g_signal_engine_pid = (sig_atomic_t)pid;
     e->proto = PROTO_UNKNOWN;
     e->kind = engine_kind_of(engine);
     e->segment = 0;
@@ -2334,6 +2454,7 @@ static int segment_engine_spawn(const char *engine, const char *shim,
     }
     close(in_pipe[0]); close(out_pipe[1]); close(err_pipe[1]);
     e->pid = pid; e->to = in_pipe[1]; e->from = out_pipe[0];
+    g_signal_engine_pid = (sig_atomic_t)pid;
     e->proto = PROTO_UNKNOWN;
     e->kind = engine_kind_of(model_type);
     e->segment = 1;
@@ -2348,6 +2469,8 @@ static int segment_engine_spawn(const char *engine, const char *shim,
 static void engine_diag(Engine *e, int booting) {
     int st = 0;
     if (e->pid > 0 && waitpid(e->pid, &st, WNOHANG) == e->pid) {
+        if (g_signal_engine_pid == (sig_atomic_t)e->pid)
+            g_signal_engine_pid = 0;
         e->pid = 0;
         if (WIFSIGNALED(st)) {
             int s = WTERMSIG(st);
@@ -2398,9 +2521,30 @@ static void engine_diag(Engine *e, int booting) {
 
 static void engine_stop(Engine *e) {
     if (e->pid <= 0) return;
-    close(e->to); close(e->from);
-    kill(e->pid, SIGTERM);
-    waitpid(e->pid, NULL, 0);
+    pid_t pid = e->pid;
+    if (g_signal_engine_pid == (sig_atomic_t)pid)
+        g_signal_engine_pid = 0;
+    /* EOF is the Segment gateway's clean shutdown protocol: it closes every
+     * remote session before exiting.  Killing it unconditionally made normal
+     * /quit leak hour-long session leases until an executor hit its quota.
+     * A signal-driven interruption has already asked it to stop and simply
+     * falls through to the bounded reap/kill path. */
+    close(e->to); e->to = -1;
+    if (e->segment && !g_stopping) {
+        for (int attempt = 0; attempt < 100; attempt++) {
+            pid_t done = waitpid(pid, NULL, WNOHANG);
+            if (done == pid || (done < 0 && errno == ECHILD)) {
+                close(e->from); e->from = -1; e->pid = 0;
+                return;
+            }
+            struct timespec pause = {0, 20 * 1000 * 1000};
+            while (nanosleep(&pause, &pause) && errno == EINTR && !g_stopping) { }
+            if (g_stopping) break;
+        }
+    }
+    close(e->from); e->from = -1;
+    kill(pid, SIGTERM);
+    waitpid(pid, NULL, 0);
     e->pid = 0;
 }
 
@@ -2645,7 +2789,8 @@ static void le_set(char *buf, size_t cap, int *len, int *pos, const char *text) 
 
 static int line_edit(char *buf, size_t cap) {
     struct termios old, raw;
-    if (tcgetattr(0, &old)) return -2;         /* not a real tty -> caller fgets */
+    if (g_chat_term_valid) old = g_chat_term;
+    else if (tcgetattr(0, &old)) return -2;    /* not a real tty -> caller fgets */
     raw = old;
     /* Clear ISIG/IEXTEN too, and IXON, so Ctrl-C / Ctrl-Z / Ctrl-S reach read()
      * as bytes instead of the tty acting on them behind our back — otherwise the
@@ -2669,7 +2814,10 @@ static int line_edit(char *buf, size_t cap) {
     for (;;) {
         unsigned char c;
         ssize_t rn = read(0, &c, 1);
-        if (rn < 0 && errno == EINTR) continue;  /* a signal, not end of input */
+        if (rn < 0 && errno == EINTR) {
+            if (g_stopping) { rc = -1; break; }
+            continue;
+        }
         if (rn <= 0) { rc = -1; break; }
 
         if (c == '\r' || c == '\n') { printf("\r\n"); break; }
@@ -2682,8 +2830,15 @@ static int line_edit(char *buf, size_t cap) {
         if (c == 26) {                           /* Ctrl-Z: suspend, terminal restored */
             tcsetattr(0, TCSANOW, &old);
             raise(SIGTSTP);
+            if (g_stopping) { rc = -1; len = 0; break; }
             tcsetattr(0, TCSANOW, &raw);         /* resumed: back to raw */
             continue;
+        }
+        if (c == 28) {                           /* Ctrl-\: conventional SIGQUIT */
+            tcsetattr(0, TCSANOW, &old);
+            printf("\r\n");
+            raise(SIGQUIT);
+            rc = -1; len = 0; break;
         }
         if (c != '\t') { completion[0] = 0; completion_next = 0; }
         if (c == '\t') {                        /* cycle slash-command matches */
@@ -3406,6 +3561,8 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
 }
 
 static int cmd_chat(int argc, char **argv) {
+    g_stopping = 0;
+    install_chat_signal_handlers();
     const char *tracker = NULL;
     const char *engine_path = NULL, *engines_dir = getenv("LUMABRI_ENGINES");
     const char *want_model = NULL, *local_dir = NULL;
@@ -3434,6 +3591,8 @@ static int cmd_chat(int argc, char **argv) {
                                "[--donate GB] [--model-dir DIR] [--donor-name S]\n");
                return 2; }
     }
+    g_chat_term_valid = g_tty && isatty(STDIN_FILENO) &&
+                        tcgetattr(STDIN_FILENO, &g_chat_term) == 0;
 
     /* The panel comes BEFORE anything is contacted: the wordmark, then what
      * is missing, then the role. A TUI user never sees a flag. */
@@ -3593,8 +3752,6 @@ static int cmd_chat(int argc, char **argv) {
                    ctx, max_new, cap_experts, &eng, &sw))
         return 1;
     if (role.disk || role.compute) {
-        signal(SIGINT, on_sigint);            /* the donors die with the chat */
-        signal(SIGTERM, on_sigint);
         role_start(&role, tracker, model, sw.model_type, eng.segment, ctx,
                    sw.total_bytes);
     }
@@ -3602,6 +3759,7 @@ static int cmd_chat(int argc, char **argv) {
     char *conv = calloc(1, 1);   /* serve-codec conversation history (after bos) */
     char line[4096];
     for (;;) {
+        if (g_stopping) break;
         int queued = live_take_pending(line, sizeof line);
         int w = term_w() - 2;
         if (g_tty) {
@@ -3619,7 +3777,7 @@ static int cmd_chat(int argc, char **argv) {
         } else
             got = prompt_line(line, sizeof line) == 0;   /* line editor when a tty */
         if (g_tty) hline("\xe2\x95\xb0", "\xe2\x95\xaf", w);
-        if (!got) break;
+        if (!got || g_stopping) break;
         size_t L = strlen(line);   /* prompt_line already stripped the newline */
         if (!L) continue;
         if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) break;
@@ -3693,6 +3851,11 @@ static int cmd_chat(int argc, char **argv) {
             int dead = stream_serve2(&eng, stat, sizeof stat, &reply);
             g_eng.streaming = 0;
             live_end();
+            if (g_stopping) {
+                free(reply);
+                printf("\n  %sinferenza interrotta%s\n", C_DIM, C_R);
+                break;
+            }
             if (dead) {
                 fprintf(stderr, "\n%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);
@@ -3709,6 +3872,10 @@ static int cmd_chat(int argc, char **argv) {
             int dead = stream_until_end(&eng, stat, sizeof stat);
             g_eng.streaming = 0;
             live_end();
+            if (g_stopping) {
+                printf("\n  %sinferenza interrotta%s\n", C_DIM, C_R);
+                break;
+            }
             if (dead) {
                 fprintf(stderr, "\n%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);
@@ -3726,6 +3893,11 @@ static int cmd_chat(int argc, char **argv) {
             g_eng.spinning = 0;
             if (live) live_end();
             else if (g_tty) pthread_join(tspin, NULL);
+            if (g_stopping) {
+                free(reply);
+                printf("\n  %sinferenza interrotta%s\n", C_DIM, C_R);
+                break;
+            }
             if (!reply) {
                 fprintf(stderr, "%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);

--- a/lumabri.c
+++ b/lumabri.c
@@ -9,8 +9,8 @@
  * first touch and stay in the local mirror), spawns the UNMODIFIED colibri
  * engine in its interactive CHAT mode, and wraps it in a terminal UI.
  *
- * In-chat commands: /swarm (anonymous network status), /model (list and
- * switch model, restarting the engine), /reset, /quit.
+ * In-chat commands: /swarm and /hosts (named live topology), /experts
+ * (executor use), /model, /debug, /storage, /reset, /help and /quit.
  *
  * The engines are taken exactly as they are, which means speaking both of
  * the protocols colibri ships: olmoe's line dialect (CHAT=1, a "> " prompt)
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <ifaddrs.h>
 #include <math.h>
+#include <poll.h>
 #include <pthread.h>
 #include <signal.h>
 #include <stdarg.h>
@@ -42,6 +43,7 @@
 #include <unistd.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_segment_discovery.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 
@@ -66,6 +68,18 @@ static int term_w(void) {
     if (g_tty && ioctl(1, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 20) return ws.ws_col;
     return 80;
 }
+
+static int term_h(void) {
+    struct winsize ws;
+    if (g_tty && ioctl(1, TIOCGWINSZ, &ws) == 0 && ws.ws_row > 7)
+        return ws.ws_row;
+    return 24;
+}
+
+static const char *const CHAT_COMMANDS[] = {
+    "/swarm", "/experts", "/hosts", "/model", "/debug", "/storage",
+    "/reset", "/help", "/quit",
+};
 
 static void exe_dir(char *dst, size_t cap) {
     ssize_t n = readlink("/proc/self/exe", dst, cap - 1);
@@ -383,6 +397,35 @@ static int machine_public_ipv4(char *out, size_t cap) {
     return found;
 }
 
+/* A readable, collision-resistant default for every role started by one
+ * `serve`.  The port distinguishes two swarms on the same machine; role
+ * suffixes distinguish storage, classic experts and Segment slices. */
+static int machine_host_base(const char *chosen, int port,
+                             char *out, size_t cap) {
+    char raw[64] = "";
+    if (chosen && chosen[0]) {
+        if (strlen(chosen) >= sizeof raw) return -1;
+        snprintf(raw, sizeof raw, "%s", chosen);
+    }
+    else if (gethostname(raw, sizeof raw - 1)) snprintf(raw, sizeof raw, "machine");
+    char clean[24];
+    size_t used = 0;
+    for (const char *p = raw; *p && used < sizeof clean - 1; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c >= 'A' && c <= 'Z') c = (unsigned char)(c - 'A' + 'a');
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-')
+            clean[used++] = (char)c;
+        else if ((c == ' ' || c == '_' || c == '.') && used &&
+                 clean[used - 1] != '-')
+            clean[used++] = '-';
+    }
+    while (used && clean[used - 1] == '-') used--;
+    clean[used] = 0;
+    if (!used) snprintf(clean, sizeof clean, "machine");
+    if (chosen && chosen[0]) return checked_printf(out, cap, "%s", clean);
+    return checked_printf(out, cap, "host-%s-%d", clean, port);
+}
+
 static const char *model_name_for(const char *model_dir, const char *explicit,
                                   char *storage, size_t cap) {
     if (explicit && explicit[0]) return explicit;
@@ -405,9 +448,12 @@ static int parse_serve_port(const char *s, int *port) {
     return 0;
 }
 
+static void serve_watch_start(const char *tracker, const char *model);
+
 static int cmd_serve(int argc, char **argv) {
     const char *model = NULL, *join = NULL, *mname = NULL, *donate = NULL;
     const char *key = NULL, *pubkey = NULL, *advertise = NULL;
+    const char *host_name = NULL;
     int port = 7300, no_exec = 0, cache_slots = 128;
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "--model") && i + 1 < argc) model = argv[++i];
@@ -423,11 +469,13 @@ static int cmd_serve(int argc, char **argv) {
         else if (!strcmp(argv[i], "--key") && i + 1 < argc) key = argv[++i];
         else if (!strcmp(argv[i], "--pubkey") && i + 1 < argc) pubkey = argv[++i];
         else if (!strcmp(argv[i], "--advertise") && i + 1 < argc) advertise = argv[++i];
+        else if (!strcmp(argv[i], "--host-name") && i + 1 < argc) host_name = argv[++i];
         else if (!strcmp(argv[i], "--no-exec")) no_exec = 1;
         else if (!strcmp(argv[i], "--exec-cache") && i + 1 < argc) cache_slots = atoi(argv[++i]);
         else { fprintf(stderr, "usage: lumabri serve --model DIR [--port N] "
                                "[--join TRACKER] [--model-name S] [--donate GB] "
                                "[--key FILE] [--pubkey FILE] [--advertise HOST] "
+                               "[--host-name NAME] "
                                "[--no-exec] [--exec-cache N]\n"); return 2; }
     }
     if (!model) { fprintf(stderr, "usage: lumabri serve --model DIR [--port N]\n"); return 2; }
@@ -446,6 +494,10 @@ static int cmd_serve(int argc, char **argv) {
         }
     }
     int disk_donor = donate != NULL;
+    char host_base[40];
+    if (machine_host_base(host_name, port, host_base, sizeof host_base)) {
+        fprintf(stderr, "--host-name is empty or too long\n"); return 2;
+    }
     struct stat st;
     if (stat(model, &st) && disk_donor) mkdir_p(model);  /* a donor starts empty */
     if (stat(model, &st) || !S_ISDIR(st.st_mode)) {
@@ -515,12 +567,16 @@ static int cmd_serve(int argc, char **argv) {
         spawn_tracked(targv, "il tracker");
         usleep(300 * 1000);
     }
-    char *margv[24];
+    char storage_name[64];
+    if (checked_printf(storage_name, sizeof storage_name, "%s-storage", host_base))
+        return 2;
+    char *margv[32];
     int a = 0;
     margv[a++] = maint_bin;
     margv[a++] = "--root"; margv[a++] = (char *)model;
     margv[a++] = "--port"; margv[a++] = mport;
     margv[a++] = "--tracker"; margv[a++] = taddr;
+    margv[a++] = "--name"; margv[a++] = storage_name;
     if (mname) { margv[a++] = "--model-name"; margv[a++] = (char *)mname; }
     if (donate) { margv[a++] = "--donate"; margv[a++] = (char *)donate; }
     if (key) { margv[a++] = "--key"; margv[a++] = (char *)key; }
@@ -555,10 +611,10 @@ static int cmd_serve(int argc, char **argv) {
         printf("  %s%s non è compilato: nessun esperto eseguito qui "
                "(make %s ENGINE=/path/to/colibri/c)%s\n", C_DIM, node, node, C_R);
     if (!no_exec && !disk_donor && node && access(exec_bin, X_OK) == 0) {
-        char eport[16], cachestr[16], ename[32];
+        char eport[16], cachestr[16], ename[64];
         snprintf(eport, sizeof eport, "%d", port + 2);
         snprintf(cachestr, sizeof cachestr, "%d", cache_slots);
-        snprintf(ename, sizeof ename, "exec-%d", port);
+        snprintf(ename, sizeof ename, "%s-experts", host_base);
         char *eargv[16];
         a = 0;
         eargv[a++] = exec_bin;
@@ -598,23 +654,38 @@ static int cmd_serve(int argc, char **argv) {
         model, mname, segment_model_storage, sizeof segment_model_storage);
     uint32_t segment_layers = 0;
     int with_segment = 0;
-    if (!disk_donor && !no_exec && segment_engine && segment_model &&
-        access(segment_bin, X_OK) == 0 &&
-        local_model_layers(model, &segment_layers) == 0) {
+    int segment_candidate = !disk_donor && !no_exec && segment_engine &&
+        segment_model && access(segment_bin, X_OK) == 0 &&
+        local_model_layers(model, &segment_layers) == 0;
+    uint64_t segment_available = machine_available_ram();
+    uint64_t segment_min_free = (uint64_t)lmb_env_int(
+        "LUMABRI_SEGMENT_MIN_FREE_MB", 8192, 1024, 262144) << 20;
+    if (segment_candidate && segment_available &&
+        segment_available < segment_min_free) {
+        printf("  %sSegment automatico non avviato: %.1f GB RAM disponibili, "
+               "il governor ne richiede %.1f. Storage ed expert restano "
+               "disponibili; regola LUMABRI_SEGMENT_MIN_FREE_MB solo se "
+               "conosci il carico della macchina.%s\n",
+               C_DIM, (double)segment_available / 1e9,
+               (double)segment_min_free / 1e9, C_R);
+        segment_candidate = 0;
+    }
+    if (segment_candidate) {
         long cores = sysconf(_SC_NPROCESSORS_ONLN);
         if (cores < 1) cores = 1;
         int chunks = lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 4, 1, 7);
         if ((uint32_t)chunks > segment_layers) chunks = (int)segment_layers;
-        int sessions = (int)(cores / chunks);
-        if (sessions < 1) sessions = 1;
-        if (sessions > 8) sessions = 8;
+        int slice_threads = (int)(cores / chunks);
+        if (slice_threads < 1) slice_threads = 1;
+        int sessions = advertise ? 4 : 2;
         uint32_t segment_context = 4096, model_context = 0;
         if (!local_model_u32(model, "max_position_embeddings", &model_context) &&
             model_context < segment_context)
             segment_context = model_context;
-        char context[16], session_text[16];
+        char context[16], session_text[16], thread_text[16];
         snprintf(context, sizeof context, "%u", segment_context);
         snprintf(session_text, sizeof session_text, "%d", sessions);
+        snprintf(thread_text, sizeof thread_text, "%d", slice_threads);
 
         /* A few disjoint origin slices retain the single-copy weight total,
          * but give placement exact boundaries it can replace independently:
@@ -630,11 +701,11 @@ static int cmd_serve(int argc, char **argv) {
             char sport[16], range[40], sname[64], sadv[80];
             snprintf(sport, sizeof sport, "%d", port + 3 + chunk);
             snprintf(range, sizeof range, "%u:%u", begin, end);
-            snprintf(sname, sizeof sname, "segment-%s-%d-%d",
-                     join ? "peer" : "origin", port, chunk);
+            snprintf(sname, sizeof sname, "%s-segment-%d", host_base,
+                     chunk + 1);
             snprintf(sadv, sizeof sadv, "%s:%d",
                      advertise ? advertise : "127.0.0.1", port + 3 + chunk);
-            char *sargv[32];
+            char *sargv[36];
             a = 0;
             sargv[a++] = segment_bin;
             sargv[a++] = "--engine";       sargv[a++] = (char *)segment_engine;
@@ -650,6 +721,7 @@ static int cmd_serve(int argc, char **argv) {
             sargv[a++] = "--context";      sargv[a++] = context;
             sargv[a++] = "--max-rows";     sargv[a++] = "16";
             sargv[a++] = "--sessions";     sargv[a++] = session_text;
+            sargv[a++] = "--threads";      sargv[a++] = thread_text;
             sargv[a++] = "--advertise";    sargv[a++] = sadv;
             sargv[a] = NULL;
             char slog[1200];
@@ -658,13 +730,13 @@ static int cmd_serve(int argc, char **argv) {
                                  donor_log_path(sname, slog, sizeof slog));
             with_segment++;
         }
-        double ram_gb = (double)machine_available_ram() / 1e9;
+        double ram_gb = (double)segment_available / 1e9;
         const char *home = getenv("HOME") ? getenv("HOME") : ".";
         printf("  %sSegment prepara %d fette layer-aligned sulle porte %d-%d "
-               "(%ld CPU, %.1f GB RAM disponibili, %d sessioni/fetta). "
+               "(%ld CPU, %.1f GB RAM disponibili, %d thread e %d sessioni/fetta). "
                "%s%s%s\n",
                C_DIM, chunks, port + 3, port + 2 + chunks, cores, ram_gb,
-               sessions, join ? "Sono peer ordinari; " :
+               slice_threads, sessions, join ? "Sono peer ordinari; " :
                "Sono il fallback sostituibile; ",
                advertise ? "data plane diretto con relay di sicurezza. " :
                            "data plane relay (nessuna porta pubblica richiesta). ",
@@ -672,9 +744,9 @@ static int cmd_serve(int argc, char **argv) {
         /* Their diagnostics belong in one file per slice: N unbuffered
          * writers on one terminal shred each other's lines exactly when
          * something has gone wrong and the line matters most. */
-        printf("  %slog delle fette: %s/.lumabri/logs/segment-%s-%d-*.log · "
+        printf("  %slog delle fette: %s/.lumabri/logs/%s-segment-*.log · "
                "%s%s\n",
-               C_DIM, home, join ? "peer" : "origin", port,
+               C_DIM, home, host_base,
                advertise ? "apri le porte Segment sul firewall per il P2P diretto"
                          : "relay NAT attivo: non serve aprire le porte Segment",
                C_R);
@@ -682,7 +754,8 @@ static int cmd_serve(int argc, char **argv) {
     signal(SIGINT, on_sigint);
     signal(SIGTERM, on_sigint);
 
-    printf("\n%sserving%s %s %s(tracker %s%s)%s\n", C_GRN, C_R, model, C_DIM, taddr,
+    printf("\n%sserving%s %s %s(host %s · tracker %s%s)%s\n", C_GRN, C_R,
+           model, C_DIM, host_base, taddr,
            with_segment ? " · Segment origin attivo" :
            (with_exec ? " · executing experts for the swarm" : ""), C_R);
     /* Without --advertise every local peer uses its signed outbound tracker
@@ -698,6 +771,8 @@ static int cmd_serve(int argc, char **argv) {
     printf("%schat from this machine:   lumabri chat%s\n", C_DIM, C_R);
     printf("%schat from another one:    lumabri chat --tracker <this-ip>:%d%s\n\n",
            C_DIM, port, C_R);
+    serve_watch_start(taddr, segment_model ? segment_model :
+                      (mname && mname[0] ? mname : model));
     while (g_nchildren) {
         int status;
         pid_t p = wait(&status);
@@ -836,6 +911,130 @@ typedef struct {
     int have_stats;
 } ExecSwarmRow;
 
+typedef struct {
+    char name[64], model[64];
+    uint32_t roles, age_s;
+    uint64_t held_bytes, served_bytes, served_reads;
+    uint32_t nfiles, nexperts, have_exec_stats;
+    uint64_t exec_calls;
+    uint32_t exec_inflight;
+    uint32_t layer_begin, layer_end;
+    uint32_t active_sessions, max_sessions, segment_queue, segment_inflight;
+    uint32_t segment_flags;
+} SwarmDetailRow;
+
+static int swarm_detail(const char *tracker, SwarmDetailRow *rows, int cap) {
+    LmbMsg message = {0};
+    if (lmb_request(tracker, LMB_SWARM_DETAIL, NULL, 0, &message)) return -1;
+    if (message.op != LMB_SWARM_DETAIL_R || message.pay_len) {
+        lmb_msg_free(&message); return -2;
+    }
+    LmbCur cursor = { message.body, message.body_len, 0 };
+    uint32_t version = 0, count = 0;
+    if (lmb_cur_u32(&cursor, &version) ||
+        version != LMB_SWARM_DETAIL_VERSION ||
+        lmb_cur_u32(&cursor, &count) || count > 4096) {
+        lmb_msg_free(&message); return -2;
+    }
+    int out = 0;
+    for (uint32_t index = 0; index < count; index++) {
+        SwarmDetailRow row = {0};
+        int bad = lmb_cur_str(&cursor, row.name, sizeof row.name) ||
+                  lmb_cur_str(&cursor, row.model, sizeof row.model) ||
+                  lmb_cur_u32(&cursor, &row.roles) ||
+                  lmb_cur_u32(&cursor, &row.age_s) ||
+                  lmb_cur_u64(&cursor, &row.held_bytes) ||
+                  lmb_cur_u64(&cursor, &row.served_bytes) ||
+                  lmb_cur_u64(&cursor, &row.served_reads) ||
+                  lmb_cur_u32(&cursor, &row.nfiles) ||
+                  lmb_cur_u32(&cursor, &row.nexperts) ||
+                  lmb_cur_u32(&cursor, &row.have_exec_stats) ||
+                  lmb_cur_u64(&cursor, &row.exec_calls) ||
+                  lmb_cur_u32(&cursor, &row.exec_inflight) ||
+                  lmb_cur_u32(&cursor, &row.layer_begin) ||
+                  lmb_cur_u32(&cursor, &row.layer_end) ||
+                  lmb_cur_u32(&cursor, &row.active_sessions) ||
+                  lmb_cur_u32(&cursor, &row.max_sessions) ||
+                  lmb_cur_u32(&cursor, &row.segment_queue) ||
+                  lmb_cur_u32(&cursor, &row.segment_inflight) ||
+                  lmb_cur_u32(&cursor, &row.segment_flags);
+        if (bad || !row.name[0] || !row.model[0] ||
+            (row.roles & ~(LMB_SWARM_ROLE_STORAGE | LMB_SWARM_ROLE_EXPERT |
+                           LMB_SWARM_ROLE_SEGMENT)) ||
+            row.have_exec_stats > 1u) {
+            lmb_msg_free(&message); return -2;
+        }
+        if (out < cap) rows[out++] = row;
+    }
+    int malformed = cursor.off != cursor.len;
+    lmb_msg_free(&message);
+    return malformed ? -2 : out;
+}
+
+typedef struct { char tracker[80], model[64]; } ServeWatch;
+
+static void *serve_watch_thread(void *opaque) {
+    ServeWatch *watch = opaque;
+    int last_hosts = -1, last_storage = -1, last_experts = -1, last_segments = -1;
+    uint64_t last_calls = UINT64_MAX;
+    unsigned tick = 0;
+    while (!g_stopping) {
+        for (int part = 0; part < 10 && !g_stopping; part++) sleep(1);
+        if (g_stopping) break;
+        SwarmDetailRow rows[64];
+        int n = swarm_detail(watch->tracker, rows, 64);
+        if (n < 0) {
+            if ((tick++ % 3u) == 0)
+                printf("%s[swarm] tracker non raggiungibile; i nodi continuano "
+                       "a ritentare%s\n", C_DIM, C_R);
+            continue;
+        }
+        int hosts = 0, storage = 0, experts = 0, segments = 0;
+        uint32_t sessions = 0, segment_inflight = 0, expert_inflight = 0;
+        uint64_t calls = 0;
+        for (int i = 0; i < n; i++) {
+            if (watch->model[0] && strcmp(rows[i].model, watch->model)) continue;
+            hosts++;
+            storage += !!(rows[i].roles & LMB_SWARM_ROLE_STORAGE);
+            experts += !!(rows[i].roles & LMB_SWARM_ROLE_EXPERT);
+            segments += !!(rows[i].roles & LMB_SWARM_ROLE_SEGMENT);
+            calls += rows[i].have_exec_stats ? rows[i].exec_calls : 0;
+            expert_inflight += rows[i].exec_inflight;
+            sessions += rows[i].active_sessions;
+            segment_inflight += rows[i].segment_inflight;
+        }
+        int changed = hosts != last_hosts || storage != last_storage ||
+                      experts != last_experts || segments != last_segments ||
+                      calls != last_calls || expert_inflight || segment_inflight;
+        if (changed || (++tick % 6u) == 0) {
+            printf("%s[swarm]%s %d nodi collegati · %d storage · %d expert "
+                   "(%llu chiamate, %u attive) · %d Segment "
+                   "(%u sessioni, %u run attive)\n",
+                   C_CORAL, C_R, hosts, storage, experts,
+                   (unsigned long long)calls, expert_inflight, segments,
+                   sessions, segment_inflight);
+            fflush(stdout);
+        }
+        last_hosts = hosts; last_storage = storage; last_experts = experts;
+        last_segments = segments; last_calls = calls;
+    }
+    free(watch);
+    return NULL;
+}
+
+static void serve_watch_start(const char *tracker, const char *model) {
+    ServeWatch *watch = calloc(1, sizeof *watch);
+    if (!watch) return;
+    if (checked_printf(watch->tracker, sizeof watch->tracker, "%s", tracker) ||
+        checked_printf(watch->model, sizeof watch->model, "%s", model)) {
+        free(watch); return;
+    }
+    pthread_t thread;
+    if (!pthread_create(&thread, NULL, serve_watch_thread, watch))
+        pthread_detach(thread);
+    else free(watch);
+}
+
 static int swarm_stats(const char *tracker, SwarmRow *rows, int cap,
                        ExecSwarmRow *exec_rows, int exec_cap, int *exec_out) {
     LmbMsg m = {0};
@@ -890,8 +1089,56 @@ static int swarm_stats(const char *tracker, SwarmRow *rows, int cap,
     return malformed ? -2 : out;
 }
 
-/* /swarm: the network, anonymous. Peers are numbered, never named. */
+static void render_named_swarm(const SwarmDetailRow *rows, int n) {
+    int storage = 0, experts = 0, segments = 0;
+    for (int i = 0; i < n; i++) {
+        storage += !!(rows[i].roles & LMB_SWARM_ROLE_STORAGE);
+        experts += !!(rows[i].roles & LMB_SWARM_ROLE_EXPERT);
+        segments += !!(rows[i].roles & LMB_SWARM_ROLE_SEGMENT);
+    }
+    printf("\n  %s%ssciame live%s  %s%d nodi · %d storage · %d expert · "
+           "%d Segment%s\n", C_BOLD, C_CORAL, C_R, C_DIM, n, storage,
+           experts, segments, C_R);
+    for (int i = 0; i < n; i++) {
+        const SwarmDetailRow *row = &rows[i];
+        printf("  %s%-28.28s%s  %-16.16s  ", C_BOLD, row->name, C_R,
+               row->model);
+        int separator = 0;
+        if (row->roles & LMB_SWARM_ROLE_STORAGE) {
+            printf("storage %.1f GB · %.0f MB/%llu req",
+                   (double)row->held_bytes / 1e9,
+                   (double)row->served_bytes / 1e6,
+                   (unsigned long long)row->served_reads);
+            separator = 1;
+        }
+        if (row->roles & LMB_SWARM_ROLE_EXPERT) {
+            if (separator) printf(" | ");
+            printf("%u expert", row->nexperts);
+            if (row->have_exec_stats)
+                printf(" · %llu call · %u attive",
+                       (unsigned long long)row->exec_calls,
+                       row->exec_inflight);
+            separator = 1;
+        }
+        if (row->roles & LMB_SWARM_ROLE_SEGMENT) {
+            if (separator) printf(" | ");
+            printf("layer %u:%u · sessioni %u/%u · %u attive%s",
+                   row->layer_begin, row->layer_end,
+                   row->active_sessions, row->max_sessions,
+                   row->segment_inflight,
+                   row->segment_flags & LMB_SEG_ADVERT_RELAY_ONLY
+                       ? " · relay" : " · diretto");
+        }
+        printf(" %s· hb %us%s\n", C_DIM, row->age_s, C_R);
+    }
+}
+
+/* /swarm: prefer operator-chosen host names and real role/load counters.
+ * Fall back to the anonymous legacy view when talking to an older tracker. */
 static void render_swarm(const char *tracker) {
+    SwarmDetailRow detail[64];
+    int nd = swarm_detail(tracker, detail, 64);
+    if (nd >= 0) { render_named_swarm(detail, nd); return; }
     SwarmRow rows[64];
     ExecSwarmRow exec_rows[64];
     int ne = 0;
@@ -935,6 +1182,49 @@ static void render_swarm(const char *tracker) {
                pad > 0 ? pad : 0, "", C_GRAY, C_R);
     }
     hline("\xe2\x95\xb0", "\xe2\x95\xaf", w);
+}
+
+/* /experts is the compact answer to "are my donated experts actually being
+ * used?". Names are stable and human-readable, so a user can recognize this
+ * machine without exposing its address. Segment ranges are included because
+ * they execute the same MoE blocks without issuing classic EXEC calls. */
+static void render_experts(const char *tracker) {
+    SwarmDetailRow rows[64];
+    int n = swarm_detail(tracker, rows, 64);
+    if (n == -1) { printf("  %stracker irraggiungibile%s\n", C_RED, C_R); return; }
+    if (n < 0) {
+        printf("  %sil tracker non espone ancora i contatori nominativi%s\n",
+               C_DIM, C_R); return;
+    }
+    int shown = 0;
+    uint64_t calls = 0;
+    printf("\n  %s%suso degli executor%s\n", C_BOLD, C_CORAL, C_R);
+    for (int i = 0; i < n; i++) {
+        SwarmDetailRow *row = &rows[i];
+        if (!(row->roles & (LMB_SWARM_ROLE_EXPERT |
+                            LMB_SWARM_ROLE_SEGMENT))) continue;
+        shown++;
+        printf("  %s%-28.28s%s  ", C_BOLD, row->name, C_R);
+        if (row->roles & LMB_SWARM_ROLE_EXPERT) {
+            if (row->have_exec_stats) {
+                printf("%llu chiamate expert · %u in corso",
+                       (unsigned long long)row->exec_calls,
+                       row->exec_inflight);
+                calls += row->exec_calls;
+            } else printf("%u expert · contatore in attesa", row->nexperts);
+        }
+        if (row->roles & LMB_SWARM_ROLE_SEGMENT) {
+            if (row->roles & LMB_SWARM_ROLE_EXPERT) printf(" | ");
+            printf("Segment %u:%u · sessioni %u/%u · %u run in corso",
+                   row->layer_begin, row->layer_end,
+                   row->active_sessions, row->max_sessions,
+                   row->segment_inflight);
+        }
+        printf("\n");
+    }
+    if (!shown) printf("  %snessun executor collegato%s\n", C_DIM, C_R);
+    else printf("  %stotale classico: %llu chiamate expert completate%s\n",
+                C_DIM, (unsigned long long)calls, C_R);
 }
 
 /* distinct model names on the swarm; returns count */
@@ -1137,6 +1427,273 @@ static void render_debug(void) {
         printf("  %snessun donatore in questa sessione%s\n", C_DIM, C_R);
 }
 
+static void render_help(void) {
+    printf("\n  %s%scomandi%s\n", C_BOLD, C_CORAL, C_R);
+    printf("  %-12s stato nominativo di host, storage, expert e Segment\n", "/swarm");
+    printf("  %-12s chiamate degli expert e sessioni Segment\n", "/experts");
+    printf("  %-12s alias compatto di /swarm\n", "/hosts");
+    printf("  %-12s elenca o cambia il modello\n", "/model");
+    printf("  %-12s diagnostica del motore e dei donor\n", "/debug");
+    printf("  %-12s spazio occupato da mirror e CAS\n", "/storage");
+    printf("  %-12s nuova conversazione\n", "/reset");
+    printf("  %-12s chiude la chat\n", "/quit");
+    printf("  %sTab completa i comandi. Durante l'inferenza puoi aprire questi "
+           "pannelli o preparare il prompt successivo.%s\n", C_DIM, C_R);
+}
+
+static int le_prev(const char *s, int pos);
+static int le_next(const char *s, int len, int pos);
+
+/* During inference the response owns the scrolling part of the terminal and
+ * these three bottom rows remain stable: separator, live phase, next input.
+ * A tiny raw-input worker lets read-only menus open immediately and queues one
+ * next prompt without ever issuing two requests against the same KV session. */
+typedef struct {
+    pthread_mutex_t lock;
+    volatile int active;
+    int enabled, rows, cols, raw_set;
+    struct termios old_term;
+    pthread_t thread;
+    char tracker[80], model[64], phase[160], notice[160];
+    char input[4096]; int input_len, input_pos;
+    char pending[4096]; int pending_ready;
+    char completion[64]; int completion_next;
+} LiveUi;
+
+static LiveUi g_live = { .lock = PTHREAD_MUTEX_INITIALIZER };
+
+static void live_draw_locked(void) {
+    if (!g_live.enabled) return;
+    int width = g_live.cols > 20 ? g_live.cols : 80;
+    printf("\x1b" "7");
+    printf("\x1b[%d;1H\x1b[2K%s", g_live.rows - 2, C_GRAY);
+    for (int i = 0; i < width; i++) fputs("\xe2\x94\x80", stdout);
+    printf("%s", C_R);
+    printf("\x1b[%d;1H\x1b[2K %s\xe2\x9c\xa6%s %.*s", g_live.rows - 1,
+           C_CORAL, C_R, width > 8 ? width - 8 : 12,
+           g_live.phase[0] ? g_live.phase : "elaborazione");
+    if (g_live.notice[0])
+        printf(" %s\xc2\xb7 %.*s%s", C_DIM, width > 30 ? width / 2 : 12,
+               g_live.notice, C_R);
+    printf("\x1b[%d;1H\x1b[2K %s%s\xe2\x80\xba%s ", g_live.rows,
+           C_CORAL, C_BOLD, C_R);
+    int room = width - 5;
+    const char *shown = g_live.input;
+    int bytes = g_live.input_len;
+    if (bytes > room) { shown += bytes - room; bytes = room; }
+    if (bytes > 0) fwrite(shown, 1, (size_t)bytes, stdout);
+    printf("\x1b" "8");
+    fflush(stdout);
+}
+
+static void live_status(const char *fmt, ...) {
+    if (!g_live.enabled) return;
+    pthread_mutex_lock(&g_live.lock);
+    va_list ap; va_start(ap, fmt);
+    vsnprintf(g_live.phase, sizeof g_live.phase, fmt, ap);
+    va_end(ap);
+    live_draw_locked();
+    pthread_mutex_unlock(&g_live.lock);
+}
+
+static void live_write(const void *data, size_t bytes) {
+    if (!g_live.enabled) {
+        if (bytes) fwrite(data, 1, bytes, stdout);
+        fflush(stdout);
+        return;
+    }
+    pthread_mutex_lock(&g_live.lock);
+    if (bytes) fwrite(data, 1, bytes, stdout);
+    fflush(stdout);
+    pthread_mutex_unlock(&g_live.lock);
+}
+
+static void live_clear_input_locked(void) {
+    g_live.input[0] = 0; g_live.input_len = 0; g_live.input_pos = 0;
+    g_live.completion[0] = 0; g_live.completion_next = 0;
+}
+
+static void live_complete_locked(void) {
+    if (!g_live.input_len || g_live.input[0] != '/' ||
+        strchr(g_live.input, ' ')) return;
+    if (!g_live.completion[0])
+        snprintf(g_live.completion, sizeof g_live.completion, "%s", g_live.input);
+    int matches = 0;
+    size_t prefix = strlen(g_live.completion);
+    for (size_t i = 0; i < sizeof CHAT_COMMANDS / sizeof *CHAT_COMMANDS; i++)
+        if (!strncmp(CHAT_COMMANDS[i], g_live.completion, prefix)) matches++;
+    if (!matches) return;
+    int wanted = g_live.completion_next++ % matches;
+    for (size_t i = 0; i < sizeof CHAT_COMMANDS / sizeof *CHAT_COMMANDS; i++) {
+        if (strncmp(CHAT_COMMANDS[i], g_live.completion, prefix)) continue;
+        if (wanted--) continue;
+        snprintf(g_live.input, sizeof g_live.input, "%s", CHAT_COMMANDS[i]);
+        g_live.input_len = g_live.input_pos = (int)strlen(g_live.input);
+        break;
+    }
+}
+
+static int live_immediate_command_locked(const char *command) {
+    if (strcmp(command, "/swarm") && strcmp(command, "/hosts") &&
+        strcmp(command, "/experts") && strcmp(command, "/debug") &&
+        strcmp(command, "/storage") && strcmp(command, "/help")) return 0;
+    putchar('\n');
+    if (!strcmp(command, "/swarm") || !strcmp(command, "/hosts"))
+        render_swarm(g_live.tracker);
+    else if (!strcmp(command, "/experts")) render_experts(g_live.tracker);
+    else if (!strcmp(command, "/debug")) render_debug();
+    else if (!strcmp(command, "/storage")) render_storage();
+    else render_help();
+    live_clear_input_locked();
+    snprintf(g_live.notice, sizeof g_live.notice, "inferenza ancora attiva");
+    live_draw_locked();
+    return 1;
+}
+
+static void live_submit_input_locked(void) {
+    if (!g_live.input_len) return;
+    if (live_immediate_command_locked(g_live.input)) return;
+    if (!g_live.pending_ready) {
+        snprintf(g_live.pending, sizeof g_live.pending, "%s", g_live.input);
+        g_live.pending_ready = 1;
+        snprintf(g_live.notice, sizeof g_live.notice,
+                 g_live.input[0] == '/' ? "comando in coda" :
+                                          "prompt successivo pronto");
+    } else {
+        snprintf(g_live.notice, sizeof g_live.notice,
+                 "c'e' gia' un prompt in coda");
+    }
+    live_clear_input_locked();
+    live_draw_locked();
+}
+
+static void *live_input_thread(void *unused) {
+    (void)unused;
+    while (g_live.active) {
+        struct pollfd pollfd = { STDIN_FILENO, POLLIN, 0 };
+        int ready = poll(&pollfd, 1, 100);
+        if (ready <= 0 || !(pollfd.revents & POLLIN)) continue;
+        unsigned char c = 0;
+        if (read(STDIN_FILENO, &c, 1) != 1) continue;
+        pthread_mutex_lock(&g_live.lock);
+        if (c == '\r' || c == '\n') {
+            live_submit_input_locked();
+        } else if (c == '\t') {
+            live_complete_locked(); live_draw_locked();
+        } else if (c == 3) {
+            if (!g_live.pending_ready) {
+                snprintf(g_live.pending, sizeof g_live.pending, "/quit");
+                g_live.pending_ready = 1;
+            }
+            snprintf(g_live.notice, sizeof g_live.notice,
+                     "uscita dopo la risposta in corso");
+            live_draw_locked();
+        } else if (c == 21) {
+            live_clear_input_locked(); live_draw_locked();
+        } else if (c == 127 || c == 8) {
+            if (g_live.input_pos > 0) {
+                int previous = le_prev(g_live.input, g_live.input_pos);
+                memmove(g_live.input + previous, g_live.input + g_live.input_pos,
+                        (size_t)(g_live.input_len - g_live.input_pos + 1));
+                g_live.input_len -= g_live.input_pos - previous;
+                g_live.input_pos = previous;
+            }
+            g_live.completion[0] = 0; live_draw_locked();
+        } else if (c == 27) {
+            unsigned char a = 0, b = 0;
+            ssize_t ar = read(STDIN_FILENO, &a, 1);
+            ssize_t br = ar == 1 ? read(STDIN_FILENO, &b, 1) : -1;
+            if (ar != 1 || br != 1) { pthread_mutex_unlock(&g_live.lock); continue; }
+            if ((a == '[' || a == 'O') && b == 'D' && g_live.input_pos > 0)
+                g_live.input_pos = le_prev(g_live.input, g_live.input_pos);
+            else if ((a == '[' || a == 'O') && b == 'C' &&
+                     g_live.input_pos < g_live.input_len)
+                g_live.input_pos = le_next(g_live.input, g_live.input_len,
+                                           g_live.input_pos);
+            live_draw_locked();
+        } else if (c >= 0x20 && g_live.input_len + 1 < (int)sizeof g_live.input) {
+            unsigned char bytes[4] = {c, 0, 0, 0};
+            int count = c >= 0xf0 ? 4 : c >= 0xe0 ? 3 : c >= 0xc0 ? 2 : 1;
+            for (int i = 1; i < count; i++)
+                if (read(STDIN_FILENO, &bytes[i], 1) != 1) { count = i; break; }
+            if (g_live.input_len + count < (int)sizeof g_live.input) {
+                memmove(g_live.input + g_live.input_pos + count,
+                        g_live.input + g_live.input_pos,
+                        (size_t)(g_live.input_len - g_live.input_pos + 1));
+                memcpy(g_live.input + g_live.input_pos, bytes, (size_t)count);
+                g_live.input_pos += count; g_live.input_len += count;
+                g_live.completion[0] = 0;
+            }
+            live_draw_locked();
+        }
+        pthread_mutex_unlock(&g_live.lock);
+    }
+    return NULL;
+}
+
+static int live_begin(const char *tracker, const char *model,
+                      const char *initial_phase) {
+    if (!g_tty || !isatty(STDIN_FILENO) || !isatty(STDOUT_FILENO)) return 0;
+    struct termios raw;
+    if (tcgetattr(STDIN_FILENO, &g_live.old_term)) return 0;
+    raw = g_live.old_term;
+    raw.c_lflag &= ~(tcflag_t)(ICANON | ECHO | ISIG | IEXTEN);
+    raw.c_iflag &= ~(tcflag_t)IXON;
+    raw.c_cc[VMIN] = 0; raw.c_cc[VTIME] = 1;
+    if (tcsetattr(STDIN_FILENO, TCSANOW, &raw)) return 0;
+    pthread_mutex_lock(&g_live.lock);
+    g_live.rows = term_h(); g_live.cols = term_w();
+    g_live.enabled = g_live.rows >= 8;
+    g_live.raw_set = 1; g_live.active = 1;
+    snprintf(g_live.tracker, sizeof g_live.tracker, "%s", tracker);
+    snprintf(g_live.model, sizeof g_live.model, "%s", model);
+    snprintf(g_live.phase, sizeof g_live.phase, "%s", initial_phase);
+    g_live.notice[0] = 0;
+    live_clear_input_locked();
+    if (g_live.enabled) {
+        printf("\x1b[1;%dr\x1b[%d;1H\x1b[2K", g_live.rows - 3,
+               g_live.rows - 3);
+        live_draw_locked();
+    }
+    pthread_mutex_unlock(&g_live.lock);
+    if (pthread_create(&g_live.thread, NULL, live_input_thread, NULL)) {
+        g_live.active = 0; g_live.enabled = 0;
+        tcsetattr(STDIN_FILENO, TCSANOW, &g_live.old_term);
+        g_live.raw_set = 0;
+        return 0;
+    }
+    return 1;
+}
+
+static void live_end(void) {
+    if (!g_live.active && !g_live.raw_set) return;
+    g_live.active = 0;
+    pthread_join(g_live.thread, NULL);
+    pthread_mutex_lock(&g_live.lock);
+    if (g_live.enabled) {
+        printf("\x1b[r\x1b[%d;1H\x1b[2K\x1b[%d;1H\x1b[2K"
+               "\x1b[%d;1H\x1b[2K", g_live.rows - 2, g_live.rows - 1,
+               g_live.rows);
+        fflush(stdout);
+    }
+    g_live.enabled = 0;
+    pthread_mutex_unlock(&g_live.lock);
+    if (g_live.raw_set)
+        tcsetattr(STDIN_FILENO, TCSANOW, &g_live.old_term);
+    g_live.raw_set = 0;
+}
+
+static int live_take_pending(char *out, size_t cap) {
+    pthread_mutex_lock(&g_live.lock);
+    int have = g_live.pending_ready;
+    if (have) {
+        snprintf(out, cap, "%s", g_live.pending);
+        g_live.pending[0] = 0; g_live.pending_ready = 0;
+    }
+    pthread_mutex_unlock(&g_live.lock);
+    return have;
+}
+
 /* one line, rewritten in place: the star, what it is doing, how far along */
 static void *spinner_thread(void *arg) {
     const char *verb = arg ? (const char *)arg : "thinking";
@@ -1313,10 +1870,10 @@ static void emit_no_tel(const char *p, size_t n, TelFilter *t) {
     for (size_t i = 0; i < n; i++) {
         char c = p[i];
         if (t->mode == TF_DROP) { if (c == '\n') t->mode = TF_LINESTART; continue; }
-        if (t->mode == TF_MID) { putchar(c); if (c == '\n') t->mode = TF_LINESTART; continue; }
+        if (t->mode == TF_MID) { live_write(&c, 1); if (c == '\n') t->mode = TF_LINESTART; continue; }
         /* TF_LINESTART: buffer until we can classify the line */
         if (c == '\n') {                       /* short line, can't be a dashboard row */
-            fwrite(t->pfx, 1, (size_t)t->pfxn, stdout); putchar('\n');
+            live_write(t->pfx, (size_t)t->pfxn); live_write("\n", 1);
             t->pfxn = 0; continue;
         }
         if (t->pfxn < (int)sizeof t->pfx) t->pfx[t->pfxn++] = c;
@@ -1332,20 +1889,18 @@ static void emit_no_tel(const char *p, size_t n, TelFilter *t) {
         }
         if (is_tel) { t->pfxn = 0; t->mode = TF_DROP; }
         else if (!maybe || t->pfxn == (int)sizeof t->pfx) {   /* ruled out: it is text */
-            fwrite(t->pfx, 1, (size_t)t->pfxn, stdout);
+            live_write(t->pfx, (size_t)t->pfxn);
             t->pfxn = 0; t->mode = TF_MID;
         }
         /* else: keep buffering (a keyword prefix so far) */
     }
-    fflush(stdout);
 }
 
 static void le_flush_tel(TelFilter *t) {       /* trailing buffered text at stream end */
     if (t->mode == TF_LINESTART && t->pfxn > 0) {
-        fwrite(t->pfx, 1, (size_t)t->pfxn, stdout);
+        live_write(t->pfx, (size_t)t->pfxn);
         t->pfxn = 0;
     }
-    fflush(stdout);
 }
 
 static int stream_until_end(Engine *e, char *statline, size_t scap) {
@@ -1453,11 +2008,10 @@ static int sr_take(SReader *s, size_t n, int emit, Cap *cap) {   /* copy/discard
     while (n) {
         if (s->off >= s->len && sr_fill(s) <= 0) return -1;
         size_t avail = s->len - s->off, take = avail < n ? avail : n;
-        if (emit) fwrite(s->b + s->off, 1, take, stdout);
+        if (emit) live_write(s->b + s->off, take);
         if (cap && cap_add(cap, (char *)s->b + s->off, take)) return -1;
         s->off += take; n -= take;
     }
-    if (emit) fflush(stdout);
     return 0;
 }
 
@@ -1474,6 +2028,8 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
     for (;;) {
         if (sr_line(&s, line, sizeof line) < 0) { free(cap.p); return -1; }
         if (!strncmp(line, "DATA ", 5)) {
+            live_status("decode · %s", e->segment ? "Segment sullo sciame" :
+                                                "expert/engine");
             char *sp = strchr(line + 5, ' ');            /* DATA <id> <bytes> */
             size_t n = sp ? strtoull(sp + 1, NULL, 10) : 0;
             if (sr_take(&s, n, 1, captured ? &cap : NULL) < 0) { free(cap.p); return -1; }
@@ -1488,6 +2044,26 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
             printf("%s%s%s", C_RED, msg ? msg + 1 : line + 6, C_R);
             free(cap.p);
             return 0;
+        } else if (!strncmp(line, "PROGRESS ", 9)) {
+            unsigned id = 0;
+            char phase[24] = "";
+            size_t current = 0, total = 0, third = 0;
+            if (sscanf(line, "PROGRESS %u %23s %zu %zu %zu",
+                       &id, phase, &current, &total, &third) >= 2) {
+                if (!strcmp(phase, "ROUTE"))
+                    live_status("routing · %zu host · %zu segmenti · %s",
+                                current, total, third ? "relay" : "P2P diretto");
+                else if (!strcmp(phase, "PREFILL"))
+                    live_status("prefill · %zu/%zu token · Segment", current, total);
+                else if (!strcmp(phase, "DECODE"))
+                    live_status("decode · %zu token · Segment", current);
+                else if (!strcmp(phase, "FAILOVER")) {
+                    const char *peer = strstr(line, "FAILOVER ");
+                    live_status("failover · sostituisco %s",
+                                peer ? peer + strlen("FAILOVER ") : "peer");
+                } else if (!strcmp(phase, "CHECKPOINT"))
+                    live_status("checkpoint KV · %zu token protetti", current);
+            }
         }
         /* ACCEPT / EMAP / TIERS / HITS / HWINFO / PROF / other: skip */
     }
@@ -1500,10 +2076,9 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
  * user turn ending at the assistant-generation marker); the serve reuses the KV
  * prefix, so it stays a real multi-turn chat without reprocessing the history.
  *
- * Each marker set mirrors its engine's serve/CLI source. Only DeepSeek and olmoe
- * are exercised against a real model here; qwen36/inkling/kimi are transcribed
- * from colibri and unverified — see the PR notes. Keep them in step with colibri;
- * the ideal home is each engine's serve, as GLM already does.
+ * Each marker set mirrors its engine's serve/CLI source. The six-family tiny
+ * release gate exercises GLM, Inkling, Kimi, OLMoE, Qwen and DeepSeek through
+ * this exact codec and compares their generated token IDs with Colibri oracles.
  *
  * DeepSeek: ｜ is U+FF5C, ▁ is U+2581 — each its own literal so the next letter
  * is not eaten by the \x escape. </think> is the non-thinking "answer now" form. */
@@ -2085,6 +2660,8 @@ static int line_edit(char *buf, size_t cap) {
     int len = 0, pos = 0, rc = 0;
     int hidx = le_hist_n;                       /* == "the line being typed" */
     char *save = (char *)malloc(cap);           /* in-progress line, for down */
+    char completion[64] = "";
+    int completion_next = 0;
     if (!save) { tcsetattr(0, TCSANOW, &old); return -2; }   /* -> caller fgets */
     save[0] = 0;
     buf[0] = 0;
@@ -2108,7 +2685,26 @@ static int line_edit(char *buf, size_t cap) {
             tcsetattr(0, TCSANOW, &raw);         /* resumed: back to raw */
             continue;
         }
-        if (c == 4) {                            /* Ctrl-D: EOF on empty, else Delete */
+        if (c != '\t') { completion[0] = 0; completion_next = 0; }
+        if (c == '\t') {                        /* cycle slash-command matches */
+            if (len && buf[0] == '/' && !strchr(buf, ' ')) {
+                if (!completion[0])
+                    snprintf(completion, sizeof completion, "%s", buf);
+                size_t prefix = strlen(completion);
+                int matches = 0;
+                for (size_t i = 0; i < sizeof CHAT_COMMANDS / sizeof *CHAT_COMMANDS; i++)
+                    if (!strncmp(CHAT_COMMANDS[i], completion, prefix)) matches++;
+                if (matches) {
+                    int wanted = completion_next++ % matches;
+                    for (size_t i = 0; i < sizeof CHAT_COMMANDS / sizeof *CHAT_COMMANDS; i++) {
+                        if (strncmp(CHAT_COMMANDS[i], completion, prefix)) continue;
+                        if (wanted--) continue;
+                        le_set(buf, cap, &len, &pos, CHAT_COMMANDS[i]);
+                        break;
+                    }
+                }
+            }
+        } else if (c == 4) {                    /* Ctrl-D: EOF on empty, else Delete */
             if (len == 0) { rc = -1; break; }
             if (pos < len) {
                 int nx = le_next(buf, len, pos);
@@ -2451,17 +3047,18 @@ static int role_start_segment(const Role *r, const char *tracker,
     int port = free_port(7801);
     if (!port) return 0;
     long cores = sysconf(_SC_NPROCESSORS_ONLN);
-    int sessions = cores > 1 ? (int)(cores / 2) : 1;
-    if (sessions > 4) sessions = 4;
-    char port_text[16], context_text[16], sessions_text[16];
+    int threads = cores > 1 ? (int)(cores / 2) : 1;
+    int sessions = 2;
+    char port_text[16], context_text[16], sessions_text[16], threads_text[16];
     char address[80], name[64], base[48];
     snprintf(port_text, sizeof port_text, "%d", port);
     snprintf(context_text, sizeof context_text, "%d", context);
     snprintf(sessions_text, sizeof sessions_text, "%d", sessions);
+    snprintf(threads_text, sizeof threads_text, "%d", threads);
     snprintf(address, sizeof address, "%s:%d", host, port);
     donor_base_name(r, base, sizeof base);
     snprintf(name, sizeof name, "%s-segment-%d", base, port);
-    char *argv[30];
+    char *argv[34];
     int a = 0;
     argv[a++] = bin;
     argv[a++] = "--engine";        argv[a++] = (char *)engine;
@@ -2477,6 +3074,7 @@ static int role_start_segment(const Role *r, const char *tracker,
     argv[a++] = "--context";       argv[a++] = context_text;
     argv[a++] = "--max-rows";      argv[a++] = "16";
     argv[a++] = "--sessions";      argv[a++] = sessions_text;
+    argv[a++] = "--threads";       argv[a++] = threads_text;
     argv[a] = NULL;
     if (g_nchildren >= MAX_CHILDREN) return 0;
     char logpath[1200];
@@ -2720,7 +3318,7 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
                 if (!segment_ready) {
                     e->proto = PROTO_SERVE2;
                     printf("  %s\xe2\x9c\x93 %s pronto via Segment in %.1fs%s%s "
-                           "\xc2\xb7 Edge nel CAS \xc2\xb7 /swarm /model /debug "
+                           "\xc2\xb7 Edge nel CAS \xc2\xb7 /swarm /experts /model /debug "
                            "/storage /reset /quit%s\n",
                            C_GRN, model, nowd() - segment_started, C_R,
                            C_DIM, C_R);
@@ -2802,7 +3400,7 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
         return -1;
     }
     printf("  %s\xe2\x9c\x93 %s pronto in %.1fs%s%s · net %.0f MB · "
-           "/swarm /model /debug /storage /reset /quit%s\n",
+           "/swarm /experts /model /debug /storage /reset /quit%s\n",
            C_GRN, model, nowd() - t0, C_R, C_DIM, g_eng.net_mb, C_R);
     return 0;
 }
@@ -3004,6 +3602,7 @@ static int cmd_chat(int argc, char **argv) {
     char *conv = calloc(1, 1);   /* serve-codec conversation history (after bos) */
     char line[4096];
     for (;;) {
+        int queued = live_take_pending(line, sizeof line);
         int w = term_w() - 2;
         if (g_tty) {
             printf("\n");
@@ -3012,15 +3611,24 @@ static int cmd_chat(int argc, char **argv) {
         } else
             printf("\n> ");
         fflush(stdout);
-        int got = prompt_line(line, sizeof line) == 0;   /* line editor when a tty */
+        int got;
+        if (queued) {
+            printf("%s\r\n", line);
+            le_hist_push(line);
+            got = 1;
+        } else
+            got = prompt_line(line, sizeof line) == 0;   /* line editor when a tty */
         if (g_tty) hline("\xe2\x95\xb0", "\xe2\x95\xaf", w);
         if (!got) break;
         size_t L = strlen(line);   /* prompt_line already stripped the newline */
         if (!L) continue;
         if (!strcmp(line, "/quit") || !strcmp(line, "/exit")) break;
         if (!strcmp(line, "/swarm")) { render_swarm(tracker); continue; }
+        if (!strcmp(line, "/hosts")) { render_swarm(tracker); continue; }
+        if (!strcmp(line, "/experts")) { render_experts(tracker); continue; }
         if (!strcmp(line, "/debug")) { render_debug(); continue; }
         if (!strcmp(line, "/storage")) { render_storage(); continue; }
+        if (!strcmp(line, "/help")) { render_help(); continue; }
         if (!strncmp(line, "/model", 6)) {
             const char *arg = line + 6;
             while (*arg == ' ') arg++;
@@ -3078,9 +3686,13 @@ static int cmd_chat(int argc, char **argv) {
         if (eng.proto == PROTO_SERVE2) {
             char *reply = NULL;
             printf("%s%s\xe2\x97\x86 %s%s\n  ", C_BOLD, C_CORAL, model, C_R);
+            live_begin(tracker, model,
+                       eng.segment ? "routing · cerco la catena Segment" :
+                                     "prefill · preparo il prompt");
             g_eng.streaming = 1;
             int dead = stream_serve2(&eng, stat, sizeof stat, &reply);
             g_eng.streaming = 0;
+            live_end();
             if (dead) {
                 fprintf(stderr, "\n%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);
@@ -3092,9 +3704,11 @@ static int cmd_chat(int argc, char **argv) {
             free(reply);
         } else if (eng.proto == PROTO_FRAMED) {
             if (!is_reset) printf("%s%s\xe2\x97\x86 %s%s\n  ", C_BOLD, C_CORAL, model, C_R);
+            live_begin(tracker, model, "prefill · motore sullo sciame");
             g_eng.streaming = 1;
             int dead = stream_until_end(&eng, stat, sizeof stat);
             g_eng.streaming = 0;
+            live_end();
             if (dead) {
                 fprintf(stderr, "\n%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);
@@ -3103,12 +3717,15 @@ static int cmd_chat(int argc, char **argv) {
             printf("\n");
             if (is_reset) { printf("  %s\xe2\x9c\xa6 nuova conversazione%s\n", C_DIM, C_R); continue; }
         } else {
-            g_eng.spinning = 1;
+            int live = live_begin(tracker, model,
+                                  "inferenza · motore locale/expert");
+            g_eng.spinning = !live;
             pthread_t tspin;
-            if (g_tty) pthread_create(&tspin, NULL, spinner_thread, NULL);
+            if (g_tty && !live) pthread_create(&tspin, NULL, spinner_thread, NULL);
             char *reply = read_until_prompt(eng.from);
             g_eng.spinning = 0;
-            if (g_tty) pthread_join(tspin, NULL);
+            if (live) live_end();
+            else if (g_tty) pthread_join(tspin, NULL);
             if (!reply) {
                 fprintf(stderr, "%sengine exited%s\n", C_RED, C_R);
                 engine_diag(&eng, 0);

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -101,6 +101,10 @@
 #define LMB_EREG_STATS_LENGTH    12u
 #define LMB_SWARM_EXEC_MAGIC     0x31585753u /* "SWX1" */
 #define LMB_SWARM_EXEC_VERSION   1u
+#define LMB_SWARM_DETAIL_VERSION 1u
+#define LMB_SWARM_ROLE_STORAGE   (1u << 0)
+#define LMB_SWARM_ROLE_EXPERT    (1u << 1)
+#define LMB_SWARM_ROLE_SEGMENT   (1u << 2)
 
 /* Both arguments must point at the fixed LMB_TOKEN_MAX+1 authentication
  * buffers used by the daemons.  Compare the complete buffers so a remote
@@ -238,6 +242,12 @@ enum {
      * that peer's signed outbound control connection; the executor remains
      * the sole authority for session, lease and request-id validation. */
     LMB_RSEG = 57, LMB_RSEG_FWD = 58, LMB_RSEG_R = 59,
+    /* Human-facing observability. Unlike the legacy anonymous SWARM reply,
+     * this endpoint returns the peer names chosen by their operators plus
+     * role/load counters. It deliberately omits network addresses and public
+     * keys: the TUI can explain who is doing work without leaking how to
+     * reach a private donor. The body is versioned independently. */
+    LMB_SWARM_DETAIL = 60, LMB_SWARM_DETAIL_R = 61,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -314,6 +324,7 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
         break;
     case LMB_MANIFEST_R:
     case LMB_SWARM_R:
+    case LMB_SWARM_DETAIL_R:
     case LMB_EPEERS_R:
     case LMB_EMANIFEST_R:
     case LMB_EASSIGN_R:

--- a/relay_rate_test.sh
+++ b/relay_rate_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
+RATE_BIN=${RATE_BIN:-./test_relay_rate}
+T=$(mktemp -d /tmp/lumabri-relay-rate.XXXXXX)
+PID=
+cleanup() {
+    [[ -z "$PID" ]] || kill "$PID" 2>/dev/null || true
+    [[ -z "$PID" ]] || wait "$PID" 2>/dev/null || true
+    rm -rf "$T"
+}
+trap cleanup EXIT
+LUMABRI_RSEG_RATE=1 LUMABRI_RSEG_BURST=1 \
+LUMABRI_PEER_BINDINGS="$T/bindings" "$TRACKER_BIN" --port 8092 >"$T/tracker.log" 2>&1 &
+PID=$!
+for _ in $(seq 1 100); do
+    (exec 3<>/dev/tcp/127.0.0.1/8092) 2>/dev/null && {
+        exec 3<&-; exec 3>&-; break
+    }
+    sleep .05
+done
+"$RATE_BIN" 127.0.0.1:8092
+echo 'RELAY RATE TEST: PASS (unsigned callers are bounded per source)'

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -52,6 +52,18 @@ typedef struct {
     double elapsed_seconds;
 } GenerationResult;
 
+typedef enum {
+    GEN_EVENT_PREFILL,
+    GEN_EVENT_DECODE,
+    GEN_EVENT_DATA,
+    GEN_EVENT_FAILOVER,
+    GEN_EVENT_CHECKPOINT,
+} GenerationEventKind;
+
+typedef int (*GenerationEventFn)(void *opaque, GenerationEventKind kind,
+                                 size_t current, size_t total,
+                                 const void *data, size_t data_bytes);
+
 static int retry_first_run;
 static const char *segment_tracker;
 
@@ -941,6 +953,63 @@ static void generation_result_free(GenerationResult *result) {
     memset(result, 0, sizeof *result);
 }
 
+/* Detokenize the complete generated prefix and stream only bytes confirmed by
+ * two consecutive prefixes. This one-token look-behind handles byte fallback
+ * and tokenizers that rewrite their trailing whitespace: unstable tail bytes
+ * remain buffered, while already displayed text is never contradicted. */
+static int generation_stream_prefix(ColiEdgeEngine *edge,
+                                    const int32_t *tokens, size_t count,
+                                    int32_t eos_token,
+                                    int flush,
+                                    GenerationEventFn event, void *opaque,
+                                    char **previous, size_t *previous_bytes,
+                                    size_t *emitted_bytes,
+                                    char *error, size_t error_size) {
+    while (count && tokens[count - 1] == eos_token) count--;
+    size_t bytes = 0;
+    if (count && coli_edge_detokenize(edge, tokens, count, NULL, 0, &bytes,
+                                     error, error_size)) return -1;
+    char *text = malloc(bytes + 1u);
+    if (!text) { snprintf(error, error_size, "out of memory streaming token"); return -1; }
+    if (count && coli_edge_detokenize(edge, tokens, count, text, bytes + 1u,
+                                     &bytes, error, error_size)) {
+        free(text); return -1;
+    }
+    text[bytes] = 0;
+    if (*emitted_bytes > bytes ||
+        (*emitted_bytes && (!*previous ||
+         memcmp(*previous, text, *emitted_bytes)))) {
+        free(text);
+        snprintf(error, error_size,
+                 "tokenizer rewrote text that was already streamed");
+        return -1;
+    }
+    size_t stable = 0;
+    if (flush) stable = bytes;
+    else if (*previous) {
+        size_t common = *previous_bytes < bytes ? *previous_bytes : bytes;
+        while (stable < common && (*previous)[stable] == text[stable]) stable++;
+    }
+    if (stable < *emitted_bytes) {
+        free(text);
+        snprintf(error, error_size,
+                 "tokenizer changed an already streamed prefix");
+        return -1;
+    }
+    size_t delta = stable - *emitted_bytes;
+    if (delta && event && event(opaque, GEN_EVENT_DATA, count, 0,
+                                text + *emitted_bytes, delta)) {
+        free(text);
+        snprintf(error, error_size, "stream consumer closed during generation");
+        return -1;
+    }
+    free(*previous);
+    *previous = text;
+    *previous_bytes = bytes;
+    *emitted_bytes = stable;
+    return 0;
+}
+
 static int segment_generate(ColiEdgeEngine *edge,
                             const ColiEdgeCapabilities *cap,
                             RemoteSegment *chain, size_t chain_count,
@@ -955,6 +1024,7 @@ static int segment_generate(ColiEdgeEngine *edge,
                             SegmentConversation *conversation,
                             const LmbSegRouteSnapshot *route_snapshot,
                             uint64_t route_generation,
+                            GenerationEventFn event, void *event_opaque,
                             GenerationResult *result,
                             char *error, size_t error_size) {
     memset(result, 0, sizeof *result);
@@ -967,6 +1037,8 @@ static int segment_generate(ColiEdgeEngine *edge,
     int32_t *generated = NULL;
     uint8_t *buffer_a = NULL, *buffer_b = NULL;
     float *logits = NULL;
+    char *stream_text = NULL;
+    size_t stream_text_bytes = 0, stream_emitted_bytes = 0;
     RemoteSegment *active_chain = chain;
     size_t active_count = chain_count;
     size_t prefilled = 0;
@@ -1073,6 +1145,11 @@ static int segment_generate(ColiEdgeEngine *edge,
     }
     uint8_t *final_state = NULL;
     uint32_t final_rows = 0;
+    if (event && event(event_opaque, GEN_EVENT_PREFILL, prefilled,
+                       prompt_count, NULL, 0)) {
+        snprintf(error, error_size, "stream consumer closed before prefill");
+        goto cleanup;
+    }
     for (size_t offset = prefilled; offset < prompt_count; offset += max_rows) {
         uint32_t rows = (uint32_t)(prompt_count - offset);
         if (rows > max_rows) rows = max_rows;
@@ -1088,6 +1165,12 @@ static int segment_generate(ColiEdgeEngine *edge,
         int failed = chain_run(active_chain, active_count,
                                prompt_tokens + offset, rows,
                                &first, &second, bytes);
+        if (failed && event) {
+            size_t failed_index = (size_t)(-failed - 1);
+            const char *peer = active_chain[failed_index].route.advert.peer_name;
+            (void)event(event_opaque, GEN_EVENT_FAILOVER, failed_index,
+                        active_count, peer, strlen(peer));
+        }
         if (failed && (!conversation || !route_snapshot ||
             conversation_recover(conversation, route_snapshot,
                                  (size_t)(-failed - 1), edge, cap,
@@ -1108,6 +1191,11 @@ static int segment_generate(ColiEdgeEngine *edge,
         }
         final_state = first;
         final_rows = rows;
+        if (event && event(event_opaque, GEN_EVENT_PREFILL, offset + rows,
+                           prompt_count, NULL, 0)) {
+            snprintf(error, error_size, "stream consumer closed during prefill");
+            goto cleanup;
+        }
         if (first != buffer_a) {
             uint8_t *swap = buffer_a; buffer_a = buffer_b; buffer_b = swap;
         }
@@ -1135,6 +1223,14 @@ static int segment_generate(ColiEdgeEngine *edge,
         }
     } else if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
     size_t generated_count = 1;
+    if (event &&
+        (generation_stream_prefix(edge, generated, generated_count,
+                                  cap->eos_token_id, 0, event, event_opaque,
+                                  &stream_text, &stream_text_bytes,
+                                  &stream_emitted_bytes,
+                                  error, error_size) ||
+         event(event_opaque, GEN_EVENT_DECODE, generated_count,
+               wanted_tokens, NULL, 0))) goto cleanup;
     while (generated_count < wanted_tokens &&
            generated[generated_count - 1] != cap->eos_token_id) {
         int32_t token = generated[generated_count - 1];
@@ -1148,6 +1244,12 @@ static int segment_generate(ColiEdgeEngine *edge,
         uint8_t *first = buffer_a, *second = buffer_b;
         int failed = chain_run(active_chain, active_count, &token, 1,
                                &first, &second, bytes);
+        if (failed && event) {
+            size_t failed_index = (size_t)(-failed - 1);
+            const char *peer = active_chain[failed_index].route.advert.peer_name;
+            (void)event(event_opaque, GEN_EVENT_FAILOVER, failed_index,
+                        active_count, peer, strlen(peer));
+        }
         if (failed && (!conversation || !route_snapshot ||
             conversation_recover(conversation, route_snapshot,
                                  (size_t)(-failed - 1), edge, cap,
@@ -1180,6 +1282,14 @@ static int segment_generate(ColiEdgeEngine *edge,
         } else if (coli_edge_select(edge, &select, error, error_size))
             goto cleanup;
         generated_count++;
+        if (event &&
+            (generation_stream_prefix(edge, generated, generated_count,
+                                      cap->eos_token_id, 0, event, event_opaque,
+                                      &stream_text, &stream_text_bytes,
+                                      &stream_emitted_bytes,
+                                      error, error_size) ||
+             event(event_opaque, GEN_EVENT_DECODE, generated_count,
+                   wanted_tokens, NULL, 0))) goto cleanup;
     }
     /* The token that stopped generation is a control marker, not text. The
      * monolithic engines never put it in the reply and the TUI must not
@@ -1189,19 +1299,28 @@ static int segment_generate(ColiEdgeEngine *edge,
     size_t text_tokens = generated_count;
     while (text_tokens && generated[text_tokens - 1] == cap->eos_token_id)
         text_tokens--;
-    size_t text_bytes = 0;
-    if (text_tokens &&
-        coli_edge_detokenize(edge, generated, text_tokens, NULL, 0,
-                             &text_bytes, error, error_size)) goto cleanup;
-    char *text = malloc(text_bytes + 1);
-    if (!text || (text_tokens &&
-                  coli_edge_detokenize(edge, generated, text_tokens,
-                                       text, text_bytes + 1, &text_bytes,
-                                       error, error_size))) {
-        free(text);
-        goto cleanup;
+    if (event && generation_stream_prefix(
+            edge, generated, generated_count, cap->eos_token_id, 1,
+            event, event_opaque, &stream_text, &stream_text_bytes,
+            &stream_emitted_bytes,
+            error, error_size)) goto cleanup;
+    size_t text_bytes = stream_text_bytes;
+    char *text = stream_text;
+    if (!event) {
+        if (text_tokens &&
+            coli_edge_detokenize(edge, generated, text_tokens, NULL, 0,
+                                 &text_bytes, error, error_size)) goto cleanup;
+        text = malloc(text_bytes + 1);
+        if (!text || (text_tokens &&
+                      coli_edge_detokenize(edge, generated, text_tokens,
+                                           text, text_bytes + 1, &text_bytes,
+                                           error, error_size))) {
+            free(text);
+            goto cleanup;
+        }
+        text[text_bytes] = 0;
     }
-    text[text_bytes] = 0;
+    stream_text = NULL;
     if (conversation) {
         size_t generated_committed = generated_count ? generated_count - 1 : 0;
         size_t committed_count = prompt_count + generated_committed;
@@ -1211,6 +1330,10 @@ static int segment_generate(ColiEdgeEngine *edge,
             fprintf(stderr, "[lumabri] Segment checkpoint unavailable; "
                             "failover will replay from token %zu\n",
                     conversation->checkpoint_count);
+        else if (event && conversation->checkpoint_count)
+            (void)event(event_opaque, GEN_EVENT_CHECKPOINT,
+                        conversation->checkpoint_count,
+                        committed_count, NULL, 0);
         if (committed_count > SIZE_MAX / sizeof *prompt_tokens) {
             free(text); goto cleanup;
         }
@@ -1253,6 +1376,7 @@ cleanup:
     free(logits);
     free(buffer_a);
     free(buffer_b);
+    free(stream_text);
     return rc;
 }
 
@@ -1293,6 +1417,41 @@ static int read_exact_stdin(void *output, size_t bytes) {
         bytes -= got;
     }
     return 0;
+}
+
+typedef struct { unsigned request_id; size_t emitted_bytes; } ServeGeneration;
+
+static int serve_generation_event(void *opaque, GenerationEventKind kind,
+                                  size_t current, size_t total,
+                                  const void *data, size_t data_bytes) {
+    ServeGeneration *serve = opaque;
+    switch (kind) {
+    case GEN_EVENT_PREFILL:
+        printf("PROGRESS %u PREFILL %zu %zu\n", serve->request_id,
+               current, total);
+        break;
+    case GEN_EVENT_DECODE:
+        printf("PROGRESS %u DECODE %zu %zu\n", serve->request_id,
+               current, total);
+        break;
+    case GEN_EVENT_FAILOVER:
+        printf("PROGRESS %u FAILOVER %.*s\n", serve->request_id,
+               (int)data_bytes, data ? (const char *)data : "");
+        break;
+    case GEN_EVENT_CHECKPOINT:
+        printf("PROGRESS %u CHECKPOINT %zu %zu\n", serve->request_id,
+               current, total);
+        break;
+    case GEN_EVENT_DATA:
+        printf("DATA %u %zu\n", serve->request_id, data_bytes);
+        if (data_bytes && fwrite(data, 1, data_bytes, stdout) != data_bytes)
+            return -1;
+        fputc('\n', stdout);
+        serve->emitted_bytes += data_bytes;
+        break;
+    }
+    fflush(stdout);
+    return ferror(stdout) ? -1 : 0;
 }
 
 static int segment_serve_loop(ColiEdgeEngine *edge,
@@ -1350,18 +1509,38 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
             snprintf(error, sizeof error,
                      "no complete compatible Segment chain");
         if (!bad) {
+            size_t relay_count = 0, host_count = 0;
+            for (size_t i = 0; i < chain_count; i++) {
+                relay_count += !(chain[i].route.transport &
+                                 LMB_SEG_TRANSPORT_DIRECT) &&
+                               (chain[i].route.transport &
+                                LMB_SEG_TRANSPORT_RELAY);
+                int seen = 0;
+                for (size_t j = 0; j < i; j++)
+                    if (!strcmp(chain[j].route.advert.peer_name,
+                                chain[i].route.advert.peer_name)) seen = 1;
+                if (!seen) host_count++;
+            }
+            printf("PROGRESS %u ROUTE %zu %zu %zu\n", request_id,
+                   host_count, chain_count, relay_count);
+            fflush(stdout);
             if (conversation.active && conversation.route_generation !=
                                        snapshot.route_generation)
                 route_print(stderr, "[segment-route]", &snapshot,
                             chain, chain_count);
+            ServeGeneration stream = { .request_id = request_id };
             bad = segment_generate(edge, cap, chain, chain_count,
                                    model_root, tokenizer_root,
                                    context, max_rows, prompt, prompt_bytes,
                                    NULL, 0, max_tokens,
                                    temperature, top_p, &sampler, &conversation,
                                    &snapshot,
-                                   snapshot.route_generation, &result,
+                                   snapshot.route_generation,
+                                   serve_generation_event, &stream, &result,
                                    error, sizeof error);
+            if (!bad && !stream.emitted_bytes)
+                (void)serve_generation_event(&stream, GEN_EVENT_DATA,
+                                             0, 0, NULL, 0);
         }
         free(prompt);
         if (bad) {
@@ -1369,10 +1548,6 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
             fflush(stdout);
             continue;
         }
-        printf("DATA %u %zu\n", request_id, result.text_bytes);
-        if (result.text_bytes)
-            fwrite(result.text, 1, result.text_bytes, stdout);
-        fputc('\n', stdout);
         double rate = result.elapsed_seconds > 0.0
             ? (double)result.token_count / result.elapsed_seconds : 0.0;
         printf("DONE %u STAT %zu %.3f 0 0 %zu 0\n", request_id,
@@ -1588,7 +1763,7 @@ int main(int argc, char **argv) {
                                prompt, prompt ? strlen(prompt) : 0,
                                prompt_tokens, prompt_count, wanted_tokens,
                                temperature, top_p, &sampler, NULL, &snapshot, 0,
-                               &generated, error, sizeof error);
+                               NULL, NULL, &generated, error, sizeof error);
     free(prompt_tokens);
     if (bad) {
         fprintf(stderr, "%s\n", error[0] ? error : "Segment generation failed");

--- a/segment_direct_test.sh
+++ b/segment_direct_test.sh
@@ -126,17 +126,20 @@ print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt
     # SUBMIT/DATA/DONE gateway codec.  Exercise that persistent mode for every
     # family as well as the token-ID oracle above; a single text turn is enough
     # to prove tokenizer, framing, route/session lifecycle and clean EOF.
-    serve_output=$(printf 'SUBMIT 1 0 2 2 0.7 0.95\nhi\n' | \
+    serve_output="$TMP/$family-serve.out"
+    printf 'SUBMIT 1 0 2 2 0.7 0.95\nhi\n' | \
         "${run_env[@]}" "$SEGMENT_CHAT_BIN" --serve --engine "$family" \
         --model-dir "$model_dir" --model "$model" \
         --tracker 127.0.0.1:7868 --model-root "$model_root" \
-        --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16)
-    if ! grep -q $'\001\001READY\001\001' <<<"$serve_output" ||
-       ! grep -q '^DATA 1 ' <<<"$serve_output" ||
-       ! grep -q '^DONE 1 STAT ' <<<"$serve_output"; then
-        printf '%s\n' "$serve_output"
+        --tokenizer-root "$tokenizer_root" --context 64 --max-rows 16 \
+        >"$serve_output"
+    if ! grep -aq $'\001\001READY\001\001' "$serve_output" ||
+       ! grep -aq '^DATA 1 ' "$serve_output" ||
+       [[ $(grep -ac '^DATA 1 ' "$serve_output") -lt 2 ]] ||
+       ! grep -aq '^DONE 1 STAT ' "$serve_output"; then
+        cat "$serve_output"
         cat "$TMP/$family-left.log" "$TMP/$family-right.log"
-        echo "SEGMENT DIRECT $family: serve-codec gate failed" >&2
+        echo "SEGMENT DIRECT $family: incremental serve-codec gate failed" >&2
         exit 1
     fi
     if [[ "$family" == olmoe ]]; then
@@ -171,15 +174,25 @@ def turn(request_id, prompt):
     process.stdin.flush()
     if line() != f"ACCEPT {request_id}\n".encode():
         raise RuntimeError("Segment request was not accepted")
-    data_header = line().split()
-    if data_header[:2] != [b"DATA", str(request_id).encode()]:
-        raise RuntimeError("Segment response has no DATA frame")
-    size = int(data_header[2])
-    data = process.stdout.read(size)
-    if len(data) != size or process.stdout.read(1) != b"\n":
-        raise RuntimeError("Segment DATA frame is truncated")
-    if not line().startswith(f"DONE {request_id} STAT ".encode()):
-        raise RuntimeError("Segment response has no DONE frame")
+    seen_data = seen_prefill = seen_decode = False
+    while True:
+        frame = line()
+        if frame.startswith(f"PROGRESS {request_id} PREFILL ".encode()):
+            seen_prefill = True
+        elif frame.startswith(f"PROGRESS {request_id} DECODE ".encode()):
+            seen_decode = True
+        elif frame.startswith(f"DATA {request_id} ".encode()):
+            size = int(frame.split()[2])
+            data = process.stdout.read(size)
+            if len(data) != size or process.stdout.read(1) != b"\n":
+                raise RuntimeError("Segment DATA frame is truncated")
+            seen_data = True
+        elif frame.startswith(f"DONE {request_id} STAT ".encode()):
+            break
+        elif not frame.startswith(f"PROGRESS {request_id} ".encode()):
+            raise RuntimeError("unexpected Segment frame: "+repr(frame))
+    if not (seen_data and seen_prefill and seen_decode):
+        raise RuntimeError("Segment response lacks streaming progress")
 
 turn(91, b"hi\n")
 turn(92, b"hi\nthere\n")

--- a/segment_failover_test.sh
+++ b/segment_failover_test.sh
@@ -70,9 +70,18 @@ def turn(rid, prompt):
     p.stdin.write(f"SUBMIT {rid} 0 {len(prompt)} 1 0.7 0.95\n".encode()+prompt+b"\n")
     p.stdin.flush()
     if line() != f"ACCEPT {rid}\n".encode(): raise RuntimeError("not accepted")
-    head=line().split(); size=int(head[2]); p.stdout.read(size)
-    if p.stdout.read(1) != b"\n": raise RuntimeError("truncated data")
-    if not line().startswith(f"DONE {rid} STAT ".encode()): raise RuntimeError("no done")
+    seen_data = False
+    while True:
+        frame = line()
+        if frame.startswith(f"DATA {rid} ".encode()):
+            size=int(frame.split()[2]); p.stdout.read(size)
+            if p.stdout.read(1) != b"\n": raise RuntimeError("truncated data")
+            seen_data = True
+        elif frame.startswith(f"DONE {rid} STAT ".encode()):
+            break
+        elif not frame.startswith(f"PROGRESS {rid} ".encode()):
+            raise RuntimeError("unexpected frame: "+repr(frame))
+    if not seen_data: raise RuntimeError("no streamed data")
 turn(1, b"hi\n")
 os.kill(int(donor), 15)
 time.sleep(.3)

--- a/segment_native_test.sh
+++ b/segment_native_test.sh
@@ -37,7 +37,7 @@ wait_port() {
 mkdir -p "$TMP/server-home" "$TMP/client-home"
 HOME="$TMP/server-home" ./lumabri key --out "$TMP/swarm" >/dev/null
 
-HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 \
+HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 LUMABRI_SEGMENT_SESSIONS=8 \
     LUMABRI_SEGMENT_MIN_FREE_MB=1024 OMP_NUM_THREADS=2 \
     stdbuf -oL -eL ./lumabri serve --model "$OLMOE_EDGE_MODEL" --port 7880 \
     --key "$TMP/swarm.key" \
@@ -124,6 +124,146 @@ if (not sent or not quit_sent or p.returncode != 0 or b"\x1b[1;27r" not in out o
         (b"prefill" not in out and b"decode" not in out)):
     sys.stderr.buffer.write(out)
     raise SystemExit("live TUI dock/autocomplete gate failed")
+
+def control_case(name, action):
+    master, slave = pty.openpty()
+    fcntl.ioctl(slave, termios.TIOCSWINSZ,
+                struct.pack("HHHH", 30, 100, 0, 0))
+    original = termios.tcgetattr(slave)
+    probe = os.dup(slave)
+    process = subprocess.Popen([
+        "./lumabri", "chat", "--tracker", "127.0.0.1:7880", "--ctx", "2048",
+        "--max-new", "64", "--role", "chat",
+    ], stdin=slave, stdout=slave, stderr=slave, close_fds=True,
+       start_new_session=True)
+    os.close(slave)
+    transcript = bytearray()
+
+    def pump_until(needles, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([master], [], [], .05)
+            if ready:
+                try: chunk = os.read(master, 65536)
+                except OSError: chunk = b""
+                if chunk: transcript.extend(chunk)
+            if all(needle in transcript for needle in needles): return True
+            if process.poll() is not None: return False
+        return False
+
+    if not pump_until(["pronto via Segment".encode()], 30):
+        sys.stderr.buffer.write(transcript)
+        raise SystemExit(name + ": chat did not become ready")
+    os.write(master, b"hi\n")
+    if (not pump_until([b"\x1b[1;27r"], 10) or
+            not pump_until([b"prefill"], 10)):
+        sys.stderr.buffer.write(transcript)
+        raise SystemExit(name + ": inference dock did not become active")
+    current = termios.tcgetattr(probe)
+    if current[3] & (termios.ICANON | termios.ECHO | termios.ISIG):
+        raise SystemExit(name + ": dock did not own raw input")
+
+    started = time.monotonic()
+    if isinstance(action, bytes):
+        os.write(master, action)
+    else:
+        os.kill(process.pid, action)
+
+    try: process.wait(5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL); process.wait()
+        raise SystemExit(name + ": shutdown waited for the active turn")
+    elapsed = time.monotonic() - started
+    restored = termios.tcgetattr(probe) == original
+    try: os.close(master)
+    except OSError: pass
+    os.close(probe)
+    if process.returncode != 0 or elapsed >= 5 or not restored:
+        sys.stderr.buffer.write(transcript)
+        raise SystemExit(name + ": process/termios cleanup failed")
+
+import signal
+control_case("Ctrl-C", b"\x03")
+control_case("Ctrl-backslash", b"\x1c")
+control_case("external SIGTERM", signal.SIGTERM)
+
+# Job-control stop signals are discarded for an orphan process group.  Put an
+# interactive shell in charge of the PTY and run Lumabri as its foreground job,
+# matching a real terminal: Ctrl-Z must hand canonical mode back to the shell,
+# and `fg` must reconstruct the raw dock before Ctrl-C exits.
+master, slave = pty.openpty()
+fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+original = termios.tcgetattr(slave)
+probe = os.dup(slave)
+def shell_session():
+    os.setsid()
+    fcntl.ioctl(0, termios.TIOCSCTTY, 0)
+shell = subprocess.Popen(["bash", "--noprofile", "--norc", "-i"],
+    stdin=slave, stdout=slave, stderr=slave, close_fds=True,
+    preexec_fn=shell_session)
+os.close(slave)
+transcript = bytearray()
+def shell_pump(predicate, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([master], [], [], .05)
+        if ready:
+            try: chunk = os.read(master, 65536)
+            except OSError: chunk = b""
+            if chunk: transcript.extend(chunk)
+        if predicate(): return True
+        if shell.poll() is not None: return False
+    return False
+if not shell_pump(lambda: transcript.endswith((b"# ", b"$ ")), 5):
+    raise SystemExit("Ctrl-Z: job-control shell did not become ready")
+shell_term = termios.tcgetattr(probe)
+command = ("./lumabri chat --tracker 127.0.0.1:7880 --ctx 2048 "
+           "--max-new 64 --role chat\n").encode()
+os.write(master, command)
+if not shell_pump(lambda: "pronto via Segment".encode() in transcript, 30):
+    raise SystemExit("Ctrl-Z: chat did not become ready under job-control shell")
+os.write(master, b"hi\n")
+if not shell_pump(lambda: b"prefill" in transcript, 10):
+    raise SystemExit("Ctrl-Z: inference dock did not become active")
+os.write(master, b"\x1a")
+if not shell_pump(lambda: b"Stopped" in transcript, 5):
+    sys.stderr.buffer.write(transcript)
+    raise SystemExit("Ctrl-Z: foreground job was not suspended")
+deadline = time.monotonic() + 2
+while time.monotonic() < deadline:
+    stopped_term = termios.tcgetattr(probe)
+    if stopped_term == shell_term: break
+    time.sleep(.02)
+else:
+    sys.stderr.write("Ctrl-Z flags: stopped=%#x shell=%#x pty-original=%#x\n" %
+                     (stopped_term[3], shell_term[3], original[3]))
+    sys.stderr.buffer.write(transcript)
+    raise SystemExit("Ctrl-Z: terminal stayed raw while the shell had control")
+os.write(master, b"fg\n")
+deadline = time.monotonic() + 5
+while time.monotonic() < deadline:
+    current = termios.tcgetattr(probe)
+    if not current[3] & (termios.ICANON | termios.ECHO | termios.ISIG): break
+    time.sleep(.02)
+else:
+    raise SystemExit("Ctrl-Z: dock did not return to raw mode after fg")
+os.write(master, b"\x03")
+if not shell_pump(lambda: b"inferenza interrotta" in transcript, 5):
+    raise SystemExit("Ctrl-Z: resumed chat did not accept Ctrl-C")
+os.write(master, b"exit\n")
+try: shell.wait(5)
+except subprocess.TimeoutExpired:
+    os.kill(shell.pid, signal.SIGKILL); shell.wait()
+    raise SystemExit("Ctrl-Z: job-control shell did not exit")
+restored = termios.tcgetattr(probe)
+if (shell.returncode != 0 or
+        not restored[3] & termios.ICANON or
+        not restored[3] & termios.ECHO or
+        not restored[3] & termios.ISIG):
+    raise SystemExit("Ctrl-Z: terminal was not restored after resume and exit")
+try: os.close(master)
+except OSError: pass
+os.close(probe)
 PY
 
-echo "SEGMENT NATIVE: PASS (serve + live TUI, NAT relay + context negotiation)"
+echo "SEGMENT NATIVE: PASS (serve + live TUI, signals/termios, NAT relay + context negotiation)"

--- a/segment_native_test.sh
+++ b/segment_native_test.sh
@@ -12,6 +12,11 @@ SERVER_PID=""
 cleanup() {
     if [[ -n "$SERVER_PID" ]]; then
         kill "$SERVER_PID" 2>/dev/null || true
+        for _ in $(seq 1 100); do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep .05
+        done
+        kill -KILL "$SERVER_PID" 2>/dev/null || true
         wait "$SERVER_PID" 2>/dev/null || true
     fi
     rm -rf "$TMP"
@@ -32,7 +37,8 @@ wait_port() {
 mkdir -p "$TMP/server-home" "$TMP/client-home"
 HOME="$TMP/server-home" ./lumabri key --out "$TMP/swarm" >/dev/null
 
-HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 OMP_NUM_THREADS=2 \
+HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 \
+    LUMABRI_SEGMENT_MIN_FREE_MB=1024 OMP_NUM_THREADS=2 \
     stdbuf -oL -eL ./lumabri serve --model "$OLMOE_EDGE_MODEL" --port 7880 \
     --key "$TMP/swarm.key" \
     >"$TMP/server.log" 2>&1 &
@@ -61,4 +67,63 @@ if (( status != 0 )) || ! grep -q 'pronto via Segment' "$TMP/chat.log" ||
     exit 1
 fi
 
-echo "SEGMENT NATIVE: PASS (serve + TUI chat, NAT relay + context negotiation)"
+# A real PTY is required to exercise the live dock. Type `/exp<Tab>` while a
+# deliberately latency-shaped Segment turn is still running, then queue quit.
+# The executor panel must appear before the turn's final statistics: menus and
+# autocomplete are therefore live, not a code path reached after inference.
+mkdir -p "$TMP/client-home-pty"
+HOME="$TMP/client-home-pty" OMP_NUM_THREADS=2 \
+LUMABRI_PUBKEY="$TMP/swarm.pub" LUMABRI_SEGMENT_REQUIRED=1 \
+LUMABRI_RTT_US=100000 python3 - "$TMP/pty.log" <<'PY'
+import fcntl, os, pty, select, struct, subprocess, sys, termios, time
+log_path = sys.argv[1]
+master, slave = pty.openpty()
+fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 30, 100, 0, 0))
+p = subprocess.Popen([
+    "./lumabri", "chat", "--tracker", "127.0.0.1:7880", "--ctx", "2048",
+    "--max-new", "8", "--role", "chat",
+], stdin=slave, stdout=slave, stderr=slave, close_fds=True,
+   start_new_session=True)
+os.close(slave)
+out = bytearray()
+deadline = time.monotonic() + 45
+sent = quit_sent = False
+log = open(log_path, "wb")
+while time.monotonic() < deadline:
+    ready, _, _ = select.select([master], [], [], .1)
+    if ready:
+        try:
+            chunk = os.read(master, 65536)
+        except OSError:
+            chunk = b""
+        if not chunk:
+            break
+        out.extend(chunk)
+        log.write(chunk); log.flush()
+    if not sent and "pronto via Segment".encode() in out:
+        os.write(master, b"hi\n")
+        time.sleep(.15)
+        os.write(master, b"/exp\t\n")
+        sent = True
+    if sent and not quit_sent and "uso degli executor".encode() in out:
+        os.write(master, b"/quit\n")
+        quit_sent = True
+    if p.poll() is not None:
+        break
+if p.poll() is None:
+    os.killpg(p.pid, 15)
+    try: p.wait(5)
+    except subprocess.TimeoutExpired: os.killpg(p.pid, 9); p.wait()
+try: os.close(master)
+except OSError: pass
+log.close()
+panel = "uso degli executor".encode()
+stats = b"tok/s"
+if (not sent or not quit_sent or p.returncode != 0 or b"\x1b[1;27r" not in out or
+        panel not in out or stats not in out or out.index(panel) > out.index(stats) or
+        (b"prefill" not in out and b"decode" not in out)):
+    sys.stderr.buffer.write(out)
+    raise SystemExit("live TUI dock/autocomplete gate failed")
+PY
+
+echo "SEGMENT NATIVE: PASS (serve + live TUI, NAT relay + context negotiation)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -14,6 +14,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #define NODE_SESSIONS_MAX 256u
 #define NODE_CONNECTIONS_MAX 256u
@@ -61,10 +64,12 @@ typedef struct {
     LmbSegTable *table;
     NodeSession sessions[NODE_SESSIONS_MAX];
     pthread_mutex_t sessions_lock;
+    pthread_mutex_t run_lock;      /* one OpenMP team per slice, no oversubscription */
     pthread_mutex_t connections_lock;
     pthread_cond_t connections_drained;
     int connection_fds[NODE_CONNECTIONS_MAX];
     unsigned active_connections;
+    uint64_t ram_reserve_bytes;
     TrackerRegistration registration;
 } Node;
 
@@ -75,6 +80,17 @@ static uint64_t now_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_sec * 1000u + (uint64_t)ts.tv_nsec / 1000000u;
+}
+
+static uint64_t available_memory_bytes(void) {
+    FILE *file = fopen("/proc/meminfo", "r");
+    if (!file) return UINT64_MAX; /* unknown must not make a healthy node lie */
+    char line[256];
+    unsigned long long kib = 0;
+    while (fgets(line, sizeof line, file))
+        if (sscanf(line, "MemAvailable: %llu kB", &kib) == 1) break;
+    fclose(file);
+    return kib ? (uint64_t)kib * 1024u : UINT64_MAX;
 }
 
 static void stop_handler(int sig) {
@@ -272,19 +288,57 @@ static NodeSession *session_empty(Node *node) {
     return NULL;
 }
 
-static void session_release(Node *node, NodeSession *slot) {
-    pthread_mutex_lock(&slot->lock);
+/* sessions_lock and slot->lock are both held. Keeping the slow wait for the
+ * slot out of sessions_lock is what lets unrelated OPEN/CLOSE calls proceed
+ * while a multi-GB restore is committing on one session. */
+static void session_release_locked(Node *node, NodeSession *slot) {
     coli_segment_session_destroy(slot->session);
     free(slot->cached_output);
     free(slot->snapshot);
     free(slot->restore);
+    slot->used = 0;
+    memset(&slot->id, 0, sizeof slot->id);
+    slot->session = NULL;
+    memset(&slot->cached_request, 0, sizeof slot->cached_request);
+    slot->cached_output = NULL;
+    slot->cached_bytes = 0;
+    slot->snapshot = NULL;
+    slot->snapshot_bytes = 0;
+    slot->snapshot_sequence = slot->snapshot_position = 0;
+    slot->restore = NULL;
+    slot->restore_bytes = slot->restore_received = 0;
+    memset(&slot->restore_transfer, 0, sizeof slot->restore_transfer);
+    slot->restore_updated_ms = 0;
+    slot->restore_active = 0;
+    memset(&slot->restored_request, 0, sizeof slot->restored_request);
+    slot->restored_sequence = slot->restored_position = 0;
+    slot->restored_valid = 0;
     pthread_mutex_unlock(&slot->lock);
-    pthread_mutex_destroy(&slot->lock);
-    memset(slot, 0, sizeof *slot);
     pthread_mutex_lock(&node->registration.lock);
     if (node->registration.advert.active_sessions)
         node->registration.advert.active_sessions--;
     pthread_mutex_unlock(&node->registration.lock);
+}
+
+static void session_release(Node *node, NodeSession *slot) {
+    pthread_mutex_lock(&slot->lock);
+    session_release_locked(node, slot);
+}
+
+/* Slot mutexes live for the whole node lifetime. Find under the table lock,
+ * then wait outside it and validate after taking the slot: a restore on one
+ * session can never stop OPEN/CLOSE/RUN on an unrelated session. */
+static NodeSession *session_lock_id(Node *node, const LmbSegId *id) {
+    pthread_mutex_lock(&node->sessions_lock);
+    NodeSession *slot = session_find(node, id);
+    pthread_mutex_unlock(&node->sessions_lock);
+    if (!slot) return NULL;
+    pthread_mutex_lock(&slot->lock);
+    if (!slot->used || !lmb_seg_id_equal(&slot->id, id)) {
+        pthread_mutex_unlock(&slot->lock);
+        return NULL;
+    }
+    return slot;
 }
 
 static void *session_reaper(void *opaque) {
@@ -294,7 +348,9 @@ static void *session_reaper(void *opaque) {
         for (size_t i = 0; i < NODE_SESSIONS_MAX; i++) {
             NodeSession *slot = &node->sessions[i];
             if (!slot->used) continue;
-            pthread_mutex_lock(&slot->lock);
+            /* Never wait for a restore while holding the node-wide table
+             * lock. The next pass will inspect a busy slot. */
+            if (pthread_mutex_trylock(&slot->lock)) continue;
             if (slot->restore_active &&
                 now_ms() - slot->restore_updated_ms >= 60000u) {
                 (void)lmb_seg_table_restore_finish(
@@ -305,12 +361,18 @@ static void *session_reaper(void *opaque) {
             }
             pthread_mutex_unlock(&slot->lock);
         }
+        pthread_mutex_unlock(&node->sessions_lock);
         LmbSegId expired;
         while (lmb_seg_table_reap_expired(node->table, now_ms(), &expired)) {
-            NodeSession *slot = session_find(node, &expired);
-            if (slot) session_release(node, slot);
+            NodeSession *slot = session_lock_id(node, &expired);
+            if (!slot) continue;
+            pthread_mutex_lock(&node->sessions_lock);
+            if (slot->used && lmb_seg_id_equal(&slot->id, &expired))
+                session_release_locked(node, slot);
+            else
+                pthread_mutex_unlock(&slot->lock);
+            pthread_mutex_unlock(&node->sessions_lock);
         }
-        pthread_mutex_unlock(&node->sessions_lock);
         for (int i = 0; i < 10 && !g_stop; i++) usleep(100000);
     }
     return NULL;
@@ -440,6 +502,8 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
             status = lmb_seg_table_open(node->table, &open, now_ms());
         } else if (!(slot = session_empty(node))) {
             status = LMB_SEG_STATUS_QUOTA;
+        } else if (available_memory_bytes() < node->ram_reserve_bytes) {
+            status = LMB_SEG_STATUS_QUOTA;
         } else {
             ColiSegmentSessionOptions options = {
                 .struct_size = sizeof options,
@@ -455,26 +519,14 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
             } else {
                 status = lmb_seg_table_open(node->table, &open, now_ms());
                 if (status == LMB_SEG_STATUS_OK) {
-                    memset(slot, 0, sizeof *slot);
-                    if (pthread_mutex_init(&slot->lock, NULL)) {
-                        (void)lmb_seg_table_close(node->table,
-                            &(LmbSegControl){ .session_id = open.session_id,
-                                .request_id = open.request_id,
-                                .owner = open.owner });
-                        coli_segment_session_destroy(session);
-                        status = LMB_SEG_STATUS_INTERNAL;
-                        pthread_mutex_unlock(&node->sessions_lock);
-                        LmbSegReply reply = make_reply(
-                            &open.session_id, &open.request_id,
-                            &open.owner, status);
-                        return send_reply(fd, LMB_SEG_OPEN_R, &reply, NULL, 0);
-                    }
+                    pthread_mutex_lock(&slot->lock);
                     slot->used = 1;
                     slot->id = open.session_id;
                     slot->session = session;
                     pthread_mutex_lock(&node->registration.lock);
                     node->registration.advert.active_sessions++;
                     pthread_mutex_unlock(&node->registration.lock);
+                    pthread_mutex_unlock(&slot->lock);
                 } else {
                     coli_segment_session_destroy(session);
                 }
@@ -503,10 +555,7 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
     LmbSegReply reply = make_reply(&run.session_id, &run.request_id,
                                    &run.owner, status);
     if (status == LMB_SEG_STATUS_DUPLICATE) {
-        pthread_mutex_lock(&node->sessions_lock);
-        NodeSession *slot = session_find(node, &run.session_id);
-        if (slot) pthread_mutex_lock(&slot->lock);
-        pthread_mutex_unlock(&node->sessions_lock);
+        NodeSession *slot = session_lock_id(node, &run.session_id);
         if (slot && lmb_seg_id_equal(&slot->cached_request, &run.request_id) &&
             slot->cached_output) {
             reply_state(node, &reply);
@@ -519,10 +568,8 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
         if (slot) pthread_mutex_unlock(&slot->lock);
         reply.status = LMB_SEG_STATUS_NEEDS_RESTORE;
     } else if (status == LMB_SEG_STATUS_OK) {
-        pthread_mutex_lock(&node->sessions_lock);
-        NodeSession *slot = session_find(node, &run.session_id);
+        NodeSession *slot = session_lock_id(node, &run.session_id);
         ColiSegmentSession *session = slot ? slot->session : NULL;
-        pthread_mutex_unlock(&node->sessions_lock);
         size_t bytes = lmb_state_bytes(run.rows, node->cap.state_width,
                                        node->cap.state_dtype);
         uint8_t *output = bytes ? malloc(bytes) : NULL;
@@ -530,6 +577,12 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
             status = LMB_SEG_STATUS_INTERNAL;
         } else {
             pthread_mutex_lock(&node->registration.lock);
+            node->registration.advert.queue_depth++;
+            pthread_mutex_unlock(&node->registration.lock);
+            pthread_mutex_lock(&node->run_lock);
+            pthread_mutex_lock(&node->registration.lock);
+            if (node->registration.advert.queue_depth)
+                node->registration.advert.queue_depth--;
             node->registration.advert.inflight++;
             pthread_mutex_unlock(&node->registration.lock);
             ColiSegmentRunRequest request = {
@@ -560,15 +613,13 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
             if (node->registration.advert.inflight)
                 node->registration.advert.inflight--;
             pthread_mutex_unlock(&node->registration.lock);
+            pthread_mutex_unlock(&node->run_lock);
         }
         if (status != LMB_SEG_STATUS_OK) {
             (void)lmb_seg_table_run_abort(node->table, &run);
             free(output);
+            if (slot) pthread_mutex_unlock(&slot->lock);
         } else {
-            pthread_mutex_lock(&node->sessions_lock);
-            slot = session_find(node, &run.session_id);
-            if (slot) pthread_mutex_lock(&slot->lock);
-            pthread_mutex_unlock(&node->sessions_lock);
             status = lmb_seg_table_run_commit(node->table, &run, now_ms());
             if (status == LMB_SEG_STATUS_OK && slot) {
                 free(slot->cached_output);
@@ -608,10 +659,7 @@ static int handle_snapshot(Node *node, int fd, const LmbMsg *msg) {
     uint8_t *payload = NULL;
     size_t payload_bytes = 0;
     if (status == LMB_SEG_STATUS_OK) {
-        pthread_mutex_lock(&node->sessions_lock);
-        NodeSession *slot = session_find(node, &transfer.session_id);
-        if (slot) pthread_mutex_lock(&slot->lock);
-        pthread_mutex_unlock(&node->sessions_lock);
+        NodeSession *slot = session_lock_id(node, &transfer.session_id);
         if (!slot) status = LMB_SEG_STATUS_NOT_FOUND;
         else {
             int initial = transfer.snapshot_size == 0 && transfer.offset == 0 &&
@@ -687,10 +735,7 @@ static int handle_restore(Node *node, int fd, const LmbMsg *msg) {
     if (lmb_seg_transfer_decode(msg->body, msg->body_len, &transfer) ||
         msg->pay_len != transfer.chunk_len) return -1;
     LmbSegStatus status = LMB_SEG_STATUS_OK;
-    pthread_mutex_lock(&node->sessions_lock);
-    NodeSession *slot = session_find(node, &transfer.session_id);
-    if (slot) pthread_mutex_lock(&slot->lock);
-    pthread_mutex_unlock(&node->sessions_lock);
+    NodeSession *slot = session_lock_id(node, &transfer.session_id);
     if (!slot) status = LMB_SEG_STATUS_NOT_FOUND;
     else if (slot->restored_valid &&
              lmb_seg_id_equal(&slot->restored_request, &transfer.request_id) &&
@@ -793,14 +838,21 @@ static int handle_control(Node *node, int fd, const LmbMsg *msg) {
     LmbSegStatus status;
     uint32_t response_op;
     if (msg->op == LMB_SEG_CLOSE) {
-        status = lmb_seg_table_close(node->table, &control);
         response_op = LMB_SEG_CLOSE_R;
-        if (status == LMB_SEG_STATUS_OK) {
-            pthread_mutex_lock(&node->sessions_lock);
-            NodeSession *slot = session_find(node, &control.session_id);
-            if (slot) session_release(node, slot);
-            pthread_mutex_unlock(&node->sessions_lock);
+        pthread_mutex_lock(&node->sessions_lock);
+        NodeSession *slot = session_find(node, &control.session_id);
+        if (slot && pthread_mutex_trylock(&slot->lock)) {
+            /* The client retries CLOSE; every other session remains free to
+             * open or close while this one finishes restore/run. */
+            status = LMB_SEG_STATUS_BUSY;
+        } else {
+            status = lmb_seg_table_close(node->table, &control);
+            if (status == LMB_SEG_STATUS_OK && slot)
+                session_release_locked(node, slot);
+            else if (slot)
+                pthread_mutex_unlock(&slot->lock);
         }
+        pthread_mutex_unlock(&node->sessions_lock);
     } else {
         uint64_t next_sequence = 0, next_position = 0;
         int needs_restore = 0;
@@ -850,7 +902,7 @@ static void usage(const char *program) {
         "--advertise HOST:PORT --name PEER "
         "(--auto-identity | --model-root HEX64 --tokenizer-root HEX64) "
         "[--fallback] [--relay-only] [--context N] [--max-rows N] "
-        "[--sessions N]\n",
+        "[--sessions N] [--threads N]\n",
         program);
 }
 
@@ -931,20 +983,35 @@ int main(int argc, char **argv) {
         lmb_parse_u32(port_text, 1, 65535, &port)) {
         usage(argv[0]); return 2;
     }
-    uint32_t context = 4096, max_rows = 256, max_sessions = 16;
+    uint32_t context = 4096, max_rows = 256, max_sessions = 16, threads = 0;
     const char *value;
     if (((value = arg_value(argc, argv, "--context")) &&
          lmb_parse_u32(value, 1, LMB_SEG_MAX_CONTEXT, &context)) ||
         ((value = arg_value(argc, argv, "--max-rows")) &&
          lmb_parse_u32(value, 1, LMB_SEG_MAX_ROWS, &max_rows)) ||
         ((value = arg_value(argc, argv, "--sessions")) &&
-         lmb_parse_u32(value, 1, NODE_SESSIONS_MAX, &max_sessions))) {
+         lmb_parse_u32(value, 1, NODE_SESSIONS_MAX, &max_sessions)) ||
+        ((value = arg_value(argc, argv, "--threads")) &&
+         lmb_parse_u32(value, 1, 256, &threads))) {
         usage(argv[0]); return 2;
     }
+#ifdef _OPENMP
+    if (threads) omp_set_num_threads((int)threads);
+#else
+    if (threads > 1) {
+        fprintf(stderr, "--threads needs an OpenMP build\n"); return 2;
+    }
+#endif
     if (lmb_secure_init()) return 1;
     signal(SIGINT, stop_handler); signal(SIGTERM, stop_handler);
     signal(SIGPIPE, SIG_IGN);
     if (fallback) (void)setpriority(PRIO_PROCESS, 0, 10);
+    if (threads)
+        fprintf(stderr, "[segment-node] governor: %u compute thread%s · "
+                        "%u session%s max%s\n", threads,
+                threads == 1 ? "" : "s", max_sessions,
+                max_sessions == 1 ? "" : "s",
+                (fallback || auto_range) ? " · low CPU priority" : "");
     if (lmb_colibri_register_all()) {
         fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
     }
@@ -1013,8 +1080,15 @@ int main(int argc, char **argv) {
     memset(&node, 0, sizeof node);
     for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) node.connection_fds[i] = -1;
     pthread_mutex_init(&node.sessions_lock, NULL);
+    pthread_mutex_init(&node.run_lock, NULL);
     pthread_mutex_init(&node.connections_lock, NULL);
     pthread_cond_init(&node.connections_drained, NULL);
+    for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
+        pthread_mutex_init(&node.sessions[i].lock, NULL);
+    node.ram_reserve_bytes = (uint64_t)lmb_env_int(
+        "LUMABRI_SEGMENT_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+    fprintf(stderr, "[segment-node] governor: %.1f GB RAM reserved for the "
+                    "machine\n", (double)node.ram_reserve_bytes / 1e9);
     ColiSegmentEngineOptions options = {
         .struct_size = sizeof options,
         .model_dir = model_dir,
@@ -1139,6 +1213,9 @@ int main(int argc, char **argv) {
     pthread_cond_destroy(&node.connections_drained);
     pthread_mutex_destroy(&node.connections_lock);
     pthread_mutex_destroy(&node.sessions_lock);
+    pthread_mutex_destroy(&node.run_lock);
+    for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
+        pthread_mutex_destroy(&node.sessions[i].lock);
     pthread_mutex_destroy(&registration->lock);
     return 0;
 }

--- a/signed_donor_test.sh
+++ b/signed_donor_test.sh
@@ -86,16 +86,16 @@ done
 echo "   ✓ 3 files pulled, every chunk checked against the signed truth"
 
 echo "· 2) the tracker accepts what the donor announces"
-wait_for "$T/tracker.log" "+ peer-" 15 || { cat "$T/tracker.log"; exit 1; }
-if grep -q "REJECTED: peer-" "$T/tracker.log"; then
+wait_for "$T/tracker.log" "+ .*storage" 15 || { cat "$T/tracker.log"; exit 1; }
+if grep -q "REJECTED: .*storage" "$T/tracker.log"; then
     echo "   the donor announced bytes the tracker would not take:"
     grep "REJECTED" "$T/tracker.log"; exit 1
 fi
-NF=$(grep -o "+ peer-[0-9]* @ [^ ]* (fx, [0-9]* files)" "$T/tracker.log" |
+NF=$(grep -o "+ [^ ]*storage @ [^ ]* (fx, [0-9]* files)" "$T/tracker.log" |
      tail -1 | grep -o "[0-9]* files" | cut -d' ' -f1)
 [ "${NF:-0}" -ge 3 ] || {
     echo "   the donor registered with ${NF:-0} files — it donated nothing"
-    grep "peer-" "$T/tracker.log"; exit 1; }
+    grep "storage" "$T/tracker.log"; exit 1; }
 echo "   ✓ registered with $NF files: the origin's signature travelled with them"
 
 echo "· 3) the donated copy alone serves a chatter that checks the signature"
@@ -115,9 +115,9 @@ wait "$DONOR" 2>/dev/null || true
 : > "$T/tracker.log"
 ./lumabri serve --model "$T/donor" --join 127.0.0.1:7580 --model-name fx \
     --donate 1 --pubkey "$T/swarm.pub" --port 7584 > "$T/donor2.log" 2>&1 & PIDS+=($!)
-wait_for "$T/tracker.log" "+ peer-" 30 || { cat "$T/donor2.log"; exit 1; }
+wait_for "$T/tracker.log" "+ .*storage" 30 || { cat "$T/donor2.log"; exit 1; }
 sleep 1
-if grep -q "REJECTED: peer-" "$T/tracker.log"; then
+if grep -q "REJECTED: .*storage" "$T/tracker.log"; then
     echo "   after a restart the donor announced unsigned bytes:"
     grep "REJECTED" "$T/tracker.log"; exit 1
 fi

--- a/swarm_detail_test.sh
+++ b/swarm_detail_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
+MAINTAINER_BIN=${MAINTAINER_BIN:-./maintainer}
+DETAIL_BIN=${DETAIL_BIN:-./test_swarm_detail}
+T=$(mktemp -d /tmp/lumabri-swarm-detail.XXXXXX)
+PIDS=()
+cleanup() {
+    if ((${#PIDS[@]})); then kill "${PIDS[@]}" 2>/dev/null || true; fi
+    if ((${#PIDS[@]})); then wait "${PIDS[@]}" 2>/dev/null || true; fi
+    rm -rf "$T"
+}
+trap cleanup EXIT
+wait_port() {
+    for _ in $(seq 1 100); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && {
+            exec 3<&-; exec 3>&-; return 0;
+        }
+        sleep .05
+    done
+    return 1
+}
+mkdir -p "$T/model"
+printf '{"model_type":"olmoe"}\n' >"$T/model/config.json"
+printf 'named-host-fixture\n' >"$T/model/weights.bin"
+LUMABRI_PEER_BINDINGS="$T/bindings" "$TRACKER_BIN" --port 8090 >"$T/tracker.log" 2>&1 &
+PIDS+=("$!"); wait_port 8090
+LUMABRI_PEER_KEY="$T/peer.key" "$MAINTAINER_BIN" --root "$T/model" --port 8091 \
+    --tracker 127.0.0.1:8090 --advertise 127.0.0.1:8091 \
+    --name studio-gpu-storage --model-name tiny-live >"$T/peer.log" 2>&1 &
+PIDS+=("$!"); wait_port 8091
+for _ in $(seq 1 100); do
+    grep -q '+ studio-gpu-storage' "$T/tracker.log" && break
+    sleep .05
+done
+"$DETAIL_BIN" 127.0.0.1:8090 studio-gpu-storage tiny-live
+echo 'SWARM DETAIL TEST: PASS (stable host name + storage counters)'

--- a/test_relay_rate.c
+++ b/test_relay_rate.c
@@ -1,0 +1,43 @@
+#include "lumabri_proto.h"
+#include "lumabri_segment.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int request(const char *tracker, const void *body, uint32_t body_len,
+                   const char *expected) {
+    LmbMsg message = {0};
+    int request_failed = lmb_request(tracker, LMB_RSEG, body, body_len, &message);
+    LmbCur cursor = { message.body, message.body_len, 0 };
+    char error[128] = "";
+    int malformed = lmb_cur_str(&cursor, error, sizeof error) ||
+                    cursor.off != cursor.len;
+    if (request_failed || message.op != LMB_ERR || message.pay_len || malformed ||
+        strcmp(error, expected)) {
+        fprintf(stderr, "expected '%s', got op=%u error='%s' request=%d\n",
+                expected, message.op, error, request_failed);
+        lmb_msg_free(&message);
+        return -1;
+    }
+    lmb_msg_free(&message);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) return 2;
+    LmbBuf body = {0};
+    if (lmb_buf_str(&body, "absent-segment-peer") ||
+        lmb_buf_u32(&body, LMB_SEG_HEALTH) || lmb_buf_u32(&body, 0)) return 1;
+    int bad = request(argv[1], body.p, (uint32_t)body.len,
+                      "Segment relay peer is unavailable") ||
+              request(argv[1], body.p, (uint32_t)body.len,
+                      "Segment relay source rate/concurrency limit");
+    free(body.p);
+    if (bad) {
+        fprintf(stderr, "relay token bucket did not enforce its burst\n");
+        return 1;
+    }
+    puts("Segment relay rate limit: ok");
+    return 0;
+}

--- a/test_swarm_detail.c
+++ b/test_swarm_detail.c
@@ -1,0 +1,58 @@
+#include "lumabri_proto.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s TRACKER EXPECTED_NAME EXPECTED_MODEL\n", argv[0]);
+        return 2;
+    }
+    LmbMsg message = {0};
+    if (lmb_request(argv[1], LMB_SWARM_DETAIL, NULL, 0, &message) ||
+        message.op != LMB_SWARM_DETAIL_R || message.pay_len) {
+        fprintf(stderr, "cannot read named swarm detail\n");
+        return 1;
+    }
+    LmbCur cursor = { message.body, message.body_len, 0 };
+    uint32_t version = 0, count = 0;
+    if (lmb_cur_u32(&cursor, &version) || lmb_cur_u32(&cursor, &count) ||
+        version != LMB_SWARM_DETAIL_VERSION || count > 64) return 1;
+    int found = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        char name[64], model[64];
+        uint32_t roles, age, files, experts, have_stats, expert_inflight;
+        uint32_t begin, end, active, maximum, queued, segment_inflight, flags;
+        uint64_t held, served, reads, calls;
+        if (lmb_cur_str(&cursor, name, sizeof name) ||
+            lmb_cur_str(&cursor, model, sizeof model) ||
+            lmb_cur_u32(&cursor, &roles) || lmb_cur_u32(&cursor, &age) ||
+            lmb_cur_u64(&cursor, &held) || lmb_cur_u64(&cursor, &served) ||
+            lmb_cur_u64(&cursor, &reads) || lmb_cur_u32(&cursor, &files) ||
+            lmb_cur_u32(&cursor, &experts) ||
+            lmb_cur_u32(&cursor, &have_stats) ||
+            lmb_cur_u64(&cursor, &calls) ||
+            lmb_cur_u32(&cursor, &expert_inflight) ||
+            lmb_cur_u32(&cursor, &begin) || lmb_cur_u32(&cursor, &end) ||
+            lmb_cur_u32(&cursor, &active) || lmb_cur_u32(&cursor, &maximum) ||
+            lmb_cur_u32(&cursor, &queued) ||
+            lmb_cur_u32(&cursor, &segment_inflight) ||
+            lmb_cur_u32(&cursor, &flags)) return 1;
+        (void)age; (void)served; (void)reads; (void)experts;
+        (void)have_stats; (void)calls; (void)expert_inflight;
+        (void)begin; (void)end; (void)active; (void)maximum;
+        (void)queued; (void)segment_inflight; (void)flags;
+        if (!strcmp(name, argv[2]) && !strcmp(model, argv[3]) &&
+            (roles & LMB_SWARM_ROLE_STORAGE) && held && files)
+            found = 1;
+    }
+    int bad = cursor.off != cursor.len || !found;
+    lmb_msg_free(&message);
+    if (bad) {
+        fprintf(stderr, "named storage host not present in swarm detail\n");
+        return 1;
+    }
+    puts("named swarm detail: ok");
+    return 0;
+}

--- a/tracker.c
+++ b/tracker.c
@@ -32,6 +32,7 @@
 #define MAX_FILES  4096
 #define STALE_S    30.0     /* silent this long → dropped from placements */
 #define RELAY_WAIT_S 60     /* chatter-side cap on one relayed read */
+#define RSEG_RATE_SLOTS 128
 
 typedef struct { char path[LMB_PATH_MAX]; uint64_t size; } PFile;
 
@@ -83,6 +84,15 @@ typedef struct {
 } Peer;
 
 static Peer g_peers[MAX_PEERS];
+typedef struct {
+    char source[64];
+    double tokens, updated;
+    uint32_t in_flight;
+} RsegRate;
+static RsegRate g_rseg_rates[RSEG_RATE_SLOTS];
+static pthread_mutex_t g_rseg_rate_lk = PTHREAD_MUTEX_INITIALIZER;
+static int g_rseg_rate_per_s = 2048, g_rseg_burst = 4096;
+static int g_rseg_source_concurrency = 32, g_rseg_queue_ms = 2000;
 static pthread_mutex_t g_lk = PTHREAD_MUTEX_INITIALIZER;
 static int g_known_logged[MAX_PEERS];
 static char g_token[LMB_TOKEN_MAX + 1]; /* --token: private swarm, invite required */
@@ -549,6 +559,62 @@ static void connection_source(int fd, char out[64]) {
     if (getpeername(fd, (struct sockaddr *)&ss, &sl)) return;
     if (getnameinfo((struct sockaddr *)&ss, sl, out, 64, NULL, 0,
                     NI_NUMERICHOST)) out[0] = 0;
+}
+
+/* RSEG callers do not yet carry a signed end-user identity. Bound both work
+ * rate and blocked relay threads by observed source address; private swarms
+ * additionally retain their existing tracker token. The bucket charges large
+ * activation/restore frames more than a control frame. */
+static int rseg_rate_enter(int fd, uint32_t pay_len, char source[64]) {
+    connection_source(fd, source);
+    if (!source[0]) snprintf(source, 64, "unknown");
+    double now = now_s();
+    double cost = 1.0 + (double)pay_len / (double)(1u << 20);
+    pthread_mutex_lock(&g_rseg_rate_lk);
+    RsegRate *slot = NULL, *reuse = NULL;
+    for (int i = 0; i < RSEG_RATE_SLOTS; i++) {
+        RsegRate *candidate = &g_rseg_rates[i];
+        if (!strcmp(candidate->source, source)) { slot = candidate; break; }
+        if (!candidate->source[0]) reuse = candidate;
+        else if (!candidate->in_flight &&
+                 (!reuse || candidate->updated < reuse->updated)) reuse = candidate;
+    }
+    if (!slot) {
+        slot = reuse;
+        if (slot) {
+            memset(slot, 0, sizeof *slot);
+            snprintf(slot->source, sizeof slot->source, "%s", source);
+            slot->tokens = g_rseg_burst;
+            slot->updated = now;
+        }
+    }
+    int allowed = 0;
+    if (slot) {
+        double elapsed = now - slot->updated;
+        if (elapsed > 0) {
+            slot->tokens += elapsed * g_rseg_rate_per_s;
+            if (slot->tokens > g_rseg_burst) slot->tokens = g_rseg_burst;
+            slot->updated = now;
+        }
+        if (slot->tokens >= cost &&
+            slot->in_flight < (uint32_t)g_rseg_source_concurrency) {
+            slot->tokens -= cost;
+            slot->in_flight++;
+            allowed = 1;
+        }
+    }
+    pthread_mutex_unlock(&g_rseg_rate_lk);
+    return allowed ? 0 : -1;
+}
+
+static void rseg_rate_leave(const char source[64]) {
+    pthread_mutex_lock(&g_rseg_rate_lk);
+    for (int i = 0; i < RSEG_RATE_SLOTS; i++)
+        if (!strcmp(g_rseg_rates[i].source, source)) {
+            if (g_rseg_rates[i].in_flight) g_rseg_rates[i].in_flight--;
+            break;
+        }
+    pthread_mutex_unlock(&g_rseg_rate_lk);
 }
 
 static Peer *handle_register(int fd, LmbMsg *m, const uint8_t *nonce) {
@@ -1586,6 +1652,68 @@ static int handle_swarm(int fd) {
     return rc;
 }
 
+/* Named, versioned status for humans.  The old LMB_SWARM reply stays
+ * anonymous and byte-compatible for scripts; this view is intentionally a
+ * separate opcode so adding a field can never make an old client misparse
+ * the storage prefix.  Addresses and keys are never included. */
+static int handle_swarm_detail(int fd) {
+    LmbBuf body = {0};
+    double now = now_s();
+    pthread_mutex_lock(&g_lk);
+    uint32_t count = 0;
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *p = &g_peers[i];
+        int storage = p->used && !p->is_expert && now - p->ts <= g_stale_s;
+        int expert = p->used && p->is_expert && p->has_expert &&
+                     now - p->expert_ts <= g_stale_s;
+        int segment = p->used && p->is_expert && p->has_segment &&
+                      p->segment_live && now - p->segment_ts <= g_stale_s;
+        if (storage || expert || segment) count++;
+    }
+    lmb_buf_u32(&body, LMB_SWARM_DETAIL_VERSION);
+    lmb_buf_u32(&body, count);
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *p = &g_peers[i];
+        int storage = p->used && !p->is_expert && now - p->ts <= g_stale_s;
+        int expert = p->used && p->is_expert && p->has_expert &&
+                     now - p->expert_ts <= g_stale_s;
+        int segment = p->used && p->is_expert && p->has_segment &&
+                      p->segment_live && now - p->segment_ts <= g_stale_s;
+        if (!storage && !expert && !segment) continue;
+        uint32_t roles = (storage ? LMB_SWARM_ROLE_STORAGE : 0u) |
+                         (expert ? LMB_SWARM_ROLE_EXPERT : 0u) |
+                         (segment ? LMB_SWARM_ROLE_SEGMENT : 0u);
+        double newest = storage ? p->ts : 0.0;
+        if (expert && p->expert_ts > newest) newest = p->expert_ts;
+        if (segment && p->segment_ts > newest) newest = p->segment_ts;
+        const char *model = segment ? p->segment.model : p->model;
+        lmb_buf_str(&body, p->name);
+        lmb_buf_str(&body, model);
+        lmb_buf_u32(&body, roles);
+        lmb_buf_u32(&body, (uint32_t)(now - newest));
+        lmb_buf_u64(&body, storage ? p->held_bytes : 0u);
+        lmb_buf_u64(&body, storage ? p->served_bytes : 0u);
+        lmb_buf_u64(&body, storage ? p->served_reads : 0u);
+        lmb_buf_u32(&body, storage ? p->nfiles : 0u);
+        lmb_buf_u32(&body, expert ? p->nexperts : 0u);
+        lmb_buf_u32(&body, expert && p->have_exec_stats ? 1u : 0u);
+        lmb_buf_u64(&body, expert && p->have_exec_stats ? p->exec_calls : 0u);
+        lmb_buf_u32(&body, expert && p->have_exec_stats ? p->exec_inflight : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.layer_begin : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.layer_end : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.active_sessions : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.max_sessions : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.queue_depth : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.inflight : 0u);
+        lmb_buf_u32(&body, segment ? p->segment.flags : 0u);
+    }
+    pthread_mutex_unlock(&g_lk);
+    int rc = lmb_send(fd, LMB_SWARM_DETAIL_R, body.p,
+                      (uint32_t)body.len, NULL, 0);
+    free(body.p);
+    return rc;
+}
+
 /* ---- EASSIGN: which experts should this node hold? ----------------------
  *
  * The disk side has had this since day one: a donor offers bytes, the tracker
@@ -1970,6 +2098,11 @@ static int handle_rseg(int fd, LmbMsg *m) {
         !lmb_frame_shape_ok(inner_op, inner_body_len, m->pay_len)) {
         send_err(fd, "bad Segment relay frame"); return -1;
     }
+    char rate_source[64];
+    if (rseg_rate_enter(fd, m->pay_len, rate_source)) {
+        send_err(fd, "Segment relay source rate/concurrency limit");
+        return 0;
+    }
 
     Peer *p = NULL;
     double now = now_s();
@@ -1983,20 +2116,42 @@ static int handle_rseg(int fd, LmbMsg *m) {
         p = q; p->refs++; break;
     }
     pthread_mutex_unlock(&g_lk);
-    if (!p) { send_err(fd, "Segment relay peer is unavailable"); return 0; }
+    if (!p) {
+        rseg_rate_leave(rate_source);
+        send_err(fd, "Segment relay peer is unavailable"); return 0;
+    }
 
     uint8_t *body = malloc(inner_body_len ? inner_body_len : 1u);
     uint8_t *pay = malloc(m->pay_len ? m->pay_len : 1u);
     if (!body || !pay) {
         free(body); free(pay);
         pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
+        rseg_rate_leave(rate_source);
         send_err(fd, "oom"); return -1;
     }
     if (inner_body_len) memcpy(body, c.p + c.off, inner_body_len);
     if (m->pay_len) memcpy(pay, m->pay, m->pay_len);
 
     pthread_mutex_lock(&p->rq_lk);
-    while (p->rq_busy) pthread_cond_wait(&p->rq_cv, &p->rq_lk);
+    struct timespec queue_deadline;
+    clock_gettime(CLOCK_REALTIME, &queue_deadline);
+    queue_deadline.tv_sec += g_rseg_queue_ms / 1000;
+    queue_deadline.tv_nsec += (long)(g_rseg_queue_ms % 1000) * 1000000L;
+    if (queue_deadline.tv_nsec >= 1000000000L) {
+        queue_deadline.tv_sec++;
+        queue_deadline.tv_nsec -= 1000000000L;
+    }
+    while (p->rq_busy)
+        if (pthread_cond_timedwait(&p->rq_cv, &p->rq_lk,
+                                   &queue_deadline) == ETIMEDOUT) break;
+    if (p->rq_busy) {
+        pthread_mutex_unlock(&p->rq_lk);
+        free(body); free(pay);
+        pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
+        rseg_rate_leave(rate_source);
+        send_err(fd, "Segment relay executor queue is busy");
+        return 0;
+    }
     p->rq_busy = 1; p->rq_sent = 0; p->rq_done = 0; p->rq_ok = 0;
     p->rq_id = ++p->rq_next; p->rq_op = LMB_RSEG_FWD;
     p->rq_inner_op = inner_op;
@@ -2042,6 +2197,7 @@ static int handle_rseg(int fd, LmbMsg *m) {
     }
     free(response_body); free(response_pay);
     pthread_mutex_lock(&g_lk); if (p->refs) p->refs--; pthread_mutex_unlock(&g_lk);
+    rseg_rate_leave(rate_source);
     return rc;
 }
 
@@ -2332,6 +2488,7 @@ static void *conn_thread(void *arg) {
         case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;
         case LMB_SWARM:     rc = handle_swarm(fd); break;
+        case LMB_SWARM_DETAIL: rc = handle_swarm_detail(fd); break;
         case LMB_RREAD:     rc = handle_rread(fd, &m); break;
         case LMB_REXEC:     rc = handle_rexec(fd, &m); break;
         case LMB_RSEG:      rc = handle_rseg(fd, &m); break;
@@ -2383,6 +2540,11 @@ int main(int argc, char **argv) {
     g_stale_s = (double)lmb_env_int("LUMABRI_STALE_MS", (int)(STALE_S * 1000),
                                     100, 3600000) / 1000.0;
     g_max_names_per_source = lmb_env_int("LUMABRI_MAX_NAMES_PER_SOURCE", 16, 1, MAX_PEERS);
+    g_rseg_rate_per_s = lmb_env_int("LUMABRI_RSEG_RATE", 2048, 1, 1000000);
+    g_rseg_burst = lmb_env_int("LUMABRI_RSEG_BURST", 4096, 1, 1000000);
+    g_rseg_source_concurrency = lmb_env_int("LUMABRI_RSEG_SOURCE_CONCURRENCY",
+                                            32, 1, 256);
+    g_rseg_queue_ms = lmb_env_int("LUMABRI_RSEG_QUEUE_MS", 2000, 0, 60000);
     if (bindings_load()) {
         fprintf(stderr, "[tracker] cannot load trusted peer bindings from %s\n",
                 g_bindings_path[0] ? g_bindings_path : "the state directory");


### PR DESCRIPTION
## Outcome

Makes swarm work visible without blocking the chat, and hardens the NAT Segment path introduced in #76.

### Chat UX

- streams Segment text incrementally with tokenizer-safe one-token look-behind
- fixed three-line live dock for routing, prefill, decode, checkpoint and failover
- input remains usable during inference; read-only menus open immediately and one prompt/command can be queued
- Tab autocomplete for slash commands
- `/experts`, `/hosts`, `/help`; named `/swarm` rows and executor usage counters

### Server observability

- stable readable host/role names, with optional `--host-name`
- periodic connected-node, storage, expert-call and Segment-session summary
- versioned `SWARM_DETAIL` control reply; legacy `SWARM` remains compatible

### #76 hardening

- weighted per-source RSEG token bucket, concurrency cap and bounded executor-queue wait
- permanent per-session locks: a multi-GB restore no longer holds the node-wide session lock; same-session CLOSE returns BUSY
- RUN/CLOSE adapter-state race closed
- Segment resource governor: per-slice OpenMP team, thread partitioning, low priority, smaller NAT session cap, 4 GiB session reserve and 8 GiB automatic-start floor
- explicit release note that NAT Segment slices consume CPU/RAM; `--no-exec` remains storage-only

The relay tunnel is still serialized per executor, but waiting and unsigned-caller abuse are now bounded. Source limiting is containment, not caller authentication; the remaining boundary is documented.

## Verification

- `make test` — PASS
- `make check-warnings` — PASS with `-Werror`
- real Segment gate — PASS for GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4
- relay-only NAT, checkpoint restore/replay, killed-peer failover and native `serve + chat` — PASS
- real PTY gate: `/exp<Tab>` opens `/experts` before inference finishes and queues `/quit` — PASS
- every family emits at least two DATA frames in the gateway gate
- ASan/UBSan on Segment state/discovery and tracker SWARM_DETAIL/RSEG paths — PASS
- TSan cannot run in this WSL host (`unexpected memory mapping`), documented here rather than reported as a code failure

No merge performed.