### PR TITLE
bench: add the multi-host A/B/C release gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tracker
+swarm_probe
 maintainer
 lumabri
 lumibri

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC      ?= cc
 CFLAGS  ?= -O2 -Wall -Wextra
 ENGINE  ?= ../colibri/c
 
-all: tracker maintainer liblumabri.so test_shim lumabri
+all: tracker maintainer liblumabri.so test_shim swarm_probe lumabri
 
 # A checkout with Colibri's additive ABI gets the transparent Segment path
 # from the ordinary `make`; older/release Colibri trees keep the exact legacy
@@ -397,6 +397,9 @@ test_segment_discovery: test_segment_discovery.c lumabri_segment_discovery.c \
 test_swarm_detail: test_swarm_detail.c lumabri_proto.h
 	$(CC) $(CFLAGS) -pthread test_swarm_detail.c -o $@
 
+swarm_probe: swarm_probe.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread swarm_probe.c -o $@
+
 test_relay_rate: test_relay_rate.c lumabri_segment.c lumabri_segment.h \
 		lumabri_proto.h
 	$(CC) $(CFLAGS) -pthread test_relay_rate.c lumabri_segment.c -o $@
@@ -499,6 +502,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_key_rotation
 	./test_hedge
 	./test_segment_v2
+	python3 ./test_swarm_bench.py
 	bash ./segment_discovery_test.sh
 	bash ./swarm_detail_test.sh
 	bash ./relay_rate_test.sh
@@ -513,7 +517,7 @@ PREFIX ?= /usr/local
 
 install: all
 	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/lib/lumabri
-	install -m 755 lumabri tracker maintainer $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 lumabri tracker maintainer swarm_probe $(DESTDIR)$(PREFIX)/bin/
 	install -m 644 liblumabri.so $(DESTDIR)$(PREFIX)/lib/lumabri/
 	@for b in expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	         expert_node_deepseek expert_node_qwen36 \
@@ -523,7 +527,7 @@ install: all
 	@echo "installed under $(DESTDIR)$(PREFIX)"
 
 clean:
-	rm -f tracker maintainer liblumabri.so test_shim lumabri \
+	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate \

