### PR TITLE
feat: predictive swarm scheduler

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -367,10 +367,13 @@ status shows routing/prefill/decode/failover and read-only menus open without
 waiting for the answer to finish.
 
 Verified chunks are shared across models in `~/.lumabri/cas`; override it
-with `LUMABRI_CAS=/fast/local/path`. To enable the basic straggler hedge, set
-for example `LUMABRI_HEDGE_MS=40`. Keep it disabled (`0`, the default) until
-there are at least two replicas per expert, otherwise there is nowhere to
-hedge. Prefill and speculative target verification are batched automatically.
+with `LUMABRI_CAS=/fast/local/path`. Expert routing learns an EWMA and slow-tail
+estimate per replica. It hedges automatically only after at least eight samples
+show a material p95 tail and another replica exists; set
+`LUMABRI_HEDGE_MS=40` to force a fixed policy, or leave the variable unset for
+the adaptive policy. Three consecutive failures open a short circuit instead
+of permanently deleting a valid manifest. Prefill and speculative target
+verification are batched automatically.
 
 The boot narrates itself, so you can see where the time goes:
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
+		test_scheduler \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -409,6 +410,9 @@ test_relay_rate: test_relay_rate.c lumabri_segment.c lumabri_segment.h \
 test_machine: test_machine.c $(MACHINE_DEPS) lumabri_proto.h
 	$(CC) $(CFLAGS) -pthread test_machine.c $(MACHINE_SRC) -o $@
 
+test_scheduler: test_scheduler.c lumabri_scheduler.h
+	$(CC) $(CFLAGS) test_scheduler.c -o $@
+
 test-machine-governor: lumabri tracker swarm_probe expert_node segment_node fixture test_machine
 	ENGINE=$(ENGINE) bash ./machine_governor_test.sh
 
@@ -528,7 +532,8 @@ test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
-		test_segment_discovery test_swarm_detail test_relay_rate test_machine
+		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
+		test_scheduler
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -550,6 +555,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_key_rotation
 	./test_hedge
 	./test_segment_v2
+	./test_scheduler
 	python3 ./test_swarm_bench.py
 	bash ./segment_discovery_test.sh
 	bash ./swarm_detail_test.sh
@@ -579,7 +585,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
-	      test_swarm_detail test_relay_rate test_machine \
+	      test_swarm_detail test_relay_rate test_machine test_scheduler \
 	      test_segment_v2_tsan tracker_tsan \
 	      segment_node segment_chat segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ persistent direct TCP and falls back request-for-request to the exact peer's
 signed tracker tunnel. A machine behind NAT therefore contributes without
 publishing an unreachable address or opening a data port.
 
+Discovery probes Segment endpoints on its control thread and publishes an
+immutable completion estimate with each route. Selection minimizes the sum of
+EWMA latency and advertised queue/inflight cost for the complete chain; origin
+fallback status is only a tie-breaker. Adding a slower donor therefore does not
+replace a faster known route. Expert replicas use the same EWMA model, open a
+circuit only after repeated failures, and hedge automatically only after enough
+samples show a real p95 tail. `LUMABRI_HEDGE_MS` remains an explicit override.
+These are online estimates, not a speed claim: `swarm_bench.py` on distinct
+hosts remains the authority for single-chat and aggregate throughput.
+
 The TUI's temperature and top-p are applied to logits returned by Colibri Edge;
 temperature zero retains the exact greedy selector. When a compatible replica
 exists, a completed turn checkpoints every opaque remote state. If a peer dies,

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -32,6 +32,7 @@
 #include "lumabri_proto.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
+#include "lumabri_scheduler.h"
 
 #define LUMI_MAX_PEERS 64
 #define LUMI_MAX_K     64
