### PR TITLE
fix: detect available RAM on WSL1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ a tag stay under Unreleased until a new tag is created.
 
 ## Unreleased
 
+- WSL1 memory compatibility: when `/proc/meminfo` omits `MemAvailable`,
+  machine profiling, doctor, governor, Segment and resident Expert sizing now
+  share a conservative reclaimable-cache fallback; native Linux values remain
+  authoritative when present.
 - Streaming Segment replies with live routing/prefill/decode/checkpoint/failover
   status, a fixed non-blocking input dock, slash-command autocomplete and menus
   usable during inference.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
-		test_scheduler test_run_gate \
+		test_meminfo test_scheduler test_run_gate \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -410,6 +410,9 @@ test_relay_rate: test_relay_rate.c lumabri_segment.c lumabri_segment.h \
 test_machine: test_machine.c $(MACHINE_DEPS) lumabri_proto.h
 	$(CC) $(CFLAGS) -pthread test_machine.c $(MACHINE_SRC) -o $@
 
+test_meminfo: test_meminfo.c $(MACHINE_DEPS) lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_meminfo.c $(MACHINE_SRC) -o $@
+
 test_scheduler: test_scheduler.c lumabri_scheduler.h
 	$(CC) $(CFLAGS) test_scheduler.c -o $@
 
@@ -428,10 +431,12 @@ test-sanitize:
 	$(CC) $(SANITIZE_FLAGS) -pthread test_segment_v2.c lumabri_segment.c -o build/sanitize/test_segment_v2
 	$(CC) $(SANITIZE_FLAGS) -pthread test_segment_discovery.c lumabri_segment_discovery.c lumabri_segment.c -o build/sanitize/test_segment_discovery
 	$(CC) $(SANITIZE_FLAGS) -pthread test_run_gate.c lumabri_run_gate.c -o build/sanitize/test_run_gate
+	$(CC) $(SANITIZE_FLAGS) -pthread test_meminfo.c $(MACHINE_SRC) -o build/sanitize/test_meminfo
 	$(CC) $(SANITIZE_FLAGS) test_scheduler.c -o build/sanitize/test_scheduler
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_segment_v2
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_segment_discovery
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_run_gate
+	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_meminfo
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_scheduler
 
 test-thread-sanitize:
@@ -562,7 +567,7 @@ test-segment-discovery: tracker test_segment_discovery
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
-		test_scheduler test_run_gate
+		test_meminfo test_scheduler test_run_gate
 	bash ./selftest.sh
 	bash ./donate_test.sh
 	bash ./signed_donor_test.sh
@@ -584,6 +589,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_key_rotation
 	./test_hedge
 	./test_segment_v2
+	./test_meminfo
 	./test_scheduler
 	./test_run_gate
 	python3 ./test_swarm_bench.py
@@ -619,7 +625,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
-	      test_swarm_detail test_relay_rate test_machine test_scheduler test_run_gate \
+	      test_swarm_detail test_relay_rate test_machine test_meminfo test_scheduler test_run_gate \
 	      test_segment_v2_tsan tracker_tsan \
 	      segment_node segment_chat segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ model/ISA, physical and logical cores, NUMA, RAM/swap, visible GPU/VRAM, disk,
 interfaces and optional tracker RTT. `--json` emits a stable schema for
 automation. `lumabri limits` shows the current donation budget; `lumabri pause`
 and `lumabri resume` control every local donor without killing the chat.
+On kernels without `/proc/meminfo`'s `MemAvailable` (notably WSL1), the same
+conservative reclaimable-cache fallback is shared by doctor, Segment, Expert
+and the governor; modern Linux continues to use its native value unchanged.
 `lumabri doctor --json` is the versioned deployment preflight for required
 binaries, CAS state, model readability, tracker reachability and the complete
 serving port block. The reproducible local, sanitizer, multi-host and soak

--- a/expert_node.c
+++ b/expert_node.c
@@ -73,6 +73,7 @@
 #include "lumabri_secure.h"
 
 #include <omp.h>
+#include <limits.h>
 #include <pthread.h>
 #include <sched.h>
 #include <stdatomic.h>
@@ -823,17 +824,13 @@ static void runtime_prepare(int argc, char **argv) {
 #endif
 }
 
