### PR TITLE
fix: keep Segment sessions alive through resource pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ a tag stay under Unreleased until a new tag is created.
 
 ## Unreleased
 
+- Segment pressure recovery now drains in-flight sessions through ordinary RAM
+  pressure, recovery hysteresis and manual pause; only the critical RAM/swap
+  floor aborts a kernel. A failed RUN can reopen the same exact-range executor
+  (direct or relay) with clean-state replay, and client errors preserve the
+  actual executor/transport status instead of claiming that every failure is a
+  missing replica.
 - Donor runtime coordination: one automatic RAM-sized compute donation per
   machine/user now covers both chat roles and `serve --join`; duplicate starts
   remain useful as storage-only peers and identify the current lease owner.

--- a/README.md
+++ b/README.md
@@ -262,10 +262,12 @@ origin defaults to two sessions per slice; a direct server defaults to four.
 Every executor runs the same hysteretic resource governor. `ACTIVE` publishes
 capacity; `PRESSURE` and `PAUSED` advertise Segment draining or zero Expert
 coverage and reject new work; `RECOVERY` waits three healthy samples before
-publishing again. In-flight Segment work sees the cancellation callback and is
-migrated through the existing checkpoint/replay path. Expert work already in
-flight drains, while new calls fall back to another replica or the Segment's
-local kernel. This pauses donor CPU and I/O immediately; resident RAM stays
+publishing again. Segment sessions already executing drain through ordinary
+pressure, recovery and an operator pause: those transitions must not be
+reported to the chatter as a dead peer. Only the critical RAM/swap floor can
+cancel an in-flight kernel, after which checkpoint/replay recovery runs.
+Expert work already in flight drains, while new calls fall back to another
+replica or the Segment's local kernel. Resident RAM stays
 allocated inside the donor process, protected by the reserve chosen before
 loading, so recovery does not cold-load the model again.
 Every transition names its cause and prints available RAM, the configured

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -144,14 +144,14 @@ temperature uses deterministic-seedable nucleus sampling (`--seed` or
 
 Persistent chats with at least one compatible replica take a transactional
 opaque checkpoint of every selected range at a completed turn. Origin-only
-swarms avoid that copy because there is nowhere to restore it. When one peer
-fails, the gateway selects a compatible replica with exactly the same layer
-boundaries/schema/numeric class, creates a new fenced session across the whole
-chain, restores the common checkpoint,
-replays the token delta and retries the failed batch. No model-specific KV
-layout enters Lumabri. If any exact-range replica or checkpoint is unavailable,
-the error is explicit and the conversation is never continued from partial
-state.
+swarms avoid that copy. On a failed RUN, the gateway may open a clean session
+on the same executor (including through its relay), or select a compatible
+replica with exactly the same layer boundaries/schema/numeric class. It then
+restores the common checkpoint when present, otherwise replays from token zero,
+and retries the failed batch. No model-specific KV layout enters Lumabri and a
+possibly partial session is never reused. If no exact-range recovery route can
+be opened, the error includes the executor status instead of presenting every
+engine rejection as a dead peer.
 
 ## Encryption
 

--- a/lumabri.c
+++ b/lumabri.c
@@ -2300,7 +2300,7 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
                     live_status("decode · %zu token · Segment", current);
                 else if (!strcmp(phase, "FAILOVER")) {
                     const char *peer = strstr(line, "FAILOVER ");
-                    live_status("failover · sostituisco %s",
+                    live_status("ripristino Segment · riapro %s",
                                 peer ? peer + strlen("FAILOVER ") : "peer");
                 } else if (!strcmp(phase, "CHECKPOINT"))
                     live_status("checkpoint KV · %zu token protetti", current);

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -451,6 +451,14 @@ int lmb_governor_accepting(const LmbGovernor *governor) {
     return lmb_governor_state(governor) == LMB_GOV_ACTIVE;
 }
 
+int lmb_governor_abort_inflight(const LmbGovernor *governor) {
+    if (!governor || lmb_governor_state(governor) != LMB_GOV_PAUSED)
+        return 0;
+    LmbGovernorReason reason = lmb_governor_reason(governor);
+    return reason == LMB_GOV_REASON_RAM_CRITICAL ||
+           reason == LMB_GOV_REASON_SWAP_CRITICAL;
+}
+
 LmbGovernorReason lmb_governor_reason(const LmbGovernor *governor) {
     return (LmbGovernorReason)atomic_load(&governor->reason);
 }

--- a/lumabri_machine.h
+++ b/lumabri_machine.h
@@ -73,6 +73,9 @@ LmbGovernorState lmb_governor_poll(LmbGovernor *governor);
 LmbGovernorState lmb_governor_state(const LmbGovernor *governor);
 LmbGovernorReason lmb_governor_reason(const LmbGovernor *governor);
 int lmb_governor_accepting(const LmbGovernor *governor);
+/* Existing work drains through ordinary pressure and an operator pause.  Only
+ * a genuinely critical RAM/swap condition may abort an in-flight kernel. */
+int lmb_governor_abort_inflight(const LmbGovernor *governor);
 int lmb_governor_set_manual(int paused);
 int lmb_governor_manual_paused(void);
 

--- a/relay_exec_test.sh
+++ b/relay_exec_test.sh
@@ -10,7 +10,16 @@ fi
 make -s ENGINE="$ENGINE_DIR" tracker expert_node test_relay_exec fixture
 T=$(mktemp -d /tmp/lumabri-relay-exec.XXXXXX)
 PIDS=()
-cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
+cleanup() {
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        for log in "$T"/*.log; do
+            [ -f "$log" ] && { echo "--- $log" >&2; tail -80 "$log" >&2; }
+        done
+    fi
+    kill "${PIDS[@]}" 2>/dev/null || true
+    rm -rf "$T"
+}
 trap cleanup EXIT
 export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
 
@@ -20,7 +29,7 @@ OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 ./expert_node \
     --tracker 127.0.0.1:7560 --advertise 127.0.0.1:1 \
     >"$T/node.log" 2>&1 & PIDS+=($!)
 
-for _ in $(seq 1 200); do
+for _ in $(seq 1 600); do
     grep -q "expert nat-expert" "$T/tracker.log" && break
     sleep .1
 done

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -20,7 +20,9 @@ typedef struct {
     int fd;
     int direct_failed;
     int opened;
+    int failure_transport;
     char transport_error[256];
+    char operation_error[320];
     LmbSegOpen open;
     uint64_t sequence;
     uint64_t position;
@@ -412,9 +414,9 @@ static int remote_request(RemoteSegment *remote, uint32_t op,
                           const void *pay, uint32_t pay_len,
                           LmbMsg *response) {
     uint64_t sent_bytes = 16u + (uint64_t)body_len + pay_len;
+    remote->transport_error[0] = 0;
     if (!remote->direct_failed &&
         (remote->route.transport & LMB_SEG_TRANSPORT_DIRECT)) {
-        remote->transport_error[0] = 0;
         if (remote->fd < 0) {
             remote->fd = lmb_connect(remote->route.advert.addr);
             if (remote->fd < 0)
@@ -562,15 +564,58 @@ static int remote_run(RemoteSegment *remote, const int32_t *tokens,
         return -1;
     LmbMsg msg = {0};
     LmbSegReply reply;
+    memset(&reply, 0, sizeof reply);
+    remote->operation_error[0] = 0;
+    remote->failure_transport = 0;
     int bad = remote_request(remote, LMB_SEG_RUN, body, body_len,
-                             input, (uint32_t)bytes, &msg) ||
-          reply_ok(&msg, LMB_SEG_RUN_R, &run.session_id, &run.request_id,
-                   run.owner.route_generation, &reply) ||
-          msg.pay_len != bytes;
+                             input, (uint32_t)bytes, &msg);
+    if (bad) {
+        remote->failure_transport = 1;
+        snprintf(remote->operation_error, sizeof remote->operation_error,
+                 "%s", remote->transport_error[0] ? remote->transport_error :
+                 "no usable Segment transport");
+    } else if (msg.op == LMB_ERR) {
+        snprintf(remote->operation_error, sizeof remote->operation_error,
+                 "%s refused RUN: %.*s", remote->route.advert.peer_name,
+                 (int)msg.body_len, msg.body ? (const char *)msg.body : "");
+        bad = 1;
+    } else if (msg.op != LMB_SEG_RUN_R ||
+               lmb_seg_reply_decode(msg.body, msg.body_len, &reply)) {
+        snprintf(remote->operation_error, sizeof remote->operation_error,
+                 "%s answered RUN with an unreadable message (op %u)",
+                 remote->route.advert.peer_name, msg.op);
+        bad = 1;
+    } else if (!lmb_seg_id_equal(&reply.session_id, &run.session_id) ||
+               !lmb_seg_id_equal(&reply.request_id, &run.request_id) ||
+               reply.route_generation != run.owner.route_generation) {
+        snprintf(remote->operation_error, sizeof remote->operation_error,
+                 "%s answered RUN for a different session or route generation",
+                 remote->route.advert.peer_name);
+        bad = 1;
+    } else if (reply.status != LMB_SEG_STATUS_OK &&
+               reply.status != LMB_SEG_STATUS_DUPLICATE) {
+        snprintf(remote->operation_error, sizeof remote->operation_error,
+                 "%s rejected RUN [%u:%u]: %s",
+                 remote->route.advert.peer_name,
+                 remote->route.advert.layer_begin,
+                 remote->route.advert.layer_end,
+                 segment_status_name(reply.status));
+        bad = 1;
+    } else if (msg.pay_len != bytes) {
+        snprintf(remote->operation_error, sizeof remote->operation_error,
+                 "%s returned %u activation bytes, expected %zu",
+                 remote->route.advert.peer_name, msg.pay_len, bytes);
+        bad = 1;
+    }
     if (!bad) {
         memcpy(output, msg.pay, bytes);
         if (reply.next_sequence != run.sequence + 1 ||
-            reply.next_position != run.position + rows) bad = 1;
+            reply.next_position != run.position + rows) {
+            snprintf(remote->operation_error, sizeof remote->operation_error,
+                     "%s advanced RUN to an invalid sequence/position",
+                     remote->route.advert.peer_name);
+            bad = 1;
+        }
         else {
             remote->sequence = reply.next_sequence;
             remote->position = reply.next_position;
@@ -582,6 +627,7 @@ static int remote_run(RemoteSegment *remote, const int32_t *tokens,
         memset(&msg, 0, sizeof msg);
         bad = remote_request(remote, LMB_SEG_RUN, body, body_len,
                              input, (uint32_t)bytes, &msg);
+        if (bad) remote->failure_transport = 1;
         LmbSegReply duplicate;
         if (!bad) bad =
             reply_ok(&msg, LMB_SEG_RUN_R, &run.session_id, &run.request_id,
@@ -590,6 +636,10 @@ static int remote_run(RemoteSegment *remote, const int32_t *tokens,
             duplicate.next_sequence != remote->sequence ||
             duplicate.next_position != remote->position ||
             msg.pay_len != bytes || memcmp(msg.pay, output, bytes);
+        if (bad && !remote->operation_error[0])
+            snprintf(remote->operation_error, sizeof remote->operation_error,
+                     "%s failed the idempotent RUN retry",
+                     remote->route.advert.peer_name);
         lmb_msg_free(&msg);
     }
     free(body);
@@ -855,9 +905,31 @@ static int conversation_has_replica(
     return 0;
 }
 
-static int conversation_recover(
-    SegmentConversation *conversation,
-    const LmbSegRouteSnapshot *snapshot, size_t failed_index,
+static int recovery_route_better(const LmbSegRouteEntry *candidate,
+                                 const LmbSegRouteEntry *best,
+                                 const LmbSegRouteEntry *current,
+                                 int prefer_same) {
+    if (!best) return 1;
+    int candidate_same = !strcmp(candidate->advert.peer_name,
+                                 current->advert.peer_name);
+    int best_same = !strcmp(best->advert.peer_name,
+                            current->advert.peer_name);
+    if (candidate_same != best_same)
+        return prefer_same ? candidate_same : !candidate_same;
+    if (candidate->predicted_us != best->predicted_us)
+        return candidate->predicted_us < best->predicted_us;
+    int candidate_direct = !!(candidate->transport & LMB_SEG_TRANSPORT_DIRECT);
+    int best_direct = !!(best->transport & LMB_SEG_TRANSPORT_DIRECT);
+    if (candidate_direct != best_direct) return candidate_direct;
+    int candidate_fallback =
+        !!(candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK);
+    int best_fallback = !!(best->advert.flags & LMB_SEG_ADVERT_FALLBACK);
+    return candidate_fallback < best_fallback;
+}
+
+static int conversation_recover_attempt(
+    SegmentConversation *conversation, size_t failed_index,
+    const LmbSegRouteEntry *candidate,
     ColiEdgeEngine *edge, const ColiEdgeCapabilities *cap,
     const uint8_t model_root[32], const uint8_t tokenizer_root[32],
     uint32_t context, uint32_t max_rows,
@@ -865,38 +937,11 @@ static int conversation_recover(
     const int32_t *generated, size_t generated_replayed,
     uint8_t *buffer_a, uint8_t *buffer_b,
     char *error, size_t error_size) {
-    if (!conversation || !conversation->active || !snapshot ||
-        failed_index >= conversation->chain_count) return -1;
     RemoteSegment replacement[LMB_SEG_ROUTE_MAX];
     memset(replacement, 0, sizeof replacement);
     for (size_t i = 0; i < conversation->chain_count; i++) {
-        const LmbSegRouteEntry *current = &conversation->chain[i].route;
-        const LmbSegRouteEntry *chosen = current;
-        if (i == failed_index) {
-            chosen = NULL;
-            for (uint32_t j = 0; j < snapshot->count; j++) {
-                const LmbSegRouteEntry *candidate = &snapshot->entries[j];
-                if (!strcmp(candidate->advert.peer_name,
-                            current->advert.peer_name) ||
-                    !route_same_range(candidate, current,
-                                      context, max_rows)) continue;
-                if (!chosen ||
-                    candidate->predicted_us < chosen->predicted_us ||
-                    (candidate->predicted_us == chosen->predicted_us &&
-                     (candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
-                     !(chosen->transport & LMB_SEG_TRANSPORT_DIRECT)) ||
-                    (candidate->predicted_us == chosen->predicted_us &&
-                     (candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK) == 0 &&
-                     (chosen->advert.flags & LMB_SEG_ADVERT_FALLBACK)))
-                    chosen = candidate;
-            }
-            if (!chosen) {
-                snprintf(error, error_size,
-                         "Segment peer failed and no compatible replica exists");
-                return -1;
-            }
-        }
-        replacement[i].route = *chosen;
+        replacement[i].route = i == failed_index
+            ? *candidate : conversation->chain[i].route;
         replacement[i].fd = -1;
     }
 
@@ -915,27 +960,38 @@ static int conversation_recover(
             };
             if (!checkpoint.data ||
                 checkpoint.position != conversation->checkpoint_count ||
-                remote_restore(&replacement[opened], &checkpoint)) break;
+                remote_restore(&replacement[opened], &checkpoint)) {
+                snprintf(error, error_size,
+                         "%.120s could not restore the checkpoint",
+                         replacement[opened].route.advert.peer_name);
+                break;
+            }
         }
     }
     if (opened != conversation->chain_count) {
         for (size_t i = 0; i <= opened && i < conversation->chain_count; i++)
             remote_dispose(&replacement[i]);
-        snprintf(error, error_size,
-                 "Segment replica could not restore the last checkpoint");
+        if (!error[0])
+            snprintf(error, error_size,
+                     "Segment recovery OPEN/restore was rejected");
         return -1;
     }
 
     size_t total = prompt_replayed + generated_replayed;
     int32_t *history = total ? malloc(total * sizeof *history) : NULL;
-    if (total && !history) goto recovery_failed;
+    if (total && !history) {
+        snprintf(error, error_size, "out of memory replaying Segment history");
+        goto recovery_failed;
+    }
     if (prompt_replayed)
         memcpy(history, prompt_tokens, prompt_replayed * sizeof *history);
     if (generated_replayed)
         memcpy(history + prompt_replayed, generated,
                generated_replayed * sizeof *history);
     if (conversation->checkpoint_count > total) {
-        free(history); goto recovery_failed;
+        free(history);
+        snprintf(error, error_size, "Segment checkpoint is ahead of token history");
+        goto recovery_failed;
     }
     for (size_t offset = conversation->checkpoint_count;
          offset < total; offset += max_rows) {
@@ -951,8 +1007,15 @@ static int conversation_recover(
             free(history); goto recovery_failed;
         }
         uint8_t *first = buffer_a, *second = buffer_b;
-        if (chain_run(replacement, conversation->chain_count,
-                      history + offset, rows, &first, &second, bytes)) {
+        int failed = chain_run(replacement, conversation->chain_count,
+                               history + offset, rows,
+                               &first, &second, bytes);
+        if (failed) {
+            size_t index = (size_t)(-failed - 1);
+            snprintf(error, error_size, "%.240s",
+                     replacement[index].operation_error[0]
+                         ? replacement[index].operation_error
+                         : "Segment recovery replay RUN failed");
             free(history); goto recovery_failed;
         }
     }
@@ -964,12 +1027,20 @@ static int conversation_recover(
         replacement[i].snapshot_sequence = old->snapshot_sequence;
         replacement[i].snapshot_position = old->snapshot_position;
         old->snapshot = NULL; old->snapshot_bytes = 0;
+        /* RUN already exhausted direct and relay. Do not spend another relay
+         * timeout sending CLOSE to the dead transport after recovery succeeded;
+         * the abandoned session is fenced and expires by TTL. */
+        if (i == failed_index && old->failure_transport) {
+            if (old->fd >= 0) lmb_close(old->fd);
+            old->fd = -1;
+            old->opened = 0;
+        }
         remote_dispose(old);
         *old = replacement[i];
     }
-    conversation->route_generation = snapshot->route_generation;
-    fprintf(stderr, "[lumabri] Segment failover: restored checkpoint at token "
-                    "%zu and replayed %zu token%s\n",
+    fprintf(stderr, "[lumabri] Segment failover: recovered through %s; restored "
+                    "checkpoint at token %zu and replayed %zu token%s\n",
+            candidate->advert.peer_name,
             conversation->checkpoint_count,
             total - conversation->checkpoint_count,
             total - conversation->checkpoint_count == 1 ? "" : "s");
@@ -978,8 +1049,72 @@ static int conversation_recover(
 recovery_failed:
     for (size_t i = 0; i < conversation->chain_count; i++)
         remote_dispose(&replacement[i]);
-    snprintf(error, error_size,
-             "Segment checkpoint replay failed on the replacement chain");
+    if (!error[0])
+        snprintf(error, error_size,
+                 "Segment recovery replay failed on the reopened chain");
+    return -1;
+}
+
+static int conversation_recover(
+    SegmentConversation *conversation,
+    const LmbSegRouteSnapshot *snapshot, size_t failed_index,
+    ColiEdgeEngine *edge, const ColiEdgeCapabilities *cap,
+    const uint8_t model_root[32], const uint8_t tokenizer_root[32],
+    uint32_t context, uint32_t max_rows,
+    const int32_t *prompt_tokens, size_t prompt_replayed,
+    const int32_t *generated, size_t generated_replayed,
+    uint8_t *buffer_a, uint8_t *buffer_b,
+    char *error, size_t error_size) {
+    if (!conversation || !conversation->active || !snapshot ||
+        failed_index >= conversation->chain_count) return -1;
+    char initial_failure[320], last_failure[256] = "";
+    snprintf(initial_failure, sizeof initial_failure, "%s",
+             conversation->chain[failed_index].operation_error[0]
+                 ? conversation->chain[failed_index].operation_error
+                 : "Segment RUN failed");
+    const LmbSegRouteEntry *current = &conversation->chain[failed_index].route;
+    int prefer_same = !conversation->chain[failed_index].failure_transport;
+    uint8_t attempted[LMB_SEG_ROUTE_MAX] = {0};
+    size_t attempts = 0;
+    for (;;) {
+        uint32_t chosen_index = UINT32_MAX;
+        const LmbSegRouteEntry *chosen = NULL;
+        for (uint32_t j = 0; j < snapshot->count; j++) {
+            const LmbSegRouteEntry *candidate = &snapshot->entries[j];
+            /* An executor which returned a status gets one clean-session retry;
+             * a transport failure already exhausted direct and relay, so exact-
+             * range replicas come first. Every candidate remains a final tier. */
+            if (attempted[j] ||
+                !route_same_range(candidate, current, context, max_rows))
+                continue;
+            if (recovery_route_better(candidate, chosen, current, prefer_same)) {
+                chosen = candidate;
+                chosen_index = j;
+            }
+        }
+        if (!chosen) break;
+        attempted[chosen_index] = 1;
+        attempts++;
+        error[0] = 0;
+        if (!conversation_recover_attempt(
+                conversation, failed_index, chosen, edge, cap,
+                model_root, tokenizer_root, context, max_rows,
+                prompt_tokens, prompt_replayed, generated, generated_replayed,
+                buffer_a, buffer_b, error, error_size)) {
+            conversation->route_generation = snapshot->route_generation;
+            return 0;
+        }
+        snprintf(last_failure, sizeof last_failure, "%s",
+                 error[0] ? error : "recovery route failed");
+    }
+    if (!attempts)
+        snprintf(error, error_size,
+                 "%.180s; no compatible Segment recovery route exists",
+                 initial_failure);
+    else
+        snprintf(error, error_size,
+                 "%.96s; all Segment recovery routes failed: %.96s",
+                 initial_failure, last_failure);
     return -1;
 }
 
@@ -1725,7 +1860,10 @@ int main(int argc, char **argv) {
     snprintf(query.engine_id, sizeof query.engine_id, "%s", cap.engine_id);
     snprintf(query.state_schema, sizeof query.state_schema, "%s", cap.state_schema);
     snprintf(query.numeric_class, sizeof query.numeric_class, "%s", cap.numeric_class);
-    LmbSegDiscovery *discovery = lmb_seg_discovery_start(tracker, &query, 250);
+    uint32_t discovery_refresh_ms = (uint32_t)lmb_env_int(
+        "LUMABRI_SEGMENT_DISCOVERY_MS", 250, 50, 3600000);
+    LmbSegDiscovery *discovery = lmb_seg_discovery_start(
+        tracker, &query, discovery_refresh_ms);
     if (!discovery) { fprintf(stderr, "cannot start Segment discovery\n"); return 1; }
     LmbSegRouteSnapshot snapshot;
     memset(&snapshot, 0, sizeof snapshot);

--- a/segment_failover_test.sh
+++ b/segment_failover_test.sh
@@ -11,6 +11,12 @@ TRACKER_BIN=${TRACKER_BIN:-./tracker}
 TMP=$(mktemp -d /tmp/lumabri-segment-failover.XXXXXX)
 PIDS=()
 cleanup() {
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        for log in "$TMP"/*.log; do
+            [ -f "$log" ] && { echo "--- $log" >&2; tail -80 "$log" >&2; }
+        done
+    fi
     for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
     for pid in "${PIDS[@]}"; do wait "$pid" 2>/dev/null || true; done
     rm -rf "$TMP"
@@ -35,7 +41,12 @@ common=(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/node.key"
         LUMABRI_KNOWN_HOSTS="$TMP/known")
 start_node() {
     local range=$1 port=$2 name=$3 fallback=$4
-    "${common[@]}" "$SEGMENT_NODE_BIN" --engine olmoe \
+    local latency=()
+    # The predictive scheduler correctly prefers measured completion time over
+    # the fallback bit. Make the intended donor selection deterministic instead
+    # of depending on sub-millisecond loopback probe noise.
+    [ -n "$fallback" ] && latency=(LUMABRI_RTT_US=20000)
+    "${common[@]}" "${latency[@]}" "$SEGMENT_NODE_BIN" --engine olmoe \
         --model-dir "$OLMOE_EDGE_MODEL" --model tiny-failover \
         --range "$range" --port "$port" --tracker 127.0.0.1:8068 \
         --advertise "127.0.0.1:$port" --name "$name" \
@@ -51,6 +62,7 @@ sleep 1
 
 env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
     LUMABRI_KNOWN_HOSTS="$TMP/known" LUMABRI_SAMPLE_SEED=11 \
+    LUMABRI_SEGMENT_DISCOVERY_MS=60000 \
     python3 - "$DONOR_PID" "$SEGMENT_CHAT_BIN" "$OLMOE_EDGE_MODEL" "$root" "$tok" <<'PY'
 import os, subprocess, sys, time
 donor, binary, model_dir, root, tok = sys.argv[1:]
@@ -66,10 +78,15 @@ def line():
     return value
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("gateway not ready")
-def turn(rid, prompt):
+def turn(rid, prompt, kill_after_accept=None):
     p.stdin.write(f"SUBMIT {rid} 0 {len(prompt)} 1 0.7 0.95\n".encode()+prompt+b"\n")
     p.stdin.flush()
     if line() != f"ACCEPT {rid}\n".encode(): raise RuntimeError("not accepted")
+    # ACCEPT is emitted before the immutable route snapshot is consumed by the
+    # generation. Kill here so the turn exercises recovery of that selected
+    # route, rather than the discovery thread cleanly choosing the origin first.
+    if kill_after_accept is not None:
+        os.kill(int(kill_after_accept), 9)
     seen_data = False
     while True:
         frame = line()
@@ -83,13 +100,12 @@ def turn(rid, prompt):
             raise RuntimeError("unexpected frame: "+repr(frame))
     if not seen_data: raise RuntimeError("no streamed data")
 turn(1, b"hi\n")
-os.kill(int(donor), 15)
-time.sleep(.3)
-turn(2, b"hi\nthere\n")
+turn(2, b"hi\nthere\n", donor)
 p.stdin.close()
 if p.wait(timeout=30): raise RuntimeError("gateway failed")
 diagnostics=p.stderr.read().decode("utf-8", "replace")
-if "Segment failover: restored checkpoint" not in diagnostics:
+if ("Segment failover: recovered through origin-left; restored checkpoint"
+        not in diagnostics):
     raise RuntimeError("checkpoint failover did not run:\n"+diagnostics)
 PY
 echo "SEGMENT FAILOVER: PASS (checkpoint restore + replay after peer death)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -105,28 +105,39 @@ static uint64_t resident_memory_bytes(void) {
     return resident * (uint64_t)page;
 }
 
-static int memory_pressure(void *opaque) {
-    Node *node = opaque;
+static int process_budget_exhausted(Node *node) {
     uint64_t rss = resident_memory_bytes();
-    return g_stop || !lmb_governor_accepting(&node->governor) ||
-           available_memory_bytes() < node->ram_reserve_bytes ||
-           (node->process_memory_limit_bytes && rss &&
-            rss > node->process_memory_limit_bytes);
+    return node->process_memory_limit_bytes && rss &&
+           rss >= node->process_memory_limit_bytes;
+}
+
+/* OPEN and route publication stop at the reserve.  A RUN which already owns a
+ * session is different: aborting it throws away the conversation state and
+ * turns a harmless pressure transition into a fake peer failure.  Let active
+ * work drain through PRESSURE/RECOVERY and operator pause; only shutdown or the
+ * governor's critical RAM/swap floor may interrupt a Colibri kernel. */
+static int run_should_cancel(void *opaque) {
+    Node *node = opaque;
+    return g_stop || lmb_governor_abort_inflight(&node->governor);
 }
 
 static void *governor_worker(void *opaque) {
     Node *node = opaque;
     LmbGovernorState previous = lmb_governor_state(&node->governor);
+    int previous_accepting = lmb_governor_accepting(&node->governor) &&
+                             !process_budget_exhausted(node);
     int first = 1;
     while (!g_stop && !node->registration.stop) {
         LmbGovernorState state = lmb_governor_poll(&node->governor);
+        int process_limited = process_budget_exhausted(node);
+        int accepting = state == LMB_GOV_ACTIVE && !process_limited;
         pthread_mutex_lock(&node->registration.lock);
-        if (state == LMB_GOV_ACTIVE)
+        if (accepting)
             node->registration.advert.flags &= ~LMB_SEG_ADVERT_DRAINING;
         else
             node->registration.advert.flags |= LMB_SEG_ADVERT_DRAINING;
         pthread_mutex_unlock(&node->registration.lock);
-        if (first || state != previous) {
+        if (first || state != previous || accepting != previous_accepting) {
             uint64_t available = lmb_machine_available_ram();
             uint64_t rss = resident_memory_bytes();
             fprintf(stderr, "[segment-node %s] governor ",
@@ -135,9 +146,11 @@ static void *governor_worker(void *opaque) {
                                 lmb_governor_state_name(previous));
             fprintf(stderr, "%s · %s",
                     lmb_governor_state_name(state),
-                    state == LMB_GOV_ACTIVE ? "accepting sessions" :
-                                             "draining and refusing new work");
-            if (state != LMB_GOV_ACTIVE)
+                    accepting ? "accepting sessions" :
+                                "draining and refusing new work");
+            if (process_limited)
+                fprintf(stderr, " · reason: process memory budget reached");
+            else if (state != LMB_GOV_ACTIVE)
                 fprintf(stderr, " · reason: %s",
                         lmb_governor_reason_name(
                             lmb_governor_reason(&node->governor)));
@@ -149,6 +162,7 @@ static void *governor_worker(void *opaque) {
                     (double)node->process_memory_limit_bytes / 1e9);
             first = 0;
             previous = state;
+            previous_accepting = accepting;
         }
         for (int i = 0; i < 10 && !g_stop && !node->registration.stop; i++)
             usleep(100000);
@@ -570,7 +584,8 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
         } else if (!(slot = session_empty(node))) {
             status = LMB_SEG_STATUS_QUOTA;
         } else if (!lmb_governor_accepting(&node->governor) ||
-                   available_memory_bytes() < node->ram_reserve_bytes) {
+                   available_memory_bytes() < node->ram_reserve_bytes ||
+                   process_budget_exhausted(node)) {
             status = LMB_SEG_STATUS_QUOTA;
         } else {
             ColiSegmentSessionOptions options = {
@@ -647,7 +662,7 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
         } else {
             int admitted = lmb_run_gate_enter(&node->run_gate,
                                                node->run_wait_ms,
-                                               memory_pressure, node);
+                                               run_should_cancel, node);
             if (admitted != 1) {
                 status = admitted < 0 ? LMB_SEG_STATUS_QUOTA :
                                         LMB_SEG_STATUS_BUSY;
@@ -662,7 +677,7 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                 .input_bytes = msg->pay_len,
                 .output = output,
                 .output_bytes = bytes,
-                .should_cancel = memory_pressure,
+                .should_cancel = run_should_cancel,
                 .cancel_user_data = node,
             };
             char error[256] = "";
@@ -677,7 +692,18 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
                         run.rows == 1 ? "" : "s",
                         (unsigned long long)run.position,
                         engine_error(error));
-                status = LMB_SEG_STATUS_INTERNAL;
+                if (lmb_governor_abort_inflight(&node->governor)) {
+                    fprintf(stderr, "[segment-node %s] in-flight emergency: %s "
+                                    "(available %.1f GB / reserve %.1f GB)\n",
+                            node->advert.peer_name,
+                            lmb_governor_reason_name(
+                                lmb_governor_reason(&node->governor)),
+                            (double)available_memory_bytes() / 1e9,
+                            (double)node->ram_reserve_bytes / 1e9);
+                    status = LMB_SEG_STATUS_QUOTA;
+                } else {
+                    status = LMB_SEG_STATUS_INTERNAL;
+                }
             }
             if (admitted == 1) lmb_run_gate_leave(&node->run_gate);
         }

--- a/test_machine.c
+++ b/test_machine.c
@@ -27,6 +27,13 @@ int main(void) {
     assert(lmb_governor_poll(&governor) == LMB_GOV_PAUSED);
     assert(lmb_governor_reason(&governor) == LMB_GOV_REASON_MANUAL);
     assert(!lmb_governor_accepting(&governor));
+    assert(!lmb_governor_abort_inflight(&governor));
+    atomic_store(&governor.reason, LMB_GOV_REASON_RAM_CRITICAL);
+    assert(lmb_governor_abort_inflight(&governor));
+    atomic_store(&governor.reason, LMB_GOV_REASON_SWAP_CRITICAL);
+    assert(lmb_governor_abort_inflight(&governor));
+    atomic_store(&governor.state, LMB_GOV_PRESSURE);
+    assert(!lmb_governor_abort_inflight(&governor));
     assert(lmb_governor_set_manual(0) == 0);
     assert(lmb_governor_poll(&governor) == LMB_GOV_RECOVERY);
     assert(lmb_governor_reason(&governor) == LMB_GOV_REASON_RECOVERY);
@@ -40,6 +47,6 @@ int main(void) {
     assert(unlink(state_file) == 0);
     assert(rmdir(state_dir) == 0);
     assert(rmdir(home) == 0);
-    puts("MACHINE GOVERNOR UNIT: PASS (pause, hysteresis, recovery)");
+    puts("MACHINE GOVERNOR UNIT: PASS (pause, drain, critical abort, recovery)");
     return 0;
 }


### PR DESCRIPTION
## Outcome

Fixes the live DeepSeek failure reported as `Segment peer failed and no compatible replica exists` when the executor log actually said `segment run cancelled` during `ACTIVE -> PRESSURE -> RECOVERY`.

This PR closes a defect that invalidates A/B measurements: an admitted chat could be terminated by an ordinary RAM-pressure transition even though the machine never crossed the critical safety floor.

## Changes

- separate new-session admission from in-flight cancellation;
- drain active Segment work through PRESSURE, RECOVERY and manual pause;
- retain emergency cancellation for genuinely critical RAM/swap pressure and shutdown;
- keep process-budget enforcement for publication and new sessions;
- preserve RUN transport/protocol/status diagnostics instead of collapsing every error into a dead peer;
- recovery tries a clean session on the same exact-range executor for application failures, then every compatible replica; transport failures, which already exhausted direct and relay, prefer replicas immediately;
- abandon a dead fenced session without paying another relay timeout;
- allow origin-only recovery by replaying from token zero when no checkpoint replica exists;
- make the TUI say `ripristino Segment` instead of promising a replacement before recovery succeeds;
- make failover/relay gates deterministic and print child logs on failure.

Colibri remains unchanged. All behavior is implemented in Lumabri and applies through the universal Segment ABI to all six adapters.

## Verification

- `make test ENGINE=/tmp/colibri-validation/c` — PASS
- Werror build of `segment_node`, `segment_chat`, `lumabri`, and governor unit — PASS
- `make test-machine-governor ENGINE=/tmp/colibri-validation/c` — PASS
- `segment_relay_test.sh` — PASS (relay-only OPEN/RUN/SNAPSHOT/CLOSE)
- `segment_failover_test.sh` — PASS (selected donor killed between ACCEPT and RUN; origin replica restores checkpoint and completes)

Stacked on #91. Do not merge automatically.