@@ -45,6 +46,8 @@ typedef struct {
     long rtt_us;
     int dead;
     double retry_at;          /* do not redial a relay-only/NAT address per layer */
+    LmbLatencyPredictor latency;
+    uint32_t inflight;
 } LumiPeer;
 
 static struct {
@@ -85,17 +88,33 @@ static void lumi_die(const char *msg) {
     exit(1);
 }
 
+static uint64_t lumi_now_ms(void) { return (uint64_t)(lumi_now() * 1000.0); }
+
+static void lumi_peer_failed(LumiPeer *peer) {
+    lmb_predict_failure(&peer->latency, lumi_now_ms());
+}
+
+static void lumi_peer_observed(LumiPeer *peer, double started) {
+    uint64_t elapsed = (uint64_t)((lumi_now() - started) * 1e6);
+    lmb_predict_observe(&peer->latency, elapsed ? elapsed : 1);
+}
+
+static void lumi_peer_sent(LumiPeer *peer) { peer->inflight++; }
+static void lumi_peer_done(LumiPeer *peer) {
+    if (peer->inflight) peer->inflight--;
+}
+
 /* One socket per in-flight request: a peer executing two experts of the same
- * layer must see them as two concurrent requests, not a queue of one.
- * Returns -1 (and marks the peer dead) when it cannot connect: the caller
- * has replicas to fall back to, so a dead peer must not be fatal here. */
+ * layer must see them as two concurrent requests, not a queue of one. A
+ * transport failure feeds the circuit breaker; it does not erase a valid
+ * manifest permanently. */
 static int lumi_take_sock(LumiPeer *p) {
     if (p->nsocks) return p->socks[--p->nsocks];
     int fd = lmb_connect(p->addr);
     if (fd >= 0 && lmb_auth(fd)) { close(fd); fd = -1; }
     if (fd < 0) {
-        fprintf(stderr, "[lumabri] peer %s unreachable — marked dead\n", p->addr);
-        p->dead = 1;
+        fprintf(stderr, "[lumabri] peer %s unreachable — circuit failure\n", p->addr);
+        lumi_peer_failed(p);
     }
     return fd;
 }
@@ -113,7 +132,7 @@ static void lumi_probe(LumiPeer *p) {
         double a = lumi_now();
         LmbMsg m = {0};
         if (lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) || lmb_recv(fd, &m)) {
-            close(fd); p->dead = 1; return;
+            close(fd); lumi_peer_failed(p); return;
         }
         lmb_msg_free(&m);
         long us = (long)((lumi_now() - a) * 1e6);
@@ -294,6 +313,8 @@ static int lumi_add_peer(const char *addr) {
     lmb_msg_free(&m);
     p->dead = 0;
     p->retry_at = 0;
+    p->inflight = 0;
+    if (reprobe < 0) lmb_predict_init(&p->latency, 1000);
     lumi_probe(p);
     if (p->rtt_us == LONG_MAX) {
         if (reprobe < 0)
@@ -301,6 +322,7 @@ static int lumi_add_peer(const char *addr) {
                 if (L.own[i] == pi) L.own[i] = -1;
         return -1;
     }
+    lmb_predict_observe(&p->latency, (uint64_t)p->rtt_us);
     fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms\n",
             p->addr, n, claimed, (double)p->rtt_us / 1000.0);
     if (reprobe < 0) L.npeers++;
@@ -586,22 +608,28 @@ static uint32_t lumi_hash_gid(int gid) {   /* fnv1a over the (layer,expert) id *
 static int lumi_pick(int gid, uint32_t tried) {
     const int *own = &L.own[(size_t)gid * LUMI_MAX_REP];
     int best = -1;
-    long bestr = LONG_MAX;
+    uint64_t best_score = UINT64_MAX;
+    uint64_t now = lumi_now_ms();
     for (int r = 0; r < LUMI_MAX_REP; r++) {
         int pi = own[r];
-        if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead) continue;
-        if (best < 0 || L.peers[pi].rtt_us < bestr)
-            { best = r; bestr = L.peers[pi].rtt_us; }
+        if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead ||
+            !lmb_predict_available(&L.peers[pi].latency, now)) continue;
+        uint64_t score = lmb_predict_score(&L.peers[pi].latency,
+                                            L.peers[pi].inflight);
+        if (best < 0 || score < best_score)
+            { best = r; best_score = score; }
     }
-    if (best < 0 || !L.spread || bestr == LONG_MAX) return best;
+    if (best < 0 || !L.spread || best_score == UINT64_MAX) return best;
 
-    long band = bestr + bestr / 4 + 2000;   /* 1.25*best + 2ms; bestr is finite here */
+    uint64_t band = best_score + best_score / 4 + 2000;
     int cand[LUMI_MAX_REP], nc = 0;
     for (int r = 0; r < LUMI_MAX_REP; r++) {
         int pi = own[r];
-        if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead) continue;
-        long rt = L.peers[pi].rtt_us;
-        if (rt != LONG_MAX && rt <= band) cand[nc++] = r;
+        if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead ||
+            !lmb_predict_available(&L.peers[pi].latency, now)) continue;
+        uint64_t score = lmb_predict_score(&L.peers[pi].latency,
+                                            L.peers[pi].inflight);
+        if (score <= band) cand[nc++] = r;
     }
     if (nc <= 1) return best;
     for (int i = 1; i < nc; i++)            /* canonical: sort the band by address */
@@ -641,23 +669,25 @@ static int lumi_send_exec(int fd, int layer, int eid, const float *x, int D, int
     return rc;
 }
 
-/* Fixed-delay hedging, intentionally a mechanism rather than an SLA policy.
- * If the nearest replica has not produced a readable reply after
- * LUMABRI_HEDGE_MS, issue the identical deterministic call to the next one
- * and accept the first valid result. The losing socket is closed so its late
- * frame can never be mistaken for a future request. */
+/* Adaptive p95 hedging, with LUMABRI_HEDGE_MS as an explicit fixed override.
+ * The losing socket is closed so its late frame can never be mistaken for a
+ * future request. */
 static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr,
                                const float *w, int primary_fd, LumiPeer *primary,
-                               uint32_t *tried, LumiPeer **from) {
+                               double primary_started, uint32_t *tried,
+                               LumiPeer **from) {
     if (from) *from = NULL;
     if (primary_fd < 0 || !primary) return NULL;
     int fd[2] = { primary_fd, -1 };
     LumiPeer *p[2] = { primary, NULL };
     uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
-    if (L.hedge_ms > 0) {
+    double started[2] = { primary_started, 0.0 };
+    uint32_t hedge_ms = L.hedge_ms > 0 ? (uint32_t)L.hedge_ms :
+                        lmb_predict_hedge_ms(&primary->latency);
+    if (hedge_ms > 0) {
         struct pollfd one = { fd[0], POLLIN, 0 };
         int pr;
-        do pr = poll(&one, 1, L.hedge_ms); while (pr < 0 && errno == EINTR);
+        do pr = poll(&one, 1, (int)hedge_ms); while (pr < 0 && errno == EINTR);
         if (pr == 0) {
             int gid = layer * L.n_experts + eid;
             int r = lumi_pick(gid, *tried);
@@ -665,10 +695,11 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
                 *tried |= 1u << r;
                 p[1] = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
                 fd[1] = lumi_take_sock(p[1]);
+                started[1] = lumi_now();
                 if (fd[1] >= 0 && lumi_send_exec(fd[1], layer, eid, x, D, nr, w)) {
-                    close(fd[1]); p[1]->dead = 1; fd[1] = -1;
+                    close(fd[1]); lumi_peer_failed(p[1]); fd[1] = -1;
                 }
-                if (fd[1] >= 0) L.hedges++;
+                if (fd[1] >= 0) { lumi_peer_sent(p[1]); L.hedges++; }
             }
         }
     }
@@ -687,18 +718,23 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
             LmbMsg m = {0};
             if (lmb_recv(fd[i], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
                 float *res = (float *)lmb_msg_take_pay(&m); lmb_msg_free(&m);
+                lumi_peer_done(p[i]);
                 lumi_put_sock(p[i], fd[i]); fd[i] = -1;
                 if (i == 1) L.hedge_wins++;
-                for (int j = 0; j < 2; j++) if (fd[j] >= 0) close(fd[j]);
+                lumi_peer_observed(p[i], started[i]);
+                for (int j = 0; j < 2; j++) if (fd[j] >= 0) {
+                    close(fd[j]); lumi_peer_done(p[j]);
+                }
                 if (from) *from = p[i];
                 return res;
             }
             lmb_msg_free(&m);
-            close(fd[i]); fd[i] = -1; p[i]->dead = 1; alive--;
+            close(fd[i]); fd[i] = -1; lumi_peer_done(p[i]);
+            lumi_peer_failed(p[i]); alive--;
         }
     }
     for (int i = 0; i < 2; i++) if (fd[i] >= 0) {
-        close(fd[i]); p[i]->dead = 1;
+        close(fd[i]); lumi_peer_done(p[i]); lumi_peer_failed(p[i]);
     }
     return NULL;
 }
