### PR TITLE
Machine Profile and pressure-aware Resource Governor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,15 @@ endif
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
-		test_segment_discovery test_swarm_detail test_relay_rate \
+		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
+MACHINE_SRC = lumabri_machine.c
+MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
-lumabri: lumabri.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
-	$(CC) $(CFLAGS) -pthread lumabri.c -o $@
+lumabri: lumabri.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS) $(MACHINE_DEPS)
+	$(CC) $(CFLAGS) -pthread lumabri.c $(MACHINE_SRC) -o $@
 
 # ---- phase 2: peers execute experts ------------------------------------
 # Both sides are built from the engine's own source so the expert math cannot
@@ -129,26 +131,26 @@ phase2-all: engines chatters
 # One expert-node binary per engine. The body is the same file; everything
 # engine-shaped lives in expert_engines/<name>.h, which pulls in the engine's
 # own source so remote and local run the same kernels on the same weights.
-EXPERT_DEPS = expert_node.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
+EXPERT_DEPS = expert_node.c lumabri_proto.h lumabri_sign.h $(SECURE_DEPS) $(MACHINE_DEPS)
 
 expert_node: $(EXPERT_DEPS) expert_engines/olmoe.h $(ENGINE)/olmoe.c \
              engine_patches/olmoe-p2p.diff $(ENGINE_PROFILE_DEPS)
-	$(CC) $(P2P_CFLAGS) $(PROFILE_olmoe) expert_node.c -o $@ -lm -lpthread
+	$(CC) $(P2P_CFLAGS) $(PROFILE_olmoe) expert_node.c $(MACHINE_SRC) -o $@ -lm -lpthread
 
 expert_node_glm: $(EXPERT_DEPS) expert_engines/colibri.h $(ENGINE)/colibri.c \
                  engine_patches/colibri-p2p.diff $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_colibri) -DLMBE_ENGINE_HEADER='"expert_engines/colibri.h"' \
-	      expert_node.c -o $@ -lm -lpthread
+	      expert_node.c $(MACHINE_SRC) -o $@ -lm -lpthread
 
 expert_node_inkling: $(EXPERT_DEPS) expert_engines/inkling.h $(ENGINE)/inkling.c \
                      engine_patches/inkling-p2p.diff $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_inkling) -DLMBE_ENGINE_HEADER='"expert_engines/inkling.h"' \
-	      expert_node.c -o $@ -lm -lpthread
+	      expert_node.c $(MACHINE_SRC) -o $@ -lm -lpthread
 
 expert_node_kimi: $(EXPERT_DEPS) expert_engines/kimi_k3.h $(ENGINE)/kimi_k3.c \
                   engine_patches/kimi_k3-p2p.diff $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_kimi_k3) $(K3_ZQ_FLAG) -DLMBE_ENGINE_HEADER='"expert_engines/kimi_k3.h"' \
-	      expert_node.c -o $@ -lm -lpthread
+	      expert_node.c $(MACHINE_SRC) -o $@ -lm -lpthread
 
 # qwen36 (Qwen3.6): olmoe dialect, experts group-scaled and int4/int8, one row
 # at a time. The CUDA VRAM tier is compiled out on CPU (qwen36_tier.h supplies
@@ -156,7 +158,7 @@ expert_node_kimi: $(EXPERT_DEPS) expert_engines/kimi_k3.h $(ENGINE)/kimi_k3.c \
 expert_node_qwen36: $(EXPERT_DEPS) expert_engines/qwen36.h $(ENGINE)/qwen36.c \
                     engine_patches/qwen36-p2p.diff $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_qwen36) -DLMBE_ENGINE_HEADER='"expert_engines/qwen36.h"' \
-	      expert_node.c -o $@ -lm -lpthread
+	      expert_node.c $(MACHINE_SRC) -o $@ -lm -lpthread
 
 # DeepSeek V4 needs two extra things at build time.
 #
@@ -219,7 +221,7 @@ build/ds_%.o: build/deepseek_v4_noentry.c $(DS_HDRS)
 expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h $(DS_OBJS) $(DS_SIBLING_OBJS) $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -DLMBE_DS_MULTIFILE -I$(ENGINE) \
 	      -DLMBE_ENGINE_HEADER='"expert_engines/deepseek.h"' \
-	      expert_node.c $(DS_OBJS) $(DS_SIBLING_OBJS) -o $@ -lm -lpthread
+	      expert_node.c $(MACHINE_SRC) $(DS_OBJS) $(DS_SIBLING_OBJS) -o $@ -lm -lpthread
 
 # The chatter: the same units WITH main (it is the CLI), patched at the three
 # expert-apply sites to delegate routed experts to peers. The lumabri client
@@ -260,7 +262,7 @@ expert_node_deepseek: $(EXPERT_DEPS) expert_engines/deepseek.h build/deepseek_no
                       engine_patches/deepseek-p2p.diff $(ENGINE_PROFILE_DEPS)
 	$(CC) $(P2P_CFLAGS) $(PROFILE_deepseek) $(DS_CFLAGS) -Ibuild \
 	      -DLMBE_ENGINE_HEADER='"expert_engines/deepseek.h"' \
-	      expert_node.c -o $@ -lm -lpthread
+	      expert_node.c $(MACHINE_SRC) -o $@ -lm -lpthread
 endif
 
 # Regenerate the engine patches from a colibri checkout (never modifies it)
@@ -404,6 +406,12 @@ test_relay_rate: test_relay_rate.c lumabri_segment.c lumabri_segment.h \
 		lumabri_proto.h
 	$(CC) $(CFLAGS) -pthread test_relay_rate.c lumabri_segment.c -o $@
 
+test_machine: test_machine.c $(MACHINE_DEPS) lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_machine.c $(MACHINE_SRC) -o $@
+
+test-machine-governor: lumabri tracker swarm_probe expert_node segment_node fixture test_machine
+	ENGINE=$(ENGINE) bash ./machine_governor_test.sh
+
 # ---- Segment direct data plane (requires Colibri's additive Edge ABI) ---
 # `all` includes this only when both additive headers are present. A Lumabri
 # checkout pointed at an older/release Colibri therefore keeps building the
@@ -447,9 +455,9 @@ $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_brid
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 
-segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
+segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS)
 	$(CC) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
-		lumabri_segment_discovery.c $(COLIBRI_SEGMENT_LIB) -o $@ -lm
+		lumabri_segment_discovery.c $(MACHINE_SRC) $(COLIBRI_SEGMENT_LIB) -o $@ -lm
 
 segment_chat: segment_chat.c lumabri_sampling.c lumabri_sampling.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
@@ -520,7 +528,7 @@ test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
-		test_segment_discovery test_swarm_detail test_relay_rate
+		test_segment_discovery test_swarm_detail test_relay_rate test_machine
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -546,6 +554,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	bash ./segment_discovery_test.sh
 	bash ./swarm_detail_test.sh
 	bash ./relay_rate_test.sh
+	bash ./machine_governor_test.sh
 
 # ---- deploy -------------------------------------------------------------
 # make install                    → /usr/local (needs sudo)
@@ -570,7 +579,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
-	      test_swarm_detail test_relay_rate \
+	      test_swarm_detail test_relay_rate test_machine \
 	      test_segment_v2_tsan tracker_tsan \
 	      segment_node segment_chat segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \
@@ -586,4 +595,5 @@ clean:
         patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 test-elastic \
         test-cas test-key-rotation test-hedge test-segment-v2 \
         test-segment-discovery segment-direct test-segment-direct-real \
-        test-segment-relay-real test-segment-failover-real test-segment-hybrid
+        test-segment-relay-real test-segment-failover-real test-segment-hybrid \
+        test-machine-governor

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ the finer-grained expert donor remains the lower-memory fallback.
 Both run at low priority and die with the TUI. Nothing to configure — Enter
 picks "just chat".
 