-/* Free RAM in KB (MemAvailable), or -1 if it cannot be read. Used by --hold auto
- * to size how many experts this donor should carry. */
+/* Use the same modern-Linux/legacy-WSL calculation as machine, doctor,
+ * Segment and the governor. A second /proc parser here used to leave WSL1
+ * Expert donors at zero even after the machine profile was corrected. */
 static long meminfo_avail_kb(void) {
-    FILE *f = fopen("/proc/meminfo", "r");
-    if (!f) return -1;
-    char line[256];
-    long kb = -1;
-    while (fgets(line, sizeof line, f))
-        if (sscanf(line, "MemAvailable: %ld kB", &kb) == 1) break;
-    fclose(f);
-    return kb;
+    uint64_t kb = lmb_machine_available_ram() >> 10;
+    if (!kb) return -1;
+    return kb > (uint64_t)LONG_MAX ? LONG_MAX : (long)kb;
 }
 
 int main(int argc, char **argv) {

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
+#include <limits.h>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <stdlib.h>
@@ -28,24 +29,65 @@ static int read_u64_file(const char *path, uint64_t *value) {
     return 0;
 }
 
+static uint64_t kib_to_bytes(unsigned long long kib) {
+    if (kib > (unsigned long long)(UINT64_MAX >> 10)) return UINT64_MAX;
+    return (uint64_t)kib << 10;
+}
+
+static unsigned long long add_kib(unsigned long long left,
+                                  unsigned long long right) {
+    return ULLONG_MAX - left < right ? ULLONG_MAX : left + right;
+}
+
+int lmb_machine_read_meminfo(FILE *file, uint64_t *total,
+                             uint64_t *available, uint64_t *swap_total,
+                             uint64_t *swap_free) {
+    if (!file) return -1;
+    char line[256];
+    unsigned long long mt = 0, ma = 0, mf = 0, buffers = 0;
+    unsigned long long cached = 0, reclaimable = 0, shmem = 0;
+    unsigned long long st = 0, sf = 0;
+    int have_available = 0;
+    while (fgets(line, sizeof line, file)) {
+        (void)sscanf(line, "MemTotal: %llu kB", &mt);
+        if (sscanf(line, "MemAvailable: %llu kB", &ma) == 1)
+            have_available = 1;
+        (void)sscanf(line, "MemFree: %llu kB", &mf);
+        (void)sscanf(line, "Buffers: %llu kB", &buffers);
+        (void)sscanf(line, "Cached: %llu kB", &cached);
+        (void)sscanf(line, "SReclaimable: %llu kB", &reclaimable);
+        (void)sscanf(line, "Shmem: %llu kB", &shmem);
+        (void)sscanf(line, "SwapTotal: %llu kB", &st);
+        (void)sscanf(line, "SwapFree: %llu kB", &sf);
+    }
+    if (!have_available) {
+        /* Linux added MemAvailable in 3.14, but WSL1's 4.4 compatibility
+         * procfs omits it. Match the conservative procps fallback: genuinely
+         * free pages plus reclaimable buffer/page/slab cache, excluding
+         * shared-memory pages. Never claim more than MemTotal. */
+        unsigned long long cache = add_kib(cached, reclaimable);
+        cache = cache > shmem ? cache - shmem : 0;
+        ma = add_kib(add_kib(mf, buffers), cache);
+        if (mt && ma > mt) ma = mt;
+    }
+    if (total) *total = kib_to_bytes(mt);
+    if (available) *available = kib_to_bytes(ma);
+    if (swap_total) *swap_total = kib_to_bytes(st);
+    if (swap_free) *swap_free = kib_to_bytes(sf);
+    return mt ? 0 : -1;
+}
+
 static void meminfo(uint64_t *total, uint64_t *available,
                     uint64_t *swap_total, uint64_t *swap_free) {
     FILE *file = fopen("/proc/meminfo", "r");
-    char line[256];
-    unsigned long long mt = 0, ma = 0, st = 0, sf = 0;
-    if (file) {
-        while (fgets(line, sizeof line, file)) {
-            (void)sscanf(line, "MemTotal: %llu kB", &mt);
-            (void)sscanf(line, "MemAvailable: %llu kB", &ma);
-            (void)sscanf(line, "SwapTotal: %llu kB", &st);
-            (void)sscanf(line, "SwapFree: %llu kB", &sf);
-        }
-        fclose(file);
+    if (!file || lmb_machine_read_meminfo(file, total, available,
+                                          swap_total, swap_free)) {
+        if (total) *total = 0;
+        if (available) *available = 0;
+        if (swap_total) *swap_total = 0;
+        if (swap_free) *swap_free = 0;
     }
-    if (total) *total = (uint64_t)mt << 10;
-    if (available) *available = (uint64_t)ma << 10;
-    if (swap_total) *swap_total = (uint64_t)st << 10;
-    if (swap_free) *swap_free = (uint64_t)sf << 10;
+    if (file) fclose(file);
 }
 
 uint64_t lmb_machine_available_ram(void) {

--- a/lumabri_machine.h
+++ b/lumabri_machine.h
@@ -44,6 +44,11 @@ typedef struct {
 
 int lmb_machine_probe(LmbMachineProfile *profile, const char *disk_path,
                       const char *tracker);
+/* Parse Linux /proc/meminfo. Exposed so compatibility fixtures can exercise
+ * kernels that predate MemAvailable without replacing the process procfs. */
+int lmb_machine_read_meminfo(FILE *stream, uint64_t *total,
+                             uint64_t *available, uint64_t *swap_total,
+                             uint64_t *swap_free);
 void lmb_machine_print(FILE *out, const LmbMachineProfile *profile, int json);
 uint64_t lmb_machine_available_ram(void);
 uint64_t lmb_machine_total_ram(void);

--- a/test_meminfo.c
+++ b/test_meminfo.c
@@ -1,0 +1,48 @@
+#include "lumabri_machine.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static void parse(const char *text, uint64_t *total, uint64_t *available) {
+    FILE *stream = tmpfile();
+    assert(stream);
+    assert(fputs(text, stream) >= 0);
+    rewind(stream);
+    assert(lmb_machine_read_meminfo(stream, total, available, NULL, NULL) == 0);
+    fclose(stream);
+}
+
+int main(void) {
+    uint64_t total = 0, available = 0;
+
+    /* A modern Linux value remains authoritative. The fallback inputs are
+     * deliberately much larger so accidentally combining them fails. */
+    parse("MemTotal: 100000 kB\n"
+          "MemAvailable: 12000 kB\n"
+          "MemFree: 90000 kB\n"
+          "Buffers: 1000 kB\n"
+          "Cached: 2000 kB\n"
+          "SReclaimable: 3000 kB\n"
+          "Shmem: 500 kB\n", &total, &available);
+    assert(total == 100000ull * 1024);
+    assert(available == 12000ull * 1024);
+
+    /* WSL1 omits MemAvailable. Use free + buffers + reclaimable cache -
+     * shared memory, which is the value old procps reports as available. */
+    parse("MemTotal: 134217728 kB\n"
+          "MemFree: 83886080 kB\n"
+          "Buffers: 100000 kB\n"
+          "Cached: 200000 kB\n"
+          "SReclaimable: 50000 kB\n"
+          "Shmem: 25000 kB\n", &total, &available);
+    assert(available == 84211080ull * 1024);
+
+    /* Malformed legacy counters can never publish more RAM than exists. */
+    parse("MemTotal: 1000 kB\n"
+          "MemFree: 900 kB\n"
+          "Cached: 900 kB\n", &total, &available);
+    assert(available == total);
+
+    puts("MEMINFO TEST: PASS (native MemAvailable preserved; WSL1 fallback)");
+    return 0;
+}


### PR DESCRIPTION
## Problem

WSL1's `4.4.0-*-Microsoft` procfs can report `MemTotal`, `MemFree` and cache
counters while omitting `MemAvailable`. Lumabri treated the missing field as
zero. A 128 GiB machine therefore showed `RAM 0.0/137.2 GB available`, doctor
warned, `limits` exposed 0 GB, Segment declined to start and Expert
`--hold auto` advertised nothing.

`RAM_GB` could not help because it controls only Colibri's local cache.

## Fix

- preserve native `MemAvailable` exactly whenever the kernel supplies it
- only when it is absent, use the conservative procps-style fallback:
  `MemFree + Buffers + max(Cached + SReclaimable - Shmem, 0)`
- cap only the fallback at `MemTotal`
- make Expert auto-residency use the same shared reader as machine, doctor,
  Segment and the governor instead of maintaining a second parser
- add a deterministic modern-Linux fixture, a WSL1 fixture and an invalid
  over-cap fixture
- include the fixture in Werror, ordinary test and ASan/UBSan gates

This does not change Colibri and does not modify the behavior of Linux kernels
that already expose `MemAvailable`.

## Validation

- focused `test_meminfo` under `-Werror`: PASS
- full `make check-warnings ENGINE=/tmp/colibri-validation/c`: PASS
- full `make test ENGINE=/tmp/colibri-validation/c`: PASS
- new fixture under ASan/UBSan: PASS
- local LeakSanitizer aggregate target could not initialize under the current
  ptrace environment; the new ASan/UBSan binary itself passed with leak
  detection disabled, and GitHub CI runs the complete target outside ptrace

## Stack

Base: `feat/production-hardening` (#87). This PR is intentionally separate and
must not be merged before the earlier roadmap stack.
