### PR TITLE
feat: bound concurrent Segment serving

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -375,6 +375,14 @@ the adaptive policy. Three consecutive failures open a short circuit instead
 of permanently deleting a valid manifest. Prefill and speculative target
 verification are batched automatically.
 
+Segment compute has a FIFO admission queue (`LUMABRI_SEGMENT_RUN_QUEUE`, default
+32) and a real deadline (`LUMABRI_SEGMENT_RUN_WAIT_MS`, default 30000). Queue and
+inflight counts are advertised to new placements. Keep the queue bounded: it is
+backpressure, not extra capacity. Current Colibri adapters serialize calls to
+one engine instance for numeric/state safety; aggregate concurrency comes from
+the layer pipeline and compatible replicas, while Expert executors continue to
+run their safe per-machine parallel gate.
+
 The boot narrates itself, so you can see where the time goes:
 
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
-		test_scheduler \
+		test_scheduler test_run_gate \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -413,6 +413,9 @@ test_machine: test_machine.c $(MACHINE_DEPS) lumabri_proto.h
 test_scheduler: test_scheduler.c lumabri_scheduler.h
 	$(CC) $(CFLAGS) test_scheduler.c -o $@
 
+test_run_gate: test_run_gate.c lumabri_run_gate.c lumabri_run_gate.h
+	$(CC) $(CFLAGS) -pthread test_run_gate.c lumabri_run_gate.c -o $@
+
 test-machine-governor: lumabri tracker swarm_probe expert_node segment_node fixture test_machine
 	ENGINE=$(ENGINE) bash ./machine_governor_test.sh
 
@@ -459,9 +462,11 @@ $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_brid
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 
-segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS)
+segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS) \
+		lumabri_run_gate.c lumabri_run_gate.h
 	$(CC) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
-		lumabri_segment_discovery.c $(MACHINE_SRC) $(COLIBRI_SEGMENT_LIB) -o $@ -lm
+		lumabri_segment_discovery.c $(MACHINE_SRC) lumabri_run_gate.c \
+		$(COLIBRI_SEGMENT_LIB) -o $@ -lm
 
 segment_chat: segment_chat.c lumabri_sampling.c lumabri_sampling.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
@@ -533,7 +538,7 @@ test-segment-discovery: tracker test_segment_discovery
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
-		test_scheduler
+		test_scheduler test_run_gate
 	./selftest.sh
 	./donate_test.sh
 	./signed_donor_test.sh
@@ -556,6 +561,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_hedge
 	./test_segment_v2
 	./test_scheduler
+	./test_run_gate
 	python3 ./test_swarm_bench.py
 	bash ./segment_discovery_test.sh
 	bash ./swarm_detail_test.sh
@@ -585,7 +591,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
-	      test_swarm_detail test_relay_rate test_machine test_scheduler \
+	      test_swarm_detail test_relay_rate test_machine test_scheduler test_run_gate \
 	      test_segment_v2_tsan tracker_tsan \
 	      segment_node segment_chat segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \

--- a/README.md
+++ b/README.md
@@ -300,6 +300,16 @@ covered MoE layer to strict-RAM Expert donors. Selected experts are sent in
 parallel; incomplete layers and failed donor calls execute locally. Thus even a
 peer too small for a complete Segment range contributes useful resident expert
 work, while the server remains the correctness fallback.
+
+Concurrent chats are admitted FIFO at every Segment range. Queue depth and
+inflight work are published to the predictive scheduler, the queue is bounded,
+and a request that misses its admission deadline returns `BUSY` so an exact
+replica can take over instead of waiting behind a 300-second socket timeout.
+The four origin ranges form a pipeline, so different chats can occupy different
+ranges concurrently. Lumabri deliberately does not fuse rows from unrelated
+sessions: current Colibri adapters own opaque per-session state and can round a
+cross-session batch differently. Calling that continuous batching before an
+engine-neutral multi-session batch ABI exists would break the token oracle.
 When two donors happen to hold the *same* expert, add `LUMABRI_SPREAD=1` on the
 chatter to balance the load between them too. Neither donor needs to know the
 others exist. Expert requests can fail over to another replica. Stateful

