### PR TITLE
fix: coordinate resident donors and runtime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ a tag stay under Unreleased until a new tag is created.
 
 ## Unreleased
 
+- Donor runtime coordination: one automatic RAM-sized compute donation per
+  machine/user now covers both chat roles and `serve --join`; duplicate starts
+  remain useful as storage-only peers and identify the current lease owner.
+  Linux children also terminate with their parent instead of leaving resident
+  Expert/Segment executors behind after a killed TUI.
+- Colibri's mutable local `.coli_*` runtime state (including `.coli_usage`) is
+  excluded from storage manifests, so it can no longer generate repeated
+  unsigned-content rejections. Governor transitions now report the exact
+  pressure reason, available/reserved RAM and resident RSS/weights.
 - WSL1 memory compatibility: when `/proc/meminfo` omits `MemAvailable`,
   machine profiling, doctor, governor, Segment and resident Expert sizing now
   share a conservative reclaimable-cache fallback; native Linux values remain

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -345,6 +345,14 @@ On first launch the chat asks what you are bringing — Enter for chat only,
 donors live as long as the chat does. `--role chat|disk|compute|all` skips
 the question for scripts and services.
 
+Only one automatic compute role is admitted per machine/user across both chat
+and `serve --join`. If another process already owns the donable RAM, Lumabri
+prints its PID/model/tracker and leaves the second process storage-only. This is
+intentional: one resident executor receives the complete disjoint assignment;
+four independently auto-sized executors would all reserve the same RAM. Stop
+old Lumabri parents before retesting a new build. On Linux, executors spawned by
+the new build terminate automatically when their parent dies.
+
 **Chat** — this is the whole point:
 
 ```sh
@@ -518,6 +526,11 @@ Two things worth knowing:
   does not reopen names for takeover.
 - **A client with a warm mirror keeps working with the server off.** That
   is the design, and `selftest.sh` pass 3 tests exactly it.
+- **`.coli_*` files never leave their machine.** They are mutable Colibri
+  runtime telemetry/cache state, not signed model bytes. If a tracker still
+  prints `REJECTED ... unsigned .../.coli_usage`, restart that donor with the
+  same current Lumabri build; an older maintainer process is still announcing
+  its startup manifest.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
 		test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
-		test_meminfo test_scheduler test_run_gate \
+		test_meminfo test_compute_lease test_content_filter \
+		test_scheduler test_run_gate \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -364,7 +365,8 @@ tracker: tracker.c lumabri_segment_discovery.c lumabri_segment_discovery.h \
 	$(CC) $(CFLAGS) -pthread tracker.c lumabri_segment_discovery.c \
 		lumabri_segment.c -o $@
 
-maintainer: maintainer.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
+maintainer: maintainer.c lumabri_content.h lumabri_proto.h lumabri_sha.h \
+		lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread maintainer.c -o $@
 
 # The shim interposes libc symbols, so it must not itself be interposable
@@ -372,7 +374,7 @@ maintainer: maintainer.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_D
 liblumabri.so: lumashim.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -shared -fPIC -pthread lumashim.c -o $@ -ldl
 
-test_shim: test_shim.c
+test_shim: test_shim.c lumabri_content.h
 	$(CC) $(CFLAGS) test_shim.c -o $@
 
 test_relay_exec: test_relay_exec.c lumabri_proto.h
@@ -413,6 +415,12 @@ test_machine: test_machine.c $(MACHINE_DEPS) lumabri_proto.h
 test_meminfo: test_meminfo.c $(MACHINE_DEPS) lumabri_proto.h
 	$(CC) $(CFLAGS) -pthread test_meminfo.c $(MACHINE_SRC) -o $@
 
+test_compute_lease: test_compute_lease.c $(MACHINE_DEPS) lumabri_proto.h
+	$(CC) $(CFLAGS) -pthread test_compute_lease.c $(MACHINE_SRC) -o $@
+
+test_content_filter: test_content_filter.c lumabri_content.h
+	$(CC) $(CFLAGS) test_content_filter.c -o $@
+
 test_scheduler: test_scheduler.c lumabri_scheduler.h
 	$(CC) $(CFLAGS) test_scheduler.c -o $@
 
@@ -432,11 +440,15 @@ test-sanitize:
 	$(CC) $(SANITIZE_FLAGS) -pthread test_segment_discovery.c lumabri_segment_discovery.c lumabri_segment.c -o build/sanitize/test_segment_discovery
 	$(CC) $(SANITIZE_FLAGS) -pthread test_run_gate.c lumabri_run_gate.c -o build/sanitize/test_run_gate
 	$(CC) $(SANITIZE_FLAGS) -pthread test_meminfo.c $(MACHINE_SRC) -o build/sanitize/test_meminfo
+	$(CC) $(SANITIZE_FLAGS) -pthread test_compute_lease.c $(MACHINE_SRC) -o build/sanitize/test_compute_lease
+	$(CC) $(SANITIZE_FLAGS) test_content_filter.c -o build/sanitize/test_content_filter
 	$(CC) $(SANITIZE_FLAGS) test_scheduler.c -o build/sanitize/test_scheduler
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_segment_v2
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_segment_discovery
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_run_gate
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_meminfo
+	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_compute_lease
+	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_content_filter
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_scheduler
 
 test-thread-sanitize:
@@ -567,7 +579,8 @@ test-segment-discovery: tracker test_segment_discovery
 
 test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
-		test_meminfo test_scheduler test_run_gate
+		test_meminfo test_compute_lease test_content_filter \
+		test_scheduler test_run_gate
 	bash ./selftest.sh
 	bash ./donate_test.sh
 	bash ./signed_donor_test.sh
@@ -590,6 +603,8 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	./test_hedge
 	./test_segment_v2
 	./test_meminfo
+	./test_compute_lease
+	./test_content_filter
 	./test_scheduler
 	./test_run_gate
 	python3 ./test_swarm_bench.py
@@ -625,7 +640,8 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
-	      test_swarm_detail test_relay_rate test_machine test_meminfo test_scheduler test_run_gate \
+	      test_swarm_detail test_relay_rate test_machine test_meminfo \
+	      test_compute_lease test_content_filter test_scheduler test_run_gate \
 	      test_segment_v2_tsan tracker_tsan \
 	      segment_node segment_chat segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \

--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ flight drains, while new calls fall back to another replica or the Segment's
 local kernel. This pauses donor CPU and I/O immediately; resident RAM stays
 allocated inside the donor process, protected by the reserve chosen before
 loading, so recovery does not cold-load the model again.
+Every transition names its cause and prints available RAM, the configured
+reserve and process residency; a `draining` advert is therefore diagnosable
+from the executor log instead of being a bare state bit.
 
 On every other machine, pick a role:
 
@@ -290,6 +293,12 @@ does not see the donor until every assigned weight is RAM-ready. The origin's
 explicit `--cache` executor remains the labelled disk fallback. Both
 load through the verified swarm mirror, so the whole model never lands on the
 donor.
+Automatic compute donation has one machine/user lease shared by `chat` and
+`serve --join`. Opening the menu repeatedly therefore cannot start several
+executors that each size themselves from the same available-RAM snapshot. A
+second process prints the PID/model/tracker of the active owner and may still
+donate storage. Stop the owning chat or joined server before replacing it; on
+Linux, its executors also receive `SIGTERM` if their parent is killed.
 Donors register under `donor-<hostname>-…` (pick one with `--donor-name`);
 a name already owned by another peer key is retried with a numbered suffix
 instead of being silently rejected forever. So several
@@ -307,6 +316,11 @@ covered MoE layer to strict-RAM Expert donors. Selected experts are sent in
 parallel; incomplete layers and failed donor calls execute locally. Thus even a
 peer too small for a complete Segment range contributes useful resident expert
 work, while the server remains the correctness fallback.
+
+Files written by the running engine are deliberately not model content.
+Lumabri excludes `.coli_*` state such as `.coli_usage`, KV/checkpoint state and
+SSD metadata from storage manifests. These files remain local and mutable;
+only checkpoint/model payloads enter signed CAS identity.
 
 Concurrent chats are admitted FIFO at every Segment range. Queue depth and
 inflight work are published to the predictive scheduler, the queue is bounded,

--- a/expert_node.c
+++ b/expert_node.c
@@ -608,16 +608,30 @@ static int send_ereg(int fd, const uint8_t nonce[32], int send_stats) {
 static void *governor_thread(void *arg) {
     (void)arg;
     LmbGovernorState previous = lmb_governor_state(&g.governor);
+    int first = 1;
     for (;;) {
         LmbGovernorState state = lmb_governor_poll(&g.governor);
         atomic_store(&g.resident_state, state == LMB_GOV_ACTIVE ?
                      LMB_EXPERT_STATE_ACTIVE : LMB_EXPERT_STATE_DRAINING);
-        if (state != previous) {
-            fprintf(stderr, "[%s] governor %s -> %s%s\n", g.name,
-                    lmb_governor_state_name(previous),
+        if (first || state != previous) {
+            uint64_t available = lmb_machine_available_ram();
+            fprintf(stderr, "[%s] governor ", g.name);
+            if (!first) fprintf(stderr, "%s -> ",
+                                lmb_governor_state_name(previous));
+            fprintf(stderr, "%s · %s",
                     lmb_governor_state_name(state),
-                    state == LMB_GOV_ACTIVE ? " · publishing resident experts" :
-                                             " · draining and advertising zero coverage");
+                    state == LMB_GOV_ACTIVE ? "publishing resident experts" :
+                                             "draining and advertising zero coverage");
+            if (state != LMB_GOV_ACTIVE)
+                fprintf(stderr, " · reason: %s",
+                        lmb_governor_reason_name(
+                            lmb_governor_reason(&g.governor)));
+            fprintf(stderr, " · available %.1f GB / reserve %.1f GB · "
+                    "resident weights %.1f GB\n",
+                    (double)available / 1e9,
+                    (double)g.governor.ram_reserve_bytes / 1e9,
+                    (double)g.resident_bytes / 1e9);
+            first = 0;
             previous = state;
         }
         sleep(1);

--- a/lumabri.c
+++ b/lumabri.c
@@ -44,6 +44,10 @@
 
 #include "lumabri_proto.h"
 #include "lumabri_machine.h"
+
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 #include "lumabri_segment_discovery.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
@@ -172,9 +176,24 @@ static void panel_row(int w, const char *left, const char *right) {
 
 /* ---- serve -------------------------------------------------------------- */
 
+static int child_follow_parent(pid_t parent) {
+#ifdef __linux__
+    /* Close fork-to-prctl: the parent may have died before the child armed
+     * its signal. This also keeps a 30 GB executor from surviving its TUI. */
+    return prctl(PR_SET_PDEATHSIG, SIGTERM) || getppid() != parent;
+#else
+    (void)parent;
+    return 0;
+#endif
+}
+
 static pid_t spawn_argv(char *const argv[]) {
+    pid_t parent = getpid();
     pid_t pid = fork();
-    if (pid == 0) { execv(argv[0], argv); perror(argv[0]); _exit(127); }
+    if (pid == 0) {
+        if (child_follow_parent(parent)) _exit(125);
+        execv(argv[0], argv); perror(argv[0]); _exit(127);
+    }
     return pid;
 }
 
@@ -203,8 +222,10 @@ static const char *donor_log_path(const char *name, char *buf, size_t cap) {
 
 static pid_t spawn_argv_logged(char *const argv[], char *const envv[],
                                const char *logpath) {
+    pid_t parent = getpid();
     pid_t pid = fork();
     if (pid == 0) {
+        if (child_follow_parent(parent)) _exit(125);
         for (int i = 0; envv && envv[i]; i++) putenv(envv[i]);
         int lfd = open(logpath, O_WRONLY | O_CREAT | O_APPEND, 0644);
         if (lfd >= 0) { dup2(lfd, 1); dup2(lfd, 2); close(lfd); }
@@ -218,6 +239,9 @@ static pid_t spawn_argv_logged(char *const argv[], char *const envv[],
 #define MAX_CHILDREN 16
 static pid_t g_children[MAX_CHILDREN];
 static int g_nchildren = 0;
+/* Held by the parent and inherited by its compute child. It serializes
+ * automatic RAM-sized donation across chat/serve processes on one machine. */
+static int g_compute_lease_fd = -1;
 /* The async handler never reads the mutable table/count.  Each fixed slot is
  * one sig_atomic_t publication, so delivery on any worker thread cannot see a
  * compacted/torn child table. */
@@ -600,6 +624,32 @@ static int cmd_serve(int argc, char **argv) {
                "disponibili.%s\n", C_DIM,
                (double)segment_available / 1e9,
                (double)segment_min_free / 1e9, C_R);
+
+    /* A joined host donates one RAM-sized compute role, regardless of how
+     * many `chat` or `serve --join` commands its user happens to open. The
+     * origin is intentionally exempt: it is the swarm's fallback server. */
+    int has_expert_runtime = node && access(exec_bin, X_OK) == 0;
+    if (join && !disk_donor && !no_exec &&
+        (segment_candidate || has_expert_runtime)) {
+        char lease_owner[256] = "";
+        g_compute_lease_fd = lmb_machine_compute_lease_acquire(
+            segment_model ? segment_model : model, taddr,
+            lease_owner, sizeof lease_owner);
+        if (g_compute_lease_fd < 0) {
+            if (errno == EWOULDBLOCK || errno == EAGAIN)
+                printf("  %sdono calcolo gia' attivo su questa macchina%s%s%s; "
+                       "questo processo offre soltanto storage%s\n", C_DIM,
+                       lease_owner[0] ? " (" : "",
+                       lease_owner[0] ? lease_owner : "",
+                       lease_owner[0] ? ")" : "", C_R);
+            else
+                printf("  %slease RAM del donor non disponibile: %s; "
+                       "questo processo offre soltanto storage%s\n",
+                       C_DIM, strerror(errno), C_R);
+            no_exec = 1;
+            segment_candidate = 0;
+        }
+    }
     int planned_chunks = segment_candidate
         ? lmb_env_int("LUMABRI_SEGMENT_CHUNKS", 4, 1, 7) : 0;
     if ((uint32_t)planned_chunks > segment_layers)
@@ -3404,7 +3454,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             { char lp[1200];
               pid_t np = spawn_argv_logged(argv, NULL,
                                            donor_log_path(name, lp, sizeof lp));
-              child_publish(g_nchildren++, np); }
+              if (np > 0) child_publish(g_nchildren++, np); }
             printf("  %s\xe2\x9c\xa6 dono %.0f GB di %s%s%s%s: il tracker mi assegna "
                    "i file piu\xcc\x80 rari%s\n",
                    C_GRN, r->gb, C_R, C_BOLD, model, C_DIM, C_R);
@@ -3412,14 +3462,32 @@ static void role_start(const Role *r, const char *tracker, const char *model,
     }
 
     if (r->compute) {
-        int segment_started = segment_active &&
-            role_start_segment(r, tracker, model, model_type, context,
-                               model_bytes);
-        if (!segment_started) {
-        const char *node = expert_node_for(model_type ? model_type : "");
-        char bin[1200];
-        snprintf(bin, sizeof bin, "%s/%s", dir, node ? node : "expert_node");
-        int port = free_port(7701);
+        int compute_children_before = g_nchildren;
+        char lease_owner[256] = "";
+        int lease = lmb_machine_compute_lease_acquire(
+            model, tracker, lease_owner, sizeof lease_owner);
+        if (lease < 0) {
+            if (errno == EWOULDBLOCK || errno == EAGAIN)
+                printf("  %sdono calcolo gia' attivo su questa macchina%s%s%s; "
+                       "non avvio un secondo executor che prenoterebbe la "
+                       "stessa RAM%s\n", C_DIM,
+                       lease_owner[0] ? " (" : "",
+                       lease_owner[0] ? lease_owner : "",
+                       lease_owner[0] ? ")" : "", C_R);
+            else
+                printf("  %snon posso acquisire la lease RAM del donor: %s; "
+                       "dono calcolo saltato%s\n", C_DIM, strerror(errno), C_R);
+        } else {
+            g_compute_lease_fd = lease;
+            int segment_started = segment_active &&
+                role_start_segment(r, tracker, model, model_type, context,
+                                   model_bytes);
+            if (!segment_started) {
+                const char *node = expert_node_for(model_type ? model_type : "");
+                char bin[1200];
+                snprintf(bin, sizeof bin, "%s/%s", dir,
+                         node ? node : "expert_node");
+                int port = free_port(7701);
         /* Which container does the node read? The user's local copy when
          * there is one. Otherwise the model's vroot behind the shim: every
          * loader read becomes a verified block fetch from the swarm, so the
@@ -3494,7 +3562,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             { char lp[1200];
               pid_t np = spawn_argv_logged(argv, local ? NULL : envv,
                                            donor_log_path(name, lp, sizeof lp));
-              child_publish(g_nchildren++, np); }
+              if (np > 0) child_publish(g_nchildren++, np); }
             if (local)
                 printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s · "
                        "log in ~/.lumabri/logs, /debug per vederli)%s\n",
@@ -3503,7 +3571,12 @@ static void role_start(const Role *r, const char *tracker, const char *model,
                 printf("  %s\xe2\x9c\xa6 eseguo esperti per lo sciame%s %s(%s, "
                        "la fetta assegnata arriva dallo sciame · /debug per i log)%s\n",
                        C_GRN, C_R, C_DIM, node, C_R);
-        }
+            }
+            }
+            if (g_nchildren == compute_children_before) {
+                close(g_compute_lease_fd);
+                g_compute_lease_fd = -1;
+            }
         }
     }
     if (r->disk || r->compute)
@@ -4060,6 +4133,10 @@ static int cmd_chat(int argc, char **argv) {
         child_unpublish(i);
         kill(p, SIGTERM);
         waitpid(p, NULL, 0);
+    }
+    if (g_compute_lease_fd >= 0) {
+        close(g_compute_lease_fd);
+        g_compute_lease_fd = -1;
     }
     if (g_nchildren) printf("  %sdonazione chiusa%s\n", C_DIM, C_R);
     printf("\n");

--- a/lumabri_content.h
+++ b/lumabri_content.h
@@ -1,0 +1,16 @@
+#ifndef LUMABRI_CONTENT_H
+#define LUMABRI_CONTENT_H
+
+#include <string.h>
+
+/* Files created and mutated by a running engine belong to that machine, not
+ * to the signed model inventory. Publishing one makes its next heartbeat
+ * look like a model-integrity violation. Keep the prefix future-proof: every
+ * current Colibri runtime artifact uses .coli_* (.coli_usage, .coli_kv,
+ * .coli_ssd and .coli_ckpt), while checkpoint/model files do not. */
+static inline int lmb_content_runtime_local_name(const char *name) {
+    return name && (!strncmp(name, ".coli_", 6) ||
+                    !strcmp(name, ".lumabri_hashes"));
+}
+
+#endif

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/statvfs.h>
+#include <sys/file.h>
 #include <sys/utsname.h>
 #include <time.h>
 #include <unistd.h>
@@ -100,6 +101,61 @@ uint64_t lmb_machine_total_ram(void) {
     uint64_t value = 0;
     meminfo(&value, NULL, NULL, NULL);
     return value;
+}
+
+int lmb_machine_compute_lease_acquire(const char *model, const char *tracker,
+                                      char *owner, size_t owner_size) {
+    if (owner && owner_size) owner[0] = 0;
+    const char *home = getenv("HOME");
+    if (!home || !home[0]) { errno = ENOENT; return -1; }
+    char directory[1200], path[1280];
+    int n = snprintf(directory, sizeof directory, "%s/.lumabri", home);
+    if (n < 0 || (size_t)n >= sizeof directory) {
+        errno = ENAMETOOLONG; return -1;
+    }
+    if (mkdir(directory, 0700) && errno != EEXIST) return -1;
+    struct stat st;
+    if (stat(directory, &st) || !S_ISDIR(st.st_mode)) {
+        errno = ENOTDIR; return -1;
+    }
+    n = snprintf(path, sizeof path, "%s/compute-donor.lock", directory);
+    if (n < 0 || (size_t)n >= sizeof path) {
+        errno = ENAMETOOLONG; return -1;
+    }
+    int flags = O_RDWR | O_CREAT;
+#ifdef O_NOFOLLOW
+    flags |= O_NOFOLLOW;
+#endif
+    /* Intentionally not O_CLOEXEC: the compute child retains the lease if
+     * its TUI parent is killed, so a surviving orphan cannot be joined by a
+     * second RAM-sized donor. Normal shutdown kills the child first. */
+    int fd = open(path, flags, 0600);
+    if (fd < 0) return -1;
+    if (flock(fd, LOCK_EX | LOCK_NB)) {
+        int saved = errno;
+        if (owner && owner_size) {
+            if (lseek(fd, 0, SEEK_SET) >= 0) {
+                ssize_t got = read(fd, owner, owner_size - 1);
+                if (got > 0) {
+                    owner[got] = 0;
+                    owner[strcspn(owner, "\r\n")] = 0;
+                }
+            }
+        }
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    if (ftruncate(fd, 0) || lseek(fd, 0, SEEK_SET) < 0 ||
+        dprintf(fd, "pid=%ld model=%s tracker=%s\n", (long)getpid(),
+                model && model[0] ? model : "?",
+                tracker && tracker[0] ? tracker : "?") < 0 || fsync(fd)) {
+        int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
 }
 
 static void cpu_profile(LmbMachineProfile *profile) {
@@ -366,11 +422,25 @@ const char *lmb_governor_state_name(LmbGovernorState state) {
     return "UNKNOWN";
 }
 
+const char *lmb_governor_reason_name(LmbGovernorReason reason) {
+    switch (reason) {
+        case LMB_GOV_REASON_NONE: return "none";
+        case LMB_GOV_REASON_MANUAL: return "manual pause";
+        case LMB_GOV_REASON_RAM_PRESSURE: return "RAM below reserve";
+        case LMB_GOV_REASON_RAM_CRITICAL: return "RAM below half reserve";
+        case LMB_GOV_REASON_SWAP_CRITICAL: return "swap pressure";
+        case LMB_GOV_REASON_RECOVERY: return "recovery hysteresis";
+    }
+    return "unknown";
+}
+
 void lmb_governor_init(LmbGovernor *governor, uint64_t reserve) {
     memset(governor, 0, sizeof *governor);
     governor->ram_reserve_bytes = reserve;
     atomic_store(&governor->state,
                  lmb_governor_manual_paused() ? LMB_GOV_PAUSED : LMB_GOV_ACTIVE);
+    atomic_store(&governor->reason, lmb_governor_manual_paused() ?
+                 LMB_GOV_REASON_MANUAL : LMB_GOV_REASON_NONE);
 }
 
 LmbGovernorState lmb_governor_state(const LmbGovernor *governor) {
@@ -381,30 +451,43 @@ int lmb_governor_accepting(const LmbGovernor *governor) {
     return lmb_governor_state(governor) == LMB_GOV_ACTIVE;
 }
 
+LmbGovernorReason lmb_governor_reason(const LmbGovernor *governor) {
+    return (LmbGovernorReason)atomic_load(&governor->reason);
+}
+
 LmbGovernorState lmb_governor_poll(LmbGovernor *governor) {
     LmbGovernorState previous = lmb_governor_state(governor), next;
+    LmbGovernorReason reason = LMB_GOV_REASON_NONE;
     if (lmb_governor_manual_paused()) {
         next = LMB_GOV_PAUSED;
+        reason = LMB_GOV_REASON_MANUAL;
         governor->recovery_ticks = 0;
     } else {
         uint64_t available = 0, swap_total = 0, swap_free = 0;
         meminfo(NULL, &available, &swap_total, &swap_free);
-        int critical = available && available < governor->ram_reserve_bytes / 2;
-        if (swap_total && swap_free < swap_total / 20 &&
-            available < governor->ram_reserve_bytes) critical = 1;
-        if (critical) {
+        int ram_critical = available &&
+            available < governor->ram_reserve_bytes / 2;
+        int swap_critical = swap_total && swap_free < swap_total / 20 &&
+            available < governor->ram_reserve_bytes;
+        if (ram_critical || swap_critical) {
             next = LMB_GOV_PAUSED;
+            reason = swap_critical ? LMB_GOV_REASON_SWAP_CRITICAL :
+                                     LMB_GOV_REASON_RAM_CRITICAL;
             governor->recovery_ticks = 0;
         } else if (available && available < governor->ram_reserve_bytes) {
             next = LMB_GOV_PRESSURE;
+            reason = LMB_GOV_REASON_RAM_PRESSURE;
             governor->recovery_ticks = 0;
         } else if (previous != LMB_GOV_ACTIVE) {
             next = ++governor->recovery_ticks >= 3 ?
                    LMB_GOV_ACTIVE : LMB_GOV_RECOVERY;
+            reason = next == LMB_GOV_ACTIVE ? LMB_GOV_REASON_NONE :
+                                              LMB_GOV_REASON_RECOVERY;
         } else {
             next = LMB_GOV_ACTIVE;
         }
     }
+    atomic_store(&governor->reason, reason);
     atomic_store(&governor->state, next);
     return next;
 }

--- a/lumabri_machine.h
+++ b/lumabri_machine.h
@@ -36,10 +36,20 @@ typedef enum {
     LMB_GOV_RECOVERY = 3,
 } LmbGovernorState;
 
+typedef enum {
+    LMB_GOV_REASON_NONE = 0,
+    LMB_GOV_REASON_MANUAL,
+    LMB_GOV_REASON_RAM_PRESSURE,
+    LMB_GOV_REASON_RAM_CRITICAL,
+    LMB_GOV_REASON_SWAP_CRITICAL,
+    LMB_GOV_REASON_RECOVERY,
+} LmbGovernorReason;
+
 typedef struct {
     uint64_t ram_reserve_bytes;
     unsigned recovery_ticks;
     _Atomic int state;
+    _Atomic int reason;
 } LmbGovernor;
 
 int lmb_machine_probe(LmbMachineProfile *profile, const char *disk_path,
@@ -52,10 +62,16 @@ int lmb_machine_read_meminfo(FILE *stream, uint64_t *total,
 void lmb_machine_print(FILE *out, const LmbMachineProfile *profile, int json);
 uint64_t lmb_machine_available_ram(void);
 uint64_t lmb_machine_total_ram(void);
+/* One automatic compute donor owns the machine's donable RAM. The returned
+ * descriptor is the lease and must stay open for the donation lifetime. */
+int lmb_machine_compute_lease_acquire(const char *model, const char *tracker,
+                                      char *owner, size_t owner_size);
 const char *lmb_governor_state_name(LmbGovernorState state);
+const char *lmb_governor_reason_name(LmbGovernorReason reason);
 void lmb_governor_init(LmbGovernor *governor, uint64_t ram_reserve_bytes);
 LmbGovernorState lmb_governor_poll(LmbGovernor *governor);
 LmbGovernorState lmb_governor_state(const LmbGovernor *governor);
+LmbGovernorReason lmb_governor_reason(const LmbGovernor *governor);
 int lmb_governor_accepting(const LmbGovernor *governor);
 int lmb_governor_set_manual(int paused);
 int lmb_governor_manual_paused(void);

--- a/machine_governor_test.sh
+++ b/machine_governor_test.sh
@@ -4,7 +4,17 @@ cd "$(dirname "$0")"
 PORT=${PORT:-7900}
 TMP=$(mktemp -d /tmp/lumabri-governor.XXXXXX)
 PIDS=()
-cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; wait "${PIDS[@]}" 2>/dev/null || true; rm -rf "$TMP"; }
+cleanup() {
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        for log in "$TMP"/*.log; do
+            [ -f "$log" ] && { echo "--- $log" >&2; tail -80 "$log" >&2; }
+        done
+    fi
+    kill "${PIDS[@]}" 2>/dev/null || true
+    wait "${PIDS[@]}" 2>/dev/null || true
+    rm -rf "$TMP"
+}
 trap cleanup EXIT
 wait_port() {
     for _ in $(seq 1 240); do
@@ -90,9 +100,13 @@ wait_segment_flag 1
 wait_state 5 8
 wait_segment_flag 0
 grep -q 'governor ACTIVE -> PAUSED' "$TMP/expert.log"
+grep -q 'reason: manual pause' "$TMP/expert.log"
+grep -q 'available .* / reserve .*resident weights' "$TMP/expert.log"
 grep -q 'governor PAUSED -> RECOVERY' "$TMP/expert.log"
 grep -q 'governor RECOVERY -> ACTIVE' "$TMP/expert.log"
 grep -q 'governor ACTIVE -> PAUSED' "$TMP/segment.log"
+grep -q 'reason: manual pause' "$TMP/segment.log"
+grep -q 'available .* / reserve .*RSS .* / budget' "$TMP/segment.log"
 grep -q 'governor PAUSED -> RECOVERY' "$TMP/segment.log"
 grep -q 'governor RECOVERY -> ACTIVE' "$TMP/segment.log"
 echo 'MACHINE GOVERNOR TEST: PASS (profile, Expert zero coverage, Segment drain, recovery)'

--- a/maintainer.c
+++ b/maintainer.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_content.h"
 #include "lumabri_sha.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
@@ -69,7 +70,7 @@ static void scan_dir(const char *dir) {
     struct dirent *e;
     while ((e = readdir(d))) {
         if (!strcmp(e->d_name, ".") || !strcmp(e->d_name, "..")) continue;
-        if (!strcmp(e->d_name, ".lumabri_hashes")) continue;   /* our sidecars */
+        if (lmb_content_runtime_local_name(e->d_name)) continue;
         snprintf(full, sizeof full, "%s/%s", dir, e->d_name);
         struct stat st;
         if (stat(full, &st)) continue;

--- a/segment_hybrid_test.sh
+++ b/segment_hybrid_test.sh
@@ -139,5 +139,8 @@ OMP_NUM_THREADS=2 ./segment_chat --engine olmoe --model-dir tiny_olmoe \
     --context 64 --max-rows 16 --retry-first-run >"$TMP/fallback.log" 2>&1
 
 grep -q 'phase 2 partial: 1 of 16 routed layers' "$TMP/segment.log"
-grep -Eq 'trying next replica|relay unavailable' "$TMP/segment.log"
+# Do not require a failed socket attempt: the async discovery thread may evict
+# the dead donor before this run reaches layer 0. The donor has been killed and
+# waited above, no other Expert exists, and the exact token oracle already
+# proves that the only remaining path—the local kernel—completed the turn.
 echo 'SEGMENT HYBRID TEST: PASS (resident donor used; dead donor falls back locally)'

--- a/segment_node.c
+++ b/segment_node.c
@@ -117,6 +117,7 @@ static int memory_pressure(void *opaque) {
 static void *governor_worker(void *opaque) {
     Node *node = opaque;
     LmbGovernorState previous = lmb_governor_state(&node->governor);
+    int first = 1;
     while (!g_stop && !node->registration.stop) {
         LmbGovernorState state = lmb_governor_poll(&node->governor);
         pthread_mutex_lock(&node->registration.lock);
@@ -125,13 +126,28 @@ static void *governor_worker(void *opaque) {
         else
             node->registration.advert.flags |= LMB_SEG_ADVERT_DRAINING;
         pthread_mutex_unlock(&node->registration.lock);
-        if (state != previous) {
-            fprintf(stderr, "[segment-node %s] governor %s -> %s%s\n",
-                    node->advert.peer_name,
-                    lmb_governor_state_name(previous),
+        if (first || state != previous) {
+            uint64_t available = lmb_machine_available_ram();
+            uint64_t rss = resident_memory_bytes();
+            fprintf(stderr, "[segment-node %s] governor ",
+                    node->advert.peer_name);
+            if (!first) fprintf(stderr, "%s -> ",
+                                lmb_governor_state_name(previous));
+            fprintf(stderr, "%s · %s",
                     lmb_governor_state_name(state),
-                    state == LMB_GOV_ACTIVE ? " · accepting sessions" :
-                                             " · draining and refusing new work");
+                    state == LMB_GOV_ACTIVE ? "accepting sessions" :
+                                             "draining and refusing new work");
+            if (state != LMB_GOV_ACTIVE)
+                fprintf(stderr, " · reason: %s",
+                        lmb_governor_reason_name(
+                            lmb_governor_reason(&node->governor)));
+            fprintf(stderr, " · available %.1f GB / reserve %.1f GB · "
+                    "RSS %.1f GB / budget %.1f GB\n",
+                    (double)available / 1e9,
+                    (double)node->ram_reserve_bytes / 1e9,
+                    (double)rss / 1e9,
+                    (double)node->process_memory_limit_bytes / 1e9);
+            first = 0;
             previous = state;
         }
         for (int i = 0; i < 10 && !g_stop && !node->registration.stop; i++)

--- a/signed_donor_test.sh
+++ b/signed_donor_test.sh
@@ -60,6 +60,11 @@ mkdir -p "$T/src/sub"
 head -c $((3 * 1024 * 1024 + 77)) /dev/urandom > "$T/src/w.bin"
 head -c 4096 /dev/urandom > "$T/src/sub/tok.bin"
 printf '{"model_type":"olmoe"}\n' > "$T/src/config.json"
+# A real model directory is not immutable while Colibri runs. These files are
+# machine-local telemetry/state and must never become signed swarm content.
+printf 'runtime telemetry\n' > "$T/src/.coli_usage"
+mkdir -p "$T/src/.coli_ckpt"
+printf 'local checkpoint\n' > "$T/src/.coli_ckpt/session-1"
 
 ./lumabri key --out "$T/swarm" > /dev/null
 ./lumabri key --out "$T/other" > /dev/null      # a different operator entirely
@@ -71,6 +76,13 @@ wait_port 7580
              --model-name fx --key "$T/swarm.key" > "$T/origin.log" 2>&1 & ORIGIN=$!; PIDS+=($!)
 wait_port 7581
 wait_for "$T/tracker.log" "+ origin" 15 || { cat "$T/tracker.log"; exit 1; }
+grep -q '+ origin .* (fx, 3 files)' "$T/tracker.log" || {
+    echo "   runtime-local .coli_* files entered the origin manifest"
+    cat "$T/tracker.log"; exit 1; }
+if grep -q 'REJECTED: .*\.coli_' "$T/tracker.log"; then
+    echo "   tracker saw runtime-local Colibri state"
+    grep 'REJECTED' "$T/tracker.log"; exit 1
+fi
 
 echo "· 1) the donor verifies what it pulls"
 ./lumabri serve --model "$T/donor" --join 127.0.0.1:7580 --model-name fx \

--- a/test_compute_lease.c
+++ b/test_compute_lease.c
@@ -1,0 +1,67 @@
+#define _GNU_SOURCE
+#include "lumabri_machine.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(void) {
+    char home[] = "/tmp/lumabri-compute-lease.XXXXXX";
+    assert(mkdtemp(home));
+    assert(setenv("HOME", home, 1) == 0);
+
+    char owner[256];
+    int first = lmb_machine_compute_lease_acquire(
+        "DeepSeek-V4-Flash", "tracker.example:7300", owner, sizeof owner);
+    assert(first >= 0);
+
+    pid_t child = fork();
+    assert(child >= 0);
+    if (!child) {
+        /* Drop the inherited reference; the parent still owns the same open
+         * file description, so a fresh contender must fail non-blocking. */
+        close(first);
+        int other = lmb_machine_compute_lease_acquire(
+            "DeepSeek-V4-Flash", "tracker.example:7300", owner, sizeof owner);
+        if (other >= 0 || (errno != EWOULDBLOCK && errno != EAGAIN) ||
+            !strstr(owner, "DeepSeek-V4-Flash")) _exit(2);
+        _exit(0);
+    }
+    int status = 0;
+    assert(waitpid(child, &status, 0) == child);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+    /* The spawned executor inherits the lease. If its parent disappears,
+     * the lock therefore remains held until that executor actually exits. */
+    pid_t keeper = fork();
+    assert(keeper >= 0);
+    if (!keeper) {
+        for (;;) pause();
+    }
+    close(first);
+    int blocked = lmb_machine_compute_lease_acquire(
+        "another-model", "tracker.example:7300", owner, sizeof owner);
+    assert(blocked < 0 && (errno == EWOULDBLOCK || errno == EAGAIN));
+    assert(kill(keeper, SIGTERM) == 0);
+    assert(waitpid(keeper, &status, 0) == keeper);
+    assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGTERM);
+
+    int replacement = lmb_machine_compute_lease_acquire(
+        "another-model", "tracker.example:7300", owner, sizeof owner);
+    assert(replacement >= 0);
+    close(replacement);
+
+    char lock[1200], directory[1100];
+    snprintf(directory, sizeof directory, "%s/.lumabri", home);
+    snprintf(lock, sizeof lock, "%s/compute-donor.lock", directory);
+    assert(unlink(lock) == 0);
+    assert(rmdir(directory) == 0);
+    assert(rmdir(home) == 0);
+    puts("COMPUTE LEASE TEST: PASS (one RAM owner; crash-safe release)");
+    return 0;
+}

--- a/test_content_filter.c
+++ b/test_content_filter.c
@@ -1,0 +1,20 @@
+#include "lumabri_content.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+int main(void) {
+    assert(lmb_content_runtime_local_name(".coli_usage"));
+    assert(lmb_content_runtime_local_name(".coli_kv"));
+    assert(lmb_content_runtime_local_name(".coli_kv.3"));
+    assert(lmb_content_runtime_local_name(".coli_ssd"));
+    assert(lmb_content_runtime_local_name(".coli_ckpt"));
+    assert(lmb_content_runtime_local_name(".lumabri_hashes"));
+    assert(!lmb_content_runtime_local_name("config.json"));
+    assert(!lmb_content_runtime_local_name("model-00001.safetensors"));
+    assert(!lmb_content_runtime_local_name("tokenizer.json"));
+    assert(!lmb_content_runtime_local_name("coli_usage"));
+    assert(!lmb_content_runtime_local_name(".colibri_weights"));
+    puts("CONTENT FILTER TEST: PASS (runtime-local files never enter manifests)");
+    return 0;
+}

--- a/test_machine.c
+++ b/test_machine.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 int main(void) {
     LmbMachineProfile profile;
@@ -12,18 +13,33 @@ int main(void) {
     assert(profile.ram_total_bytes > 0);
     assert(profile.ram_available_bytes > 0);
 
+    /* Never alter the real user's persistent pause state while testing. */
+    char home[] = "/tmp/lumabri-machine.XXXXXX";
+    assert(mkdtemp(home));
+    assert(setenv("HOME", home, 1) == 0);
+    assert(unsetenv("LUMABRI_GOVERNOR_FILE") == 0);
     assert(lmb_governor_set_manual(0) == 0);
     LmbGovernor governor;
     lmb_governor_init(&governor, 1);
     assert(lmb_governor_poll(&governor) == LMB_GOV_ACTIVE);
+    assert(lmb_governor_reason(&governor) == LMB_GOV_REASON_NONE);
     assert(lmb_governor_set_manual(1) == 0);
     assert(lmb_governor_poll(&governor) == LMB_GOV_PAUSED);
+    assert(lmb_governor_reason(&governor) == LMB_GOV_REASON_MANUAL);
     assert(!lmb_governor_accepting(&governor));
     assert(lmb_governor_set_manual(0) == 0);
     assert(lmb_governor_poll(&governor) == LMB_GOV_RECOVERY);
+    assert(lmb_governor_reason(&governor) == LMB_GOV_REASON_RECOVERY);
     assert(lmb_governor_poll(&governor) == LMB_GOV_RECOVERY);
     assert(lmb_governor_poll(&governor) == LMB_GOV_ACTIVE);
+    assert(lmb_governor_reason(&governor) == LMB_GOV_REASON_NONE);
     assert(lmb_governor_accepting(&governor));
+    char state_dir[1200], state_file[1280];
+    snprintf(state_dir, sizeof state_dir, "%s/.lumabri", home);
+    snprintf(state_file, sizeof state_file, "%s/governor.state", state_dir);
+    assert(unlink(state_file) == 0);
+    assert(rmdir(state_dir) == 0);
+    assert(rmdir(home) == 0);
     puts("MACHINE GOVERNOR UNIT: PASS (pause, hysteresis, recovery)");
     return 0;
 }

--- a/test_shim.c
+++ b/test_shim.c
@@ -21,6 +21,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "lumabri_content.h"
+
 #define CHUNK (1u << 20)
 
 static const char *g_vroot, *g_src;
@@ -142,6 +144,7 @@ int main(int argc, char **argv) {
     DIR *d = opendir(g_src);
     struct dirent *e;
     while (d && (e = readdir(d))) {
+        if (lmb_content_runtime_local_name(e->d_name)) continue;
         char p[1024];
         struct stat st;
         join_path(p, sizeof p, g_src, e->d_name);


### PR DESCRIPTION
## Outcome

Fixes the two concrete failures seen on the live DeepSeek swarm after WSL1 RAM detection was corrected:

- `.coli_usage` and every mutable `.coli_*` runtime artifact stay local and never enter signed model manifests, so the tracker no longer repeats `REJECTED ... unsigned bytes`;
- one automatic RAM-sized compute donation is admitted per machine/user across both `chat` and `serve --join`, preventing several 30 GB executors from sizing themselves against the same free-RAM snapshot.

The origin server is intentionally exempt: it remains the replaceable fallback. A duplicate joined process can still donate storage and prints the PID/model/tracker of the compute lease owner. On Linux, spawned executors receive `SIGTERM` when their parent dies, and the inherited `flock` keeps the lease held until the last executor has actually exited.

## Draining diagnostics

Expert and Segment logs now explain `draining` with:

- governor reason (`manual pause`, RAM pressure/critical, swap pressure, recovery);
- available RAM and configured reserve;
- resident Expert weights or Segment RSS/process budget.

The governor policy itself is unchanged: native Linux `MemAvailable` remains authoritative and the WSL1 fallback from #89 is not weakened.

## Metric affected

This closes defects that invalidated **C (expert calls per peer)** and destabilized **A/B** through RAM oversubscription. It does not claim a speedup by itself.

## Validation

- `make check-warnings ENGINE=/tmp/colibri-validation/c`
- `make test ENGINE=/tmp/colibri-validation/c` (all suites through governor; governor rerun separately after isolating its test state)
- `make test-machine-governor ENGINE=/tmp/colibri-validation/c`
- `make test-segment-hybrid ENGINE=/tmp/colibri-validation/c` — resident donor executed 64 calls; dead donor fell back locally
- `bash ./signed_donor_test.sh` — `.coli_usage` + `.coli_ckpt` fixture excluded; exactly 3 signed model files propagated
- ASan/UBSan binaries all pass with `detect_leaks=0`; LeakSanitizer cannot run under the workspace ptrace wrapper and remains enabled in CI

Generic machinery only: no model-specific branch was added; all six model adapters continue through the same build/runtime paths.

No merge requested.