--- a/SWARM_BENCH.md
+++ b/SWARM_BENCH.md
@@ -1,0 +1,33 @@
+# Multi-host performance gate
+
+`swarm_bench.py` records the three release metrics without scraping the TUI:
+
+- A: median decode tokens/s for one chat;
+- B: aggregate decode tokens/s for 1, 2, 4 and 8 concurrent chats;
+- C: the change in executed expert calls for every named peer.
+
+The run is invalid unless every sample returns exactly the configured oracle
+token IDs. Use temperature zero, one fixed prompt and build-compatible peers.
+Run at least one warm-up and five measured repetitions. Compare `swarm` with
+both `baseline-local` (stock local Colibri) and `baseline-single` (one resident
+Segment on one machine); do not compare against an intentionally starved
+four-process origin.
+
+The chatter command in the spec is an adapter: `segment_chat --json` already
+implements it, and a local-engine wrapper can implement the same small
+contract for `baseline-local`. Its final stdout
+line must be a JSON object with `token_ids`, `decode_tokens`,
+`decode_seconds`, and optional CAS/Expert/Segment byte counters. The example
+spec shows the contract. Commands run locally when `host` is `local`, and via
+non-interactive SSH otherwise. Lumabri does not install keys or open hosts.
+
+Example:
+
+```sh
+./swarm_bench.sh run.json results/deepseek-swarm.json --mode swarm
+./swarm_bench.sh run.json results/deepseek-local.json --mode baseline-local
+```
+
+Use 0, 1, 2, then 3 compute donors on the same prompt. A release candidate
+meets the speed objective only when the three-donor median A is at least 2x
+the best single-machine baseline and no additional READY peer makes it slower.

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -50,6 +50,7 @@ typedef struct {
     size_t token_count;
     size_t prompt_count;
     double elapsed_seconds;
+    double decode_seconds;
 } GenerationResult;
 
 typedef enum {
@@ -66,6 +67,7 @@ typedef int (*GenerationEventFn)(void *opaque, GenerationEventKind kind,
 
 static int retry_first_run;
 static const char *segment_tracker;
+static uint64_t segment_wire_bytes;
 
 #define SEGMENT_FRAME_READY "\x01\x01" "READY" "\x01\x01"
 #define REMOTE_SNAPSHOT_CHUNK (1u << 20)
@@ -93,7 +95,7 @@ static void usage(const char *program) {
         "((--prompt TEXT | --prompt-ids CSV) | --serve) "
         "[--expect-ids CSV] [--tokens N] [--context N] [--max-rows N] "
         "[--temperature F --top-p F --seed N] "
-        "[--discovery-timeout-ms N] [--retry-first-run]\n",
+        "[--discovery-timeout-ms N] [--retry-first-run] [--json]\n",
         program);
 }
 
@@ -380,6 +382,7 @@ static int remote_request(RemoteSegment *remote, uint32_t op,
                           const void *body, uint32_t body_len,
                           const void *pay, uint32_t pay_len,
                           LmbMsg *response) {
+    uint64_t sent_bytes = 16u + (uint64_t)body_len + pay_len;
     if (!remote->direct_failed &&
         (remote->route.transport & LMB_SEG_TRANSPORT_DIRECT)) {
         remote->transport_error[0] = 0;
@@ -405,7 +408,11 @@ static int remote_request(RemoteSegment *remote, uint32_t op,
                          "%s at %s sent no reply to op %u",
                          remote->route.advert.peer_name,
                          remote->route.advert.addr, op);
-            else return 0;
+            else {
+                segment_wire_bytes += sent_bytes + 16u + response->body_len +
+                                      response->pay_len;
+                return 0;
+            }
         }
         lmb_msg_free(response);
         if (remote->fd >= 0) lmb_close(remote->fd);
@@ -414,7 +421,11 @@ static int remote_request(RemoteSegment *remote, uint32_t op,
     }
     if (!(remote->route.transport & LMB_SEG_TRANSPORT_RELAY)) return -1;
     if (!remote_relay_request(remote, op, body, body_len,
-                              pay, pay_len, response)) return 0;
+                              pay, pay_len, response)) {
+        segment_wire_bytes += sent_bytes + 16u + response->body_len +
+                              response->pay_len;
+        return 0;
+    }
     size_t used = strlen(remote->transport_error);
     snprintf(remote->transport_error + used,
              sizeof remote->transport_error - used,
@@ -1200,6 +1211,10 @@ static int segment_generate(ColiEdgeEngine *edge,
             uint8_t *swap = buffer_a; buffer_a = buffer_b; buffer_b = swap;
         }
     }
+    /* Decode timing starts after the complete prompt has traversed the
+     * chain. Keep it separate from TTFT so metric A is not prompt-length
+     * dependent. */
+    double decode_started = monotonic_seconds();
     size_t element = cap->state_dtype == COLI_EDGE_DTYPE_F32 ? 4u : 2u;
     const uint8_t *last = final_state +
         (size_t)(final_rows - 1) * cap->state_width * element;