@@ -803,18 +839,24 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
         LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
         int fd = lumi_take_sock(p);
         if (fd < 0) continue;
+        double started = lumi_now();
         LmbMsg m = {0};
-        if (lumi_send_exec(fd, layer, eid, x, D, nr, w) || lmb_recv(fd, &m) ||
+        int send_bad = lumi_send_exec(fd, layer, eid, x, D, nr, w);
+        if (!send_bad) lumi_peer_sent(p);
+        if (send_bad || lmb_recv(fd, &m) ||
             m.op != LMB_EXEC_R || m.pay_len != want) {
             close(fd);
-            p->dead = 1;
+            if (!send_bad) lumi_peer_done(p);
+            lumi_peer_failed(p);
             lmb_msg_free(&m);
             fprintf(stderr, "[lumabri] peer %s failed — trying next replica\n", p->addr);
             continue;
         }
         float *res = (float *)lmb_msg_take_pay(&m);
         lmb_msg_free(&m);
+        lumi_peer_done(p);
         lumi_put_sock(p, fd);
+        lumi_peer_observed(p, started);
         L.failovers++;
         if (tried_io) *tried_io = tried;
         if (from) *from = p;
@@ -885,6 +927,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
     uint32_t tried[LUMI_MAX_K];
     LumiPeer *ps[LUMI_MAX_K];
     float *res[LUMI_MAX_K];
+    double sent[LUMI_MAX_K];
     double t0 = lumi_now();
 
     /* issue all K first — this is what buys one RTT per layer */
@@ -898,11 +941,13 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
             LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
             int fd = lumi_take_sock(p);
             if (fd < 0) continue;
+            sent[k] = lumi_now();
             if (lumi_send_exec(fd, layer, idx[k], x, D, 1, NULL)) {
                 close(fd);
-                p->dead = 1;
+                lumi_peer_failed(p);
                 continue;
             }
+            lumi_peer_sent(p);
             fds[k] = fd; ps[k] = p;
             break;
         }
