### PR TITLE
fix: give hedging an off switch again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ test_segment_discovery
 test_swarm_detail
 test_relay_rate
 test_machine
+test_meminfo
+test_compute_lease
+test_content_filter
 test_scheduler
 test_run_gate
 expert_node_*

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ EWMA latency and advertised queue/inflight cost for the complete chain; origin
 fallback status is only a tie-breaker. Adding a slower donor therefore does not
 replace a faster known route. Expert replicas use the same EWMA model, open a
 circuit only after repeated failures, and hedge automatically only after enough
-samples show a real p95 tail. `LUMABRI_HEDGE_MS` remains an explicit override.
+samples show a real p95 tail. `LUMABRI_HEDGE_MS` remains an explicit
+override: a positive value is the fixed delay, and `-1` turns hedging off.
 These are online estimates, not a speed claim: `swarm_bench.py` on distinct
 hosts remains the authority for single-chat and aggregate throughput.
 
@@ -360,6 +361,7 @@ the command, e.g. `LUMABRI_SPREAD=1 lumabri chat …`.
 | `LUMABRI_SPREAD=1` | spread the load across peers that hold the *same* expert (default: the nearest one wins) |
 | `LUMABRI_VERIFY=N` | re-run N% of expert calls on a second peer and demand the same answer — a lie stops the run |
 | `LUMABRI_HEDGE_MS=N` | after N ms with no reply, ask a second peer too and take whichever comes first |
+| `LUMABRI_HEDGE_MS=-1` | never ask a second peer — the only way to get one request per call, which attribution and benchmarking need |
 | `LUMABRI_ALLOW_CODEGEN_SKEW=1` | let peers built with a different compiler or CPU join (results are then verified, not bit-identical) |
 | `LUMABRI_ENCRYPT=1` | encrypt the transport (see below) |
 | `RAM_GB=N` | tell a `--local` run how much RAM it may use to keep experts resident |

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -68,7 +68,14 @@ static struct {
     int verify_pct;             /* LUMABRI_VERIFY: % of calls double-checked */
     int allow_codegen_skew;     /* LUMABRI_ALLOW_CODEGEN_SKEW: cc/isa -> warn, not refuse */
     int spread;                 /* LUMABRI_SPREAD: near-band replica spreading, not strict argmin */
-    int hedge_ms;               /* 0 disables; base policy, fixed delay */
+    /* Hedging policy, from LUMABRI_HEDGE_MS:
+     *   < 0  off — no second replica is ever issued
+     *     0  automatic (default): the predictor hedges only once a peer has
+     *        enough samples and a genuinely heavy tail
+     *   > 0  fixed delay in milliseconds, the original base policy
+     * Off matters to anyone who needs deterministic attribution — a
+     * measurement harness cannot tell a chosen replica from a hedge copy. */
+    int hedge_ms;
     /* How long one EXEC reply may take before the replica is treated as
      * failed. A dead peer resets its socket and fails instantly; a peer that
      * is merely wedged — swapping, saturated, or behind a black hole — never
@@ -544,7 +551,7 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
         if (!v && L.verify_pct == 0) L.verify_pct = 5;
     }
     L.spread = getenv("LUMABRI_SPREAD") && atoi(getenv("LUMABRI_SPREAD")) != 0;
-    L.hedge_ms = lmb_env_int("LUMABRI_HEDGE_MS", 0, 0, 60000);
+    L.hedge_ms = lmb_env_int("LUMABRI_HEDGE_MS", 0, -1, 60000);
     L.exec_wait_ms = lmb_env_int("LUMABRI_EXEC_WAIT_MS", 30000, 100, 3600000);
     L.initialized = 1;
 
@@ -689,7 +696,8 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
     LumiPeer *p[2] = { primary, NULL };
     uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
     double started[2] = { primary_started, 0.0 };
-    uint32_t hedge_ms = L.hedge_ms > 0 ? (uint32_t)L.hedge_ms :
+    uint32_t hedge_ms = L.hedge_ms < 0 ? 0u :
+                        L.hedge_ms > 0 ? (uint32_t)L.hedge_ms :
                         lmb_predict_hedge_ms(&primary->latency);
     if (hedge_ms > 0) {
         struct pollfd one = { fd[0], POLLIN, 0 };

--- a/test_hedge.c
+++ b/test_hedge.c
@@ -55,11 +55,66 @@ int main(void) {
                                                 &tried, &from);
     bad |= !out || memcmp(out, x, sizeof x) || from != &L.peers[1] ||
            L.hedges != 1 || L.hedge_wins != 1;
-    free(out); free(L.own);
+    free(out);
     void *ra = NULL, *rb = NULL;
     pthread_join(a, &ra); pthread_join(b, &rb);
     bad |= (intptr_t)ra || (intptr_t)rb;
+
+    /* hedge_ms < 0 is off: the slow primary must answer alone. Without a way
+     * to say that, a measurement harness cannot tell a chosen replica from a
+     * hedge copy, which is exactly what attribution work needs. */
+    Echo slow_off = {7566, 150}, fast_off = {7567, 0};
+    pthread_t c, d;
+    pthread_create(&c, NULL, echo_server, &slow_off);
+    pthread_create(&d, NULL, echo_server, &fast_off);
+    usleep(100000);
+    for (int i = 0; i < 2; i++)
+        while (L.peers[i].nsocks > 0) close(L.peers[i].socks[--L.peers[i].nsocks]);
+    snprintf(L.peers[0].addr, sizeof L.peers[0].addr,
+             "127.0.0.1:%d", slow_off.port);
+    snprintf(L.peers[1].addr, sizeof L.peers[1].addr,
+             "127.0.0.1:%d", fast_off.port);
+    /* Put the primary's predictor where the automatic policy *would* hedge:
+     * enough samples and a tail well past 1.5x the mean. Without that the
+     * automatic branch returns zero on its own and the case proves nothing. */
+    lmb_predict_init(&L.peers[0].latency, 1000);
+    for (int i = 0; i < 8; i++) lmb_predict_observe(&L.peers[0].latency, 1000);
+    /* One tail spike, then fast replies: the mean falls by eighths while the
+     * p95 falls by thirty-seconds, which is precisely the shape the automatic
+     * policy is meant to hedge against. */
+    lmb_predict_observe(&L.peers[0].latency, 400000);
+    for (int i = 0; i < 10; i++) lmb_predict_observe(&L.peers[0].latency, 1000);
+    if (lmb_predict_hedge_ms(&L.peers[0].latency) == 0) {
+        fputs("hedge fixture did not arm the automatic policy\n", stderr);
+        return 1;
+    }
+    L.hedge_ms = -1;
+    unsigned long long hedges_before = L.hedges;
+    int off_fd = lumi_take_sock(&L.peers[0]);
+    uint32_t off_tried = 1;
+    double off_started = lumi_now();
+    bad |= off_fd < 0 || lumi_send_exec(off_fd, 0, 0, x, 4, 3, NULL);
+    LumiPeer *off_from = NULL;
+    float *off_out = bad ? NULL
+                         : lumi_finish_exec(0, 0, x, 4, 3, NULL, off_fd,
+                                            &L.peers[0], off_started,
+                                            &off_tried, &off_from);
+    bad |= !off_out || memcmp(off_out, x, sizeof x) ||
+           off_from != &L.peers[0] || L.hedges != hedges_before;
+    free(off_out);
+    /* The fast replica stays listening on purpose: had a hedge fired it would
+     * have been counted. Since it must not, its accept is still pending, so
+     * release it with one throwaway connection before joining. */
+    int wake = lmb_connect(L.peers[1].addr);
+    if (wake >= 0) close(wake);
+    void *rc = NULL, *rd = NULL;
+    pthread_join(c, &rc); pthread_join(d, &rd);
+    (void)rd;                       /* the woken replica saw no valid request */
+    bad |= (intptr_t)rc;
+
+    free(L.own);
     if (bad) { fputs("hedged request test failed\n", stderr); return 1; }
-    puts("HEDGED EXEC: PASS (3-row batch, fast replica won after 20 ms)");
+    puts("HEDGED EXEC: PASS (3-row batch, fast replica won after 20 ms; "
+         "hedge_ms<0 leaves the primary alone)");
     return 0;
 }