@@ -1358,6 +1373,7 @@ static int segment_generate(ColiEdgeEngine *edge,
     result->token_count = generated_count;
     result->prompt_count = prompt_count;
     result->elapsed_seconds = monotonic_seconds() - started;
+    result->decode_seconds = monotonic_seconds() - decode_started;
     generated = NULL;
     rc = 0;
 
@@ -1573,11 +1589,12 @@ int main(int argc, char **argv) {
     const char *prompt_ids_text = arg_value(argc, argv, "--prompt-ids");
     const char *expect_ids_text = arg_value(argc, argv, "--expect-ids");
     int serve_mode = has_arg(argc, argv, "--serve");
+    int json_output = has_arg(argc, argv, "--json");
     segment_tracker = tracker;
     for (int i = 1; i < argc; i++)
         if (!strcmp(argv[i], "--retry-first-run")) retry_first_run = 1;
     if (!engine_id || !model_dir || !model || !tracker ||
-        (serve_mode ? (prompt || prompt_ids_text || expect_ids_text)
+        (serve_mode ? (prompt || prompt_ids_text || expect_ids_text || json_output)
                     : (!!prompt == !!prompt_ids_text))) {
         usage(argv[0]); return 2;
     }
@@ -1772,11 +1789,13 @@ int main(int argc, char **argv) {
         free(expected);
         return 1;
     }
-    printf("%s\n", generated.text);
-    printf("[lumabri] token-ids:");
-    for (size_t i = 0; i < generated.token_count; i++)
-        printf("%s%d", i ? "," : " ", generated.tokens[i]);
-    printf("\n");
+    if (!json_output) {
+        printf("%s\n", generated.text);
+        printf("[lumabri] token-ids:");
+        for (size_t i = 0; i < generated.token_count; i++)
+            printf("%s%d", i ? "," : " ", generated.tokens[i]);
+        printf("\n");
+    }
     if (expected && (generated.token_count != expected_count ||
         memcmp(generated.tokens, expected,
                expected_count * sizeof *expected))) {
@@ -1786,6 +1805,17 @@ int main(int argc, char **argv) {
         coli_edge_engine_close(edge);
         free(expected);
         return 1;
+    }
+    if (json_output) {
+        printf("{\"token_ids\":[");
+        for (size_t i = 0; i < generated.token_count; i++)
+            printf("%s%d", i ? "," : "", generated.tokens[i]);
+        printf("],\"decode_tokens\":%zu,\"decode_seconds\":%.9f,"
+               "\"prefill_decode_seconds\":%.9f,"
+               "\"bytes\":{\"segment\":%llu}}\n",
+               generated.token_count, generated.decode_seconds,
+               generated.elapsed_seconds,
+               (unsigned long long)segment_wire_bytes);
     }
     generation_result_free(&generated);
     lmb_seg_discovery_stop(discovery);

--- a/swarm_bench.example.json
+++ b/swarm_bench.example.json
@@ -1,0 +1,27 @@
+{
+  "model": "DeepSeek-V4-Flash",
+  "family": "deepseek_v4",
+  "prompt": "Write exactly one short greeting.",
+  "oracle_token_ids": [123, 456],
+  "chatter": {
+    "host": "chatter.example.net",
+    "command": [
+      "/opt/lumabri/bin/segment_chat",
+      "--engine", "deepseek_v4",
+      "--model-dir", "/home/bench/.lumabri/DeepSeek-V4-Flash/vroot",
+      "--tracker", "148.251.4.122:7300",
+      "--model", "{model}",
+      "--prompt", "{prompt}",
+      "--tokens", "{max_tokens}",
+      "--json"
+    ]
+  },
+  "probe": {
+    "host": "chatter.example.net",
+    "command": [
+      "/opt/lumabri/bin/swarm_probe",
+      "--tracker", "148.251.4.122:7300",
+      "--model", "DeepSeek-V4-Flash"
+    ]
+  }
+}

--- a/swarm_bench.py
+++ b/swarm_bench.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Reproducible multi-host Lumabri benchmark.
+
+The runner deliberately treats deployment as data.  A spec supplies commands
+for already-installed Lumabri binaries; commands may run locally or through
+ssh.  Each inference command must finish with one JSON object containing:
+
+  {"token_ids":[1,2], "decode_tokens":2, "decode_seconds":0.42,
+   "bytes":{"cas":0,"expert":12,"segment":34}}
+
+This keeps the performance gate independent from terminal wording and makes a
+failed/mismatching generation an invalid sample, never a fast sample.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import math
+import os
+import shlex
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+FAMILIES = {"glm", "inkling", "kimi_k3", "qwen36", "olmoe", "deepseek_v4"}
+
+
+def remote_command(host: str, command: list[str]) -> list[str]:
+    if host in ("", "local", "localhost"):
+        return command
+    return ["ssh", "-o", "BatchMode=yes", host, "--", shlex.join(command)]
+
+
+def render(value: str, fields: dict[str, Any]) -> str:
+    return value.format_map({key: str(val) for key, val in fields.items()})
+
+
+def run_json(host: str, command: list[str], fields: dict[str, Any], timeout: float) -> dict:
+    argv = remote_command(host, [render(part, fields) for part in command])
+    proc = subprocess.run(argv, text=True, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, timeout=timeout, check=False)
+    if proc.returncode:
+        raise RuntimeError(f"command failed ({proc.returncode}): {shlex.join(argv)}\n{proc.stderr[-2000:]}")
+    for line in reversed(proc.stdout.splitlines()):
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            return obj
+    raise RuntimeError(f"command produced no JSON object: {shlex.join(argv)}")
+
+
+def validate_sample(sample: dict, oracle: list[int]) -> dict:
+    ids = sample.get("token_ids")
+    count = sample.get("decode_tokens")
+    seconds = sample.get("decode_seconds")
+    if not isinstance(ids, list) or any(not isinstance(v, int) for v in ids):
+        raise ValueError("sample has no integer token_ids array")
+    if ids != oracle:
+        raise ValueError(f"tokens differ from oracle: {ids} != {oracle}")
+    if not isinstance(count, int) or count <= 0 or count != len(ids):
+        raise ValueError("decode_tokens must equal len(token_ids) and be positive")
+    if not isinstance(seconds, (int, float)) or not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError("decode_seconds must be finite and positive")
+    byte_counts = sample.get("bytes", {})
+    for key in ("cas", "expert", "segment"):
+        value = byte_counts.get(key, 0)
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f"bytes.{key} must be a non-negative integer")
+    return {"tok_s": count / seconds, "seconds": seconds,
+            "bytes": {key: int(byte_counts.get(key, 0))
+                      for key in ("cas", "expert", "segment")}}
+
+
+def peer_counters(spec: dict, timeout: float) -> dict:
+    probe = spec.get("probe")
+    if not probe:
+        return {}
+    obj = run_json(probe.get("host", "local"), probe["command"], {}, timeout)
+    return {peer["name"]: int(peer.get("expert", {}).get("calls", 0))
+            for peer in obj.get("peers", [])}
+
+
+def one_sample(spec: dict, fields: dict[str, Any], oracle: list[int], timeout: float) -> dict:
+    chatter = spec["chatter"]
+    raw = run_json(chatter.get("host", "local"), chatter["command"], fields, timeout)
+    return validate_sample(raw, oracle)
+
+
+def client_batch(spec: dict, clients: int, fields: dict[str, Any],
+                 oracle: list[int], timeout: float) -> tuple[list[dict], float]:
+    started = time.monotonic()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=clients) as pool:
+        jobs = [pool.submit(one_sample, spec, fields | {"client": i}, oracle, timeout)
+                for i in range(clients)]
+        samples = [job.result() for job in jobs]
+    elapsed = time.monotonic() - started
+    total_tokens = sum(len(oracle) for _ in samples)
+    return samples, total_tokens / elapsed
+
+
+def median(values: list[float]) -> float:
+    if not values:
+        raise ValueError("cannot take median of empty list")
+    return statistics.median(values)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--spec", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--mode", choices=("baseline-local", "baseline-single", "swarm"),
+                        default="swarm")
+    parser.add_argument("--clients", default="1,2,4,8")
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    args = parser.parse_args()
+
+    spec = json.loads(args.spec.read_text(encoding="utf-8"))
+    family = spec.get("family")
+    if family not in FAMILIES:
+        raise SystemExit(f"family must be one of {sorted(FAMILIES)}")
+    oracle = spec.get("oracle_token_ids")
+    if not isinstance(oracle, list) or not oracle:
+        raise SystemExit("spec.oracle_token_ids must be a non-empty array")
+    clients = [int(v) for v in args.clients.split(",")]
+    if any(v <= 0 for v in clients) or args.runs < 1 or args.warmup < 0:
+        raise SystemExit("clients/runs/warmup must be positive")
+
+    fields = {"mode": args.mode, "prompt": spec.get("prompt", ""),
+              "max_tokens": len(oracle), "model": spec["model"]}
+    for _ in range(args.warmup):
+        one_sample(spec, fields | {"client": 0}, oracle, args.timeout)
+
+    before = peer_counters(spec, args.timeout)
+    single, aggregate, all_bytes = [], {}, {"cas": 0, "expert": 0, "segment": 0}
+    for count in clients:
+        rates = []
+        for _ in range(args.runs):
+            samples, rate = client_batch(spec, count, fields, oracle, args.timeout)
+            rates.append(rate)
+            for sample in samples:
+                if count == 1:
+                    single.append(sample["tok_s"])
+                for key, value in sample["bytes"].items():
+                    all_bytes[key] += value
+        aggregate[str(count)] = median(rates)
+    after = peer_counters(spec, args.timeout)
+    calls = {name: after.get(name, 0) - before.get(name, 0)
+             for name in sorted(set(before) | set(after))}
+
+    result = {
+        "schema": 1, "model": spec["model"], "family": family,
+        "mode": args.mode, "runs": args.runs, "warmup": args.warmup,
+        "peers": len(calls), "tok_s_single": median(single),
+        "tok_s_aggregate": aggregate, "expert_calls_per_peer": calls,
+        "bytes": all_bytes, "tokens_match_oracle": True,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    temp = args.output.with_suffix(args.output.suffix + ".tmp")
+    temp.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temp, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, subprocess.TimeoutExpired) as exc:
+        print(f"swarm_bench: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/swarm_bench.sh
+++ b/swarm_bench.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 SPEC.json OUTPUT.json [swarm_bench.py options...]" >&2
+    exit 2
+fi
+spec=$1
+output=$2
+shift 2
+exec python3 "$(dirname "$0")/swarm_bench.py" --spec "$spec" --output "$output" "$@"

--- a/swarm_probe.c
+++ b/swarm_probe.c
@@ -1,0 +1,107 @@
+#include "lumabri_proto.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void json_string(const char *s) {
+    putchar('"');
+    for (; *s; s++) {
+        unsigned char c = (unsigned char)*s;
+        if (c == '"' || c == '\\') printf("\\%c", c);
+        else if (c == '\n') fputs("\\n", stdout);
+        else if (c == '\r') fputs("\\r", stdout);
+        else if (c == '\t') fputs("\\t", stdout);
+        else if (c < 0x20) printf("\\u%04x", c);
+        else putchar(c);
+    }
+    putchar('"');
+}
+
+int main(int argc, char **argv) {
+    const char *tracker = NULL, *model_filter = NULL;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "--tracker") && i + 1 < argc) tracker = argv[++i];
+        else if (!strcmp(argv[i], "--model") && i + 1 < argc)
+            model_filter = argv[++i];
+        else {
+            fprintf(stderr, "usage: %s --tracker HOST:PORT [--model NAME]\n", argv[0]);
+            return 2;
+        }
+    }
+    if (!tracker) {
+        fprintf(stderr, "--tracker is required\n");
+        return 2;
+    }
+
+    LmbMsg message = {0};
+    if (lmb_request(tracker, LMB_SWARM_DETAIL, NULL, 0, &message) ||
+        message.op != LMB_SWARM_DETAIL_R || message.pay_len) {
+        fprintf(stderr, "cannot read swarm detail from %s\n", tracker);
+        lmb_msg_free(&message);
+        return 1;
+    }
+    LmbCur cursor = { message.body, message.body_len, 0 };
+    uint32_t version = 0, count = 0;
+    if (lmb_cur_u32(&cursor, &version) ||
+        version != LMB_SWARM_DETAIL_VERSION ||
+        lmb_cur_u32(&cursor, &count) || count > 4096) {
+        fprintf(stderr, "malformed swarm detail\n");
+        lmb_msg_free(&message);
+        return 1;
+    }
+
+    printf("{\"schema\":1,\"tracker\":");
+    json_string(tracker);
+    printf(",\"peers\":[");
+    unsigned emitted = 0;
+    for (uint32_t i = 0; i < count; i++) {
+        char name[64], model[64];
+        uint32_t roles, age, files, experts, have_stats, expert_inflight;
+        uint32_t begin, end, active, maximum, queued, segment_inflight, flags;
+        uint64_t held, served, reads, calls;
+        int bad = lmb_cur_str(&cursor, name, sizeof name) ||
+                  lmb_cur_str(&cursor, model, sizeof model) ||
+                  lmb_cur_u32(&cursor, &roles) || lmb_cur_u32(&cursor, &age) ||
+                  lmb_cur_u64(&cursor, &held) || lmb_cur_u64(&cursor, &served) ||
+                  lmb_cur_u64(&cursor, &reads) || lmb_cur_u32(&cursor, &files) ||
+                  lmb_cur_u32(&cursor, &experts) ||
+                  lmb_cur_u32(&cursor, &have_stats) ||
+                  lmb_cur_u64(&cursor, &calls) ||
+                  lmb_cur_u32(&cursor, &expert_inflight) ||
+                  lmb_cur_u32(&cursor, &begin) || lmb_cur_u32(&cursor, &end) ||
+                  lmb_cur_u32(&cursor, &active) ||
+                  lmb_cur_u32(&cursor, &maximum) ||
+                  lmb_cur_u32(&cursor, &queued) ||
+                  lmb_cur_u32(&cursor, &segment_inflight) ||
+                  lmb_cur_u32(&cursor, &flags);
+        if (bad) {
+            fprintf(stderr, "malformed peer row\n");
+            lmb_msg_free(&message);
+            return 1;
+        }
+        if (model_filter && strcmp(model_filter, model)) continue;
+        printf("%s{\"name\":", emitted++ ? "," : ""); json_string(name);
+        printf(",\"model\":"); json_string(model);
+        printf(",\"roles\":%u,\"age_s\":%u", roles, age);
+        printf(",\"storage\":{\"bytes_held\":%" PRIu64
+               ",\"bytes_served\":%" PRIu64 ",\"reads\":%" PRIu64
+               ",\"files\":%u}", held, served, reads, files);
+        printf(",\"expert\":{\"count\":%u,\"stats\":%s,\"calls\":%" PRIu64
+               ",\"inflight\":%u}", experts,
+               have_stats ? "true" : "false", calls, expert_inflight);
+        printf(",\"segment\":{\"begin\":%u,\"end\":%u,\"sessions\":%u"
+               ",\"max_sessions\":%u,\"queue\":%u,\"inflight\":%u"
+               ",\"flags\":%u}}", begin, end, active, maximum, queued,
+               segment_inflight, flags);
+    }
+    printf("]}\n");
+    int malformed = cursor.off != cursor.len;
+    lmb_msg_free(&message);
+    if (malformed) {
+        fprintf(stderr, "trailing bytes in swarm detail\n");
+        return 1;
+    }
+    return 0;
+}

