### PR TITLE
fix: make Segment budgets and startup truthful

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,7 +46,7 @@ adduser --disabled-password --gecos "" lumabri
 Open only what the swarm needs. **7300** is the required tracker/control port.
 The signed relay makes every data path work with only that inbound port. For
 the lower-latency direct path also open **7301** (bytes), **7302** (classic
-experts) and, by default, **7303-7306** (four Segment ranges). Allow through
+experts) and, by default, **7303** (one full-core Segment fallback). Allow through
 7309 only when intentionally using up to seven public ranges.
 
 ```sh
@@ -182,7 +182,8 @@ su - lumabri -c 'lumabri peer-key'
 ```
 
 Clients can preseed a strict pin file with that value for every server
-endpoint (the default four Segment ranges use ports 7303-7306):
+endpoint (the default Segment fallback uses port 7303; an explicit
+`LUMABRI_SEGMENT_CHUNKS=N` uses 7303 through `7302+N`):
 
 ```text
 YOUR_SERVER_IP:7300 64_HEX_ENDPOINT_KEY
@@ -480,6 +481,18 @@ and fallback/NAT executors are niced. Direct origins default to four sessions
 per slice and NAT/relay origins to two; the override above is bounded but can
 increase real KV RAM substantially. These ranges consume real RAM and CPU; use
 `--no-exec` when this server must provide storage only.
+
+`serve` gives every Segment child an explicit process budget computed as
+`(MemAvailable - LUMABRI_SEGMENT_MIN_FREE_MB) / slices`. The node forwards it
+to Colibri's engine options, divides the remaining post-engine RSS among its
+session slots, and cancels a run when RSS or the system reserve is crossed. A
+compute donor receives the total layer count with its tracker assignment and
+evaluates the assigned range—not a fixed quarter of the model. If it does not
+fit, the placement promise is released immediately and the chat starts the
+finer-grained Expert donor instead.
+
+Low-level operators may set `segment_node --memory-limit-mb N`; the ordinary
+`lumabri serve` and `lumabri chat` flows calculate it automatically.
 
 Two things worth knowing:
 

--- a/Makefile
+++ b/Makefile
@@ -487,6 +487,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./signed_donor_test.sh
 	./hot_cache_integrity_test.sh
 	./role_test.sh
+	./serve_failfast_test.sh
 	./security_test.sh
 	./expert_input_test.sh
 	./prefetch_policy_test.sh

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -41,7 +41,9 @@ lumabri serve --model /models/olmoe --advertise PUBLIC_IP
 ```
 
 Lumabri detects the family, layer/context shape, CPU/RAM and network capability,
-then starts four disjoint fallback executors. A public interface enables the
+then starts one full-core fallback executor. An explicit
+`LUMABRI_SEGMENT_CHUNKS=N` starts disjoint fallback executors for placement
+tests. A public interface enables the
 preferred direct path. Behind NAT the same executors register as relay-only and
 remain reachable through their signed outbound tracker tunnels; Lumabri never
 publishes a guessed private address as direct.

--- a/SEGMENT_V2.md
+++ b/SEGMENT_V2.md
@@ -48,6 +48,12 @@ a fixed-size immutable `LmbSegRouteSnapshot`. The inference thread copies that
 snapshot; it never asks the tracker. A session binds the selected generation
 at `SEG_OPEN`, so later discovery does not silently move a running chat.
 
+Automatic assignment uses the versioned `GSA1` v2 reply
+`{begin,end,total_layers}`. A model-less donor can therefore check its real
+range against its RAM budget before opening the engine. A rejected range is
+released with `SEG_ASSIGN_RELEASE`; this only removes the short placement
+promise and never grants or revokes a signed execution lease.
+
 ## Wire operations
 
 The shared frame opcodes are:

--- a/lumabri.c
+++ b/lumabri.c
@@ -482,6 +482,13 @@ static int parse_serve_port(const char *s, int *port) {
     return 0;
 }
 