+`lumabri machine` shows the quick startup profile used for donation: CPU
+model/ISA, physical and logical cores, NUMA, RAM/swap, visible GPU/VRAM, disk,
+interfaces and optional tracker RTT. `--json` emits a stable schema for
+automation. `lumabri limits` shows the current donation budget; `lumabri pause`
+and `lumabri resume` control every local donor without killing the chat.
+
 Inside the chat, `/swarm` (or `/hosts`) shows stable human-readable machine
 names, storage served, expert calls and live Segment ranges. `/experts` answers
 how often each executor has actually been used; `/model`, `/debug`, `/storage`
@@ -229,10 +235,22 @@ summary reports connected hosts, bytes served, expert calls and active Segment
 runs, so successful swarm work is visible on both sides.
 
 Automatic Segment is a real compute service. It starts only with at least 8 GiB
-available by default (`LUMABRI_SEGMENT_MIN_FREE_MB`), divides CPU threads among
-the slices, runs fallback work at low priority and keeps 4 GiB free before
-accepting a new session (`LUMABRI_SEGMENT_RAM_RESERVE_MB`). A relay-only/NAT
+available by default (`LUMABRI_SEGMENT_MIN_FREE_MB`), gives each sequential
+slice a full physical-core team, runs fallback work at low priority and keeps
+4 GiB free before accepting a new session. `LUMABRI_RAM_RESERVE_MB` is the
+common limit; `LUMABRI_SEGMENT_RAM_RESERVE_MB` and
+`LUMABRI_EXPERT_RAM_RESERVE_MB` are per-role overrides. A relay-only/NAT
 origin defaults to two sessions per slice; a direct server defaults to four.
+
+Every executor runs the same hysteretic resource governor. `ACTIVE` publishes
+capacity; `PRESSURE` and `PAUSED` advertise Segment draining or zero Expert
+coverage and reject new work; `RECOVERY` waits three healthy samples before
+publishing again. In-flight Segment work sees the cancellation callback and is
+migrated through the existing checkpoint/replay path. Expert work already in
+flight drains, while new calls fall back to another replica or the Segment's
+local kernel. This pauses donor CPU and I/O immediately; resident RAM stays
+allocated inside the donor process, protected by the reserve chosen before
+loading, so recovery does not cold-load the model again.
 
 On every other machine, pick a role:
 

--- a/expert_input_test.sh
+++ b/expert_input_test.sh
@@ -55,6 +55,7 @@ EOF
 SAN="-fsanitize=address,undefined -fno-omit-frame-pointer"
 cc -O1 -g $SAN -fopenmp -pthread -I"$T" -I. \
     -DLMBE_ENGINE_HEADER='"test_engine.h"' expert_node.c \
+    lumabri_machine.c \
     -o "$T/expert_node" -lm
 
 # One helper can impersonate a peer or tracker and can inspect a real node.

--- a/expert_node.c
+++ b/expert_node.c
@@ -68,6 +68,7 @@
 #endif
 
 #include "lumabri_proto.h"