--- a/test_swarm_bench.py
+++ b/test_swarm_bench.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location("swarm_bench", HERE / "swarm_bench.py")
+BENCH = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(BENCH)
+
+
+class SwarmBenchTest(unittest.TestCase):
+    def test_valid_sample(self):
+        got = BENCH.validate_sample({
+            "token_ids": [7, 8], "decode_tokens": 2, "decode_seconds": 0.5,
+            "bytes": {"cas": 1, "expert": 2, "segment": 3},
+        }, [7, 8])
+        self.assertEqual(got["tok_s"], 4.0)
+
+    def test_oracle_mismatch_invalidates_run(self):
+        with self.assertRaisesRegex(ValueError, "differ from oracle"):
+            BENCH.validate_sample({
+                "token_ids": [7], "decode_tokens": 1, "decode_seconds": 1.0,
+            }, [8])
+
+    def test_command_uses_last_json_line(self):
+        with tempfile.TemporaryDirectory() as directory:
+            script = Path(directory) / "sample.py"
+            script.write_text("print('noise')\nprint('{\\\"ok\\\": true}')\n")
+            got = BENCH.run_json("local", ["python3", str(script)], {}, 5)
+            self.assertEqual(got, {"ok": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Adds a reproducible, machine-readable gate for the three project metrics:

- **A** — median decode tok/s for one chat
- **B** — aggregate tok/s at 1/2/4/8 concurrent chats
- **C** — executed expert calls per named peer

The runner supports local or SSH hosts, warm-up plus repeated medians, concurrent clients, atomic JSON results, byte counters, and invalidates the run unless every generated token matches the independent oracle. `segment_chat --json` provides a native adapter with separate decode timing and Segment wire bytes. `swarm_probe` exposes stable tracker counters without scraping the TUI.

## Scope

- Covers all six family identifiers: GLM, Inkling, Kimi K3, Qwen3.6, OLMoE, DeepSeek V4.
- Does not modify Colibri.
- Does not claim a speedup; it makes the 2x decision measurable.

## Validation

- `make test` — PASS
- `make check-warnings` — PASS
- `python3 test_swarm_bench.py` — PASS
- Segment runtime compiled against Colibri dev `1049927`
- End-to-end: tracker + two OLMoE Segment peers + `segment_chat --json`; 3 tokens generated, positive decode time, 166214 Segment wire bytes

## Metric moved

**A/B/C: measurement gate.** No performance claim is accepted without this output.