+static int serve_port_available(int port) {
+    int fd = lmb_listen(port);
+    if (fd < 0) return 0;
+    close(fd);
+    return 1;
+}
+
 static void serve_watch_start(const char *tracker, const char *model);
 
 static int cmd_serve(int argc, char **argv) {
@@ -573,6 +580,55 @@ static int cmd_serve(int argc, char **argv) {
     if (join) snprintf(taddr, sizeof taddr, "%s", join);
     else      snprintf(taddr, sizeof taddr, "127.0.0.1:%d", port);
 
+    /* Resolve the complete local topology before forking anything. Starting
+     * half a server and then discovering EADDRINUSE made the supervisor retry
+     * forever and produced a misleading apparently-live `serve`. */
+    char exec_bin[1200] = "", mtype[64] = "";
+    local_model_type(model, mtype, sizeof mtype);
+    const char *node = expert_node_for(mtype);
+    if (node) snprintf(exec_bin, sizeof exec_bin, "%s/%s", dir, node);
+    char segment_bin[1200], segment_model_storage[64];
+    snprintf(segment_bin, sizeof segment_bin, "%s/segment_node", dir);
+    const char *segment_engine = segment_engine_for(mtype);
+    const char *segment_model = model_name_for(
+        model, mname, segment_model_storage, sizeof segment_model_storage);
+    uint32_t segment_layers = 0;
+    uint64_t segment_available = machine_available_ram();
+    uint64_t segment_min_free = (uint64_t)lmb_env_int(
+        "LUMABRI_SEGMENT_MIN_FREE_MB", 8192, 1024, 262144) << 20;
+    int segment_candidate = !disk_donor && !no_exec && segment_engine &&
+        segment_model && access(segment_bin, X_OK) == 0 &&
+        local_model_layers(model, &segment_layers) == 0 &&
+        (!segment_available || segment_available >= segment_min_free);
+    if (!segment_candidate && !disk_donor && !no_exec && segment_engine &&
+        segment_model && access(segment_bin, X_OK) == 0 && segment_available &&
+        segment_available < segment_min_free)
+        printf("  %sSegment automatico non avviato: %.1f GB RAM disponibili, "
+               "il governor ne richiede %.1f. Storage ed expert restano "
+               "disponibili.%s\n", C_DIM,
+               (double)segment_available / 1e9,
+               (double)segment_min_free / 1e9, C_R);
+    int planned_chunks = segment_candidate
+        ? lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 1, 1, 7) : 0;
+    if ((uint32_t)planned_chunks > segment_layers)
+        planned_chunks = (int)segment_layers;
+    int first_port = join ? port + 1 : port;
+    int last_port = port + 1;
+    if (!disk_donor && !no_exec && node && access(exec_bin, X_OK) == 0)
+        last_port = port + 2;
+    if (planned_chunks) last_port = port + 2 + planned_chunks;
+    for (int candidate_port = first_port; candidate_port <= last_port;
+         candidate_port++) {
+        if (candidate_port == port + 2 &&
+            (disk_donor || no_exec || !node || access(exec_bin, X_OK)))
+            continue;
+        if (!serve_port_available(candidate_port)) {
+            fprintf(stderr, "lumabri serve: port %d is already in use; "
+                    "nothing was started\n", candidate_port);
+            return 1;
+        }
+    }
+
     if (!join) {
         /* LUMABRI_TOKEN makes the whole serve private: the spawned tracker
          * requires it, the maintainer inherits it from the environment */
@@ -631,11 +687,7 @@ static int cmd_serve(int argc, char **argv) {
      * this server executing every expert. Donors that join later are
      * discovered by the chatters and win the calls they are nearest for;
      * this node stays the replica of last resort. */
-    char exec_bin[1200], mtype[64];
-    local_model_type(model, mtype, sizeof mtype);
     /* one node binary per engine family — they do not share an expert shape */
-    const char *node = expert_node_for(mtype);
-    if (node) snprintf(exec_bin, sizeof exec_bin, "%s/%s", dir, node);
     int with_exec = 0;
     if (!no_exec && !disk_donor && !node && mtype[0])
         printf("  %sfase 2 non disponibile per il motore %s: questo server "
@@ -681,33 +733,16 @@ static int cmd_serve(int argc, char **argv) {
      * addition to the expert executor.  This binary exists only in builds
      * made against Colibri's additive Edge/Segment archive; release builds
      * without it preserve the exact old serve topology. */
-    char segment_bin[1200], segment_model_storage[64];
-    snprintf(segment_bin, sizeof segment_bin, "%s/segment_node", dir);
-    const char *segment_engine = segment_engine_for(mtype);
-    const char *segment_model = model_name_for(
-        model, mname, segment_model_storage, sizeof segment_model_storage);
-    uint32_t segment_layers = 0;
     int with_segment = 0;
-    int segment_candidate = !disk_donor && !no_exec && segment_engine &&
-        segment_model && access(segment_bin, X_OK) == 0 &&
-        local_model_layers(model, &segment_layers) == 0;
-    uint64_t segment_available = machine_available_ram();
-    uint64_t segment_min_free = (uint64_t)lmb_env_int(
-        "LUMABRI_SEGMENT_MIN_FREE_MB", 8192, 1024, 262144) << 20;
-    if (segment_candidate && segment_available &&
-        segment_available < segment_min_free) {
-        printf("  %sSegment automatico non avviato: %.1f GB RAM disponibili, "
-               "il governor ne richiede %.1f. Storage ed expert restano "
-               "disponibili; regola LUMABRI_SEGMENT_MIN_FREE_MB solo se "
-               "conosci il carico della macchina.%s\n",
-               C_DIM, (double)segment_available / 1e9,
-               (double)segment_min_free / 1e9, C_R);
-        segment_candidate = 0;
-    }
     if (segment_candidate) {
         long cores = sysconf(_SC_NPROCESSORS_ONLN);
         if (cores < 1) cores = 1;
-        int chunks = lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 4, 1, 7);
+        /* A chain of slices on one host is sequential: four processes used
+         * one quarter of the CPU at a time and added three loopback hops.
+         * One full-core fallback is the honest single-machine baseline.
+         * Explicit partitioning remains available for replacement tests;
+         * distributed sharding is selected from READY peers by the tracker. */
+        int chunks = lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 1, 1, 7);
         if ((uint32_t)chunks > segment_layers) chunks = (int)segment_layers;
         int slice_threads = (int)(cores / chunks);
         if (slice_threads < 1) slice_threads = 1;
@@ -717,10 +752,16 @@ static int cmd_serve(int argc, char **argv) {
         if (!local_model_u32(model, "max_position_embeddings", &model_context) &&
             model_context < segment_context)
             segment_context = model_context;
-        char context[16], session_text[16], thread_text[16];
+        char context[16], session_text[16], thread_text[16], memory_text[32];
         snprintf(context, sizeof context, "%u", segment_context);
         snprintf(session_text, sizeof session_text, "%d", sessions);
         snprintf(thread_text, sizeof thread_text, "%d", slice_threads);
+        uint64_t total_budget = segment_available > segment_min_free
+                              ? segment_available - segment_min_free : 0;
+        uint64_t slice_budget_mb = (total_budget / (uint64_t)chunks) >> 20;
+        if (!slice_budget_mb) slice_budget_mb = 1;
+        snprintf(memory_text, sizeof memory_text, "%llu",
+                 (unsigned long long)slice_budget_mb);
 
         /* A few disjoint origin slices retain the single-copy weight total,
          * but give placement exact boundaries it can replace independently:
@@ -740,7 +781,7 @@ static int cmd_serve(int argc, char **argv) {
                      chunk + 1);
             snprintf(sadv, sizeof sadv, "%s:%d",
                      advertise ? advertise : "127.0.0.1", port + 3 + chunk);
-            char *sargv[36];
+            char *sargv[40];
             a = 0;
             sargv[a++] = segment_bin;
             sargv[a++] = "--engine";       sargv[a++] = (char *)segment_engine;
@@ -757,6 +798,7 @@ static int cmd_serve(int argc, char **argv) {
             sargv[a++] = "--max-rows";     sargv[a++] = "16";
             sargv[a++] = "--sessions";     sargv[a++] = session_text;
             sargv[a++] = "--threads";      sargv[a++] = thread_text;
+            sargv[a++] = "--memory-limit-mb"; sargv[a++] = memory_text;
             sargv[a++] = "--advertise";    sargv[a++] = sadv;
             sargv[a] = NULL;
             char slog[1200];
@@ -3155,18 +3197,17 @@ static int role_start_segment(const Role *r, const char *tracker,
         relay_only = 1;
     }
 
-    /* The origin's default four-way partition makes one slice roughly a
-     * quarter of the checkpoint. Keep both a fixed OS reserve and 25% of the
-     * currently available RAM; if it would not fit, the expert donor below
-     * is the finer-grained, auto-sized contribution. This is intentionally
-     * conservative: a donation must never win by pushing the desktop to swap. */
+    /* The executor receives its actual range before applying this budget.
+     * This process therefore only publishes what the machine can donate;
+     * segment_node compares it with the assigned range and releases the
+     * promise immediately when it cannot fit. */
     uint64_t available = machine_available_ram();
     uint64_t reserve = available / 4;
     if (reserve < 4ull * 1000 * 1000 * 1000)
         reserve = 4ull * 1000 * 1000 * 1000;
-    uint64_t estimated = model_bytes / 4 + model_bytes / 20;
-    if (!available || reserve >= available || estimated > available - reserve)
+    if (!available || reserve >= available)
         return 0;
+    uint64_t memory_budget = available - reserve;
 
     char probe[1100];
     snprintf(probe, sizeof probe, "%s/config.json", r->model_dir);
@@ -3205,15 +3246,28 @@ static int role_start_segment(const Role *r, const char *tracker,
     int threads = cores > 1 ? (int)(cores / 2) : 1;
     int sessions = 2;
     char port_text[16], context_text[16], sessions_text[16], threads_text[16];
+    char memory_text[32], model_bytes_text[32], preflight_text[32];
     char address[80], name[64], base[48];
     snprintf(port_text, sizeof port_text, "%d", port);
     snprintf(context_text, sizeof context_text, "%d", context);
     snprintf(sessions_text, sizeof sessions_text, "%d", sessions);
     snprintf(threads_text, sizeof threads_text, "%d", threads);
+    snprintf(memory_text, sizeof memory_text, "%llu",
+             (unsigned long long)(memory_budget >> 20));
+    snprintf(model_bytes_text, sizeof model_bytes_text, "%llu",
+             (unsigned long long)model_bytes);
     snprintf(address, sizeof address, "%s:%d", host, port);
     donor_base_name(r, base, sizeof base);
     snprintf(name, sizeof name, "%s-segment-%d", base, port);
-    char *argv[34];
+    int ready_pipe[2];
+    if (pipe2(ready_pipe, O_CLOEXEC)) return 0;
+    int fd_flags = fcntl(ready_pipe[1], F_GETFD);
+    if (fd_flags < 0 || fcntl(ready_pipe[1], F_SETFD,
+                              fd_flags & ~FD_CLOEXEC)) {
+        close(ready_pipe[0]); close(ready_pipe[1]); return 0;
+    }
+    snprintf(preflight_text, sizeof preflight_text, "%d", ready_pipe[1]);
+    char *argv[42];
     int a = 0;
     argv[a++] = bin;
     argv[a++] = "--engine";        argv[a++] = (char *)engine;
@@ -3230,13 +3284,36 @@ static int role_start_segment(const Role *r, const char *tracker,
     argv[a++] = "--max-rows";      argv[a++] = "16";
     argv[a++] = "--sessions";      argv[a++] = sessions_text;
     argv[a++] = "--threads";       argv[a++] = threads_text;
+    argv[a++] = "--memory-limit-mb"; argv[a++] = memory_text;
+    argv[a++] = "--model-bytes";   argv[a++] = model_bytes_text;
+    argv[a++] = "--preflight-fd";  argv[a++] = preflight_text;
     argv[a] = NULL;
-    if (g_nchildren >= MAX_CHILDREN) return 0;
+    if (g_nchildren >= MAX_CHILDREN) {
+        close(ready_pipe[0]); close(ready_pipe[1]); return 0;
+    }
     char logpath[1200];
     pid_t pid = spawn_argv_logged(argv, local ? NULL : envv,
                                   donor_log_path(name, logpath,
                                                  sizeof logpath));
-    if (pid <= 0) return 0;
+    close(ready_pipe[1]);
+    if (pid <= 0) { close(ready_pipe[0]); return 0; }
+    struct pollfd ready_poll = { .fd = ready_pipe[0], .events = POLLIN | POLLHUP };
+    char readiness = 0;
+    int polled;
+    do polled = poll(&ready_poll, 1, 10000); while (polled < 0 && errno == EINTR);
+    ssize_t readiness_bytes = polled > 0
+                            ? read(ready_pipe[0], &readiness, 1) : 0;
+    close(ready_pipe[0]);
+    if (readiness_bytes != 1 || readiness != 'P') {
+        int status = 0;
+        if (waitpid(pid, &status, WNOHANG) == 0) {
+            kill(pid, SIGTERM);
+            waitpid(pid, &status, 0);
+        }
+        printf("  %sla fetta Segment assegnata non entra nel budget RAM; "
+               "passo al donatore di esperti%s\n", C_DIM, C_R);
+        return 0;
+    }
     child_publish(g_nchildren++, pid);
     printf("  %s\xe2\x9c\xa6 eseguo una fetta Segment assegnata dal tracker "
            "per lo sciame%s %s(priorita' bassa, %d sessioni massime%s)%s\n",

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -87,7 +87,7 @@
 #define LMB_SEG_V2_MAGIC          0x32474553u /* "SEG2" */
 #define LMB_SEG_V2_VERSION        2u
 #define LMB_SEG_ASSIGN_MAGIC      0x31415347u /* "GSA1" */
-#define LMB_SEG_ASSIGN_VERSION    1u
+#define LMB_SEG_ASSIGN_VERSION    2u
 
 /* Optional executor telemetry is negotiated on the existing EREG LMB_OK.
  * Every extension has its own magic, version, and bounded payload length so
@@ -248,6 +248,10 @@ enum {
      * keys: the TUI can explain who is doing work without leaking how to
      * reach a private donor. The body is versioned independently. */
     LMB_SWARM_DETAIL = 60, LMB_SWARM_DETAIL_R = 61,
+    /* A donor that cannot fit its assigned range releases the short-lived
+     * placement promise immediately, so another READY-capable machine need
+     * not wait for its timeout. This grants no lease or execution authority. */
+    LMB_SEG_ASSIGN_RELEASE = 62,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,

--- a/segment_node.c
+++ b/segment_node.c
@@ -70,6 +70,8 @@ typedef struct {
     int connection_fds[NODE_CONNECTIONS_MAX];
     unsigned active_connections;
     uint64_t ram_reserve_bytes;
+    uint64_t process_memory_limit_bytes;
+    uint64_t session_memory_limit_bytes;
     TrackerRegistration registration;
 } Node;
 
@@ -91,6 +93,25 @@ static uint64_t available_memory_bytes(void) {
         if (sscanf(line, "MemAvailable: %llu kB", &kib) == 1) break;
     fclose(file);
     return kib ? (uint64_t)kib * 1024u : UINT64_MAX;
+}
+
+static uint64_t resident_memory_bytes(void) {
+    FILE *file = fopen("/proc/self/statm", "r");
+    unsigned long long pages = 0, resident = 0;
+    if (!file) return 0;
+    int ok = fscanf(file, "%llu %llu", &pages, &resident) == 2;
+    fclose(file);
+    long page = sysconf(_SC_PAGESIZE);
+    if (!ok || page <= 0 || resident > UINT64_MAX / (uint64_t)page) return 0;
+    return resident * (uint64_t)page;
+}
+
+static int memory_pressure(void *opaque) {
+    Node *node = opaque;
+    uint64_t rss = resident_memory_bytes();
+    return g_stop || available_memory_bytes() < node->ram_reserve_bytes ||
+           (node->process_memory_limit_bytes && rss &&
+            rss > node->process_memory_limit_bytes);
 }
 
 static void stop_handler(int sig) {
@@ -508,6 +529,7 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
             ColiSegmentSessionOptions options = {
                 .struct_size = sizeof options,
                 .context_tokens = open.context_tokens,
+                .memory_limit_bytes = node->session_memory_limit_bytes,
             };
             ColiSegmentSession *session = NULL;
             char error[256] = "";
@@ -595,6 +617,8 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                 .input_bytes = msg->pay_len,
                 .output = output,
                 .output_bytes = bytes,
+                .should_cancel = memory_pressure,
+                .cancel_user_data = node,
             };
             char error[256] = "";
             if (coli_segment_run(session, &request, error, sizeof error)) {
@@ -902,7 +926,8 @@ static void usage(const char *program) {
         "--advertise HOST:PORT --name PEER "
         "(--auto-identity | --model-root HEX64 --tokenizer-root HEX64) "
         "[--fallback] [--relay-only] [--context N] [--max-rows N] "
-        "[--sessions N] [--threads N]\n",
+        "[--sessions N] [--threads N] [--memory-limit-mb N] "
+        "[--model-bytes N --model-layers N] [--preflight-fd N]\n",
         program);
 }
 
@@ -919,7 +944,8 @@ static int has_arg(int argc, char **argv, const char *name) {
 static int auto_range_get(const char *tracker, const char *model,
                           const char *name, const char *engine_id,
                           const uint8_t model_root[LMB_SEG_ROOT_BYTES],
-                          unsigned *begin, unsigned *end) {
+                          unsigned *begin, unsigned *end,
+                          unsigned *model_layers) {
     LmbBuf body = {0};
     if (lmb_buf_u32(&body, LMB_SEG_ASSIGN_MAGIC) ||
         lmb_buf_u32(&body, LMB_SEG_ASSIGN_VERSION) ||
@@ -936,16 +962,54 @@ static int auto_range_get(const char *tracker, const char *model,
         lmb_msg_free(&reply); return -1;
     }
     LmbCur cursor = { reply.body, reply.body_len, 0 };
-    uint32_t magic = 0, version = 0, first = 0, last = 0;
+    uint32_t magic = 0, version = 0, first = 0, last = 0, total = 0;
     rc = lmb_cur_u32(&cursor, &magic) ||
          lmb_cur_u32(&cursor, &version) ||
          lmb_cur_u32(&cursor, &first) || lmb_cur_u32(&cursor, &last) ||
+         lmb_cur_u32(&cursor, &total) ||
          cursor.off != cursor.len || magic != LMB_SEG_ASSIGN_MAGIC ||
-         version != LMB_SEG_ASSIGN_VERSION || first >= last;
+         version != LMB_SEG_ASSIGN_VERSION || first >= last || last > total;
     lmb_msg_free(&reply);
     if (rc) return -1;
-    *begin = first; *end = last;
+    *begin = first; *end = last; *model_layers = total;
     return 0;
+}
+
+static int parse_u64_decimal(const char *text, uint64_t *out) {
+    if (!text || !*text || text[0] == '-') return -1;
+    errno = 0;
+    char *end = NULL;
+    unsigned long long value = strtoull(text, &end, 10);
+    if (errno || end == text || *end) return -1;
+    *out = (uint64_t)value;
+    return 0;
+}
+
+static int auto_range_release(const char *tracker, const char *model,
+                              const char *name, const char *engine_id,
+                              const uint8_t model_root[LMB_SEG_ROOT_BYTES]) {
+    LmbBuf body = {0};
+    if (lmb_buf_u32(&body, LMB_SEG_ASSIGN_MAGIC) ||
+        lmb_buf_u32(&body, LMB_SEG_ASSIGN_VERSION) ||
+        lmb_buf_str(&body, model) || lmb_buf_str(&body, name) ||
+        lmb_buf_str(&body, engine_id) ||
+        lmb_buf_bytes(&body, model_root, LMB_SEG_ROOT_BYTES)) {
+        free(body.p); return -1;
+    }
+    LmbMsg reply = {0};
+    int rc = lmb_request(tracker, LMB_SEG_ASSIGN_RELEASE, body.p,
+                         (uint32_t)body.len, &reply);
+    free(body.p);
+    int bad = rc || reply.op != LMB_OK || reply.body_len || reply.pay_len;
+    lmb_msg_free(&reply);
+    return bad ? -1 : 0;
+}
+
+static void preflight_signal(int *fd, char status) {
+    if (!fd || *fd < 0) return;
+    while (write(*fd, &status, 1) < 0 && errno == EINTR) { }
+    close(*fd);
+    *fd = -1;
 }
 
 int main(int argc, char **argv) {
@@ -984,6 +1048,9 @@ int main(int argc, char **argv) {
         usage(argv[0]); return 2;
     }
     uint32_t context = 4096, max_rows = 256, max_sessions = 16, threads = 0;
+    uint32_t memory_limit_mb = 0, model_layers = 0, preflight_fd_u32 = 0;
+    uint64_t model_bytes = 0;
+    int preflight_fd = -1;
     const char *value;
     if (((value = arg_value(argc, argv, "--context")) &&
          lmb_parse_u32(value, 1, LMB_SEG_MAX_CONTEXT, &context)) ||
@@ -992,9 +1059,20 @@ int main(int argc, char **argv) {
         ((value = arg_value(argc, argv, "--sessions")) &&
          lmb_parse_u32(value, 1, NODE_SESSIONS_MAX, &max_sessions)) ||
         ((value = arg_value(argc, argv, "--threads")) &&
-         lmb_parse_u32(value, 1, 256, &threads))) {
+         lmb_parse_u32(value, 1, 256, &threads)) ||
+        ((value = arg_value(argc, argv, "--memory-limit-mb")) &&
+         lmb_parse_u32(value, 1, 1048576, &memory_limit_mb)) ||
+        ((value = arg_value(argc, argv, "--model-bytes")) &&
+         parse_u64_decimal(value, &model_bytes)) ||
+        ((value = arg_value(argc, argv, "--model-layers")) &&
+         lmb_parse_u32(value, 1, 1048576, &model_layers)) ||
+        ((value = arg_value(argc, argv, "--preflight-fd")) &&
+         lmb_parse_u32(value, 0, 1048576, &preflight_fd_u32)) ||
+        (range && model_bytes && !model_layers)) {
         usage(argv[0]); return 2;
     }
+    if (arg_value(argc, argv, "--preflight-fd"))
+        preflight_fd = (int)preflight_fd_u32;
 #ifdef _OPENMP
     if (threads) omp_set_num_threads((int)threads);
 #else
@@ -1012,6 +1090,16 @@ int main(int argc, char **argv) {
                 threads == 1 ? "" : "s", max_sessions,
                 max_sessions == 1 ? "" : "s",
                 (fallback || auto_range) ? " · low CPU priority" : "");
+    /* The upstream batched expert union currently rejects the V4 Flash
+     * checkpoint used by Segment. Disable it before adapter registration in
+     * this dedicated process: ordinary Colibri and expert_node keep their
+     * own environment and their normal code path. Retrying after a failed
+     * RUN is unsafe because recurrent/attention state may already have moved. */
+    if (!strcmp(engine_id, "deepseek_v4") && !getenv("V4_EXPERT_UNION")) {
+        setenv("V4_EXPERT_UNION", "0", 0);
+        fprintf(stderr, "[segment-node] DeepSeek V4 batched expert union "
+                        "disabled for Segment safety\n");
+    }
     if (lmb_colibri_register_all()) {
         fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
     }
@@ -1059,7 +1147,8 @@ int main(int argc, char **argv) {
     if (auto_range) {
         int announced = 0;
         while (!g_stop && auto_range_get(tracker, model, name, engine_id,
-                                         resolved_model_root, &begin, &end)) {
+                                         resolved_model_root, &begin, &end,
+                                         &model_layers)) {
             if (!announced) {
                 fprintf(stderr, "[segment-node] waiting for an automatic "
                         "range assignment for %s\n", model);
@@ -1076,6 +1165,34 @@ int main(int argc, char **argv) {
          * applies the same priority; explicit low-level nodes remain neutral. */
         (void)setpriority(PRIO_PROCESS, 0, 10);
     }
+    uint64_t process_limit = (uint64_t)memory_limit_mb << 20;
+    uint64_t available = available_memory_bytes();
+    uint64_t reserve = (uint64_t)lmb_env_int(
+        "LUMABRI_SEGMENT_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+    if (!process_limit && available != UINT64_MAX && available > reserve)
+        process_limit = available - reserve;
+    if (process_limit && model_bytes && model_layers) {
+        uint64_t range_layers = end - begin;
+        uint64_t proportional = model_bytes / model_layers * range_layers;
+        uint64_t remainder = model_bytes % model_layers * range_layers /
+                             model_layers;
+        uint64_t overhead = model_bytes / 20u;
+        uint64_t estimated = proportional + remainder;
+        if (estimated <= UINT64_MAX - overhead) estimated += overhead;
+        else estimated = UINT64_MAX;
+        if (estimated > process_limit) {
+            fprintf(stderr, "[segment-node] assigned range %u:%u needs about "
+                    "%.1f GB but the donor budget is %.1f GB; releasing it "
+                    "before loading weights\n", begin, end,
+                    (double)estimated / 1e9, (double)process_limit / 1e9);
+            if (auto_range)
+                (void)auto_range_release(tracker, model, name, engine_id,
+                                         resolved_model_root);
+            preflight_signal(&preflight_fd, 'F');
+            return 3;
+        }
+    }
+    preflight_signal(&preflight_fd, 'P');
     Node node;
     memset(&node, 0, sizeof node);
     for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) node.connection_fds[i] = -1;
@@ -1085,8 +1202,8 @@ int main(int argc, char **argv) {
     pthread_cond_init(&node.connections_drained, NULL);
     for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
         pthread_mutex_init(&node.sessions[i].lock, NULL);
-    node.ram_reserve_bytes = (uint64_t)lmb_env_int(
-        "LUMABRI_SEGMENT_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+    node.ram_reserve_bytes = reserve;
+    node.process_memory_limit_bytes = process_limit;
     fprintf(stderr, "[segment-node] governor: %.1f GB RAM reserved for the "
                     "machine\n", (double)node.ram_reserve_bytes / 1e9);
     ColiSegmentEngineOptions options = {
@@ -1095,12 +1212,16 @@ int main(int argc, char **argv) {
         .layer_begin = begin,
         .layer_end = end,
         .context_tokens = context,
+        .memory_limit_bytes = process_limit,
     };
     char error[256] = "";
     if (coli_segment_engine_open(engine_id, &options, &node.engine,
                                  error, sizeof error)) {
         fprintf(stderr, "cannot open Colibri Segment engine: %s\n",
                 engine_error(error));
+        if (auto_range)
+            (void)auto_range_release(tracker, model, name, engine_id,
+                                     resolved_model_root);
         return 1;
     }
     node.cap.struct_size = sizeof node.cap;
@@ -1109,11 +1230,34 @@ int main(int argc, char **argv) {
                                          error, sizeof error)) {
         fprintf(stderr, "cannot read Segment capabilities: %s\n",
                 engine_error(error));
+        if (auto_range)
+            (void)auto_range_release(tracker, model, name, engine_id,
+                                     resolved_model_root);
         return 1;
     }
+    uint64_t engine_rss = resident_memory_bytes();
+    if (process_limit && engine_rss && engine_rss >= process_limit) {
+        fprintf(stderr, "[segment-node] engine RSS %.1f GB exhausted the "
+                        "%.1f GB process budget before opening sessions\n",
+                (double)engine_rss / 1e9, (double)process_limit / 1e9);
+        if (auto_range)
+            (void)auto_range_release(tracker, model, name, engine_id,
+                                     resolved_model_root);
+        return 1;
+    }
+    if (process_limit && process_limit > engine_rss)
+        node.session_memory_limit_bytes =
+            (process_limit - engine_rss) / max_sessions;
+    fprintf(stderr, "[segment-node] governor: %.1f GB process budget · "
+                    "%.1f MB per session\n",
+            (double)process_limit / 1e9,
+            (double)node.session_memory_limit_bytes / 1e6);
     if (end > node.cap.num_layers || context > node.cap.max_context_tokens ||
         max_rows > node.cap.max_batch_rows) {
         fprintf(stderr, "requested range/context/rows exceed model capabilities\n");
+        if (auto_range)
+            (void)auto_range_release(tracker, model, name, engine_id,
+                                     resolved_model_root);
         return 1;
     }
     LmbSegAdvert *a = &node.advert;

--- a/serve_failfast_test.sh
+++ b/serve_failfast_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+tmp=$(mktemp -d /tmp/lumabri-serve-failfast.XXXXXX)
+listener=
+cleanup() {
+    [[ -z "$listener" ]] || kill "$listener" 2>/dev/null || true
+    rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp/model"
+printf '{"model_type":"olmoe","num_hidden_layers":1}\n' >"$tmp/model/config.json"
+
+# Occupy the storage port, not the tracker port. The old implementation had
+# already spawned the tracker when the maintainer discovered EADDRINUSE.
+python3 - 7951 <<'PY' &
+import socket,sys,time
+s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
+s.bind(("127.0.0.1",int(sys.argv[1]))); s.listen(); time.sleep(30)
+PY
+listener=$!
+for _ in $(seq 1 100); do
+    (exec 3<>/dev/tcp/127.0.0.1/7951) 2>/dev/null && { exec 3<&-; exec 3>&-; break; }
+    sleep .02
+done
+
+set +e
+./lumabri serve --model "$tmp/model" --port 7950 --advertise 127.0.0.1 \
+    --no-exec >"$tmp/out" 2>&1
+status=$?
+set -e
+if (( status == 0 )) || ! grep -q 'port 7951 is already in use; nothing was started' "$tmp/out"; then
+    cat "$tmp/out"
+    echo "serve did not fail atomically on an occupied child port" >&2
+    exit 1
+fi
+if (exec 3<>/dev/tcp/127.0.0.1/7950) 2>/dev/null; then
+    exec 3<&-; exec 3>&-
+    echo "tracker was left running after preflight failure" >&2
+    exit 1
+fi
+echo "SERVE FAIL-FAST TEST: PASS (occupied topology starts no children)"

--- a/test_segment_discovery.c
+++ b/test_segment_discovery.c
@@ -176,6 +176,37 @@ static int register_advert(const char *tracker, const LmbSegAdvert *a,
     return 0;
 }
 
+static void segment_assign_request(const char *tracker, const LmbSegAdvert *origin,
+                                   const char *name, uint32_t op,
+                                   uint32_t *begin, uint32_t *end,
+                                   uint32_t *layers) {
+    LmbBuf body = {0};
+    assert(!lmb_buf_u32(&body, LMB_SEG_ASSIGN_MAGIC));
+    assert(!lmb_buf_u32(&body, LMB_SEG_ASSIGN_VERSION));
+    assert(!lmb_buf_str(&body, origin->model));
+    assert(!lmb_buf_str(&body, name));
+    assert(!lmb_buf_str(&body, origin->engine_id));
+    assert(!lmb_buf_bytes(&body, origin->model_root, sizeof origin->model_root));
+    LmbMsg reply = {0};
+    assert(!lmb_request(tracker, op, body.p, (uint32_t)body.len, &reply));
+    free(body.p);
+    if (op == LMB_SEG_ASSIGN_RELEASE) {
+        assert(reply.op == LMB_OK && !reply.body_len && !reply.pay_len);
+    } else {
+        assert(reply.op == LMB_SEG_ASSIGN_R && !reply.pay_len);
+        LmbCur cursor = { reply.body, reply.body_len, 0 };
+        uint32_t magic = 0, version = 0;
+        assert(!lmb_cur_u32(&cursor, &magic));
+        assert(!lmb_cur_u32(&cursor, &version));
+        assert(!lmb_cur_u32(&cursor, begin));
+        assert(!lmb_cur_u32(&cursor, end));
+        assert(!lmb_cur_u32(&cursor, layers));
+        assert(cursor.off == cursor.len && magic == LMB_SEG_ASSIGN_MAGIC &&
+               version == LMB_SEG_ASSIGN_VERSION);
+    }
+    lmb_msg_free(&reply);
+}
+
 static void test_tracker(const char *tracker) {
     enum { NF = (int)(sizeof families / sizeof families[0]), NR = NF + 2 };
     Registration registrations[NR];
@@ -234,17 +265,38 @@ static void test_tracker(const char *tracker) {
      * second range and one replica: the returned list preserves replicas and
      * contains a complete exact-boundary chain. */
     adverts[0].layer_end = 2;
+    adverts[0].flags = LMB_SEG_ADVERT_FALLBACK;
     assert(!register_advert(tracker, &adverts[0], 20, &registrations[0]));
     assert(registrations[0].owner.route_generation > before.route_generation);
     assert(registrations[0].owner.fencing_epoch > before.fencing_epoch);
     assert(!lmb_seg_id_equal(&registrations[0].owner.lease_id, &before.lease_id));
     LmbSegAdvert upper = make_advert(0, 90, 2, 4);
     LmbSegAdvert replica = make_advert(0, 91, 2, 4);
+    upper.flags = LMB_SEG_ADVERT_FALLBACK;
     registrations[NF].fd = registrations[NF + 1].fd = -1;
     assert(!register_advert(tracker, &upper, 90, &registrations[NF]));
     assert(!register_advert(tracker, &replica, 91, &registrations[NF + 1]));
     assert(!lmb_seg_routes_fetch(tracker, &oq, &os));
     assert(os.complete && os.count == 3);
+
+    /* Promises spread concurrent donors across the exact fallback ranges.
+     * A capacity rejection releases its promise immediately: the next donor
+     * can take the rare range without waiting five minutes. The reply also
+     * carries total layers so a model-less donor can estimate its real slice. */
+    uint32_t first_begin = 99, first_end = 99, first_layers = 0;
+    uint32_t second_begin = 99, second_end = 99, second_layers = 0;
+    uint32_t third_begin = 99, third_end = 99, third_layers = 0;
+    segment_assign_request(tracker, &adverts[0], "capacity-a", LMB_SEG_ASSIGN,
+                           &first_begin, &first_end, &first_layers);
+    segment_assign_request(tracker, &adverts[0], "capacity-b", LMB_SEG_ASSIGN,
+                           &second_begin, &second_end, &second_layers);
+    assert(first_begin == 0 && first_end == 2 && first_layers == 4);
+    assert(second_begin == 2 && second_end == 4 && second_layers == 4);
+    segment_assign_request(tracker, &adverts[0], "capacity-a",
+                           LMB_SEG_ASSIGN_RELEASE, NULL, NULL, NULL);
+    segment_assign_request(tracker, &adverts[0], "capacity-c", LMB_SEG_ASSIGN,
+                           &third_begin, &third_end, &third_layers);
+    assert(third_begin == 0 && third_end == 2 && third_layers == 4);
 
     /* Draining removes a peer from new placements but does not mutate an old
      * snapshot already held by a running session. One replica remains. */

--- a/tracker.c
+++ b/tracker.c
@@ -1295,7 +1295,7 @@ static int handle_segment_assign(int fd, LmbMsg *m) {
         send_err(fd, "incomplete segment assignment identity"); return -1;
     }
 
-    uint32_t chosen_begin = 0, chosen_end = 0;
+    uint32_t chosen_begin = 0, chosen_end = 0, chosen_model_layers = 0;
     uint32_t best_replicas = UINT32_MAX, best_load = UINT32_MAX;
     int retained = 0;
     double now = now_s();
@@ -1414,8 +1414,19 @@ static int handle_segment_assign(int fd, LmbMsg *m) {
             memcpy(slot->model_root, root, sizeof root);
         }
     }
+    for (int i = 0; i < MAX_PEERS; i++) {
+        Peer *origin = &g_peers[i];
+        if (origin->used && origin->has_segment && origin->segment_live &&
+            now - origin->segment_ts <= g_stale_s &&
+            (origin->segment.flags & LMB_SEG_ADVERT_FALLBACK) &&
+            !strcmp(origin->segment.model, model) &&
+            !strcmp(origin->segment.engine_id, engine) &&
+            !memcmp(origin->segment.model_root, root, sizeof root) &&
+            origin->segment.layer_end > chosen_model_layers)
+            chosen_model_layers = origin->segment.layer_end;
+    }
     pthread_mutex_unlock(&g_lk);
-    if (!chosen_end) {
+    if (!chosen_end || chosen_model_layers < chosen_end) {
         send_err(fd, "no compatible origin Segment slice"); return 0;
     }
     LmbBuf reply = {0};
@@ -1423,6 +1434,7 @@ static int handle_segment_assign(int fd, LmbMsg *m) {
     lmb_buf_u32(&reply, LMB_SEG_ASSIGN_VERSION);
     lmb_buf_u32(&reply, chosen_begin);
     lmb_buf_u32(&reply, chosen_end);
+    lmb_buf_u32(&reply, chosen_model_layers);
     int rc = lmb_send(fd, LMB_SEG_ASSIGN_R, reply.p,
                       (uint32_t)reply.len, NULL, 0);
     free(reply.p);
@@ -1435,6 +1447,39 @@ static int handle_segment_assign(int fd, LmbMsg *m) {
                best_replicas, best_replicas == 1 ? "" : "s");
     fflush(stdout);
     return rc;
+}
+
+static int handle_segment_assign_release(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    uint32_t magic = 0, version = 0;
+    char model[LMB_SEG_MODEL_MAX], name[LMB_SEG_PEER_NAME_MAX];
+    char engine[LMB_SEG_ENGINE_MAX];
+    uint8_t root[LMB_SEG_ROOT_BYTES];
+    if (m->pay_len || lmb_cur_u32(&c, &magic) ||
+        lmb_cur_u32(&c, &version) || magic != LMB_SEG_ASSIGN_MAGIC ||
+        version != LMB_SEG_ASSIGN_VERSION ||
+        lmb_cur_str(&c, model, sizeof model) ||
+        lmb_cur_str(&c, name, sizeof name) ||
+        lmb_cur_str(&c, engine, sizeof engine) ||
+        lmb_cur_bytes(&c, root, sizeof root) || c.off != c.len) {
+        send_err(fd, "bad segment assignment release"); return -1;
+    }
+    int released = 0;
+    pthread_mutex_lock(&g_lk);
+    for (int i = 0; i < MAX_SEGMENT_PROMISES; i++) {
+        SegmentPromise *promise = &g_segment_promises[i];
+        if (promise->used && !strcmp(promise->model, model) &&
+            !strcmp(promise->name, name) &&
+            !strcmp(promise->engine, engine) &&
+            !memcmp(promise->model_root, root, sizeof root)) {
+            memset(promise, 0, sizeof *promise);
+            released = 1;
+        }
+    }
+    pthread_mutex_unlock(&g_lk);
+    if (released)
+        printf("[tracker] Segment assign %s: released before READY\n", name);
+    return lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
 }
 
 static int handle_ecover(int fd, LmbMsg *m) {
@@ -2484,6 +2529,8 @@ static void *conn_thread(void *arg) {
         }
         case LMB_SEG_ROUTES: rc = handle_segment_routes(fd, &m); break;
         case LMB_SEG_ASSIGN: rc = handle_segment_assign(fd, &m); break;
+        case LMB_SEG_ASSIGN_RELEASE:
+            rc = handle_segment_assign_release(fd, &m); break;
         case LMB_HASHES:    rc = handle_hashes(fd, &m); break;
         case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;


### PR DESCRIPTION
## Outcome

Closes the correctness defects that made A/B measurements misleading:

- passes an explicit process memory budget into every Colibri Segment engine;
- derives a per-session limit from post-engine RSS and cancels runs on system/RSS pressure;
- changes the single-host origin default from four sequential quarter-core processes to one full-core Segment;
- returns total layer count in Segment assignment v2, estimates the actual assigned range, releases an unfit promise immediately, and falls back to the Expert donor;
- applies `V4_EXPERT_UNION=0` only inside the dedicated DeepSeek Segment process, before adapter registration; stock Colibri and expert nodes are untouched;
- preflights the complete serve port topology before forking, so EADDRINUSE starts nothing instead of entering a restart loop.

## Metrics moved

- **A:** removes the four-process sequential baseline penalty.
- **B:** bounds per-process/session memory instead of allowing swap-driven collapse.
- **C:** preserves Expert fallback when a Segment range cannot fit.

## Validation

- `make test ENGINE=/tmp/colibri-validation/c` — PASS
- `make check-warnings ENGINE=/tmp/colibri-validation/c` — PASS
- all-six-family discovery/lease gate — PASS
- assignment spread + immediate release/reassignment — PASS
- occupied child port starts zero children — PASS
- real OLMoE Segment with 1 MB limit refuses before publication (RSS 0.3 GB)

## Stacking

This PR is based on #78. Merge order: #78, then this PR. No Colibri source or branch is changed.