@@ -912,7 +957,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
         if (fds[k] >= 0) {
             LumiPeer *winner = NULL;
             res[k] = lumi_finish_exec(layer, idx[k], x, D, 1, NULL,
-                                      fds[k], ps[k], &tried[k], &winner);
+                                      fds[k], ps[k], sent[k], &tried[k], &winner);
             if (res[k]) {
                 lumi_maybe_spot_check(layer, idx[k], x, D, 1, NULL, res[k],
                                       winner, tried[k]);
@@ -924,7 +969,9 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
         LumiPeer *rf = NULL;
         res[k] = lumi_exec_retry(layer, idx[k], x, D, 1, NULL, &tried[k], &rf);
         if (!res[k]) {
-            for (int j = k + 1; j < K; j++) if (fds[j] >= 0) close(fds[j]);
+            for (int j = k + 1; j < K; j++) if (fds[j] >= 0) {
+                close(fds[j]); lumi_peer_done(ps[j]);
+            }
             for (int j = 0; j < K; j++) free(res[j]);
             return 0;
         }
@@ -988,6 +1035,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
     uint32_t tried[LUMI_BLOCK];
     LumiPeer *ps[LUMI_BLOCK];
     int nrs[LUMI_BLOCK];
+    double sent[LUMI_BLOCK];
 
     for (int base = 0; base < nu; base += LUMI_BLOCK) {
         int nb = nu - base < LUMI_BLOCK ? nu - base : LUMI_BLOCK;
@@ -1016,9 +1064,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
                 LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
                 int fd = lumi_take_sock(p);
                 if (fd < 0) continue;
+                sent[j] = lumi_now();
                 if (lumi_send_exec(fd, layer, eid, xj, D, nr, NULL)) {
-                    close(fd); p->dead = 1; continue;
+                    close(fd); lumi_peer_failed(p); continue;
                 }
+                lumi_peer_sent(p);
                 fds[j] = fd; ps[j] = p;
                 break;
             }
@@ -1029,7 +1079,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
             if (fds[j] >= 0) {
                 LumiPeer *winner = NULL;
                 res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
-                                       fds[j], ps[j], &tried[j], &winner);
+                                       fds[j], ps[j], sent[j], &tried[j], &winner);
                 fds[j] = -1;
                 if (res) {
                     lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res,
@@ -1044,7 +1094,9 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
                 res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, &tried[j], &rf);
                 if (!res) {
                     for (int q = j + 1; q < nb; q++)
-                        if (fds[q] >= 0) close(fds[q]);
+                        if (fds[q] >= 0) {
+                            close(fds[q]); lumi_peer_done(ps[q]);
+                        }
                     memcpy(out, saved, (size_t)S * (size_t)D * sizeof(float));
                     free(seen); free(uniq); free(rows); free(rw); free(xg); free(saved);
                     return 0;
@@ -1097,6 +1149,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
     int fds[LUMI_BLOCK];
     uint32_t tried[LUMI_BLOCK];
     LumiPeer *ps[LUMI_BLOCK];
+    double sent[LUMI_BLOCK];
 
     for (int base = 0; base < nu; base += LUMI_BLOCK) {
         int nb = nu - base < LUMI_BLOCK ? nu - base : LUMI_BLOCK;
@@ -1115,9 +1168,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
                 LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
                 int fd = lumi_take_sock(p);
                 if (fd < 0) continue;
+                sent[j] = lumi_now();
                 if (lumi_send_exec(fd, layer, eid, xj, D, nr, NULL)) {
-                    close(fd); p->dead = 1; continue;
+                    close(fd); lumi_peer_failed(p); continue;
                 }
+                lumi_peer_sent(p);
                 fds[j] = fd; ps[j] = p;
                 break;
             }
@@ -1128,7 +1183,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
             if (fds[j] >= 0) {
                 LumiPeer *winner = NULL;
                 res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
-                                       fds[j], ps[j], &tried[j], &winner);
+                                       fds[j], ps[j], sent[j], &tried[j], &winner);
                 fds[j] = -1;
                 if (res) {
                     lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res,
@@ -1143,7 +1198,9 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
                 res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, &tried[j], &rf);
                 if (!res) {
                     for (int q = j + 1; q < nb; q++)
-                        if (fds[q] >= 0) close(fds[q]);
+                        if (fds[q] >= 0) {
+                            close(fds[q]); lumi_peer_done(ps[q]);
+                        }
                     memcpy(U, saved, (size_t)positions * (size_t)D * sizeof(float));
                     free(xg); free(saved);
                     return 0;
@@ -1206,6 +1263,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
     uint32_t tried[LUMI_BLOCK];
     LumiPeer *ps[LUMI_BLOCK];
     int nrs[LUMI_BLOCK];
+    double sent[LUMI_BLOCK];
 
     for (int base = 0; base < nu; base += LUMI_BLOCK) {
         int nb = nu - base < LUMI_BLOCK ? nu - base : LUMI_BLOCK;
@@ -1236,9 +1294,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
                 LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
                 int fd = lumi_take_sock(p);
                 if (fd < 0) continue;
+                sent[j] = lumi_now();
                 if (lumi_send_exec(fd, layer, eid, xj, D, nr, wj)) {
-                    close(fd); p->dead = 1; continue;
+                    close(fd); lumi_peer_failed(p); continue;
                 }
+                lumi_peer_sent(p);
                 fds[j] = fd; ps[j] = p;
                 break;
             }
@@ -1251,7 +1311,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
             if (fds[j] >= 0) {
                 LumiPeer *winner = NULL;
                 res = lumi_finish_exec(layer, eid, xj, D, nr, wj,
-                                       fds[j], ps[j], &tried[j], &winner);
+                                       fds[j], ps[j], sent[j], &tried[j], &winner);
                 fds[j] = -1;
                 if (res) {
                     lumi_maybe_spot_check(layer, eid, xj, D, nr, wj, res,
@@ -1266,7 +1326,9 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
                 res = lumi_exec_retry(layer, eid, xj, D, nr, wj, &tried[j], &rf);
                 if (!res) {
                     for (int q = j + 1; q < nb; q++)
-                        if (fds[q] >= 0) close(fds[q]);
+                        if (fds[q] >= 0) {
+                            close(fds[q]); lumi_peer_done(ps[q]);
+                        }
                     memcpy(out, saved, (size_t)batch * (size_t)D * sizeof(float));
                     free(used); free(uid); free(rows); free(rw); free(xg); free(saved);
                     return 0;

--- a/lumabri_scheduler.h
+++ b/lumabri_scheduler.h
@@ -1,0 +1,69 @@
+#ifndef LUMABRI_SCHEDULER_H
+#define LUMABRI_SCHEDULER_H
+
+#include <stdint.h>
+
+/* Small, allocation-free latency model shared by Expert and Segment routing.
+ * Times are microseconds. The p95 estimate deliberately falls slowly: a tail
+ * spike should influence hedging longer than one fast reply influences EWMA. */
+typedef struct {
+    uint64_t ewma_us;
+    uint64_t p95_us;
+    uint64_t circuit_until_ms;
+    uint32_t samples;
+    uint32_t consecutive_failures;
+} LmbLatencyPredictor;
+
+static inline void lmb_predict_init(LmbLatencyPredictor *p, uint64_t initial_us) {
+    if (!initial_us) initial_us = 1000;
+    p->ewma_us = p->p95_us = initial_us;
+    p->circuit_until_ms = 0;
+    p->samples = p->consecutive_failures = 0;
+}
+
+static inline void lmb_predict_observe(LmbLatencyPredictor *p, uint64_t sample_us) {
+    if (!sample_us) sample_us = 1;
+    if (!p->ewma_us) lmb_predict_init(p, sample_us);
+    p->ewma_us = (p->ewma_us * 7 + sample_us) / 8;
+    if (sample_us > p->p95_us)
+        p->p95_us = (p->p95_us * 7 + sample_us) / 8;
+    else
+        p->p95_us = (p->p95_us * 31 + sample_us) / 32;
+    p->samples++;
+    p->consecutive_failures = 0;
+    p->circuit_until_ms = 0;
+}
+
+static inline void lmb_predict_failure(LmbLatencyPredictor *p, uint64_t now_ms) {
+    if (!p->ewma_us) lmb_predict_init(p, 1000);
+    if (p->consecutive_failures < 31) p->consecutive_failures++;
+    if (p->consecutive_failures >= 3) {
+        uint32_t shift = p->consecutive_failures - 3;
+        uint64_t cooldown = 1000ull << (shift > 5 ? 5 : shift);
+        p->circuit_until_ms = now_ms + cooldown;
+    }
+}
+
+static inline int lmb_predict_available(const LmbLatencyPredictor *p,
+                                        uint64_t now_ms) {
+    return !p->circuit_until_ms || now_ms >= p->circuit_until_ms;
+}
+
+static inline uint64_t lmb_predict_score(const LmbLatencyPredictor *p,
+                                         uint32_t queue_ahead) {
+    uint64_t base = p->ewma_us ? p->ewma_us : 1000;
+    uint64_t score = base * ((uint64_t)queue_ahead + 1);
+    score += (uint64_t)p->consecutive_failures * base;
+    return score;
+}
+
+/* Zero means do not hedge. A user override is handled by the caller. */
+static inline uint32_t lmb_predict_hedge_ms(const LmbLatencyPredictor *p) {
+    if (p->samples < 8 || p->p95_us <= p->ewma_us + p->ewma_us / 2) return 0;
+    uint64_t delay = (p->ewma_us + p->p95_us) / 2000;
+    if (delay < 2) delay = 2;
+    if (delay > 250) delay = 250;
+    return (uint32_t)delay;
+}
+
+#endif

--- a/lumabri_segment_discovery.c
+++ b/lumabri_segment_discovery.c
@@ -410,13 +410,86 @@ struct LmbSegDiscovery {
     char tracker[256];
     LmbSegQuery query;
     LmbSegRouteSnapshot snapshot;
+    uint32_t probe_cursor;
 };
+
+static int disc_same_route(const LmbSegRouteEntry *a,
+                           const LmbSegRouteEntry *b) {
+    return !strcmp(a->advert.peer_name, b->advert.peer_name) &&
+           !strcmp(a->advert.addr, b->advert.addr) &&
+           a->advert.layer_begin == b->advert.layer_begin &&
+           a->advert.layer_end == b->advert.layer_end;
+}
+
+static uint64_t disc_probe_us(const char *addr) {
+    uint64_t before = disc_now_ms();
+    int fd = lmb_connect_ms(addr, 250);
+    if (fd < 0) return 0;
+    LmbMsg reply = {0};
+    int bad = lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) ||
+              lmb_recv(fd, &reply) || reply.op != LMB_OK;
+    lmb_msg_free(&reply);
+    lmb_close(fd);
+    if (bad) return 0;
+    uint64_t elapsed = (disc_now_ms() - before) * 1000u;
+    return elapsed ? elapsed : 1u;
+}
+
+static void disc_enrich_routes(LmbSegDiscovery *d,
+                               LmbSegRouteSnapshot *next,
+                               const LmbSegRouteSnapshot *previous,
+                               int have_previous) {
+    uint64_t now = disc_now_ms();
+    uint32_t probe_budget = next->count < 8u ? next->count : 8u;
+    for (uint32_t i = 0; i < next->count; i++) {
+        LmbSegRouteEntry *entry = &next->entries[i];
+        const LmbSegRouteEntry *old = NULL;
+        if (have_previous)
+            for (uint32_t j = 0; j < previous->count; j++)
+                if (disc_same_route(entry, &previous->entries[j])) {
+                    old = &previous->entries[j]; break;
+                }
+        if (old) {
+            entry->latency = old->latency;
+            entry->last_probe_ms = old->last_probe_ms;
+        } else {
+            lmb_predict_init(&entry->latency,
+                entry->transport & LMB_SEG_TRANSPORT_DIRECT ? 50000u : 120000u);
+        }
+    }
+    for (uint32_t n = 0; n < probe_budget && next->count; n++) {
+        uint32_t i = d->probe_cursor++ % next->count;
+        LmbSegRouteEntry *entry = &next->entries[i];
+        if (!(entry->transport & LMB_SEG_TRANSPORT_DIRECT)) continue;
+        uint64_t sample = disc_probe_us(entry->advert.addr);
+        if (sample) {
+            lmb_predict_observe(&entry->latency, sample);
+            entry->last_probe_ms = now;
+        } else {
+            lmb_predict_failure(&entry->latency, now);
+        }
+    }
+    for (uint32_t i = 0; i < next->count; i++) {
+        LmbSegRouteEntry *entry = &next->entries[i];
+        uint32_t queue = entry->advert.queue_depth + entry->advert.inflight;
+        entry->predicted_us = lmb_predict_score(&entry->latency, queue);
+        if (!lmb_predict_available(&entry->latency, now))
+            entry->predicted_us = UINT64_MAX / 4u;
+    }
+}
 
 static void *disc_worker(void *arg) {
     LmbSegDiscovery *d = (LmbSegDiscovery *)arg;
     for (;;) {
         LmbSegRouteSnapshot next;
         if (!lmb_seg_routes_fetch(d->tracker, &d->query, &next)) {
+            LmbSegRouteSnapshot previous;
+            int have_previous;
+            pthread_mutex_lock(&d->lock);
+            previous = d->snapshot;
+            have_previous = d->have_snapshot;
+            pthread_mutex_unlock(&d->lock);
+            disc_enrich_routes(d, &next, &previous, have_previous);
             pthread_mutex_lock(&d->lock);
             /* Generations fence placements. Equal generations still replace
              * telemetry; a lower generation can only be a stale tracker. */

--- a/lumabri_segment_discovery.h
+++ b/lumabri_segment_discovery.h
@@ -9,6 +9,7 @@
 #define LUMABRI_SEGMENT_DISCOVERY_H
 
 #include "lumabri_segment.h"
+#include "lumabri_scheduler.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -84,6 +85,12 @@ typedef struct {
     LmbSegAdvert advert;
     LmbSegOwner owner;
     uint32_t transport;
+    /* Runtime-only control-plane observations. They are deliberately not
+     * part of the v1 wire encoding: an immutable snapshot carries them from
+     * discovery to inference without changing tracker compatibility. */
+    LmbLatencyPredictor latency;
+    uint64_t predicted_us;
+    uint64_t last_probe_ms;
 } LmbSegRouteEntry;
 
 /* Fixed-size by design: copying this value produces an immutable routing

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -187,6 +187,7 @@ static int parse_ids(const char *text, int32_t **ids, size_t *count) {
 static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                         uint32_t required_context, uint32_t required_rows,
                         RemoteSegment *chain, size_t *chain_count) {
+    uint64_t completion_us[LMB_SEG_ROUTE_MAX] = {0};
     uint64_t fallback_layers[LMB_SEG_ROUTE_MAX] = {0};
     uint64_t load_cost[LMB_SEG_ROUTE_MAX] = {0};
     uint32_t hops[LMB_SEG_ROUTE_MAX] = {0};
@@ -206,12 +207,20 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                     ? entry->advert.layer_end - entry->advert.layer_begin : 0;
             uint64_t own_load = (uint64_t)entry->advert.queue_depth +
                                 entry->advert.inflight;
+            uint64_t own_completion = entry->predicted_us ? entry->predicted_us :
+                (entry->transport & LMB_SEG_TRANSPORT_DIRECT ? 50000u : 120000u) *
+                (own_load + 1u);
             if (entry->advert.layer_end == layers) {
-                if (!viable[i] || own_fallback < fallback_layers[i] ||
-                    (own_fallback == fallback_layers[i] && 1 < hops[i]) ||
-                    (own_fallback == fallback_layers[i] && hops[i] == 1 &&
+                if (!viable[i] || own_completion < completion_us[i] ||
+                    (own_completion == completion_us[i] &&
+                     own_fallback < fallback_layers[i]) ||
+                    (own_completion == completion_us[i] &&
+                     own_fallback == fallback_layers[i] && 1 < hops[i]) ||
+                    (own_completion == completion_us[i] &&
+                     own_fallback == fallback_layers[i] && hops[i] == 1 &&
                      own_load < load_cost[i])) {
                     viable[i] = 1;
+                    completion_us[i] = own_completion;
                     fallback_layers[i] = own_fallback;
                     load_cost[i] = own_load;
                     hops[i] = 1;
@@ -220,6 +229,7 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 continue;
             }
             int found = 0;
+            uint64_t best_completion = UINT64_MAX;
             uint64_t best_fallback = UINT64_MAX, best_load = UINT64_MAX;
             uint32_t best_hops = UINT32_MAX;
             for (uint32_t j = 0; j < snapshot->count; j++) {
@@ -227,26 +237,39 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                                   entry->advert.layer_end) continue;
                 uint64_t candidate_fallback = own_fallback + fallback_layers[j];
                 uint64_t candidate_load = own_load + load_cost[j];
+                uint64_t candidate_completion = completion_us[j] >
+                    UINT64_MAX - own_completion ? UINT64_MAX :
+                    own_completion + completion_us[j];
                 uint32_t candidate_hops = 1 + hops[j];
-                if (!found || candidate_fallback < best_fallback ||
-                    (candidate_fallback == best_fallback &&
+                if (!found || candidate_completion < best_completion ||
+                    (candidate_completion == best_completion &&
+                     candidate_fallback < best_fallback) ||
+                    (candidate_completion == best_completion &&
+                     candidate_fallback == best_fallback &&
                      candidate_hops < best_hops) ||
-                    (candidate_fallback == best_fallback &&
+                    (candidate_completion == best_completion &&
+                     candidate_fallback == best_fallback &&
                      candidate_hops == best_hops &&
                      candidate_load < best_load)) {
                     found = 1;
+                    best_completion = candidate_completion;
                     best_fallback = candidate_fallback;
                     best_hops = candidate_hops;
                     best_load = candidate_load;
                 }
             }
             if (found) {
-                if (!viable[i] || best_fallback < fallback_layers[i] ||
-                    (best_fallback == fallback_layers[i] &&
+                if (!viable[i] || best_completion < completion_us[i] ||
+                    (best_completion == completion_us[i] &&
+                     best_fallback < fallback_layers[i]) ||
+                    (best_completion == completion_us[i] &&
+                     best_fallback == fallback_layers[i] &&
                      best_hops < hops[i]) ||
-                    (best_fallback == fallback_layers[i] &&
+                    (best_completion == completion_us[i] &&
+                     best_fallback == fallback_layers[i] &&
                      best_hops == hops[i] && best_load < load_cost[i])) {
                     viable[i] = 1;
+                    completion_us[i] = best_completion;
                     fallback_layers[i] = best_fallback;
                     hops[i] = best_hops;
                     load_cost[i] = best_load;
@@ -267,18 +290,24 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 candidate->advert.layer_end > layers) continue;
             if (!best) { best = candidate; continue; }
             uint32_t best_index = (uint32_t)(best - snapshot->entries);
-            if (fallback_layers[i] < fallback_layers[best_index] ||
-                (fallback_layers[i] == fallback_layers[best_index] &&
+            if (completion_us[i] < completion_us[best_index] ||
+                (completion_us[i] == completion_us[best_index] &&
+                 fallback_layers[i] < fallback_layers[best_index]) ||
+                (completion_us[i] == completion_us[best_index] &&
+                 fallback_layers[i] == fallback_layers[best_index] &&
                  hops[i] < hops[best_index]) ||
-                (fallback_layers[i] == fallback_layers[best_index] &&
+                (completion_us[i] == completion_us[best_index] &&
+                 fallback_layers[i] == fallback_layers[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] < load_cost[best_index]) ||
-                (fallback_layers[i] == fallback_layers[best_index] &&
+                (completion_us[i] == completion_us[best_index] &&
+                 fallback_layers[i] == fallback_layers[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] == load_cost[best_index] &&
                  (candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
                  !(best->transport & LMB_SEG_TRANSPORT_DIRECT)) ||
-                (fallback_layers[i] == fallback_layers[best_index] &&
+                (completion_us[i] == completion_us[best_index] &&
+                 fallback_layers[i] == fallback_layers[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] == load_cost[best_index] &&
                  !!(candidate->transport & LMB_SEG_TRANSPORT_DIRECT) ==
@@ -1414,12 +1443,14 @@ static void route_print(FILE *stream, const char *prefix,
             const LmbSegRouteEntry *entry = &snapshot->entries[index];
             fprintf(stream, "[lumabri] Segment candidate %s[%u:%u] "
                     "flags=%u load=%u/%u transport=%u context=%u rows=%u "
-                    "numeric=%s\n",
+                    "predicted=%.2fms numeric=%s\n",
                     entry->advert.peer_name, entry->advert.layer_begin,
                     entry->advert.layer_end, entry->advert.flags,
                     entry->advert.queue_depth, entry->advert.inflight,
                     entry->transport, entry->advert.max_context,
-                    entry->advert.max_rows, entry->advert.numeric_class);
+                    entry->advert.max_rows,
+                    (double)entry->predicted_us / 1000.0,
+                    entry->advert.numeric_class);
         }
     fflush(stream);
 }

--- a/segment_node.c
+++ b/segment_node.c
@@ -927,7 +927,11 @@ static void *connection_worker(void *opaque) {
         LmbMsg msg = {0};
         if (lmb_recv(fd, &msg)) break;
         int rc;
-        if (msg.op == LMB_SEG_OPEN) rc = handle_open(node, fd, &msg);
+        if (msg.op == LMB_PING) {
+            lmb_emu_delay();
+            rc = lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
+        }
+        else if (msg.op == LMB_SEG_OPEN) rc = handle_open(node, fd, &msg);
         else if (msg.op == LMB_SEG_RUN) rc = handle_run(node, fd, &msg);
         else if (msg.op == LMB_SEG_SNAPSHOT) rc = handle_snapshot(node, fd, &msg);
         else if (msg.op == LMB_SEG_RESTORE) rc = handle_restore(node, fd, &msg);

--- a/test_hedge.c
+++ b/test_hedge.c
@@ -47,10 +47,12 @@ int main(void) {
     float x[12]; for (int i = 0; i < 12; i++) x[i] = (float)i / 7.0f;
     int fd = lumi_take_sock(&L.peers[0]);
     uint32_t tried = 1;
+    double started = lumi_now();
     int bad = fd < 0 || lumi_send_exec(fd, 0, 0, x, 4, 3, NULL);
     LumiPeer *from = NULL;
     float *out = bad ? NULL : lumi_finish_exec(0, 0, x, 4, 3, NULL, fd,
-                                                &L.peers[0], &tried, &from);
+                                                &L.peers[0], started,
+                                                &tried, &from);
     bad |= !out || memcmp(out, x, sizeof x) || from != &L.peers[1] ||
            L.hedges != 1 || L.hedge_wins != 1;
     free(out); free(L.own);

--- a/test_scheduler.c
+++ b/test_scheduler.c
@@ -1,0 +1,27 @@
+#include "lumabri_scheduler.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    LmbLatencyPredictor fast, slow;
+    lmb_predict_init(&fast, 1000);
+    lmb_predict_init(&slow, 5000);
+    for (int i = 0; i < 24; i++) {
+        lmb_predict_observe(&fast, i == 8 ? 50000 : 1000);
+        lmb_predict_observe(&slow, 5000);
+    }
+    assert(lmb_predict_score(&fast, 0) < lmb_predict_score(&slow, 0));
+    assert(lmb_predict_score(&fast, 8) > lmb_predict_score(&slow, 0));
+    assert(lmb_predict_hedge_ms(&fast) > 0);
+    lmb_predict_failure(&fast, 100);
+    lmb_predict_failure(&fast, 100);
+    assert(lmb_predict_available(&fast, 100));
+    lmb_predict_failure(&fast, 100);
+    assert(!lmb_predict_available(&fast, 100));
+    assert(lmb_predict_available(&fast, 1100));
+    lmb_predict_observe(&fast, 900);
+    assert(lmb_predict_available(&fast, 100));
+    puts("PREDICTIVE SCHEDULER: PASS (EWMA, queue, p95 hedge, circuit breaker)");
+    return 0;
+}


### PR DESCRIPTION
## Outcome

Adds a shared predictive scheduler for Expert replicas and Segment chains. This PR moves **A (single-chat tok/s)** by refusing a slower estimated route, and **B/C** by spreading concurrent Expert work according to live inflight load instead of static RTT alone.

- Expert EWMA and slow-tail model with current inflight cost
- automatic p95 hedge after enough samples; `LUMABRI_HEDGE_MS` remains an override
- three-failure circuit breaker with bounded cooldown rather than permanent peer deletion
- Segment endpoint probes run only on the discovery control thread
- immutable snapshots carry predicted completion without changing the v1 wire encoding
- complete-chain selection minimizes predicted completion; fallback is a tie-breaker
- debug routes expose predicted milliseconds
- allocation-free scheduler unit gate

Adding a peer cannot displace a route whose current predicted completion is better. The multi-host gate remains the authority for an actual speedup claim.

## Compatibility

Colibri is unchanged. All Segment hooks still apply only to the temporary source copy under `build/`. The common Expert client is used by GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4.

## Verification

- `make check-warnings ENGINE=/tmp/colibri-validation/c`
- `make test ENGINE=/tmp/colibri-validation/c`
- predictive scheduler, hedge, verified failover and six-family discovery gates
- Segment Hybrid: 72 resident donor calls, identical oracle, dead-donor local fallback
- six-family Segment direct gate passed through OLMoE; the external Qwen tiny fixture emitted one UTF-8 DATA group for two invalid-byte tokens while that legacy script requires two frames (codec output remained valid and token oracle passed)

No merge performed.