--- a/lumabri.c
+++ b/lumabri.c
@@ -742,14 +742,20 @@ static int cmd_serve(int argc, char **argv) {
         if (slice_threads < 1) slice_threads = 1;
         int sessions = lmb_env_int("LUMABRI_SEGMENT_SESSIONS",
                                    advertise ? 4 : 2, 1, 64);
+        int run_queue = lmb_env_int("LUMABRI_SEGMENT_RUN_QUEUE", 32, 0, 256);
+        int run_wait_ms = lmb_env_int("LUMABRI_SEGMENT_RUN_WAIT_MS",
+                                      30000, 50, 60000);
         uint32_t segment_context = 4096, model_context = 0;
         if (!local_model_u32(model, "max_position_embeddings", &model_context) &&
             model_context < segment_context)
             segment_context = model_context;
         char context[16], session_text[16], thread_text[16], memory_text[32];
+        char run_queue_text[16], run_wait_text[16];
         snprintf(context, sizeof context, "%u", segment_context);
         snprintf(session_text, sizeof session_text, "%d", sessions);
         snprintf(thread_text, sizeof thread_text, "%d", slice_threads);
+        snprintf(run_queue_text, sizeof run_queue_text, "%d", run_queue);
+        snprintf(run_wait_text, sizeof run_wait_text, "%d", run_wait_ms);
         uint64_t total_budget = segment_available > segment_min_free
                               ? segment_available - segment_min_free : 0;
         uint64_t slice_budget_mb = (total_budget / (uint64_t)chunks) >> 20;
@@ -792,6 +798,8 @@ static int cmd_serve(int argc, char **argv) {
             sargv[a++] = "--max-rows";     sargv[a++] = "16";
             sargv[a++] = "--sessions";     sargv[a++] = session_text;
             sargv[a++] = "--threads";      sargv[a++] = thread_text;
+            sargv[a++] = "--run-queue";    sargv[a++] = run_queue_text;
+            sargv[a++] = "--run-wait-ms";  sargv[a++] = run_wait_text;
             sargv[a++] = "--memory-limit-mb"; sargv[a++] = memory_text;
             sargv[a++] = "--advertise";    sargv[a++] = sadv;
             sargv[a] = NULL;
@@ -3271,13 +3279,19 @@ static int role_start_segment(const Role *r, const char *tracker,
     long cores = profile.physical_cores;
     int threads = cores > 1 ? (int)(cores / 2) : 1;
     int sessions = 2;
+    int run_queue = lmb_env_int("LUMABRI_SEGMENT_RUN_QUEUE", 32, 0, 256);
+    int run_wait_ms = lmb_env_int("LUMABRI_SEGMENT_RUN_WAIT_MS",
+                                  30000, 50, 60000);
     char port_text[16], context_text[16], sessions_text[16], threads_text[16];
+    char run_queue_text[16], run_wait_text[16];
     char memory_text[32], model_bytes_text[32], preflight_text[32];
     char address[80], name[64], base[48];
     snprintf(port_text, sizeof port_text, "%d", port);
     snprintf(context_text, sizeof context_text, "%d", context);
     snprintf(sessions_text, sizeof sessions_text, "%d", sessions);
     snprintf(threads_text, sizeof threads_text, "%d", threads);
+    snprintf(run_queue_text, sizeof run_queue_text, "%d", run_queue);
+    snprintf(run_wait_text, sizeof run_wait_text, "%d", run_wait_ms);
     snprintf(memory_text, sizeof memory_text, "%llu",
              (unsigned long long)(memory_budget >> 20));
     snprintf(model_bytes_text, sizeof model_bytes_text, "%llu",
@@ -3310,6 +3324,8 @@ static int role_start_segment(const Role *r, const char *tracker,
     argv[a++] = "--max-rows";      argv[a++] = "16";
     argv[a++] = "--sessions";      argv[a++] = sessions_text;
     argv[a++] = "--threads";       argv[a++] = threads_text;
+    argv[a++] = "--run-queue";     argv[a++] = run_queue_text;
+    argv[a++] = "--run-wait-ms";   argv[a++] = run_wait_text;
     argv[a++] = "--memory-limit-mb"; argv[a++] = memory_text;
     argv[a++] = "--model-bytes";   argv[a++] = model_bytes_text;
     argv[a++] = "--preflight-fd";  argv[a++] = preflight_text;

--- a/lumabri_run_gate.c
+++ b/lumabri_run_gate.c
@@ -1,0 +1,132 @@
+#define _POSIX_C_SOURCE 200809L
+#include "lumabri_run_gate.h"
+
+#include <errno.h>
+#include <string.h>
+#include <time.h>
+
+struct LmbRunWaiter {
+    struct LmbRunWaiter *next;
+    int admitted;
+};
+
+static void publish(LmbRunGate *gate) {
+    atomic_store(&gate->published_in_use, gate->in_use);
+    atomic_store(&gate->published_queued, gate->queued);
+}
+
+static void admit(LmbRunGate *gate) {
+    while (gate->in_use < gate->capacity && gate->head) {
+        LmbRunWaiter *waiter = gate->head;
+        gate->head = waiter->next;
+        if (!gate->head) gate->tail = NULL;
+        gate->queued--;
+        gate->in_use++;
+        waiter->admitted = 1;
+    }
+    publish(gate);
+    pthread_cond_broadcast(&gate->changed);
+}
+
+int lmb_run_gate_init(LmbRunGate *gate, uint32_t capacity,
+                      uint32_t max_queue) {
+    if (!gate || !capacity) return -1;
+    memset(gate, 0, sizeof *gate);
+    gate->capacity = capacity;
+    gate->max_queue = max_queue;
+    if (pthread_mutex_init(&gate->lock, NULL)) return -1;
+    if (pthread_cond_init(&gate->changed, NULL)) {
+        pthread_mutex_destroy(&gate->lock); return -1;
+    }
+    publish(gate);
+    return 0;
+}
+
+void lmb_run_gate_destroy(LmbRunGate *gate) {
+    if (!gate) return;
+    pthread_cond_destroy(&gate->changed);
+    pthread_mutex_destroy(&gate->lock);
+}
+
+static void deadline_after(struct timespec *deadline, uint32_t wait_ms) {
+    clock_gettime(CLOCK_REALTIME, deadline);
+    deadline->tv_sec += wait_ms / 1000u;
+    deadline->tv_nsec += (long)(wait_ms % 1000u) * 1000000L;
+    if (deadline->tv_nsec >= 1000000000L) {
+        deadline->tv_sec++;
+        deadline->tv_nsec -= 1000000000L;
+    }
+}
+
+static void waiter_remove(LmbRunGate *gate, LmbRunWaiter *waiter) {
+    LmbRunWaiter *previous = NULL;
+    for (LmbRunWaiter *item = gate->head; item; item = item->next) {
+        if (item != waiter) { previous = item; continue; }
+        if (previous) previous->next = item->next;
+        else gate->head = item->next;
+        if (gate->tail == item) gate->tail = previous;
+        gate->queued--;
+        break;
+    }
+    admit(gate);
+}
+
+int lmb_run_gate_enter(LmbRunGate *gate, uint32_t wait_ms,
+                       LmbRunCancelFn cancel, void *cancel_opaque) {
+    if (!gate || !wait_ms) return 0;
+    pthread_mutex_lock(&gate->lock);
+    if (!gate->head && gate->in_use < gate->capacity) {
+        gate->in_use++;
+        publish(gate);
+        pthread_mutex_unlock(&gate->lock);
+        return 1;
+    }
+    if (gate->queued >= gate->max_queue) {
+        pthread_mutex_unlock(&gate->lock);
+        return 0;
+    }
+    LmbRunWaiter waiter = {0};
+    if (gate->tail) gate->tail->next = &waiter;
+    else gate->head = &waiter;
+    gate->tail = &waiter;
+    gate->queued++;
+    publish(gate);
+
+    struct timespec deadline;
+    deadline_after(&deadline, wait_ms);
+    int result = 0;
+    while (!waiter.admitted) {
+        if (cancel && cancel(cancel_opaque)) { result = -1; break; }
+        struct timespec poll_deadline;
+        deadline_after(&poll_deadline, wait_ms < 100u ? wait_ms : 100u);
+        if (poll_deadline.tv_sec > deadline.tv_sec ||
+            (poll_deadline.tv_sec == deadline.tv_sec &&
+             poll_deadline.tv_nsec > deadline.tv_nsec))
+            poll_deadline = deadline;
+        int rc = pthread_cond_timedwait(&gate->changed, &gate->lock,
+                                        &poll_deadline);
+        if (waiter.admitted) break;
+        if (rc == ETIMEDOUT && poll_deadline.tv_sec == deadline.tv_sec &&
+            poll_deadline.tv_nsec == deadline.tv_nsec) break;
+    }
+    if (waiter.admitted) result = 1;
+    else waiter_remove(gate, &waiter);
+    pthread_mutex_unlock(&gate->lock);
+    return result;
+}
+
+void lmb_run_gate_leave(LmbRunGate *gate) {
+    if (!gate) return;
+    pthread_mutex_lock(&gate->lock);
+    if (gate->in_use) gate->in_use--;
+    admit(gate);
+    pthread_mutex_unlock(&gate->lock);
+}
+
+uint32_t lmb_run_gate_inflight(const LmbRunGate *gate) {
+    return gate ? atomic_load(&gate->published_in_use) : 0;
+}
+
+uint32_t lmb_run_gate_queued(const LmbRunGate *gate) {
+    return gate ? atomic_load(&gate->published_queued) : 0;
+}

--- a/lumabri_run_gate.h
+++ b/lumabri_run_gate.h
@@ -1,0 +1,39 @@
+#ifndef LUMABRI_RUN_GATE_H
+#define LUMABRI_RUN_GATE_H
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+typedef int (*LmbRunCancelFn)(void *opaque);
+
+typedef struct LmbRunWaiter LmbRunWaiter;
+
+typedef struct {
+    pthread_mutex_t lock;
+    pthread_cond_t changed;
+    LmbRunWaiter *head;
+    LmbRunWaiter *tail;
+    uint32_t capacity;
+    uint32_t max_queue;
+    uint32_t in_use;
+    uint32_t queued;
+    _Atomic uint32_t published_in_use;
+    _Atomic uint32_t published_queued;
+} LmbRunGate;
+
+int lmb_run_gate_init(LmbRunGate *gate, uint32_t capacity,
+                      uint32_t max_queue);
+void lmb_run_gate_destroy(LmbRunGate *gate);
+
+/* FIFO admission. Returns 1 when admitted, 0 on queue limit/timeout and -1
+ * when cancellation was requested. wait_ms is a real interactive deadline,
+ * not the transport's long safety timeout. */
+int lmb_run_gate_enter(LmbRunGate *gate, uint32_t wait_ms,
+                       LmbRunCancelFn cancel, void *cancel_opaque);
+void lmb_run_gate_leave(LmbRunGate *gate);
+
+uint32_t lmb_run_gate_inflight(const LmbRunGate *gate);
+uint32_t lmb_run_gate_queued(const LmbRunGate *gate);
+
+#endif

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -881,9 +881,12 @@ static int conversation_recover(
                     !route_same_range(candidate, current,
                                       context, max_rows)) continue;
                 if (!chosen ||
-                    ((candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
+                    candidate->predicted_us < chosen->predicted_us ||
+                    (candidate->predicted_us == chosen->predicted_us &&
+                     (candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
                      !(chosen->transport & LMB_SEG_TRANSPORT_DIRECT)) ||
-                    ((candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK) == 0 &&
+                    (candidate->predicted_us == chosen->predicted_us &&
+                     (candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK) == 0 &&
                      (chosen->advert.flags & LMB_SEG_ADVERT_FALLBACK)))
                     chosen = candidate;
             }

--- a/segment_node.c
+++ b/segment_node.c
@@ -5,6 +5,7 @@
 #include "lumabri_segment.h"
 #include "lumabri_segment_discovery.h"
 #include "lumabri_machine.h"
+#include "lumabri_run_gate.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 #include "segment_colibri.h"
@@ -54,6 +55,7 @@ typedef struct {
     LmbSegAdvert advert;
     uint8_t pk[32], sk[64];
     LmbSegOwner owner;
+    LmbRunGate *run_gate;
     int ready;
     volatile sig_atomic_t stop;
 } TrackerRegistration;
@@ -65,7 +67,8 @@ typedef struct {
     LmbSegTable *table;
     NodeSession sessions[NODE_SESSIONS_MAX];
     pthread_mutex_t sessions_lock;
-    pthread_mutex_t run_lock;      /* one OpenMP team per slice, no oversubscription */
+    LmbRunGate run_gate;
+    uint32_t run_wait_ms;
     pthread_mutex_t connections_lock;
     pthread_cond_t connections_drained;
     int connection_fds[NODE_CONNECTIONS_MAX];
@@ -167,6 +170,10 @@ static int tracker_register_send(int fd, const uint8_t nonce[32],
     pthread_mutex_lock(&r->lock);
     advert = r->advert;
     pthread_mutex_unlock(&r->lock);
+    if (r->run_gate) {
+        advert.queue_depth = lmb_run_gate_queued(r->run_gate);
+        advert.inflight = lmb_run_gate_inflight(r->run_gate);
+    }
     uint8_t *wire = NULL;
     uint32_t wire_len = 0;
     if (lmb_seg_advert_encode(&advert, &wire, &wire_len)) return -1;
@@ -622,15 +629,13 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
         if (!session || !output || bytes != msg->pay_len) {
             status = LMB_SEG_STATUS_INTERNAL;
         } else {
-            pthread_mutex_lock(&node->registration.lock);
-            node->registration.advert.queue_depth++;
-            pthread_mutex_unlock(&node->registration.lock);
-            pthread_mutex_lock(&node->run_lock);
-            pthread_mutex_lock(&node->registration.lock);
-            if (node->registration.advert.queue_depth)
-                node->registration.advert.queue_depth--;
-            node->registration.advert.inflight++;
-            pthread_mutex_unlock(&node->registration.lock);
+            int admitted = lmb_run_gate_enter(&node->run_gate,
+                                               node->run_wait_ms,
+                                               memory_pressure, node);
+            if (admitted != 1) {
+                status = admitted < 0 ? LMB_SEG_STATUS_QUOTA :
+                                        LMB_SEG_STATUS_BUSY;
+            }
             ColiSegmentRunRequest request = {
                 .struct_size = sizeof request,
                 .rows = run.rows,
@@ -645,7 +650,8 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                 .cancel_user_data = node,
             };
             char error[256] = "";
-            if (coli_segment_run(session, &request, error, sizeof error)) {
+            if (admitted == 1 &&
+                coli_segment_run(session, &request, error, sizeof error)) {
                 /* Name the slice: an origin runs several of these at once and
                  * an unlabelled line cannot be attributed to a layer range. */
                 fprintf(stderr, "[segment-node %s %u:%u] run failed on %u row%s "
@@ -657,11 +663,7 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                         engine_error(error));
                 status = LMB_SEG_STATUS_INTERNAL;
             }
-            pthread_mutex_lock(&node->registration.lock);
-            if (node->registration.advert.inflight)
-                node->registration.advert.inflight--;
-            pthread_mutex_unlock(&node->registration.lock);
-            pthread_mutex_unlock(&node->run_lock);
+            if (admitted == 1) lmb_run_gate_leave(&node->run_gate);
         }
         if (status != LMB_SEG_STATUS_OK) {
             (void)lmb_seg_table_run_abort(node->table, &run);
@@ -954,7 +956,8 @@ static void usage(const char *program) {
         "--advertise HOST:PORT --name PEER "
         "(--auto-identity | --model-root HEX64 --tokenizer-root HEX64) "
         "[--fallback] [--relay-only] [--context N] [--max-rows N] "
-        "[--sessions N] [--threads N] [--memory-limit-mb N] "
+        "[--sessions N] [--threads N] [--run-queue N] [--run-wait-ms N] "
+        "[--memory-limit-mb N] "
         "[--model-bytes N --model-layers N] [--preflight-fd N]\n",
         program);
 }
@@ -1076,6 +1079,7 @@ int main(int argc, char **argv) {
         usage(argv[0]); return 2;
     }
     uint32_t context = 4096, max_rows = 256, max_sessions = 16, threads = 0;
+    uint32_t run_queue = 32, run_wait_ms = 30000;
     uint32_t memory_limit_mb = 0, model_layers = 0, preflight_fd_u32 = 0;
     uint64_t model_bytes = 0;
     int preflight_fd = -1;
@@ -1088,6 +1092,10 @@ int main(int argc, char **argv) {
          lmb_parse_u32(value, 1, NODE_SESSIONS_MAX, &max_sessions)) ||
         ((value = arg_value(argc, argv, "--threads")) &&
          lmb_parse_u32(value, 1, 256, &threads)) ||
+        ((value = arg_value(argc, argv, "--run-queue")) &&
+         lmb_parse_u32(value, 0, NODE_SESSIONS_MAX, &run_queue)) ||
+        ((value = arg_value(argc, argv, "--run-wait-ms")) &&
+         lmb_parse_u32(value, 50, 60000, &run_wait_ms)) ||
         ((value = arg_value(argc, argv, "--memory-limit-mb")) &&
          lmb_parse_u32(value, 1, 1048576, &memory_limit_mb)) ||
         ((value = arg_value(argc, argv, "--model-bytes")) &&
@@ -1243,7 +1251,11 @@ int main(int argc, char **argv) {
     memset(&node, 0, sizeof node);
     for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) node.connection_fds[i] = -1;
     pthread_mutex_init(&node.sessions_lock, NULL);
-    pthread_mutex_init(&node.run_lock, NULL);
+    if (lmb_run_gate_init(&node.run_gate, 1, run_queue)) {
+        fprintf(stderr, "cannot initialize Segment admission gate\n");
+        return 1;
+    }
+    node.run_wait_ms = run_wait_ms;
     pthread_mutex_init(&node.connections_lock, NULL);
     pthread_cond_init(&node.connections_drained, NULL);
     for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
@@ -1253,6 +1265,8 @@ int main(int argc, char **argv) {
     node.process_memory_limit_bytes = process_limit;
     fprintf(stderr, "[segment-node] governor: %.1f GB RAM reserved for the "
                     "machine\n", (double)node.ram_reserve_bytes / 1e9);
+    fprintf(stderr, "[segment-node] admission: one engine team · FIFO queue "
+                    "%u · %u ms deadline\n", run_queue, run_wait_ms);
     ColiSegmentEngineOptions options = {
         .struct_size = sizeof options,
         .model_dir = model_dir,
@@ -1336,6 +1350,7 @@ int main(int argc, char **argv) {
     node.table = lmb_seg_table_create(max_sessions);
     if (!node.table) { fprintf(stderr, "cannot create session table\n"); return 1; }
     TrackerRegistration *registration = &node.registration;
+    registration->run_gate = &node.run_gate;
     pthread_mutex_init(&registration->lock, NULL);
     snprintf(registration->tracker, sizeof registration->tracker, "%s", tracker);
     snprintf(registration->local_addr, sizeof registration->local_addr,
@@ -1418,7 +1433,7 @@ int main(int argc, char **argv) {
     pthread_cond_destroy(&node.connections_drained);
     pthread_mutex_destroy(&node.connections_lock);
     pthread_mutex_destroy(&node.sessions_lock);
-    pthread_mutex_destroy(&node.run_lock);
+    lmb_run_gate_destroy(&node.run_gate);
     for (size_t i = 0; i < NODE_SESSIONS_MAX; i++)
         pthread_mutex_destroy(&node.sessions[i].lock);
     pthread_mutex_destroy(&registration->lock);

--- a/test_run_gate.c
+++ b/test_run_gate.c
@@ -1,0 +1,75 @@
+#define _DEFAULT_SOURCE
+#include "lumabri_run_gate.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+typedef struct {
+    LmbRunGate *gate;
+    int id;
+    uint32_t wait_ms;
+    _Atomic int *order_index;
+    int *order;
+    int result;
+} Worker;
+
+static void *worker(void *opaque) {
+    Worker *work = opaque;
+    work->result = lmb_run_gate_enter(work->gate, work->wait_ms, NULL, NULL);
+    if (work->result == 1) {
+        int index = atomic_fetch_add(work->order_index, 1);
+        work->order[index] = work->id;
+        usleep(30000);
+        lmb_run_gate_leave(work->gate);
+    }
+    return NULL;
+}
+
+static int cancelled(void *opaque) {
+    return atomic_load((_Atomic int *)opaque);
+}
+
+int main(void) {
+    LmbRunGate gate;
+    assert(!lmb_run_gate_init(&gate, 1, 2));
+    assert(lmb_run_gate_enter(&gate, 100, NULL, NULL) == 1);
+
+    _Atomic int index = 0;
+    int order[2] = {-1, -1};
+    Worker works[3] = {
+        { &gate, 1, 1000, &index, order, 0 },
+        { &gate, 2, 1000, &index, order, 0 },
+        { &gate, 3, 20, &index, order, 0 },
+    };
+    pthread_t threads[3];
+    pthread_create(&threads[0], NULL, worker, &works[0]);
+    usleep(10000);
+    pthread_create(&threads[1], NULL, worker, &works[1]);
+    usleep(10000);
+    assert(lmb_run_gate_queued(&gate) == 2);
+    pthread_create(&threads[2], NULL, worker, &works[2]);
+    pthread_join(threads[2], NULL);
+    assert(works[2].result == 0); /* bounded queue rejects immediately */
+    lmb_run_gate_leave(&gate);
+    pthread_join(threads[0], NULL);
+    pthread_join(threads[1], NULL);
+    assert(works[0].result == 1 && works[1].result == 1);
+    assert(order[0] == 1 && order[1] == 2); /* FIFO, no chat starvation */
+    assert(!lmb_run_gate_inflight(&gate) && !lmb_run_gate_queued(&gate));
+
+    assert(lmb_run_gate_enter(&gate, 100, NULL, NULL) == 1);
+    Worker timeout = { &gate, 4, 20, &index, order, 0 };
+    pthread_create(&threads[0], NULL, worker, &timeout);
+    pthread_join(threads[0], NULL);
+    assert(timeout.result == 0);
+    _Atomic int stop = 1;
+    assert(lmb_run_gate_enter(&gate, 100, cancelled, &stop) == -1);
+    lmb_run_gate_leave(&gate);
+    lmb_run_gate_destroy(&gate);
+    puts("RUN GATE: PASS (FIFO, bounded queue, deadline, cancellation, telemetry)");
+    return 0;
+}


### PR DESCRIPTION
## Outcome

Adds bounded, fair concurrent admission for stateful Segment serving. This PR moves **B (aggregate tok/s at 1/2/4/8 chats)** by making the existing multi-range pipeline schedulable under load and moves **A/B reliability** by failing over saturated ranges before the transport's 300-second safety timeout.

- FIFO admission per Segment engine, without chat starvation
- bounded queue and a 30-second default interactive admission deadline
- immediate `BUSY`/governor cancellation so an exact replica can take over
- live queue/inflight telemetry in Segment heartbeats
- failover replica choice uses predicted completion
- user-level controls: `LUMABRI_SEGMENT_RUN_QUEUE` and `LUMABRI_SEGMENT_RUN_WAIT_MS`
- deterministic gate tests for FIFO order, queue bounds, deadlines, cancellation and telemetry

Current Colibri adapters intentionally serialize one engine instance for opaque state and numeric safety. Lumabri therefore does not fuse unrelated sessions and call it continuous batching: the safe aggregate parallelism comes from the four-range pipeline, Segment replicas and the already parallel Expert executors. A true fused multi-session batch needs a future engine-neutral ABI and a token-oracle gate.

## Compatibility

Colibri is unchanged. The gate is entirely in Lumabri and applies uniformly to GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4.

## Verification

- Werror build of `lumabri`, `segment_node`, `segment_chat` and the gate
- complete `make test ENGINE=/tmp/colibri-validation/c`
- Segment Hybrid gate: 72 resident donor calls and local fallback after donor death

No merge performed.