### PR DESCRIPTION
## The defect

`lumabri_client.h` still documented the field as:

```c
int hedge_ms;   /* 0 disables; base policy, fixed delay */
```

but #85 changed what zero means:

```c
uint32_t hedge_ms = L.hedge_ms > 0 ? (uint32_t)L.hedge_ms
                                   : lmb_predict_hedge_ms(&primary->latency);
```

Zero now selects the automatic p95 policy. And since the environment read was
`lmb_env_int("LUMABRI_HEDGE_MS", 0, 0, 60000)`, clamped at zero, **there was no
longer any way to turn hedging off** — the field contradicted its own comment
and the capability was simply gone.

## Why it matters beyond tidiness

A hedge issues the same request to a second replica. Anyone measuring *which
peer did the work* therefore cannot distinguish a chosen replica from a hedge
copy. Deterministic attribution is exactly what the benchmark harness in #78
and @benmaster82's RTT measurement in #29 rely on, and it went away silently.

It is currently blocking #84: that test sets `L.hedge_ms = 0` believing it
disables hedging, the automatic policy fires partway through its eight calls,
and the parked-routing assertion reads 5/3 instead of 8/0. Whether it fires at
all depends on whether the measured tail crosses `1.5 x ewma`, which is why
the runner and a developer machine disagree about that PR.

## The change

- `< 0` — off, no second replica is ever issued
- `0` — automatic, unchanged, still the default
- `> 0` — fixed delay, the original base policy

The environment range widens to `[-1, 60000]` so `LUMABRI_HEDGE_MS=-1` reaches
the code. No default behaviour changes.

## The test, and why the first version of it was worthless

The new case first **arms** the automatic policy: eight samples, one tail
spike, then fast replies, so the p95 sits above `1.5 x ewma` where
`lmb_predict_hedge_ms` returns non-zero. Only then does it assert that a
negative setting leaves the slow primary to answer alone.

Without that fixture the case passes whether or not the switch works, because
the automatic branch returns zero by itself when a peer has no history — my
first attempt did exactly that. Verified by mutation: with the guard removed
the test fails, with it restored it passes.

## Verification

- `make check-warnings ENGINE=<colibri dev>` — PASS
- `make test ENGINE=<colibri dev>` — PASS
- `test_hedge` — 3 consecutive runs PASS; fails when the guard is removed

Also adds the three test binaries #91 introduced to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)