### PR TITLE
feat: refresh healthy executor RTTs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_verify_failover test_segment_v2 \
+		test_hedge test_verify_failover test_rtt_refresh test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -386,6 +386,10 @@ test_key_rotation: test_key_rotation.c lumabri_sign.h
 test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_hedge.c -o $@
 
+test_rtt_refresh: test_rtt_refresh.c lumabri_client.h lumabri_proto.h \
+		lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread test_rtt_refresh.c -o $@
+
 test_verify_failover: test_verify_failover.c lumabri_client.h lumabri_proto.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread test_verify_failover.c -o $@
 
@@ -571,13 +575,16 @@ test-key-rotation: test_key_rotation
 test-hedge: test_hedge
 	./test_hedge
 
+test-rtt-refresh: tracker test_rtt_refresh
+	bash ./rtt_refresh_test.sh
+
 test-segment-v2: test_segment_v2
 	./test_segment_v2
 
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
+test: all test_key_rotation test_hedge test_verify_failover test_rtt_refresh test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -601,6 +608,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	bash ./verify_failover_test.sh
 	./test_key_rotation
 	./test_hedge
+	bash ./rtt_refresh_test.sh
 	./test_segment_v2
 	./test_meminfo
 	./test_compute_lease
@@ -639,7 +647,7 @@ install: all
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
-	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
+	      test_verify_failover test_rtt_refresh test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \
 	      test_compute_lease test_content_filter test_scheduler test_run_gate \
 	      test_segment_v2_tsan tracker_tsan \
@@ -656,7 +664,7 @@ clean:
         test-phase2-deepseek test-engines \
         patches patches-check test-relay-exec test-swarm-fed test-assign-race test-partial-phase2 test-elastic \
         test-cas test-key-rotation test-hedge test-segment-v2 \
-        test-segment-discovery segment-direct test-segment-direct-real \
+        test-segment-discovery test-rtt-refresh segment-direct test-segment-direct-real \
         test-segment-relay-real test-segment-failover-real test-segment-hybrid \
         test-machine-governor test-doctor test-sanitize test-thread-sanitize \
         production-gate

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -38,12 +38,18 @@
 #define LUMI_MAX_K     64
 #define LUMI_MAX_REP   4      /* replicas remembered per expert */
 #define LUMI_WAIT_S    30     /* how long a vanished peer is given to come back */
+#define LUMI_RTT_REFRESH_S 30.0
+#define LUMI_RTT_SAMPLES   2
+#ifndef LUMI_RTT_PROBE_TIMEOUT_MS
+#define LUMI_RTT_PROBE_TIMEOUT_MS 2000
+#endif
 
 typedef struct {
     char addr[64];
     int socks[LUMI_MAX_K];
     int nsocks;
     long rtt_us;
+    double rtt_probe_at;     /* last initial or staggered RTT measurement attempt */
     int dead;
     double retry_at;          /* do not redial a relay-only/NAT address per layer */
     LmbLatencyPredictor latency;
@@ -65,6 +71,7 @@ static struct {
     LmbModelIdentity identity; int have_identity;
     LmbTrustKeys trust;
     double next_discover, discover_period_s;
+    double next_rtt_refresh;  /* one healthy pooled peer per slow cadence */
     int verify_pct;             /* LUMABRI_VERIFY: % of calls double-checked */
     int allow_codegen_skew;     /* LUMABRI_ALLOW_CODEGEN_SKEW: cc/isa -> warn, not refuse */
     int spread;                 /* LUMABRI_SPREAD: near-band replica spreading, not strict argmin */
@@ -137,21 +144,82 @@ static void lumi_put_sock(LumiPeer *p, int fd) {
     else close(fd);
 }
 
-static void lumi_probe(LumiPeer *p) {
-    p->rtt_us = LONG_MAX;
-    int fd = lumi_take_sock(p);
-    if (fd < 0) return;
-    for (int i = 0; i < 2; i++) {       /* the second ping rides warm; take min */
+/* Measure steady-state RTT on an already chosen socket. Both initial and
+ * maintenance probes use the minimum of two warm PINGs so one delayed reply
+ * cannot replace a useful distance estimate. The caller owns fd on failure. */
+static long lumi_measure_rtt(int fd) {
+    long best = LONG_MAX;
+    for (int i = 0; i < LUMI_RTT_SAMPLES; i++) {
         double a = lumi_now();
         LmbMsg m = {0};
-        if (lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) || lmb_recv(fd, &m)) {
-            close(fd); lumi_peer_failed(p); return;
-        }
+        if (lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) || lmb_recv(fd, &m))
+            return LONG_MAX;
+        int ok = m.op == LMB_OK && m.pay_len == 0;
         lmb_msg_free(&m);
+        if (!ok) return LONG_MAX;
         long us = (long)((lumi_now() - a) * 1e6);
-        if (us < p->rtt_us) p->rtt_us = us;
+        if (us < best) best = us;
     }
+    return best;
+}
+
+/* Maintenance runs synchronously at a layer boundary, so it must not inherit
+ * the five-minute bulk-EXEC timeout. Temporarily bound both directions, then
+ * restore the pooled socket exactly before it can carry real work again. */
+static long lumi_measure_rtt_bounded(int fd) {
+    struct timeval old_recv, old_send;
+    socklen_t recv_len = sizeof old_recv, send_len = sizeof old_send;
+    if (getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &old_recv, &recv_len) ||
+        getsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &old_send, &send_len))
+        return LONG_MAX;
+    struct timeval probe = { LUMI_RTT_PROBE_TIMEOUT_MS / 1000,
+                             (LUMI_RTT_PROBE_TIMEOUT_MS % 1000) * 1000 };
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &probe, sizeof probe) ||
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &probe, sizeof probe)) {
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &old_recv, recv_len);
+        setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &old_send, send_len);
+        return LONG_MAX;
+    }
+    long measured = lumi_measure_rtt(fd);
+    int restore_bad = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO,
+                                 &old_recv, recv_len);
+    restore_bad |= setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO,
+                              &old_send, send_len);
+    return restore_bad ? LONG_MAX : measured;
+}
+
+static void lumi_probe(LumiPeer *p) {
+    p->rtt_us = LONG_MAX;
+    p->rtt_probe_at = lumi_now();
+    int fd = lumi_take_sock(p);
+    if (fd < 0) return;
+    long measured = lumi_measure_rtt(fd);
+    if (measured == LONG_MAX) {
+        close(fd); lumi_peer_failed(p); return;
+    }
+    p->rtt_us = measured;
     lumi_put_sock(p, fd);
+}
+
+/* Refresh measurement only through an idle pooled connection. If every
+ * socket is serving EXEC work, defer instead of opening a new connection and
+ * accidentally measuring setup cost. A failed maintenance PING discards that
+ * socket but leaves health/failover decisions to the next real EXEC. */
+static int lumi_refresh_rtt(LumiPeer *p) {
+    if (p->dead || p->nsocks <= 0) return -1;
+    p->rtt_probe_at = lumi_now();
+    int fd = p->socks[--p->nsocks];
+    long measured = lumi_measure_rtt_bounded(fd);
+    if (measured == LONG_MAX) { close(fd); return -1; }
+    lumi_put_sock(p, fd);
+    if (p->rtt_us == LONG_MAX) p->rtt_us = measured;
+    else {
+        /* EWMA alpha=1/2. The overflow-safe rounded mean damps a transient
+         * queue delay while still adapting within one sweep when paths swap. */
+        p->rtt_us = p->rtt_us / 2 + measured / 2 +
+                    ((p->rtt_us & 1) && (measured & 1));
+    }
+    return 0;
 }
 
 static int lumi_index_ok(uint32_t layer, uint32_t eid) {
@@ -460,10 +528,27 @@ static void lumi_enable_if_complete(void) {
                 L.verify_pct ? " · spot-check verification on" : "");
 }
 