+#include "lumabri_machine.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 
@@ -126,8 +127,10 @@ static struct {
     uint8_t peer_sk[64], peer_pk[32];   /* identity to the tracker */
     int bits;
     int resident_mode;
-    uint32_t resident_state, resident_flags;
+    _Atomic uint32_t resident_state;
+    uint32_t resident_flags;
     uint64_t resident_bytes, resident_vram_bytes;
+    LmbGovernor governor;
     LmbModelIdentity identity; int have_identity;
     pthread_mutex_t identity_lk;
     _Atomic uint64_t calls, cold;
@@ -266,6 +269,7 @@ static void cache_release(CSlot *s) {
  * does not produce the same floats as nr calls of one row, and byte identity
  * with the local path is the entire claim of this project. */
 static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
+    if (!lmb_governor_accepting(&g.governor)) return -2;
     LmbCur cur = { m->body, m->body_len, 0 };
     uint32_t layer, eid, dim, nrows = 1;
     if (lmb_cur_u32(&cur, &layer) || lmb_cur_u32(&cur, &eid) || lmb_cur_u32(&cur, &dim)) {
@@ -342,8 +346,10 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
 
 static int handle_exec(int fd, LmbMsg *m) {
     float *out = NULL; uint32_t out_len = 0;
-    if (exec_compute(m, &out, &out_len)) {
-        send_err(fd, "bad exec request or expert not held");
+    int status = exec_compute(m, &out, &out_len);
+    if (status) {
+        send_err(fd, status == -2 ? "executor draining under machine pressure" :
+                                    "bad exec request or expert not held");
         return -1;
     }
     int rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, out, out_len);
@@ -553,16 +559,17 @@ static void *rebalance_thread(void *arg) {
 
 static int send_ereg(int fd, const uint8_t nonce[32], int send_stats) {
     LmbBuf b = {0};
+    int publishing = lmb_governor_accepting(&g.governor);
     lmb_buf_str(&b, g.name);
     lmb_buf_str(&b, g.advertise);
     lmb_buf_str(&b, g.model);
-    lmb_buf_u32(&b, (uint32_t)g.nholds);
+    lmb_buf_u32(&b, publishing ? (uint32_t)g.nholds : 0u);
     size_t cells = (size_t)g.n_slots * g.n_experts;
     size_t nb = (cells + 7) / 8;
     uint8_t *bits = (uint8_t *)calloc(nb ? nb : 1, 1);
     if (!bits) { free(b.p); return -1; }
     for (size_t k = 0; k < cells; k++)
-        if (g.holds[k]) bits[k >> 3] |= (uint8_t)(1u << (k & 7));
+        if (publishing && g.holds[k]) bits[k >> 3] |= (uint8_t)(1u << (k & 7));
     lmb_buf_u32(&b, (uint32_t)nb);
     lmb_buf_bytes(&b, bits, nb);
     free(bits);
@@ -581,7 +588,7 @@ static int send_ereg(int fd, const uint8_t nonce[32], int send_stats) {
         lmb_buf_u32(&b, LMB_EREG_STATS_LENGTH);
         lmb_buf_u64(&b, atomic_load(&g.calls));
         lmb_buf_u32(&b, atomic_load(&g.in_flight));
-        lmb_buf_u32(&b, g.resident_state);
+        lmb_buf_u32(&b, atomic_load(&g.resident_state));
         lmb_buf_u32(&b, g.resident_flags);
         lmb_buf_u32(&b, g.resident_mode ? (uint32_t)g.nholds : 0u);
         lmb_buf_u64(&b, g.resident_bytes);
@@ -595,6 +602,26 @@ static int send_ereg(int fd, const uint8_t nonce[32], int send_stats) {
     int rc = lmb_send(fd, LMB_EREG, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
+}
+
+static void *governor_thread(void *arg) {
+    (void)arg;
+    LmbGovernorState previous = lmb_governor_state(&g.governor);
+    for (;;) {
+        LmbGovernorState state = lmb_governor_poll(&g.governor);
+        atomic_store(&g.resident_state, state == LMB_GOV_ACTIVE ?
+                     LMB_EXPERT_STATE_ACTIVE : LMB_EXPERT_STATE_DRAINING);
+        if (state != previous) {
+            fprintf(stderr, "[%s] governor %s -> %s%s\n", g.name,
+                    lmb_governor_state_name(previous),
+                    lmb_governor_state_name(state),
+                    state == LMB_GOV_ACTIVE ? " · publishing resident experts" :
+                                             " · draining and advertising zero coverage");
+            previous = state;
+        }
+        sleep(1);
+    }
+    return NULL;
 }
 
 /* The tracker binds a name to the first peer key that registers it and
@@ -906,7 +933,15 @@ int main(int argc, char **argv) {
     }
     if (hold_auto) resident = 1;
     g.resident_mode = resident || cache == 0;
-    g.resident_state = LMB_EXPERT_STATE_ASSIGNED;
+    long governor_reserve_mb = 4096;
+    const char *global_reserve = getenv("LUMABRI_RAM_RESERVE_MB");
+    const char *expert_reserve = getenv("LUMABRI_EXPERT_RAM_RESERVE_MB");
+    if (global_reserve && atol(global_reserve) >= 256)
+        governor_reserve_mb = atol(global_reserve);
+    if (expert_reserve && atol(expert_reserve) >= 256)
+        governor_reserve_mb = atol(expert_reserve);
+    lmb_governor_init(&g.governor, (uint64_t)governor_reserve_mb << 20);
+    atomic_store(&g.resident_state, LMB_EXPERT_STATE_ASSIGNED);
     lmbe_open(dir, cache, bits);
     g.bits = lmbe_effective_bits(bits);
     lmb_build_profile(g.profile, sizeof g.profile);
@@ -920,9 +955,7 @@ int main(int argc, char **argv) {
          * slice, so several "donate compute" machines auto-spread into disjoint
          * shares instead of every one holding the whole model. */
         long avail_kb = meminfo_avail_kb();
-        long reserve_mb = 4096;
-        const char *reserve_env = getenv("LUMABRI_EXPERT_RAM_RESERVE_MB");
-        if (reserve_env && atol(reserve_env) >= 256) reserve_mb = atol(reserve_env);
+        long reserve_mb = governor_reserve_mb;
         double avail_b = avail_kb > reserve_mb * 1024L
             ? (double)(avail_kb - reserve_mb * 1024L) * 1024.0 : 0.0;
         double ebytes = 3.0 * g.inter * g.hidden;     /* same width the cache MB uses */
@@ -983,7 +1016,7 @@ int main(int argc, char **argv) {
                g.name, lmbe_engine_name(), dense, g.n_slots);
 
     double t0 = nowd();
-    g.resident_state = LMB_EXPERT_STATE_LOADING;
+    atomic_store(&g.resident_state, LMB_EXPERT_STATE_LOADING);
     if (cache > 0) {
         /* SSD residency: experts stay on disk, N slots of RAM catch the hot
          * ones. Nothing is preloaded — the first calls warm the cache, the
@@ -1033,7 +1066,9 @@ int main(int argc, char **argv) {
     } else {
         g.resident_flags = LMB_EXPERT_DISK_FALLBACK;
     }
-    g.resident_state = LMB_EXPERT_STATE_ACTIVE;
+    atomic_store(&g.resident_state,
+                 lmb_governor_accepting(&g.governor) ?
+                 LMB_EXPERT_STATE_ACTIVE : LMB_EXPERT_STATE_DRAINING);
     fflush(stdout);
 
     /* whatever the engine settled on during lmbe_open */
@@ -1068,6 +1103,7 @@ int main(int argc, char **argv) {
     pthread_t t;
     lmb_conn_gate_init(&g_conn_gate);
     if (lmb_secure_init()) return 1;
+    pthread_create(&t, NULL, governor_thread, NULL); pthread_detach(t);
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }
     if (g.tracker[0] && g.want_hold > 0 && g.ncs > 0) {
         pthread_create(&t, NULL, rebalance_thread, NULL);

--- a/lumabri.c
+++ b/lumabri.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_machine.h"
 #include "lumabri_segment_discovery.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
@@ -394,17 +395,6 @@ static int local_model_layers(const char *model_dir, uint32_t *layers) {
     return local_model_u32(model_dir, "num_hidden_layers", layers);
 }
 
-static uint64_t machine_available_ram(void) {
-    FILE *file = fopen("/proc/meminfo", "r");
-    if (!file) return 0;
-    char line[256];
-    unsigned long long kib = 0;
-    while (fgets(line, sizeof line, file))
-        if (sscanf(line, "MemAvailable: %llu kB", &kib) == 1) break;
-    fclose(file);
-    return (uint64_t)kib * 1024u;
-}
-
 /* A server with a real public IPv4 should need no networking flag. Private,
  * loopback, link-local and CGNAT addresses are deliberately not guessed:
  * publishing one to an Internet swarm would create a "complete" Segment
@@ -593,7 +583,9 @@ static int cmd_serve(int argc, char **argv) {
     const char *segment_model = model_name_for(
         model, mname, segment_model_storage, sizeof segment_model_storage);
     uint32_t segment_layers = 0;
-    uint64_t segment_available = machine_available_ram();
+    LmbMachineProfile serve_profile;
+    (void)lmb_machine_probe(&serve_profile, model, NULL);
+    uint64_t segment_available = serve_profile.ram_available_bytes;
     uint64_t segment_min_free = (uint64_t)lmb_env_int(
         "LUMABRI_SEGMENT_MIN_FREE_MB", 8192, 1024, 262144) << 20;
     int segment_candidate = !disk_donor && !no_exec && segment_engine &&
@@ -735,7 +727,7 @@ static int cmd_serve(int argc, char **argv) {
      * without it preserve the exact old serve topology. */
     int with_segment = 0;
     if (segment_candidate) {
-        long cores = sysconf(_SC_NPROCESSORS_ONLN);
+        long cores = serve_profile.physical_cores;
         if (cores < 1) cores = 1;
         /* Keep stable layer boundaries from minute zero. Donors take these
          * exact ranges one by one, so each new resident machine replaces a
@@ -811,6 +803,11 @@ static int cmd_serve(int argc, char **argv) {
         }
         double ram_gb = (double)segment_available / 1e9;
         const char *home = getenv("HOME") ? getenv("HOME") : ".";
+        printf("  %smachine %s · %ld physical cores · %s · %.1f/%.1f GB RAM"
+               " · %u GPU%s%s\n", C_DIM, serve_profile.hostname, cores,
+               serve_profile.isa, serve_profile.ram_available_bytes / 1e9,
+               serve_profile.ram_total_bytes / 1e9, serve_profile.gpu_count,
+               serve_profile.gpu_count ? " detected" : "", C_R);
         printf("  %sSegment prepara %d fette layer-aligned sulle porte %d-%d "
                "(%ld CPU, %.1f GB RAM disponibili, %d thread e %d sessioni/fetta). "
                "%s%s%s\n",
@@ -3226,10 +3223,14 @@ static int role_start_segment(const Role *r, const char *tracker,
      * This process therefore only publishes what the machine can donate;
      * segment_node compares it with the assigned range and releases the
      * promise immediately when it cannot fit. */
-    uint64_t available = machine_available_ram();
-    uint64_t reserve = available / 4;
-    if (reserve < 4ull * 1000 * 1000 * 1000)
-        reserve = 4ull * 1000 * 1000 * 1000;
+    LmbMachineProfile profile;
+    (void)lmb_machine_probe(&profile,
+                            r->model_dir[0] ? r->model_dir : ".", tracker);
+    uint64_t available = profile.ram_available_bytes;
+    uint64_t reserve = (uint64_t)lmb_env_int(
+        getenv("LUMABRI_SEGMENT_RAM_RESERVE_MB") ?
+        "LUMABRI_SEGMENT_RAM_RESERVE_MB" : "LUMABRI_RAM_RESERVE_MB",
+        4096, 256, 262144) << 20;
     if (!available || reserve >= available)
         return 0;
     uint64_t memory_budget = available - reserve;
@@ -3267,7 +3268,7 @@ static int role_start_segment(const Role *r, const char *tracker,
 
     int port = free_port(7801);
     if (!port) return 0;
-    long cores = sysconf(_SC_NPROCESSORS_ONLN);
+    long cores = profile.physical_cores;
     int threads = cores > 1 ? (int)(cores / 2) : 1;
     int sessions = 2;
     char port_text[16], context_text[16], sessions_text[16], threads_text[16];
@@ -4144,6 +4145,72 @@ static int cmd_peer_key(int argc, char **argv) {
     return 0;
 }
 
+static int cmd_machine(int argc, char **argv) {
+    int json = 0;
+    const char *tracker = NULL, *disk = ".";
+    for (int i = 0; i < argc; i++) {
+        if (!strcmp(argv[i], "--json")) json = 1;
+        else if (!strcmp(argv[i], "--tracker") && i + 1 < argc)
+            tracker = argv[++i];
+        else if (!strcmp(argv[i], "--disk") && i + 1 < argc)
+            disk = argv[++i];
+        else {
+            fprintf(stderr, "usage: lumabri machine [--json] [--tracker HOST:PORT] "
+                            "[--disk PATH]\n");
+            return 2;
+        }
+    }
+    LmbMachineProfile profile;
+    if (lmb_machine_probe(&profile, disk, tracker)) {
+        fprintf(stderr, "cannot profile this machine\n"); return 1;
+    }
+    lmb_machine_print(stdout, &profile, json);
+    if (!json) {
+        uint64_t reserve = (uint64_t)lmb_env_int(
+            "LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+        LmbGovernor governor;
+        lmb_governor_init(&governor, reserve);
+        printf("governor %s · %.1f GB system reserve\n",
+               lmb_governor_state_name(lmb_governor_poll(&governor)),
+               reserve / 1e9);
+    }
+    return 0;
+}
+
+static int cmd_limits(int argc, char **argv) {
+    (void)argv;
+    if (argc) { fprintf(stderr, "usage: lumabri limits\n"); return 2; }
+    uint64_t reserve = (uint64_t)lmb_env_int(
+        "LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+    LmbMachineProfile profile;
+    (void)lmb_machine_probe(&profile, ".", NULL);
+    uint64_t donate = profile.ram_available_bytes > reserve ?
+                      profile.ram_available_bytes - reserve : 0;
+    printf("system reserve     %.1f GB RAM\n", reserve / 1e9);
+    printf("currently donable  %.1f GB RAM\n", donate / 1e9);
+    printf("donor CPU team     %u physical cores (low priority)\n",
+           profile.physical_cores);
+    printf("manual state       %s\n",
+           lmb_governor_manual_paused() ? "PAUSED" : "ACTIVE");
+    printf("overrides          LUMABRI_RAM_RESERVE_MB, "
+           "LUMABRI_EXPERT_RAM_RESERVE_MB, LUMABRI_SEGMENT_RAM_RESERVE_MB\n");
+    return 0;
+}
+
+static int cmd_governor_manual(int argc, char **argv, int paused) {
+    (void)argv;
+    if (argc) {
+        fprintf(stderr, "usage: lumabri %s\n", paused ? "pause" : "resume");
+        return 2;
+    }
+    if (lmb_governor_set_manual(paused)) {
+        perror("cannot update governor state"); return 1;
+    }
+    printf("donation %s; running work will drain before the new state applies\n",
+           paused ? "paused" : "resumed");
+    return 0;
+}
+
 /* ---- main --------------------------------------------------------------- */
 
 int main(int argc, char **argv) {
@@ -4151,6 +4218,14 @@ int main(int argc, char **argv) {
     if (argc >= 2 && !strcmp(argv[1], "key")) return cmd_key(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "peer-key"))
         return cmd_peer_key(argc - 2, argv + 2);
+    if (argc >= 2 && (!strcmp(argv[1], "machine") || !strcmp(argv[1], "status")))
+        return cmd_machine(argc - 2, argv + 2);
+    if (argc >= 2 && !strcmp(argv[1], "limits"))
+        return cmd_limits(argc - 2, argv + 2);
+    if (argc >= 2 && !strcmp(argv[1], "pause"))
+        return cmd_governor_manual(argc - 2, argv + 2, 1);
+    if (argc >= 2 && !strcmp(argv[1], "resume"))
+        return cmd_governor_manual(argc - 2, argv + 2, 0);
     if (lmb_secure_init()) return 1; /* children inherit the same strict mode */
     const char *tok = getenv("LUMABRI_TOKEN");
     if (tok && strlen(tok) > LMB_TOKEN_MAX) {
@@ -4167,6 +4242,8 @@ int main(int argc, char **argv) {
     fprintf(stderr,
         "lumabri: run huge models from a swarm of peers\n\n"
         "  lumabri                                                    chat (asks what it needs)\n"
+        "  lumabri machine [--json] [--tracker HOST:PORT]             profile this machine\n"
+        "  lumabri status | limits | pause | resume                    resource governor\n"
         "  lumabri peer-key                                           print this machine's endpoint identity\n"
         "  lumabri serve --model DIR [--port 7300] [--join TRACKER]   share a model\n"
         "  lumabri chat  [--tracker HOST:7300] [--model NAME]         chat with it\n"

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -1,0 +1,368 @@
+#define _GNU_SOURCE
+#include "lumabri_machine.h"
+#include "lumabri_proto.h"
+
+#include <arpa/inet.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <sys/utsname.h>
+#include <time.h>
+#include <unistd.h>
+
+static int read_u64_file(const char *path, uint64_t *value) {
+    FILE *file = fopen(path, "r");
+    unsigned long long parsed = 0;
+    if (!file) return -1;
+    int ok = fscanf(file, "%llu", &parsed) == 1;
+    fclose(file);
+    if (!ok) return -1;
+    *value = (uint64_t)parsed;
+    return 0;
+}
+
+static void meminfo(uint64_t *total, uint64_t *available,
+                    uint64_t *swap_total, uint64_t *swap_free) {
+    FILE *file = fopen("/proc/meminfo", "r");
+    char line[256];
+    unsigned long long mt = 0, ma = 0, st = 0, sf = 0;
+    if (file) {
+        while (fgets(line, sizeof line, file)) {
+            (void)sscanf(line, "MemTotal: %llu kB", &mt);
+            (void)sscanf(line, "MemAvailable: %llu kB", &ma);
+            (void)sscanf(line, "SwapTotal: %llu kB", &st);
+            (void)sscanf(line, "SwapFree: %llu kB", &sf);
+        }
+        fclose(file);
+    }
+    if (total) *total = (uint64_t)mt << 10;
+    if (available) *available = (uint64_t)ma << 10;
+    if (swap_total) *swap_total = (uint64_t)st << 10;
+    if (swap_free) *swap_free = (uint64_t)sf << 10;
+}
+
+uint64_t lmb_machine_available_ram(void) {
+    uint64_t value = 0;
+    meminfo(NULL, &value, NULL, NULL);
+    return value;
+}
+
+uint64_t lmb_machine_total_ram(void) {
+    uint64_t value = 0;
+    meminfo(&value, NULL, NULL, NULL);
+    return value;
+}
+
+static void cpu_profile(LmbMachineProfile *profile) {
+    FILE *file = fopen("/proc/cpuinfo", "r");
+    char line[1024], flags[4096] = "";
+    unsigned processors = 0;
+    struct { int package, core; } seen[1024];
+    unsigned nseen = 0;
+    int package = -1, core = -1;
+    if (file) {
+        while (fgets(line, sizeof line, file)) {
+            if (!strncmp(line, "processor", 9)) {
+                if (package >= 0 && core >= 0 && nseen < 1024) {
+                    unsigned i = 0;
+                    for (; i < nseen; i++)
+                        if (seen[i].package == package && seen[i].core == core) break;
+                    if (i == nseen) seen[nseen++] = (typeof(*seen)){package, core};
+                }
+                processors++; package = core = -1;
+            } else if (!strncmp(line, "physical id", 11)) {
+                char *colon = strchr(line, ':'); if (colon) package = atoi(colon + 1);
+            } else if (!strncmp(line, "core id", 7)) {
+                char *colon = strchr(line, ':'); if (colon) core = atoi(colon + 1);
+            } else if ((!strncmp(line, "model name", 10) ||
+                        !strncmp(line, "Hardware", 8)) && !profile->cpu_model[0]) {
+                char *colon = strchr(line, ':');
+                if (colon) {
+                    while (*++colon == ' ' || *colon == '\t') {}
+                    colon[strcspn(colon, "\r\n")] = 0;
+                    snprintf(profile->cpu_model, sizeof profile->cpu_model, "%s", colon);
+                }
+            } else if ((!strncmp(line, "flags", 5) || !strncmp(line, "Features", 8)) &&
+                       !flags[0]) {
+                char *colon = strchr(line, ':');
+                if (colon) snprintf(flags, sizeof flags, " %s ", colon + 1);
+            }
+        }
+        if (package >= 0 && core >= 0 && nseen < 1024) {
+            unsigned i = 0;
+            for (; i < nseen; i++)
+                if (seen[i].package == package && seen[i].core == core) break;
+            if (i == nseen) seen[nseen++] = (typeof(*seen)){package, core};
+        }
+        fclose(file);
+    }
+    long online = sysconf(_SC_NPROCESSORS_ONLN);
+    profile->logical_cpus = online > 0 ? (uint32_t)online : processors;
+    profile->physical_cores = nseen ? nseen : profile->logical_cpus;
+    const char *isa = "generic";
+    if (strstr(flags, " avx512_bf16 ") || strstr(flags, " avx512bf16 ")) isa = "avx512bf16";
+    else if (strstr(flags, " avx512_vnni ") || strstr(flags, " avx512vnni ")) isa = "avx512vnni";
+    else if (strstr(flags, " avx512f ")) isa = "avx512f";
+    else if (strstr(flags, " avx_vnni ") || strstr(flags, " avxvnni ")) isa = "avxvnni";
+    else if (strstr(flags, " avx2 ")) isa = "avx2";
+    else if (strstr(flags, " asimd ")) isa = "asimd";
+    snprintf(profile->isa, sizeof profile->isa, "%s", isa);
+}
+
+static void numa_profile(LmbMachineProfile *profile) {
+    DIR *dir = opendir("/sys/devices/system/node");
+    struct dirent *entry;
+    if (!dir) { profile->numa_nodes = 1; return; }
+    while ((entry = readdir(dir)))
+        if (!strncmp(entry->d_name, "node", 4) &&
+            entry->d_name[4] >= '0' && entry->d_name[4] <= '9')
+            profile->numa_nodes++;
+    closedir(dir);
+    if (!profile->numa_nodes) profile->numa_nodes = 1;
+}
+
+static void gpu_profile(LmbMachineProfile *profile) {
+    DIR *dir = opendir("/sys/class/drm");
+    struct dirent *entry;
+    if (!dir) return;
+    while ((entry = readdir(dir))) {
+        unsigned card = 0; char tail = 0;
+        if (sscanf(entry->d_name, "card%u%c", &card, &tail) != 1) continue;
+        char vendor[256], total[256], used[256];
+        snprintf(vendor, sizeof vendor, "/sys/class/drm/card%u/device/vendor", card);
+        uint64_t ignored = 0;
+        if (read_u64_file(vendor, &ignored)) continue;
+        profile->gpu_count++;
+        snprintf(total, sizeof total, "/sys/class/drm/card%u/device/mem_info_vram_total", card);
+        snprintf(used, sizeof used, "/sys/class/drm/card%u/device/mem_info_vram_used", card);
+        uint64_t t = 0, u = 0;
+        if (!read_u64_file(total, &t)) {
+            (void)read_u64_file(used, &u);
+            profile->vram_total_bytes += t;
+            profile->vram_available_bytes += t > u ? t - u : 0;
+        }
+    }
+    closedir(dir);
+}
+
+static int public_address(uint32_t host_order) {
+    return (host_order >> 24) != 0 && (host_order >> 24) != 10 &&
+           (host_order >> 24) != 127 && (host_order >> 16) != 0xa9fe &&
+           (host_order >> 20) != 0xac1 && (host_order >> 16) != 0xc0a8 &&
+           (host_order >> 22) != 0x0191;
+}
+
+static void network_profile(LmbMachineProfile *profile) {
+    struct ifaddrs *all = NULL;
+    if (getifaddrs(&all)) return;
+    for (struct ifaddrs *it = all; it; it = it->ifa_next) {
+        if (!it->ifa_addr || !(it->ifa_flags & IFF_UP) ||
+            (it->ifa_flags & IFF_LOOPBACK)) continue;
+        if (it->ifa_addr->sa_family == AF_INET) {
+            profile->network_interfaces++;
+            uint32_t ip = ntohl(((struct sockaddr_in *)it->ifa_addr)->sin_addr.s_addr);
+            if (public_address(ip)) profile->public_ipv4 = 1;
+        }
+    }
+    freeifaddrs(all);
+}
+
+static double monotonic_seconds(void) {
+    struct timespec time;
+    clock_gettime(CLOCK_MONOTONIC, &time);
+    return time.tv_sec + time.tv_nsec / 1e9;
+}
+
+int lmb_machine_probe(LmbMachineProfile *profile, const char *disk_path,
+                      const char *tracker) {
+    if (!profile) return -1;
+    memset(profile, 0, sizeof *profile);
+    struct utsname system;
+    if (!uname(&system)) {
+        snprintf(profile->hostname, sizeof profile->hostname, "%.63s", system.nodename);
+        snprintf(profile->os, sizeof profile->os, "%.20s %.42s",
+                 system.sysname, system.release);
+        snprintf(profile->arch, sizeof profile->arch, "%.31s", system.machine);
+    } else {
+        (void)gethostname(profile->hostname, sizeof profile->hostname);
+    }
+    cpu_profile(profile);
+    numa_profile(profile);
+    meminfo(&profile->ram_total_bytes, &profile->ram_available_bytes,
+            &profile->swap_total_bytes, &profile->swap_free_bytes);
+    gpu_profile(profile);
+    network_profile(profile);
+    struct statvfs disk;
+    if (!statvfs(disk_path && *disk_path ? disk_path : ".", &disk))
+        profile->disk_available_bytes = (uint64_t)disk.f_bavail * disk.f_frsize;
+    double loads[1];
+    if (getloadavg(loads, 1) == 1) profile->load_one = loads[0];
+    profile->tracker_rtt_ms = -1.0;
+    if (tracker && *tracker) {
+        double start = monotonic_seconds();
+        int fd = lmb_connect(tracker);
+        if (fd >= 0) {
+            profile->tracker_rtt_ms = (monotonic_seconds() - start) * 1000.0;
+            close(fd);
+        }
+    }
+    return 0;
+}
+
+static void json_string(FILE *out, const char *value) {
+    fputc('"', out);
+    for (; value && *value; value++) {
+        unsigned char c = (unsigned char)*value;
+        if (c == '"' || c == '\\') fprintf(out, "\\%c", c);
+        else if (c < 0x20) fprintf(out, "\\u%04x", c);
+        else fputc(c, out);
+    }
+    fputc('"', out);
+}
+
+void lmb_machine_print(FILE *out, const LmbMachineProfile *p, int json) {
+    if (json) {
+        fputs("{\"schema\":1,\"hostname\":", out); json_string(out, p->hostname);
+        fputs(",\"os\":", out); json_string(out, p->os);
+        fputs(",\"arch\":", out); json_string(out, p->arch);
+        fputs(",\"cpu\":{\"model\":", out); json_string(out, p->cpu_model);
+        fprintf(out, ",\"isa\":"); json_string(out, p->isa);
+        fprintf(out, ",\"logical\":%u,\"physical\":%u,\"numa\":%u}",
+                p->logical_cpus, p->physical_cores, p->numa_nodes);
+        fprintf(out, ",\"memory\":{\"total\":%llu,\"available\":%llu,"
+                "\"swap_total\":%llu,\"swap_free\":%llu}",
+                (unsigned long long)p->ram_total_bytes,
+                (unsigned long long)p->ram_available_bytes,
+                (unsigned long long)p->swap_total_bytes,
+                (unsigned long long)p->swap_free_bytes);
+        fprintf(out, ",\"gpu\":{\"count\":%u,\"vram_total\":%llu,"
+                "\"vram_available\":%llu}", p->gpu_count,
+                (unsigned long long)p->vram_total_bytes,
+                (unsigned long long)p->vram_available_bytes);
+        fprintf(out, ",\"disk_available\":%llu,\"network\":{\"interfaces\":%u,"
+                "\"public_ipv4\":%s,\"tracker_rtt_ms\":%.3f},\"load1\":%.3f}\n",
+                (unsigned long long)p->disk_available_bytes,
+                p->network_interfaces, p->public_ipv4 ? "true" : "false",
+                p->tracker_rtt_ms, p->load_one);
+        return;
+    }
+    fprintf(out, "machine %s · %s · %s\n", p->hostname, p->os, p->arch);
+    fprintf(out, "CPU     %s · %u physical/%u logical · %s · %u NUMA\n",
+            p->cpu_model[0] ? p->cpu_model : "unknown", p->physical_cores,
+            p->logical_cpus, p->isa, p->numa_nodes);
+    fprintf(out, "RAM     %.1f/%.1f GB available · swap %.1f/%.1f GB free\n",
+            p->ram_available_bytes / 1e9, p->ram_total_bytes / 1e9,
+            p->swap_free_bytes / 1e9, p->swap_total_bytes / 1e9);
+    fprintf(out, "GPU     %u device(s) · %.1f/%.1f GB VRAM visible\n",
+            p->gpu_count, p->vram_available_bytes / 1e9, p->vram_total_bytes / 1e9);
+    fprintf(out, "disk    %.1f GB available · network %u interface(s) · public IPv4 %s",
+            p->disk_available_bytes / 1e9, p->network_interfaces,
+            p->public_ipv4 ? "yes" : "no");
+    if (p->tracker_rtt_ms >= 0) fprintf(out, " · tracker %.2f ms", p->tracker_rtt_ms);
+    fprintf(out, "\nload    %.2f (one minute)\n", p->load_one);
+}
+
+static int state_path(char *path, size_t cap) {
+    const char *forced = getenv("LUMABRI_GOVERNOR_FILE");
+    if (forced && *forced) return snprintf(path, cap, "%s", forced) >= (int)cap ? -1 : 0;
+    const char *home = getenv("HOME");
+    if (!home || !*home) return -1;
+    return snprintf(path, cap, "%s/.lumabri/governor.state", home) >= (int)cap ? -1 : 0;
+}
+
+int lmb_governor_manual_paused(void) {
+    char path[1024], value[32] = "";
+    if (state_path(path, sizeof path)) return 0;
+    FILE *file = fopen(path, "r");
+    if (!file) return 0;
+    if (!fgets(value, sizeof value, file)) value[0] = 0;
+    fclose(file);
+    return !strncmp(value, "paused", 6);
+}
+
+int lmb_governor_set_manual(int paused) {
+    char path[1024], dir[1024], temporary[1100];
+    if (state_path(path, sizeof path)) return -1;
+    snprintf(dir, sizeof dir, "%s", path);
+    char *slash = strrchr(dir, '/');
+    if (!slash) return -1;
+    *slash = 0;
+    if (mkdir(dir, 0700) && errno != EEXIST) return -1;
+    if (snprintf(temporary, sizeof temporary, "%s.tmp.%ld", path, (long)getpid()) >=
+        (int)sizeof temporary) return -1;
+    int fd = open(temporary, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, 0600);
+    if (fd < 0) return -1;
+    const char *text = paused ? "paused\n" : "active\n";
+    size_t length = strlen(text), offset = 0;
+    while (offset < length) {
+        ssize_t n = write(fd, text + offset, length - offset);
+        if (n <= 0) { int e = errno; close(fd); unlink(temporary); errno = e; return -1; }
+        offset += (size_t)n;
+    }
+    int bad = fsync(fd);
+    int saved = errno;
+    if (close(fd) && !bad) { bad = 1; saved = errno; }
+    if (!bad && rename(temporary, path)) { bad = 1; saved = errno; }
+    if (bad) { unlink(temporary); errno = saved; return -1; }
+    return 0;
+}
+
+const char *lmb_governor_state_name(LmbGovernorState state) {
+    switch (state) {
+        case LMB_GOV_ACTIVE: return "ACTIVE";
+        case LMB_GOV_PRESSURE: return "PRESSURE";
+        case LMB_GOV_PAUSED: return "PAUSED";
+        case LMB_GOV_RECOVERY: return "RECOVERY";
+    }
+    return "UNKNOWN";
+}
+
+void lmb_governor_init(LmbGovernor *governor, uint64_t reserve) {
+    memset(governor, 0, sizeof *governor);
+    governor->ram_reserve_bytes = reserve;
+    atomic_store(&governor->state,
+                 lmb_governor_manual_paused() ? LMB_GOV_PAUSED : LMB_GOV_ACTIVE);
+}
+
+LmbGovernorState lmb_governor_state(const LmbGovernor *governor) {
+    return (LmbGovernorState)atomic_load(&governor->state);
+}
+
+int lmb_governor_accepting(const LmbGovernor *governor) {
+    return lmb_governor_state(governor) == LMB_GOV_ACTIVE;
+}
+
+LmbGovernorState lmb_governor_poll(LmbGovernor *governor) {
+    LmbGovernorState previous = lmb_governor_state(governor), next;
+    if (lmb_governor_manual_paused()) {
+        next = LMB_GOV_PAUSED;
+        governor->recovery_ticks = 0;
+    } else {
+        uint64_t available = 0, swap_total = 0, swap_free = 0;
+        meminfo(NULL, &available, &swap_total, &swap_free);
+        int critical = available && available < governor->ram_reserve_bytes / 2;
+        if (swap_total && swap_free < swap_total / 20 &&
+            available < governor->ram_reserve_bytes) critical = 1;
+        if (critical) {
+            next = LMB_GOV_PAUSED;
+            governor->recovery_ticks = 0;
+        } else if (available && available < governor->ram_reserve_bytes) {
+            next = LMB_GOV_PRESSURE;
+            governor->recovery_ticks = 0;
+        } else if (previous != LMB_GOV_ACTIVE) {
+            next = ++governor->recovery_ticks >= 3 ?
+                   LMB_GOV_ACTIVE : LMB_GOV_RECOVERY;
+        } else {
+            next = LMB_GOV_ACTIVE;
+        }
+    }
+    atomic_store(&governor->state, next);
+    return next;
+}

--- a/lumabri_machine.h
+++ b/lumabri_machine.h
@@ -1,0 +1,58 @@
+#ifndef LUMABRI_MACHINE_H
+#define LUMABRI_MACHINE_H
+
+#include <stdatomic.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct {
+    char hostname[64];
+    char os[64];
+    char arch[32];
+    char cpu_model[128];
+    char isa[32];
+    uint32_t logical_cpus;
+    uint32_t physical_cores;
+    uint32_t numa_nodes;
+    uint64_t ram_total_bytes;
+    uint64_t ram_available_bytes;
+    uint64_t swap_total_bytes;
+    uint64_t swap_free_bytes;
+    uint32_t gpu_count;
+    uint64_t vram_total_bytes;
+    uint64_t vram_available_bytes;
+    uint64_t disk_available_bytes;
+    uint32_t network_interfaces;
+    uint32_t public_ipv4;
+    double load_one;
+    double tracker_rtt_ms;
+} LmbMachineProfile;
+
+typedef enum {
+    LMB_GOV_ACTIVE = 0,
+    LMB_GOV_PRESSURE = 1,
+    LMB_GOV_PAUSED = 2,
+    LMB_GOV_RECOVERY = 3,
+} LmbGovernorState;
+
+typedef struct {
+    uint64_t ram_reserve_bytes;
+    unsigned recovery_ticks;
+    _Atomic int state;
+} LmbGovernor;
+
+int lmb_machine_probe(LmbMachineProfile *profile, const char *disk_path,
+                      const char *tracker);
+void lmb_machine_print(FILE *out, const LmbMachineProfile *profile, int json);
+uint64_t lmb_machine_available_ram(void);
+uint64_t lmb_machine_total_ram(void);
+const char *lmb_governor_state_name(LmbGovernorState state);
+void lmb_governor_init(LmbGovernor *governor, uint64_t ram_reserve_bytes);
+LmbGovernorState lmb_governor_poll(LmbGovernor *governor);
+LmbGovernorState lmb_governor_state(const LmbGovernor *governor);
+int lmb_governor_accepting(const LmbGovernor *governor);
+int lmb_governor_set_manual(int paused);
+int lmb_governor_manual_paused(void);
+
+#endif

--- a/machine_governor_test.sh
+++ b/machine_governor_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+PORT=${PORT:-7900}
+TMP=$(mktemp -d /tmp/lumabri-governor.XXXXXX)
+PIDS=()
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; wait "${PIDS[@]}" 2>/dev/null || true; rm -rf "$TMP"; }
+trap cleanup EXIT
+wait_port() {
+    for _ in $(seq 1 240); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null &&
+            { exec 3<&-; exec 3>&-; return 0; }
+        sleep .05
+    done
+    return 1
+}
+
+export LUMABRI_GOVERNOR_FILE="$TMP/governor.state"
+./test_machine
+./lumabri machine --json >"$TMP/machine.json"
+python3 - "$TMP/machine.json" <<'PY'
+import json,sys
+p=json.load(open(sys.argv[1], encoding='utf-8'))
+assert p['schema']==1 and p['cpu']['physical']>0
+assert p['memory']['total']>p['memory']['available']>0
+assert p['gpu']['count']>=0 and p['disk_available']>0
+PY
+
+LUMABRI_PEER_KEY="$TMP/tracker.key" ./tracker --port "$PORT" \
+    --peer-bindings "$TMP/bindings" >"$TMP/tracker.log" 2>&1 & PIDS+=("$!")
+wait_port "$PORT"
+LUMABRI_PEER_KEY="$TMP/expert.key" OMP_NUM_THREADS=1 ./expert_node \
+    --model tiny_olmoe --model-name governor-tiny --name governed-expert \
+    --port "$((PORT+1))" --advertise "127.0.0.1:$((PORT+1))" \
+    --tracker "127.0.0.1:$PORT" --layers 0 --resident --parallel 1 \
+    >"$TMP/expert.log" 2>&1 & PIDS+=("$!")
+wait_port "$((PORT+1))"
+root=$(printf '%064x' 201)
+tokenizer=$(printf '%064x' 202)
+LUMABRI_PEER_KEY="$TMP/segment.key" OMP_NUM_THREADS=1 ./segment_node \
+    --engine olmoe --model-dir tiny_olmoe --model governor-tiny \
+    --range 0:16 --port "$((PORT+2))" --advertise "127.0.0.1:$((PORT+2))" \
+    --tracker "127.0.0.1:$PORT" --name governed-segment \
+    --model-root "$root" --tokenizer-root "$tokenizer" --context 64 \
+    --max-rows 16 --sessions 1 --threads 1 >"$TMP/segment.log" 2>&1 & PIDS+=("$!")
+wait_port "$((PORT+2))"
+
+wait_state() {
+    local wanted=$1 count=$2
+    for _ in $(seq 1 240); do
+        ./swarm_probe --tracker "127.0.0.1:$PORT" --model governor-tiny \
+            >"$TMP/probe.json" || true
+        python3 - "$TMP/probe.json" "$wanted" "$count" 2>/dev/null <<'PY' && return 0 || true
+import json,sys
+rows=json.load(open(sys.argv[1], encoding='utf-8'))['peers']
+row=next((r for r in rows if r['name']=='governed-expert'), None)
+assert row and row['expert']['state']==int(sys.argv[2])
+assert row['expert']['count']==int(sys.argv[3])
+PY
+        sleep .1
+    done
+    cat "$TMP/expert.log" "$TMP/tracker.log" "$TMP/probe.json" >&2
+    return 1
+}
+
+wait_segment_flag() {
+    local draining=$1
+    for _ in $(seq 1 240); do
+        ./swarm_probe --tracker "127.0.0.1:$PORT" --model governor-tiny \
+            >"$TMP/probe.json" || true
+        python3 - "$TMP/probe.json" "$draining" 2>/dev/null <<'PY' && return 0 || true
+import json,sys
+rows=json.load(open(sys.argv[1], encoding='utf-8'))['peers']
+row=next((r for r in rows if r['name']=='governed-segment'), None)
+assert row
+assert bool(row['segment']['flags'] & 1)==bool(int(sys.argv[2]))
+PY
+        sleep .1
+    done
+    cat "$TMP/segment.log" "$TMP/probe.json" >&2
+    return 1
+}
+
+wait_state 5 8
+wait_segment_flag 0
+./lumabri pause >/dev/null
+wait_state 6 0
+wait_segment_flag 1
+./lumabri resume >/dev/null
+wait_state 5 8
+wait_segment_flag 0
+grep -q 'governor ACTIVE -> PAUSED' "$TMP/expert.log"
+grep -q 'governor PAUSED -> RECOVERY' "$TMP/expert.log"
+grep -q 'governor RECOVERY -> ACTIVE' "$TMP/expert.log"
+grep -q 'governor ACTIVE -> PAUSED' "$TMP/segment.log"
+grep -q 'governor PAUSED -> RECOVERY' "$TMP/segment.log"
+grep -q 'governor RECOVERY -> ACTIVE' "$TMP/segment.log"
+echo 'MACHINE GOVERNOR TEST: PASS (profile, Expert zero coverage, Segment drain, recovery)'

--- a/segment_node.c
+++ b/segment_node.c
@@ -4,6 +4,7 @@
 #include "lumabri_proto.h"
 #include "lumabri_segment.h"
 #include "lumabri_segment_discovery.h"
+#include "lumabri_machine.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 #include "segment_colibri.h"
@@ -72,6 +73,7 @@ typedef struct {
     uint64_t ram_reserve_bytes;
     uint64_t process_memory_limit_bytes;
     uint64_t session_memory_limit_bytes;
+    LmbGovernor governor;
     TrackerRegistration registration;
 } Node;
 
@@ -85,14 +87,8 @@ static uint64_t now_ms(void) {
 }
 
 static uint64_t available_memory_bytes(void) {
-    FILE *file = fopen("/proc/meminfo", "r");
-    if (!file) return UINT64_MAX; /* unknown must not make a healthy node lie */
-    char line[256];
-    unsigned long long kib = 0;
-    while (fgets(line, sizeof line, file))
-        if (sscanf(line, "MemAvailable: %llu kB", &kib) == 1) break;
-    fclose(file);
-    return kib ? (uint64_t)kib * 1024u : UINT64_MAX;
+    uint64_t available = lmb_machine_available_ram();
+    return available ? available : UINT64_MAX;
 }
 
 static uint64_t resident_memory_bytes(void) {
@@ -109,9 +105,36 @@ static uint64_t resident_memory_bytes(void) {
 static int memory_pressure(void *opaque) {
     Node *node = opaque;
     uint64_t rss = resident_memory_bytes();
-    return g_stop || available_memory_bytes() < node->ram_reserve_bytes ||
+    return g_stop || !lmb_governor_accepting(&node->governor) ||
+           available_memory_bytes() < node->ram_reserve_bytes ||
            (node->process_memory_limit_bytes && rss &&
             rss > node->process_memory_limit_bytes);
+}
+
+static void *governor_worker(void *opaque) {
+    Node *node = opaque;
+    LmbGovernorState previous = lmb_governor_state(&node->governor);
+    while (!g_stop && !node->registration.stop) {
+        LmbGovernorState state = lmb_governor_poll(&node->governor);
+        pthread_mutex_lock(&node->registration.lock);
+        if (state == LMB_GOV_ACTIVE)
+            node->registration.advert.flags &= ~LMB_SEG_ADVERT_DRAINING;
+        else
+            node->registration.advert.flags |= LMB_SEG_ADVERT_DRAINING;
+        pthread_mutex_unlock(&node->registration.lock);
+        if (state != previous) {
+            fprintf(stderr, "[segment-node %s] governor %s -> %s%s\n",
+                    node->advert.peer_name,
+                    lmb_governor_state_name(previous),
+                    lmb_governor_state_name(state),
+                    state == LMB_GOV_ACTIVE ? " · accepting sessions" :
+                                             " · draining and refusing new work");
+            previous = state;
+        }
+        for (int i = 0; i < 10 && !g_stop && !node->registration.stop; i++)
+            usleep(100000);
+    }
+    return NULL;
 }
 
 static void stop_handler(int sig) {
@@ -523,7 +546,8 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
             status = lmb_seg_table_open(node->table, &open, now_ms());
         } else if (!(slot = session_empty(node))) {
             status = LMB_SEG_STATUS_QUOTA;
-        } else if (available_memory_bytes() < node->ram_reserve_bytes) {
+        } else if (!lmb_governor_accepting(&node->governor) ||
+                   available_memory_bytes() < node->ram_reserve_bytes) {
             status = LMB_SEG_STATUS_QUOTA;
         } else {
             ColiSegmentSessionOptions options = {
@@ -1182,8 +1206,11 @@ int main(int argc, char **argv) {
     }
     uint64_t process_limit = (uint64_t)memory_limit_mb << 20;
     uint64_t available = available_memory_bytes();
+    const char *reserve_name = getenv("LUMABRI_SEGMENT_RAM_RESERVE_MB") ?
+                               "LUMABRI_SEGMENT_RAM_RESERVE_MB" :
+                               "LUMABRI_RAM_RESERVE_MB";
     uint64_t reserve = (uint64_t)lmb_env_int(
-        "LUMABRI_SEGMENT_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+        reserve_name, 4096, 256, 262144) << 20;
     if (!process_limit && available != UINT64_MAX && available > reserve)
         process_limit = available - reserve;
     if (process_limit && model_bytes && model_layers) {
@@ -1218,6 +1245,7 @@ int main(int argc, char **argv) {
     for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
         pthread_mutex_init(&node.sessions[i].lock, NULL);
     node.ram_reserve_bytes = reserve;
+    lmb_governor_init(&node.governor, reserve);
     node.process_memory_limit_bytes = process_limit;
     fprintf(stderr, "[segment-node] governor: %.1f GB RAM reserved for the "
                     "machine\n", (double)node.ram_reserve_bytes / 1e9);
@@ -1288,6 +1316,8 @@ int main(int argc, char **argv) {
     a->max_sessions = max_sessions;
     if (fallback) a->flags |= LMB_SEG_ADVERT_FALLBACK;
     if (relay_only) a->flags |= LMB_SEG_ADVERT_RELAY_ONLY;
+    if (!lmb_governor_accepting(&node.governor))
+        a->flags |= LMB_SEG_ADVERT_DRAINING;
     a->capabilities = node.cap.flags & LMB_SEG_CAP_KNOWN_MASK;
     /* Registration happens after engine_open, so this is measured resident
      * memory, not a model-size promise. A zero value remains valid on systems
@@ -1317,7 +1347,7 @@ int main(int argc, char **argv) {
     }
     g_listen_fd = lmb_listen((int)port);
     if (g_listen_fd < 0) { perror("segment listen"); return 1; }
-    pthread_t registration_thread, reaper_thread;
+    pthread_t registration_thread, reaper_thread, governor_thread;
     if (pthread_create(&registration_thread, NULL, registration_worker,
                        registration)) {
         fprintf(stderr, "cannot start tracker registration\n"); return 1;
@@ -1325,6 +1355,13 @@ int main(int argc, char **argv) {
     if (pthread_create(&reaper_thread, NULL, session_reaper, &node)) {
         fprintf(stderr, "cannot start session reaper\n");
         registration->stop = 1;
+        pthread_join(registration_thread, NULL);
+        return 1;
+    }
+    if (pthread_create(&governor_thread, NULL, governor_worker, &node)) {
+        fprintf(stderr, "cannot start resource governor\n");
+        g_stop = 1; registration->stop = 1;
+        pthread_join(reaper_thread, NULL);
         pthread_join(registration_thread, NULL);
         return 1;
     }
@@ -1351,6 +1388,7 @@ int main(int argc, char **argv) {
         pthread_detach(thread);
     }
     registration->stop = 1;
+    pthread_join(governor_thread, NULL);
     pthread_join(reaper_thread, NULL);
     pthread_join(registration_thread, NULL);
     pthread_mutex_lock(&node.connections_lock);

--- a/test_machine.c
+++ b/test_machine.c
@@ -1,0 +1,29 @@
+#include "lumabri_machine.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    LmbMachineProfile profile;
+    assert(lmb_machine_probe(&profile, ".", NULL) == 0);
+    assert(profile.logical_cpus > 0);
+    assert(profile.physical_cores > 0);
+    assert(profile.ram_total_bytes > 0);
+    assert(profile.ram_available_bytes > 0);
+
+    assert(lmb_governor_set_manual(0) == 0);
+    LmbGovernor governor;
+    lmb_governor_init(&governor, 1);
+    assert(lmb_governor_poll(&governor) == LMB_GOV_ACTIVE);
+    assert(lmb_governor_set_manual(1) == 0);
+    assert(lmb_governor_poll(&governor) == LMB_GOV_PAUSED);
+    assert(!lmb_governor_accepting(&governor));
+    assert(lmb_governor_set_manual(0) == 0);
+    assert(lmb_governor_poll(&governor) == LMB_GOV_RECOVERY);
+    assert(lmb_governor_poll(&governor) == LMB_GOV_RECOVERY);
+    assert(lmb_governor_poll(&governor) == LMB_GOV_ACTIVE);
+    assert(lmb_governor_accepting(&governor));
+    puts("MACHINE GOVERNOR UNIT: PASS (pause, hysteresis, recovery)");
+    return 0;
+}

--- a/tracker.c
+++ b/tracker.c
@@ -1070,11 +1070,15 @@ static int handle_epeers(int fd, LmbMsg *m) {
     uint32_t n = 0;
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert && g_peers[i].has_expert &&
+            g_peers[i].nexperts > 0 &&
+            g_peers[i].expert_state != LMB_EXPERT_STATE_DRAINING &&
             now - g_peers[i].expert_ts <= g_stale_s &&
             (!want[0] || !strcmp(g_peers[i].model, want))) n++;
     lmb_buf_u32(&b, n);
     for (int i = 0; i < MAX_PEERS; i++)
         if (g_peers[i].used && g_peers[i].is_expert && g_peers[i].has_expert &&
+            g_peers[i].nexperts > 0 &&
+            g_peers[i].expert_state != LMB_EXPERT_STATE_DRAINING &&
             now - g_peers[i].expert_ts <= g_stale_s &&
             (!want[0] || !strcmp(g_peers[i].model, want)))
             lmb_buf_str(&b, g_peers[i].addr);


### PR DESCRIPTION
Stacked PR 6 of 9. Do not merge before its parent PRs.\n\nProtects metrics A and B from host contention and makes donor capacity honest. Lumabri now profiles CPU/ISA, physical and logical cores, NUMA, RAM/swap, visible GPU/VRAM, disk, interfaces and optional tracker RTT. The JSON schema is available through lumabri machine --json; status, limits, pause and resume are user-facing controls.\n\nExpert and Segment executors share a hysteretic ACTIVE, PRESSURE, PAUSED, RECOVERY governor. Under pressure an Expert advertises zero coverage and refuses new EXEC while in-flight work drains. A Segment advertises draining, refuses new sessions and exposes cancellation to current runs so checkpoint/replay can migrate them. Three healthy samples are required before republishing. The common reserve is configurable, with per-role overrides.\n\nVerification: all standalone binaries and the universal six-family Segment archive build with Werror; full make test passed. The integration gate observed Expert ACTIVE 8 to DRAINING 0 to ACTIVE 8 and Segment non-draining to draining to non-draining against a live tracker. Colibri remains untouched.