### PR TITLE
Resident Segment sharding with replaceable origin ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ instead of being silently rejected forever. So several
 compute donors **split the model into disjoint slices automatically**. (`--hold
 N` sets the count by hand; `--stride 2:0` / `--stride 2:1` or
 `--layers …` split it explicitly if you want to size each machine yourself.)
+The origin publishes four stable, layer-aligned fallback ranges by default
+(`LUMABRI_SEGMENT_CHUNKS=1..7` overrides it). Each range uses the full local
+CPU team because decode traverses the chain serially. A resident Segment donor
+then replaces one exact range; it advertises measured RSS only after its engine
+has opened, and the server remains the fallback for every range not yet donated.
+`LUMABRI_SEGMENT_THREADS=N` is the explicit per-range CPU override.
 When two donors happen to hold the *same* expert, add `LUMABRI_SPREAD=1` on the
 chatter to balance the load between them too. Neither donor needs to know the
 others exist. Expert requests can fail over to another replica. Stateful

--- a/lumabri.c
+++ b/lumabri.c
@@ -609,7 +609,7 @@ static int cmd_serve(int argc, char **argv) {
                (double)segment_available / 1e9,
                (double)segment_min_free / 1e9, C_R);
     int planned_chunks = segment_candidate
-        ? lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 1, 1, 7) : 0;
+        ? lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 4, 1, 7) : 0;
     if ((uint32_t)planned_chunks > segment_layers)
         planned_chunks = (int)segment_layers;
     int first_port = join ? port + 1 : port;
@@ -737,14 +737,16 @@ static int cmd_serve(int argc, char **argv) {
     if (segment_candidate) {
         long cores = sysconf(_SC_NPROCESSORS_ONLN);
         if (cores < 1) cores = 1;
-        /* A chain of slices on one host is sequential: four processes used
-         * one quarter of the CPU at a time and added three loopback hops.
-         * One full-core fallback is the honest single-machine baseline.
-         * Explicit partitioning remains available for replacement tests;
-         * distributed sharding is selected from READY peers by the tracker. */
-        int chunks = lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 1, 1, 7);
+        /* Keep stable layer boundaries from minute zero. Donors take these
+         * exact ranges one by one, so each new resident machine replaces a
+         * corresponding origin slice without migrating an active chat. The
+         * chain is sequential for decode: every local slice therefore gets
+         * the complete CPU team, rather than the old cores/chunks team that
+         * made four slices four times slower on one host. */
+        int chunks = lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 4, 1, 7);
         if ((uint32_t)chunks > segment_layers) chunks = (int)segment_layers;
-        int slice_threads = (int)(cores / chunks);
+        int slice_threads = lmb_env_int("LUMABRI_SEGMENT_THREADS",
+                                        (int)cores, 1, 256);
         if (slice_threads < 1) slice_threads = 1;
         int sessions = lmb_env_int("LUMABRI_SEGMENT_SESSIONS",
                                    advertise ? 4 : 2, 1, 64);

--- a/segment_native_test.sh
+++ b/segment_native_test.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# User-facing gate: launch the ordinary serve/chat commands, intentionally ask
-# for more context than the tiny origin advertises, and require Segment rather
-# than allowing the classic fallback to hide an integration regression.
+# User-facing gate: launch the ordinary serve/chat commands and require Segment
+# rather than allowing the classic fallback to hide an integration regression.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -37,14 +36,15 @@ wait_port() {
 mkdir -p "$TMP/server-home" "$TMP/client-home"
 HOME="$TMP/server-home" ./lumabri key --out "$TMP/swarm" >/dev/null
 
-HOME="$TMP/server-home" LUMABRI_SEGMENT_CHUNKS=2 LUMABRI_SEGMENT_SESSIONS=8 \
+HOME="$TMP/server-home" LUMABRI_SEGMENT_THREADS=2 LUMABRI_SEGMENT_SESSIONS=8 \
     LUMABRI_SEGMENT_MIN_FREE_MB=1024 OMP_NUM_THREADS=2 \
     stdbuf -oL -eL ./lumabri serve --model "$OLMOE_EDGE_MODEL" --port 7880 \
     --key "$TMP/swarm.key" \
     >"$TMP/server.log" 2>&1 &
 SERVER_PID=$!
 
-if ! wait_port 7880 || ! wait_port 7883 || ! wait_port 7884; then
+if ! wait_port 7880 || ! wait_port 7883 || ! wait_port 7884 ||
+   ! wait_port 7885 || ! wait_port 7886; then
     cat "$TMP/server.log"
     echo "SEGMENT NATIVE: origin did not become ready" >&2
     exit 1
@@ -58,7 +58,6 @@ printf 'hi\n/quit\n' | HOME="$TMP/client-home" OMP_NUM_THREADS=2 \
 status=$?
 set -e
 if (( status != 0 )) || ! grep -q 'pronto via Segment' "$TMP/chat.log" ||
-   ! grep -q 'Segment context negotiated to' "$TMP/chat.log" ||
    ! grep -q 'data plane relay (nessuna porta pubblica richiesta)' "$TMP/server.log" ||
    grep -q 'continuo con il percorso expert/CAS' "$TMP/chat.log" ||
    grep -q 'Segment route generation' "$TMP/chat.log"; then

--- a/segment_node.c
+++ b/segment_node.c
@@ -1274,6 +1274,10 @@ int main(int argc, char **argv) {
     if (fallback) a->flags |= LMB_SEG_ADVERT_FALLBACK;
     if (relay_only) a->flags |= LMB_SEG_ADVERT_RELAY_ONLY;
     a->capabilities = node.cap.flags & LMB_SEG_CAP_KNOWN_MASK;
+    /* Registration happens after engine_open, so this is measured resident
+     * memory, not a model-size promise. A zero value remains valid on systems
+     * without an RSS counter, but the node is still READY only after open. */
+    a->resident_ram_bytes = engine_rss;
     snprintf(a->engine_id, sizeof a->engine_id, "%s", node.cap.engine_id);
     snprintf(a->state_schema, sizeof a->state_schema, "%s", node.cap.state_schema);
     snprintf(a->numeric_class, sizeof a->numeric_class, "%s", node.cap.numeric_class);


### PR DESCRIPTION
Obiettivo: creare una catena di range residenti e sostituibili, cosi ogni donor Segment puo rimuovere una fetta precisa dal fallback origin. Colibri non viene modificato.\n\nMetriche: A e B possono migliorare quando range caldi migrano su macchine residenti; C non cambia. Nessun valore multi-host viene inventato in questa PR.\n\nCambia: quattro range origin stabili per default; ogni range locale usa il team CPU completo perche il decode attraversa la catena in serie; override separati per numero range e thread; RSS misurato pubblicato solo dopo engine open; assegnazioni least-replicated conservano confini esatti e failover.\n\nUniversalita: il protocollo Segment e gli adapter restano comuni alle sei famiglie.\n\nVerifica: warning gate PASS; discovery e assegnazione disgiunta sulle sei famiglie PASS; serve piu chat con quattro range OLMoE reali PASS; relay, TUI live e restore restano nel gate.\n\nPR stacked su #80. Nessun merge eseguito.