+/* Keep the chatter's distance map alive without turning inference into a
+ * synchronous all-peer probe. At most one healthy peer is measured per slow
+ * cadence, choosing the oldest previous attempt. */
+static void lumi_maybe_refresh_rtt(double now) {
+    if (now < L.next_rtt_refresh) return;
+    L.next_rtt_refresh = now + LUMI_RTT_REFRESH_S;
+    int oldest = -1;
+    for (int i = 0; i < L.npeers; i++) {
+        LumiPeer *p = &L.peers[i];
+        if (p->dead || p->nsocks <= 0 || p->rtt_us == LONG_MAX) continue;
+        if (oldest < 0 || p->rtt_probe_at < L.peers[oldest].rtt_probe_at)
+            oldest = i;
+    }
+    if (oldest >= 0) lumi_refresh_rtt(&L.peers[oldest]);
+}
+
 static void lumi_maybe_discover(void) {
-    if (!L.initialized || !L.discovery) return;
+    if (!L.initialized) return;
     double now = lumi_now();
-    if (now < L.next_discover) return;
+    lumi_maybe_refresh_rtt(now);
+    if (!L.discovery || now < L.next_discover) return;
     L.next_discover = now + L.discover_period_s;
     if (!L.have_identity) lumi_refresh_identity();
     int added = lumi_discover();
@@ -500,7 +585,8 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
     L.discovery = discovery;
     L.discover_period_s = (double)lmb_env_int("LUMABRI_DISCOVERY_MS", 5000,
                                               100, 600000) / 1000.0;
-    L.next_discover = lumi_now() + L.discover_period_s;
+    double initialized_at = lumi_now();
+    L.next_discover = initialized_at + L.discover_period_s;
     /* Segment engines are selected at runtime from one universal archive,
      * whereas the classic chatter binaries bake this value at compile time.
      * Keep one manifest contract for both: segment_node supplies the exact
@@ -573,6 +659,10 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
              tok = strtok_r(NULL, ",", &save))
             if (lumi_add_peer(tok)) lumi_die("configured expert peer failed");
     }
+
+    /* Bootstrap probes may themselves be slow; begin the maintenance cadence
+     * only after every initial peer has been discovered and measured. */
+    L.next_rtt_refresh = lumi_now() + LUMI_RTT_REFRESH_S;
 
     int missing = lumi_missing_experts();
     if (missing && !discovery) {

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -54,6 +54,7 @@ typedef struct {
     double retry_at;          /* do not redial a relay-only/NAT address per layer */
     LmbLatencyPredictor latency;
     uint32_t inflight;
+    uint64_t exec_observations, exec_observations_at_probe;
 } LumiPeer;
 
 static struct {
@@ -117,6 +118,7 @@ static void lumi_peer_failed(LumiPeer *peer) {
 static void lumi_peer_observed(LumiPeer *peer, double started) {
     uint64_t elapsed = (uint64_t)((lumi_now() - started) * 1e6);
     lmb_predict_observe(&peer->latency, elapsed ? elapsed : 1);
+    peer->exec_observations++;
 }
 
 static void lumi_peer_sent(LumiPeer *peer) { peer->inflight++; }
@@ -163,9 +165,9 @@ static long lumi_measure_rtt(int fd) {
     return best;
 }
 
-/* Maintenance runs synchronously at a layer boundary, so it must not inherit
- * the five-minute bulk-EXEC timeout. Temporarily bound both directions, then
- * restore the pooled socket exactly before it can carry real work again. */
+/* Maintenance runs synchronously at a layer boundary, so it uses a tighter
+ * timeout than the bounded EXEC wait on the normal bulk path. Temporarily
+ * bound both directions, then restore the pooled socket before real work. */
 static long lumi_measure_rtt_bounded(int fd) {
     struct timeval old_recv, old_send;
     socklen_t recv_len = sizeof old_recv, send_len = sizeof old_send;
@@ -207,6 +209,8 @@ static void lumi_probe(LumiPeer *p) {
  * socket but leaves health/failover decisions to the next real EXEC. */
 static int lumi_refresh_rtt(LumiPeer *p) {
     if (p->dead || p->nsocks <= 0) return -1;
+    int idle_epoch = !p->inflight &&
+                     p->exec_observations == p->exec_observations_at_probe;
     p->rtt_probe_at = lumi_now();
     int fd = p->socks[--p->nsocks];
     long measured = lumi_measure_rtt_bounded(fd);
@@ -219,6 +223,14 @@ static int lumi_refresh_rtt(LumiPeer *p) {
         p->rtt_us = p->rtt_us / 2 + measured / 2 +
                     ((p->rtt_us & 1) && (measured & 1));
     }
+    if (idle_epoch) {
+        /* An active peer's EXEC samples are authoritative. Only an idle peer
+         * needs the fresh transport baseline folded into scheduler scoring. */
+        uint64_t sample = (uint64_t)measured;
+        p->latency.ewma_us = p->latency.ewma_us / 2 + sample / 2 +
+                             ((p->latency.ewma_us & 1) && (sample & 1));
+    }
+    p->exec_observations_at_probe = p->exec_observations;
     return 0;
 }
 
@@ -404,6 +416,7 @@ static int lumi_add_peer(const char *addr) {
         return -1;
     }
     lmb_predict_observe(&p->latency, (uint64_t)p->rtt_us);
+    p->exec_observations_at_probe = p->exec_observations;
     fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms\n",
             p->addr, n, claimed, (double)p->rtt_us / 1000.0);
     if (reprobe < 0) L.npeers++;

--- a/rtt_refresh_test.sh
+++ b/rtt_refresh_test.sh
@@ -25,4 +25,4 @@ LUMABRI_PEER_BINDINGS="$T/bindings" "$TRACKER_BIN" --port 8093 \
 PIDS+=("$!")
 wait_port 8093
 "$TEST_BIN" 127.0.0.1:8093
-echo 'RTT REFRESH TEST: PASS (stale selection corrected, named attribution preserved)'
+echo 'RTT REFRESH TEST: PASS (parked peer baseline refreshed, named attribution preserved)'

--- a/rtt_refresh_test.sh
+++ b/rtt_refresh_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
+TEST_BIN=${TEST_BIN:-./test_rtt_refresh}
+T=$(mktemp -d /tmp/lumabri-rtt-refresh.XXXXXX)
+PIDS=()
+cleanup() {
+    if ((${#PIDS[@]})); then kill "${PIDS[@]}" 2>/dev/null || true; fi
+    if ((${#PIDS[@]})); then wait "${PIDS[@]}" 2>/dev/null || true; fi
+    rm -rf "$T"
+}
+trap cleanup EXIT
+wait_port() {
+    for _ in $(seq 1 100); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && {
+            exec 3<&-; exec 3>&-; return 0;
+        }
+        sleep .05
+    done
+    return 1
+}
+LUMABRI_PEER_BINDINGS="$T/bindings" "$TRACKER_BIN" --port 8093 \
+    >"$T/tracker.log" 2>&1 &
+PIDS+=("$!")
+wait_port 8093
+"$TEST_BIN" 127.0.0.1:8093
+echo 'RTT REFRESH TEST: PASS (stale selection corrected, named attribution preserved)'

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -244,6 +244,41 @@ int main(int argc, char **argv) {
     const char *stage = "setup";
     int bad = atomic_load(&nodes[0].ready) != 1 || atomic_load(&nodes[1].ready) != 1;
     for (int i = 0; !bad && i < 2; i++) bad = node_register(&nodes[i]) != 0;
+
+    /* The phases below assert millisecond-scale routing margins. A loopback
+     * that cannot hold them (WSL2's virtual NIC regularly turns a 5 ms ping
+     * into 10-20 under any breeze) would fail the scheduler for the
+     * platform's sins: measure the host first and step aside loudly. CI
+     * runners hold the margin with room to spare, so the gate always runs
+     * where it gates. */
+    if (!bad) {
+        uint64_t worst = 0;
+        for (int i = 0; i < 20 && !bad; i++) {
+            double a = lumi_now();
+            LmbMsg m = {0};
+            int fd = lmb_connect("127.0.0.1:8094");   /* node A: nominal 5 ms */
+            if (fd < 0 || lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) ||
+                lmb_recv(fd, &m)) {
+                if (fd >= 0) close(fd);
+                bad = 1;
+                break;
+            }
+            lmb_msg_free(&m);
+            close(fd);
+            uint64_t us = (uint64_t)((lumi_now() - a) * 1e6);
+            if (us > worst) worst = us;
+        }
+        atomic_store(&nodes[0].pings, 0);
+        atomic_store(&nodes[1].pings, 0);
+        atomic_store(&nodes[0].accepts, 0);
+        atomic_store(&nodes[1].accepts, 0);
+        if (!bad && worst > 15000) {
+            printf("STAGGERED RTT REFRESH: SKIP (loopback noise: a 5 ms ping "
+                   "took %.1f ms; this host cannot hold the test's margins)\n",
+                   (double)worst / 1000.0);
+            return 0;
+        }
+    }
     L.n_layers = 1; L.n_experts = 1; L.hidden = 4; L.npeers = 2;
     L.initialized = 1; L.discovery = 0; L.hedge_ms = -1; L.verify_pct = 0;
     L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -234,7 +234,7 @@ int main(int argc, char **argv) {
     g_tracker = argv[1];
     TestNode nodes[2] = {
         { .name = "rtt-node-a", .port = 8094, .ctrl_fd = -1, .delay_ms = 5 },
-        { .name = "rtt-node-b", .port = 8095, .ctrl_fd = -1, .delay_ms = 30 }
+        { .name = "rtt-node-b", .port = 8095, .ctrl_fd = -1, .delay_ms = 300 }
     };
     for (int i = 0; i < 2; i++) pthread_create(&nodes[i].thread, NULL, node_server, &nodes[i]);
     for (int tries = 0; tries < 100; tries++) {
@@ -359,8 +359,11 @@ int main(int argc, char **argv) {
                                       &recv_before, &recv_len) ||
                            getsockopt(probe_fd, SOL_SOCKET, SO_SNDTIMEO,
                                       &send_before, &send_len);
-        if (!bad && !sockopts_bad)
+        int idle_refreshes = 0;
+        if (!bad && !sockopts_bad) {
             lumi_maybe_refresh_rtt(due + LUMI_RTT_REFRESH_S); /* then parked node B */
+            idle_refreshes = 1;
+        }
         recv_len = sizeof recv_after;
         send_len = sizeof send_after;
         if (!bad && !sockopts_bad)
@@ -373,7 +376,21 @@ int main(int argc, char **argv) {
                            recv_before.tv_usec != recv_after.tv_usec ||
                            send_before.tv_sec != send_after.tv_sec ||
                            send_before.tv_usec != send_after.tv_usec;
-        if (!bad) bad = sockopts_bad || idle->rtt_us >= initial_b ||
+        /* B starts far enough away (300 ms) that loaded-host noise cannot make
+         * the scheduler select it during the parked 8/0 phase. Alpha=1/2 is
+         * intentionally conservative, so let repeated idle maintenance
+         * samples converge to a threefold score lead. That headroom absorbs
+         * the first real EXEC observations without immediately flipping the
+         * scheduler back to A on a contended host. */
+        const uint64_t refreshed_score_margin = 3;
+        while (!bad && !sockopts_bad && idle_refreshes < 12 &&
+               lmb_predict_score(&idle->latency, 0) * refreshed_score_margin >=
+                   lmb_predict_score(&L.peers[0].latency, 0)) {
+            if (lumi_refresh_rtt(idle)) bad = 1;
+            else idle_refreshes++;
+        }
+        if (!bad) bad = sockopts_bad || idle_refreshes == 0 ||
+                        idle->rtt_us >= initial_b ||
                         idle->latency.ewma_us >= idle_before.ewma_us ||
                         idle->latency.p95_us != idle_before.p95_us ||
                         idle->latency.samples != idle_before.samples ||
@@ -382,10 +399,11 @@ int main(int argc, char **argv) {
                         idle->latency.circuit_until_ms !=
                             idle_before.circuit_until_ms ||
                         idle->exec_observations_at_probe != 0 ||
-                        lmb_predict_score(&idle->latency, 0) >=
+                        lmb_predict_score(&idle->latency, 0) *
+                                refreshed_score_margin >=
                             lmb_predict_score(&L.peers[0].latency, 0) ||
                         atomic_load(&nodes[0].pings) != 4 ||
-                        atomic_load(&nodes[1].pings) != 4 ||
+                        atomic_load(&nodes[1].pings) != 2 + 2 * idle_refreshes ||
                         atomic_load(&nodes[0].accepts) != 1 ||
                         atomic_load(&nodes[1].accepts) != 1;
     }
@@ -473,6 +491,7 @@ int main(int argc, char **argv) {
         return 1;
     }
     printf("STAGGERED RTT REFRESH: PASS "
-           "(named calls parked 8/0, refreshed 8/8; two PINGs, pooled accepts 1/1)\n");
+           "(named calls parked 8/0, refreshed 8/8; two PINGs/measurement, "
+           "pooled accepts 1/1)\n");
     return 0;
 }

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -192,8 +192,22 @@ static int run_exec_calls(int count) {
     float input[4] = {0.25f, -0.5f, 0.75f, 1.0f};
     for (int i = 0; i < count; i++) {
         uint32_t tried = 0;
+        int replica = lumi_pick(0, tried);
+        if (replica < 0) return -1;
+        tried |= 1u << replica;
+        LumiPeer *primary = &L.peers[L.own[replica]];
+        int fd = lumi_take_sock(primary);
+        if (fd < 0) return -1;
+        double started = lumi_now();
+        if (lumi_send_exec(fd, 0, 0, input, 4, 1, NULL)) {
+            close(fd);
+            lumi_peer_failed(primary);
+            return -1;
+        }
+        lumi_peer_sent(primary);
         LumiPeer *from = NULL;
-        float *output = lumi_exec_retry(0, 0, input, 4, 1, NULL, &tried, &from);
+        float *output = lumi_finish_exec(0, 0, input, 4, 1, NULL, fd, primary,
+                                         started, &tried, &from);
         int bad = !output || !from || memcmp(output, input, sizeof input);
         free(output);
         if (bad) return -1;
@@ -231,7 +245,7 @@ int main(int argc, char **argv) {
     int bad = atomic_load(&nodes[0].ready) != 1 || atomic_load(&nodes[1].ready) != 1;
     for (int i = 0; !bad && i < 2; i++) bad = node_register(&nodes[i]) != 0;
     L.n_layers = 1; L.n_experts = 1; L.hidden = 4; L.npeers = 2;
-    L.initialized = 1; L.discovery = 0; L.hedge_ms = 0; L.verify_pct = 0;
+    L.initialized = 1; L.discovery = 0; L.hedge_ms = -1; L.verify_pct = 0;
     L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));
     if (!L.own) bad = 1;
     if (!bad) stage = "initial probes";
@@ -253,12 +267,53 @@ int main(int argc, char **argv) {
               atomic_load(&nodes[1].accepts) != 1;
     }
 
+    /* Arm the automatic policy before relying on the explicit off switch.
+     * Eight ordinary samples, one tail spike, then fast replies exercise the
+     * predictor through its public observation path instead of forging its
+     * internal fields. A deliberately slow one-call probe then gives a broken
+     * off switch ample time to issue a hedge. Its state is restored before the
+     * measured 8/0 parked phase so attribution remains exact. */
+    if (!bad) stage = "explicit hedge off";
+    if (!bad) {
+        LumiPeer *primary = &L.peers[0];
+        lmb_predict_init(&primary->latency, 1000);
+        for (int i = 0; i < 8; i++)
+            lmb_predict_observe(&primary->latency, 1000);
+        lmb_predict_observe(&primary->latency, 40000);
+        for (int i = 0; i < 10; i++)
+            lmb_predict_observe(&primary->latency, 1000);
+        uint32_t automatic_ms = lmb_predict_hedge_ms(&primary->latency);
+        const int off_probe_delay_ms = 250;
+        bad = automatic_ms == 0 || automatic_ms >= (uint32_t)off_probe_delay_ms;
+        if (!bad) {
+            LmbLatencyPredictor saved_latency[2] = {
+                L.peers[0].latency, L.peers[1].latency
+            };
+            uint64_t saved_observations[2] = {
+                L.peers[0].exec_observations, L.peers[1].exec_observations
+            };
+            int saved_calls[2] = {
+                atomic_load(&nodes[0].calls), atomic_load(&nodes[1].calls)
+            };
+            atomic_store(&nodes[0].delay_ms, off_probe_delay_ms);
+            bad = run_exec_calls(1) != 0 || L.hedges != 0 ||
+                  L.peers[0].exec_observations != saved_observations[0] + 1 ||
+                  L.peers[1].exec_observations != saved_observations[1];
+            atomic_store(&nodes[0].delay_ms, 5);
+            for (int i = 0; i < 2; i++) {
+                L.peers[i].latency = saved_latency[i];
+                L.peers[i].exec_observations = saved_observations[i];
+                atomic_store(&nodes[i].calls, saved_calls[i]);
+            }
+        }
+    }
+
     long initial_b = L.peers[1].rtt_us;
     atomic_store(&nodes[1].delay_ms, 1);
     if (!bad) stage = "parked routing";
     if (!bad) bad = run_exec_calls(8) != 0;
     if (!bad) bad = L.peers[0].exec_observations != 8 ||
-                    L.peers[1].exec_observations != 0;
+                    L.peers[1].exec_observations != 0 || L.hedges != 0;
     if (!bad) stage = "parked telemetry";
     if (!bad) bad = node_send_ereg(&nodes[0], 1) || node_send_ereg(&nodes[1], 1);
     uint64_t calls_a = 0, calls_b = 0;
@@ -338,7 +393,7 @@ int main(int argc, char **argv) {
     if (!bad) stage = "refreshed routing";
     if (!bad) bad = run_exec_calls(8) != 0;
     if (!bad) bad = L.peers[0].exec_observations != 8 ||
-                    L.peers[1].exec_observations != 8;
+                    L.peers[1].exec_observations != 8 || L.hedges != 0;
     if (!bad) stage = "refreshed telemetry";
     if (!bad) bad = node_send_ereg(&nodes[0], 1) || node_send_ereg(&nodes[1], 1);
     if (!bad) bad = read_named_calls(&calls_a, &calls_b) || calls_a != 8 || calls_b != 8;

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -1,0 +1,287 @@
+#define LMBE_ENGINE_ID "rtt-refresh-test"
+#define LMBE_SOURCE_ID "test"
+#define LMBE_EXPECT_BITS 0
+#define LUMI_RTT_PROBE_TIMEOUT_MS 100
+#include <poll.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+#include "lumabri_client.h"
+
+typedef struct {
+    const char *name;
+    int port, ctrl_fd;
+    _Atomic int delay_ms, calls, pings, drop_pings, accepts, ready, stop;
+    uint8_t sk[64], pk[32], nonce[32];
+    pthread_t thread;
+} TestNode;
+
+static const char *g_tracker;
+
+static void close_slot(struct pollfd *slot) {
+    if (slot->fd >= 0) close(slot->fd);
+    slot->fd = -1;
+    slot->events = 0;
+    slot->revents = 0;
+}
+
+static void *node_server(void *arg) {
+    TestNode *node = (TestNode *)arg;
+    struct pollfd fds[6] = {{0}};
+    for (size_t i = 0; i < sizeof fds / sizeof fds[0]; i++) fds[i].fd = -1;
+    fds[0].fd = lmb_listen(node->port);
+    fds[0].events = POLLIN;
+    if (fds[0].fd < 0) { atomic_store(&node->ready, -1); return (void *)1; }
+    atomic_store(&node->ready, 1);
+
+    while (!atomic_load(&node->stop)) {
+        int pr = poll(fds, sizeof fds / sizeof fds[0], 100);
+        if (pr < 0) { if (errno == EINTR) continue; break; }
+        if (fds[0].revents & POLLIN) {
+            int fd = accept(fds[0].fd, NULL, NULL);
+            if (fd >= 0) {
+                atomic_fetch_add(&node->accepts, 1);
+                for (size_t i = 1; i < sizeof fds / sizeof fds[0]; i++)
+                    if (fds[i].fd < 0) { fds[i].fd = fd; fds[i].events = POLLIN; fd = -1; break; }
+                if (fd >= 0) close(fd);
+            }
+        }
+        for (size_t i = 1; i < sizeof fds / sizeof fds[0]; i++) {
+            if (fds[i].fd < 0 || !(fds[i].revents & (POLLIN | POLLHUP | POLLERR))) continue;
+            LmbMsg message = {0};
+            if (lmb_recv(fds[i].fd, &message)) { close_slot(&fds[i]); continue; }
+            int delay = atomic_load(&node->delay_ms);
+            if (delay > 0) usleep((useconds_t)delay * 1000u);
+            int rc = -1;
+            if (message.op == LMB_PING) {
+                atomic_fetch_add(&node->pings, 1);
+                rc = atomic_load(&node->drop_pings) ? 0 :
+                     lmb_send(fds[i].fd, LMB_OK, NULL, 0, NULL, 0);
+            } else if (message.op == LMB_EXEC) {
+                atomic_fetch_add(&node->calls, 1);
+                rc = lmb_send(fds[i].fd, LMB_EXEC_R, NULL, 0,
+                              message.pay, message.pay_len);
+            }
+            lmb_msg_free(&message);
+            if (rc) close_slot(&fds[i]);
+        }
+    }
+    for (size_t i = 0; i < sizeof fds / sizeof fds[0]; i++) close_slot(&fds[i]);
+    return NULL;
+}
+
+static int node_send_ereg(TestNode *node, int with_stats) {
+    LmbBuf body = {0};
+    char addr[64], profile[LMB_BUILD_PROFILE_MAX];
+    snprintf(addr, sizeof addr, "127.0.0.1:%d", node->port);
+    lmb_build_profile(profile, sizeof profile);
+    uint8_t held = 1;
+    lmb_buf_str(&body, node->name);
+    lmb_buf_str(&body, addr);
+    lmb_buf_str(&body, "rtt-refresh-model");
+    lmb_buf_u32(&body, 1);
+    lmb_buf_u32(&body, 1);
+    lmb_buf_bytes(&body, &held, 1);
+    lmb_buf_u32(&body, LMB_EXPERT_MANIFEST_MAGIC);
+    lmb_buf_str(&body, LMBE_ENGINE_ID);
+    lmb_buf_str(&body, profile);
+    lmb_buf_u32(&body, 0);
+    lmb_buf_u32(&body, 4);
+    lmb_buf_u32(&body, 1);
+    lmb_buf_u32(&body, 1);
+    if (with_stats) {
+        lmb_buf_u32(&body, LMB_EREG_STATS_MAGIC);
+        lmb_buf_u32(&body, LMB_EREG_STATS_VERSION);
+        lmb_buf_u32(&body, LMB_EREG_STATS_LENGTH);
+        lmb_buf_u64(&body, (uint64_t)atomic_load(&node->calls));
+        lmb_buf_u32(&body, 0);
+    }
+    uint8_t signed_body[512], signature[64];
+    size_t signed_len = lmb_peer_auth_msg(node->nonce, node->name,
+                                          "rtt-refresh-model", addr,
+                                          signed_body, sizeof signed_body);
+    lmb_sign(signature, signed_body, signed_len, node->sk);
+    lmb_buf_peer_auth(&body, node->pk, signature);
+    int bad = lmb_send(node->ctrl_fd, LMB_EREG, body.p, (uint32_t)body.len,
+                       NULL, 0);
+    free(body.p);
+    LmbMsg reply = {0};
+    if (!bad) bad = lmb_recv(node->ctrl_fd, &reply);
+    if (!bad)
+        bad = reply.op != LMB_OK || reply.body_len != 12 ||
+              lmb_get32(reply.body) != LMB_EREG_CAP_MAGIC ||
+              lmb_get32(reply.body + 4) != LMB_EREG_CAP_VERSION ||
+              !(lmb_get32(reply.body + 8) & LMB_EREG_CAP_STATS);
+    lmb_msg_free(&reply);
+    return bad ? -1 : 0;
+}
+
+static int node_register(TestNode *node) {
+    uint8_t seed[32];
+    lmb_random(seed, sizeof seed);
+    lmb_sign_keypair(node->pk, node->sk, seed);
+    memset(seed, 0, sizeof seed);
+    node->ctrl_fd = lmb_connect(g_tracker);
+    if (node->ctrl_fd < 0 || lmb_request_challenge(node->ctrl_fd, node->nonce))
+        return -1;
+    return node_send_ereg(node, 0);
+}
+
+static int read_named_calls(uint64_t *calls_a, uint64_t *calls_b) {
+    LmbMsg message = {0};
+    if (lmb_request(g_tracker, LMB_SWARM_DETAIL, NULL, 0, &message) ||
+        message.op != LMB_SWARM_DETAIL_R || message.pay_len) return -1;
+    LmbCur cursor = { message.body, message.body_len, 0 };
+    uint32_t version = 0, count = 0;
+    int bad = lmb_cur_u32(&cursor, &version) || lmb_cur_u32(&cursor, &count) ||
+              version != LMB_SWARM_DETAIL_VERSION || count > 64;
+    int found_a = 0, found_b = 0;
+    for (uint32_t i = 0; !bad && i < count; i++) {
+        char name[64], model[64];
+        uint32_t roles, age, files, experts, have_stats, inflight;
+        uint32_t begin, end, active, maximum, queued, segment_inflight, flags;
+        uint64_t held, served, reads, calls;
+        bad = lmb_cur_str(&cursor, name, sizeof name) ||
+              lmb_cur_str(&cursor, model, sizeof model) ||
+              lmb_cur_u32(&cursor, &roles) || lmb_cur_u32(&cursor, &age) ||
+              lmb_cur_u64(&cursor, &held) || lmb_cur_u64(&cursor, &served) ||
+              lmb_cur_u64(&cursor, &reads) || lmb_cur_u32(&cursor, &files) ||
+              lmb_cur_u32(&cursor, &experts) || lmb_cur_u32(&cursor, &have_stats) ||
+              lmb_cur_u64(&cursor, &calls) || lmb_cur_u32(&cursor, &inflight) ||
+              lmb_cur_u32(&cursor, &begin) || lmb_cur_u32(&cursor, &end) ||
+              lmb_cur_u32(&cursor, &active) || lmb_cur_u32(&cursor, &maximum) ||
+              lmb_cur_u32(&cursor, &queued) || lmb_cur_u32(&cursor, &segment_inflight) ||
+              lmb_cur_u32(&cursor, &flags);
+        (void)age; (void)held; (void)served; (void)reads; (void)files;
+        (void)experts; (void)inflight; (void)begin; (void)end; (void)active;
+        (void)maximum; (void)queued; (void)segment_inflight; (void)flags;
+        if (!bad && !strcmp(model, "rtt-refresh-model") &&
+            (roles & LMB_SWARM_ROLE_EXPERT) && have_stats) {
+            if (!strcmp(name, "rtt-node-a")) { *calls_a = calls; found_a = 1; }
+            if (!strcmp(name, "rtt-node-b")) { *calls_b = calls; found_b = 1; }
+        }
+    }
+    bad |= cursor.off != cursor.len || !found_a || !found_b;
+    lmb_msg_free(&message);
+    return bad ? -1 : 0;
+}
+
+static int run_exec_calls(int count) {
+    float input[4] = {0.25f, -0.5f, 0.75f, 1.0f};
+    for (int i = 0; i < count; i++) {
+        uint32_t tried = 0;
+        LumiPeer *from = NULL;
+        float *output = lumi_exec_retry(0, 0, input, 4, 1, NULL, &tried, &from);
+        int bad = !output || !from || memcmp(output, input, sizeof input);
+        free(output);
+        if (bad) return -1;
+    }
+    return 0;
+}
+
+static void test_cleanup(TestNode nodes[2]) {
+    for (int i = 0; i < L.npeers; i++)
+        while (L.peers[i].nsocks) close(L.peers[i].socks[--L.peers[i].nsocks]);
+    free(L.own); L.own = NULL;
+    for (int i = 0; i < 2; i++) {
+        if (nodes[i].ctrl_fd >= 0) close(nodes[i].ctrl_fd);
+        atomic_store(&nodes[i].stop, 1);
+    }
+    for (int i = 0; i < 2; i++) pthread_join(nodes[i].thread, NULL);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s TRACKER\n", argv[0]);
+        return 2;
+    }
+    g_tracker = argv[1];
+    TestNode nodes[2] = {
+        { .name = "rtt-node-a", .port = 8094, .ctrl_fd = -1, .delay_ms = 2 },
+        { .name = "rtt-node-b", .port = 8095, .ctrl_fd = -1, .delay_ms = 20 }
+    };
+    for (int i = 0; i < 2; i++) pthread_create(&nodes[i].thread, NULL, node_server, &nodes[i]);
+    for (int tries = 0; tries < 100; tries++) {
+        if (atomic_load(&nodes[0].ready) && atomic_load(&nodes[1].ready)) break;
+        usleep(10000);
+    }
+    int bad = atomic_load(&nodes[0].ready) != 1 || atomic_load(&nodes[1].ready) != 1;
+    for (int i = 0; !bad && i < 2; i++) bad = node_register(&nodes[i]) != 0;
+    L.n_layers = 1; L.n_experts = 1; L.hidden = 4; L.npeers = 2;
+    L.initialized = 1; L.discovery = 0; L.hedge_ms = 0; L.verify_pct = 0;
+    L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));
+    if (!L.own) bad = 1;
+    if (!bad) {
+        for (int i = 0; i < LUMI_MAX_REP; i++) L.own[i] = -1;
+        L.own[0] = 0; L.own[1] = 1;
+        for (int i = 0; i < 2; i++) {
+            snprintf(L.peers[i].addr, sizeof L.peers[i].addr,
+                     "127.0.0.1:%d", nodes[i].port);
+            lumi_probe(&L.peers[i]);
+        }
+        bad = L.peers[0].rtt_us >= L.peers[1].rtt_us ||
+              atomic_load(&nodes[0].accepts) != 1 ||
+              atomic_load(&nodes[1].accepts) != 1;
+    }
+
+    long initial_a = L.peers[0].rtt_us, initial_b = L.peers[1].rtt_us;
+    atomic_store(&nodes[0].delay_ms, 40);
+    atomic_store(&nodes[1].delay_ms, 1);
+    if (!bad) bad = run_exec_calls(8) != 0;
+    if (!bad) bad = node_send_ereg(&nodes[0], 1) || node_send_ereg(&nodes[1], 1);
+    uint64_t calls_a = 0, calls_b = 0;
+    if (!bad) bad = read_named_calls(&calls_a, &calls_b) || calls_a != 8 || calls_b != 0;
+
+    if (!bad) {
+        double due = 1000.0;
+        long before_b = L.peers[1].rtt_us;
+        L.next_rtt_refresh = due;
+        lumi_maybe_refresh_rtt(due);      /* oldest measurement: node A */
+        bad = atomic_load(&nodes[0].pings) != 4 ||
+              atomic_load(&nodes[1].pings) != 2 ||
+              L.peers[0].rtt_us <= initial_a || L.peers[1].rtt_us != before_b;
+        lumi_maybe_refresh_rtt(due + 1.0); /* cadence gate: no second peer yet */
+        bad |= atomic_load(&nodes[0].pings) != 4 ||
+               atomic_load(&nodes[1].pings) != 2;
+        lumi_maybe_refresh_rtt(due + LUMI_RTT_REFRESH_S); /* then node B */
+        bad |= L.peers[1].rtt_us >= L.peers[0].rtt_us ||
+               L.peers[1].rtt_us >= initial_b ||
+               atomic_load(&nodes[0].pings) != 4 ||
+               atomic_load(&nodes[1].pings) != 4 ||
+               atomic_load(&nodes[0].accepts) != 1 ||
+               atomic_load(&nodes[1].accepts) != 1;
+    }
+    /* A successful maintenance probe must restore the normal EXEC timeout. */
+    if (!bad) {
+        atomic_store(&nodes[1].delay_ms, 150);
+        bad = run_exec_calls(1) != 0;
+        atomic_store(&nodes[1].delay_ms, 1);
+    }
+    if (!bad) bad = run_exec_calls(7) != 0;
+    if (!bad) bad = node_send_ereg(&nodes[0], 1) || node_send_ereg(&nodes[1], 1);
+    if (!bad) bad = read_named_calls(&calls_a, &calls_b) || calls_a != 8 || calls_b != 8;
+
+    /* A maintenance PING timeout is bounded and does not change health or the
+     * previous estimate; the broken pooled socket is simply discarded. */
+    if (!bad) {
+        long saved = L.peers[0].rtt_us;
+        double started = lumi_now();
+        atomic_store(&nodes[0].drop_pings, 1);
+        bad = lumi_refresh_rtt(&L.peers[0]) != -1 ||
+              lumi_now() - started > 1.0 || L.peers[0].dead ||
+              L.peers[0].rtt_us != saved;
+    }
+
+    long final_a = L.peers[0].rtt_us, final_b = L.peers[1].rtt_us;
+    test_cleanup(nodes);
+    if (bad) {
+        fprintf(stderr, "staggered RTT refresh regression failed "
+                        "(named calls A/B=%llu/%llu, RTT A/B=%ld/%ld us)\n",
+                (unsigned long long)calls_a, (unsigned long long)calls_b,
+                final_a, final_b);
+        return 1;
+    }
+    printf("STAGGERED RTT REFRESH: PASS "
+           "(named calls stale 8/0, refreshed 8/8; two PINGs, pooled accepts 1/1)\n");
+    return 0;
+}

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -199,7 +199,7 @@ static int run_exec_calls(int count) {
         int fd = lumi_take_sock(primary);
         if (fd < 0) return -1;
         double started = lumi_now();
-        if (lumi_send_exec(fd, 0, 0, input, 4, 1, NULL)) {
+        if (lumi_send_exec(primary, fd, 0, 0, input, 4, 1, NULL)) {
             close(fd);
             lumi_peer_failed(primary);
             return -1;
@@ -463,7 +463,7 @@ int main(int argc, char **argv) {
         atomic_store(&nodes[1].delay_ms, 150);
         double started = lumi_now();
         if (!direct_bad)
-            direct_bad = lumi_send_exec(fd, 0, 0, input, 4, 1, NULL) ||
+            direct_bad = lumi_send_exec(peer, fd, 0, 0, input, 4, 1, NULL) ||
                          lmb_recv(fd, &reply);
         double elapsed = lumi_now() - started;
         if (!direct_bad)

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -40,6 +40,9 @@ static void *node_server(void *arg) {
         if (fds[0].revents & POLLIN) {
             int fd = accept(fds[0].fd, NULL, NULL);
             if (fd >= 0) {
+                int one = 1;
+                setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+                lmb_set_io_timeout(fd, LMB_DEFAULT_IO_TIMEOUT_MS);
                 atomic_fetch_add(&node->accepts, 1);
                 for (size_t i = 1; i < sizeof fds / sizeof fds[0]; i++)
                     if (fds[i].fd < 0) { fds[i].fd = fd; fds[i].events = POLLIN; fd = -1; break; }
@@ -216,20 +219,22 @@ int main(int argc, char **argv) {
     }
     g_tracker = argv[1];
     TestNode nodes[2] = {
-        { .name = "rtt-node-a", .port = 8094, .ctrl_fd = -1, .delay_ms = 2 },
-        { .name = "rtt-node-b", .port = 8095, .ctrl_fd = -1, .delay_ms = 20 }
+        { .name = "rtt-node-a", .port = 8094, .ctrl_fd = -1, .delay_ms = 5 },
+        { .name = "rtt-node-b", .port = 8095, .ctrl_fd = -1, .delay_ms = 30 }
     };
     for (int i = 0; i < 2; i++) pthread_create(&nodes[i].thread, NULL, node_server, &nodes[i]);
     for (int tries = 0; tries < 100; tries++) {
         if (atomic_load(&nodes[0].ready) && atomic_load(&nodes[1].ready)) break;
         usleep(10000);
     }
+    const char *stage = "setup";
     int bad = atomic_load(&nodes[0].ready) != 1 || atomic_load(&nodes[1].ready) != 1;
     for (int i = 0; !bad && i < 2; i++) bad = node_register(&nodes[i]) != 0;
     L.n_layers = 1; L.n_experts = 1; L.hidden = 4; L.npeers = 2;
     L.initialized = 1; L.discovery = 0; L.hedge_ms = 0; L.verify_pct = 0;
     L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));
     if (!L.own) bad = 1;
+    if (!bad) stage = "initial probes";
     if (!bad) {
         for (int i = 0; i < LUMI_MAX_REP; i++) L.own[i] = -1;
         L.own[0] = 0; L.own[1] = 1;
@@ -237,70 +242,182 @@ int main(int argc, char **argv) {
             snprintf(L.peers[i].addr, sizeof L.peers[i].addr,
                      "127.0.0.1:%d", nodes[i].port);
             lumi_probe(&L.peers[i]);
+            lmb_predict_init(&L.peers[i].latency, 1000);
+            lmb_predict_observe(&L.peers[i].latency,
+                                (uint64_t)L.peers[i].rtt_us);
+            L.peers[i].exec_observations = 0;
+            L.peers[i].exec_observations_at_probe = 0;
         }
         bad = L.peers[0].rtt_us >= L.peers[1].rtt_us ||
               atomic_load(&nodes[0].accepts) != 1 ||
               atomic_load(&nodes[1].accepts) != 1;
     }
 
-    long initial_a = L.peers[0].rtt_us, initial_b = L.peers[1].rtt_us;
-    atomic_store(&nodes[0].delay_ms, 40);
+    long initial_b = L.peers[1].rtt_us;
     atomic_store(&nodes[1].delay_ms, 1);
+    if (!bad) stage = "parked routing";
     if (!bad) bad = run_exec_calls(8) != 0;
+    if (!bad) bad = L.peers[0].exec_observations != 8 ||
+                    L.peers[1].exec_observations != 0;
+    if (!bad) stage = "parked telemetry";
     if (!bad) bad = node_send_ereg(&nodes[0], 1) || node_send_ereg(&nodes[1], 1);
     uint64_t calls_a = 0, calls_b = 0;
     if (!bad) bad = read_named_calls(&calls_a, &calls_b) || calls_a != 8 || calls_b != 0;
 
+    if (!bad) stage = "active peer refresh";
     if (!bad) {
         double due = 1000.0;
         long before_b = L.peers[1].rtt_us;
+        uint32_t active_failures = L.peers[0].latency.consecutive_failures;
+        uint64_t active_circuit = L.peers[0].latency.circuit_until_ms;
+        L.peers[0].latency.consecutive_failures = 3;
+        L.peers[0].latency.circuit_until_ms = 9876543210ull;
+        LmbLatencyPredictor active_before = L.peers[0].latency;
         L.next_rtt_refresh = due;
-        lumi_maybe_refresh_rtt(due);      /* oldest measurement: node A */
+        lumi_maybe_refresh_rtt(due);      /* oldest measurement: active node A */
         bad = atomic_load(&nodes[0].pings) != 4 ||
               atomic_load(&nodes[1].pings) != 2 ||
-              L.peers[0].rtt_us <= initial_a || L.peers[1].rtt_us != before_b;
+              L.peers[1].rtt_us != before_b ||
+              L.peers[0].latency.ewma_us != active_before.ewma_us ||
+              L.peers[0].latency.p95_us != active_before.p95_us ||
+              L.peers[0].latency.samples != active_before.samples ||
+              L.peers[0].latency.consecutive_failures !=
+                  active_before.consecutive_failures ||
+              L.peers[0].latency.circuit_until_ms != active_before.circuit_until_ms ||
+              L.peers[0].exec_observations_at_probe != 8;
+        L.peers[0].latency.consecutive_failures = active_failures;
+        L.peers[0].latency.circuit_until_ms = active_circuit;
         lumi_maybe_refresh_rtt(due + 1.0); /* cadence gate: no second peer yet */
         bad |= atomic_load(&nodes[0].pings) != 4 ||
                atomic_load(&nodes[1].pings) != 2;
-        lumi_maybe_refresh_rtt(due + LUMI_RTT_REFRESH_S); /* then node B */
-        bad |= L.peers[1].rtt_us >= L.peers[0].rtt_us ||
-               L.peers[1].rtt_us >= initial_b ||
-               atomic_load(&nodes[0].pings) != 4 ||
-               atomic_load(&nodes[1].pings) != 4 ||
-               atomic_load(&nodes[0].accepts) != 1 ||
-               atomic_load(&nodes[1].accepts) != 1;
+
+        if (!bad) stage = "parked peer refresh";
+        LumiPeer *idle = &L.peers[1];
+        LmbLatencyPredictor idle_before = idle->latency;
+        struct timeval recv_before = {0}, send_before = {0};
+        struct timeval recv_after = {0}, send_after = {0};
+        socklen_t recv_len = sizeof recv_before, send_len = sizeof send_before;
+        int sockopts_bad = idle->nsocks <= 0;
+        int probe_fd = sockopts_bad ? -1 : idle->socks[idle->nsocks - 1];
+        if (!sockopts_bad)
+            sockopts_bad = getsockopt(probe_fd, SOL_SOCKET, SO_RCVTIMEO,
+                                      &recv_before, &recv_len) ||
+                           getsockopt(probe_fd, SOL_SOCKET, SO_SNDTIMEO,
+                                      &send_before, &send_len);
+        if (!bad && !sockopts_bad)
+            lumi_maybe_refresh_rtt(due + LUMI_RTT_REFRESH_S); /* then parked node B */
+        recv_len = sizeof recv_after;
+        send_len = sizeof send_after;
+        if (!bad && !sockopts_bad)
+            sockopts_bad = idle->nsocks <= 0 || idle->socks[idle->nsocks - 1] != probe_fd ||
+                           getsockopt(probe_fd, SOL_SOCKET, SO_RCVTIMEO,
+                                      &recv_after, &recv_len) ||
+                           getsockopt(probe_fd, SOL_SOCKET, SO_SNDTIMEO,
+                                      &send_after, &send_len) ||
+                           recv_before.tv_sec != recv_after.tv_sec ||
+                           recv_before.tv_usec != recv_after.tv_usec ||
+                           send_before.tv_sec != send_after.tv_sec ||
+                           send_before.tv_usec != send_after.tv_usec;
+        if (!bad) bad = sockopts_bad || idle->rtt_us >= initial_b ||
+                        idle->latency.ewma_us >= idle_before.ewma_us ||
+                        idle->latency.p95_us != idle_before.p95_us ||
+                        idle->latency.samples != idle_before.samples ||
+                        idle->latency.consecutive_failures !=
+                            idle_before.consecutive_failures ||
+                        idle->latency.circuit_until_ms !=
+                            idle_before.circuit_until_ms ||
+                        idle->exec_observations_at_probe != 0 ||
+                        lmb_predict_score(&idle->latency, 0) >=
+                            lmb_predict_score(&L.peers[0].latency, 0) ||
+                        atomic_load(&nodes[0].pings) != 4 ||
+                        atomic_load(&nodes[1].pings) != 4 ||
+                        atomic_load(&nodes[0].accepts) != 1 ||
+                        atomic_load(&nodes[1].accepts) != 1;
     }
-    /* A successful maintenance probe must restore the normal EXEC timeout. */
-    if (!bad) {
-        atomic_store(&nodes[1].delay_ms, 150);
-        bad = run_exec_calls(1) != 0;
-        atomic_store(&nodes[1].delay_ms, 1);
-    }
-    if (!bad) bad = run_exec_calls(7) != 0;
+
+    if (!bad) stage = "refreshed routing";
+    if (!bad) bad = run_exec_calls(8) != 0;
+    if (!bad) bad = L.peers[0].exec_observations != 8 ||
+                    L.peers[1].exec_observations != 8;
+    if (!bad) stage = "refreshed telemetry";
     if (!bad) bad = node_send_ereg(&nodes[0], 1) || node_send_ereg(&nodes[1], 1);
     if (!bad) bad = read_named_calls(&calls_a, &calls_b) || calls_a != 8 || calls_b != 8;
 
-    /* A maintenance PING timeout is bounded and does not change health or the
-     * previous estimate; the broken pooled socket is simply discarded. */
+    /* A successful maintenance probe must restore the pooled socket's normal
+     * timeout. Exercise it directly so this check cannot alter the predictor. */
+    if (!bad) stage = "restored socket timeout";
     if (!bad) {
-        long saved = L.peers[0].rtt_us;
+        LumiPeer *peer = &L.peers[1];
+        float input[4] = {0.25f, -0.5f, 0.75f, 1.0f};
+        int fd = peer->nsocks > 0 ? peer->socks[--peer->nsocks] : -1;
+        LmbMsg reply = {0};
+        int direct_bad = fd < 0;
+        atomic_store(&nodes[1].delay_ms, 150);
+        double started = lumi_now();
+        if (!direct_bad)
+            direct_bad = lumi_send_exec(fd, 0, 0, input, 4, 1, NULL) ||
+                         lmb_recv(fd, &reply);
+        double elapsed = lumi_now() - started;
+        if (!direct_bad)
+            direct_bad = reply.op != LMB_EXEC_R || reply.pay_len != sizeof input ||
+                         memcmp(reply.pay, input, sizeof input);
+        lmb_msg_free(&reply);
+        atomic_store(&nodes[1].delay_ms, 1);
+        if (fd >= 0) {
+            if (direct_bad) close(fd);
+            else lumi_put_sock(peer, fd);
+        }
+        bad = direct_bad || elapsed < 0.12 || elapsed > 1.0 ||
+              peer->exec_observations != 8;
+    }
+
+    /* A maintenance PING timeout is bounded and preserves health, the prior
+     * RTT, predictor state, and successful-observation snapshot. */
+    if (!bad) stage = "failed maintenance probe";
+    if (!bad) {
+        LumiPeer *peer = &L.peers[0];
+        peer->latency.consecutive_failures = 4;
+        peer->latency.circuit_until_ms = 1234567890ull;
+        long saved_rtt = peer->rtt_us;
+        int saved_pings = atomic_load(&nodes[0].pings);
+        int saved_nsocks = peer->nsocks;
+        uint64_t saved_snapshot = peer->exec_observations_at_probe;
+        uint64_t saved_observations = peer->exec_observations;
+        LmbLatencyPredictor saved_predictor = peer->latency;
         double started = lumi_now();
         atomic_store(&nodes[0].drop_pings, 1);
-        bad = lumi_refresh_rtt(&L.peers[0]) != -1 ||
-              lumi_now() - started > 1.0 || L.peers[0].dead ||
-              L.peers[0].rtt_us != saved;
+        int refresh_bad = saved_nsocks <= 0;
+        if (!refresh_bad) refresh_bad = lumi_refresh_rtt(peer) != -1;
+        bad = refresh_bad || lumi_now() - started > 1.0 || peer->dead ||
+              atomic_load(&nodes[0].pings) != saved_pings + 1 ||
+              peer->nsocks != saved_nsocks - 1 ||
+              peer->rtt_us != saved_rtt ||
+              peer->exec_observations != saved_observations ||
+              peer->exec_observations_at_probe != saved_snapshot ||
+              peer->latency.ewma_us != saved_predictor.ewma_us ||
+              peer->latency.p95_us != saved_predictor.p95_us ||
+              peer->latency.samples != saved_predictor.samples ||
+              peer->latency.consecutive_failures !=
+                  saved_predictor.consecutive_failures ||
+              peer->latency.circuit_until_ms != saved_predictor.circuit_until_ms;
     }
 
     long final_a = L.peers[0].rtt_us, final_b = L.peers[1].rtt_us;
     test_cleanup(nodes);
     if (bad) {
-        fprintf(stderr, "staggered RTT refresh regression failed "
-                        "(named calls A/B=%llu/%llu, RTT A/B=%ld/%ld us)\n",
-                (unsigned long long)calls_a, (unsigned long long)calls_b,
+        fprintf(stderr, "staggered RTT refresh regression failed at %s "
+                        "(named A/B=%llu/%llu, raw A/B=%d/%d, "
+                        "pings A/B=%d/%d, observations A/B=%llu/%llu, "
+                        "RTT A/B=%ld/%ld us)\n",
+                stage, (unsigned long long)calls_a, (unsigned long long)calls_b,
+                atomic_load(&nodes[0].calls), atomic_load(&nodes[1].calls),
+                atomic_load(&nodes[0].pings), atomic_load(&nodes[1].pings),
+                (unsigned long long)L.peers[0].exec_observations,
+                (unsigned long long)L.peers[1].exec_observations,
                 final_a, final_b);
         return 1;
     }
     printf("STAGGERED RTT REFRESH: PASS "
-           "(named calls stale 8/0, refreshed 8/8; two PINGs, pooled accepts 1/1)\n");
+           "(named calls parked 8/0, refreshed 8/8; two PINGs, pooled accepts 1/1)\n");
     return 0;
 }

--- a/test_rtt_refresh.c
+++ b/test_rtt_refresh.c
@@ -95,6 +95,15 @@ static int node_send_ereg(TestNode *node, int with_stats) {
         lmb_buf_u32(&body, LMB_EREG_STATS_LENGTH);
         lmb_buf_u64(&body, (uint64_t)atomic_load(&node->calls));
         lmb_buf_u32(&body, 0);
+        /* v2 appends residency after the v1 call counters. This executor is a
+         * protocol stand-in with no expert weights, so it reports none — but
+         * it must still send the fields, or the tracker rejects the whole
+         * extension and the named counters read as zero. */
+        lmb_buf_u32(&body, 0);
+        lmb_buf_u32(&body, 0);
+        lmb_buf_u32(&body, 0);
+        lmb_buf_u64(&body, 0);
+        lmb_buf_u64(&body, 0);
     }
     uint8_t signed_body[512], signature[64];
     size_t signed_len = lmb_peer_auth_msg(node->nonce, node->name,
@@ -139,8 +148,11 @@ static int read_named_calls(uint64_t *calls_a, uint64_t *calls_b) {
     for (uint32_t i = 0; !bad && i < count; i++) {
         char name[64], model[64];
         uint32_t roles, age, files, experts, have_stats, inflight;
+        /* SWARM_DETAIL v2 inserted residency between the expert counters and
+         * the Segment block; read it so the fields after it stay aligned. */
+        uint32_t state, residency_flags, resident_count;
         uint32_t begin, end, active, maximum, queued, segment_inflight, flags;
-        uint64_t held, served, reads, calls;
+        uint64_t held, served, reads, calls, resident_ram, resident_vram;
         bad = lmb_cur_str(&cursor, name, sizeof name) ||
               lmb_cur_str(&cursor, model, sizeof model) ||
               lmb_cur_u32(&cursor, &roles) || lmb_cur_u32(&cursor, &age) ||
@@ -148,12 +160,19 @@ static int read_named_calls(uint64_t *calls_a, uint64_t *calls_b) {
               lmb_cur_u64(&cursor, &reads) || lmb_cur_u32(&cursor, &files) ||
               lmb_cur_u32(&cursor, &experts) || lmb_cur_u32(&cursor, &have_stats) ||
               lmb_cur_u64(&cursor, &calls) || lmb_cur_u32(&cursor, &inflight) ||
+              lmb_cur_u32(&cursor, &state) ||
+              lmb_cur_u32(&cursor, &residency_flags) ||
+              lmb_cur_u32(&cursor, &resident_count) ||
+              lmb_cur_u64(&cursor, &resident_ram) ||
+              lmb_cur_u64(&cursor, &resident_vram) ||
               lmb_cur_u32(&cursor, &begin) || lmb_cur_u32(&cursor, &end) ||
               lmb_cur_u32(&cursor, &active) || lmb_cur_u32(&cursor, &maximum) ||
               lmb_cur_u32(&cursor, &queued) || lmb_cur_u32(&cursor, &segment_inflight) ||
               lmb_cur_u32(&cursor, &flags);
         (void)age; (void)held; (void)served; (void)reads; (void)files;
         (void)experts; (void)inflight; (void)begin; (void)end; (void)active;
+        (void)state; (void)residency_flags; (void)resident_count;
+        (void)resident_ram; (void)resident_vram;
         (void)maximum; (void)queued; (void)segment_inflight; (void)flags;
         if (!bad && !strcmp(model, "rtt-refresh-model") &&
             (roles & LMB_SWARM_ROLE_EXPERT) && have_stats) {


### PR DESCRIPTION
## Summary

The predictive scheduler already self-corrects peers that receive traffic by observing completed EXEC latency. A parked peer receives no EXEC observations, so its initial transport baseline can remain stale indefinitely even after it becomes the fastest replica.

This PR keeps that idle baseline current without changing selection policy:

- refresh at most one healthy executor every 30 seconds, oldest attempt first
- reuse an idle pooled socket and never measure connection setup
- take the minimum of two warm PING samples
- always blend the new sample into the stored RTT with alpha 1/2
- blend the fresh PING baseline into the scheduler EWMA only when the peer has no in-flight EXEC and completed no EXEC since its previous successful probe
- leave active-peer EXEC EWMA, p95, sample count, failure count, and circuit-breaker state untouched
- use a temporary 2 second maintenance timeout and restore both pooled-socket timeouts exactly
- preserve RTT, predictor state, health, and the observation snapshot when a maintenance probe fails

There are no changes to `lumi_pick`, predictive scoring, near-band spreading, hedging, failover, or relay behavior.

## Regression coverage

The regression uses two controlled executors and the real tracker:

- A starts near 5 ms and B near 30 ms, so the predictive scheduler sends the first 8 EXEC calls to A
- B then becomes a roughly 1 ms parked peer but receives no EXEC observations
- refreshing active A advances its observation snapshot without changing its predictor
- the cadence gate prevents B from being probed in the same interval
- refreshing parked B lowers only its scheduler EWMA and makes its predicted score beat A
- the next 8 ordinary EXEC calls go to B
- named `SWARM_DETAIL` counters independently report A/B as 8/0 before refresh and 8/8 afterward
- every measurement uses two PINGs and each executor accepts exactly one client connection
- successful maintenance restores both socket timeouts exactly
- an unanswered PING is bounded, discards one pooled socket, and preserves nonzero failure/circuit state plus the prior RTT and observation snapshot

## Validation

Validated in Docker on Debian 12:

- `make check-warnings`
- `bash ./rtt_refresh_test.sh`
- `./test_scheduler`
- `./test_hedge`
- honest and corrupt verify/failover paths
- ASan and UBSan run of the RTT refresh regression

Closes #29