### PR TITLE
fix: refresh fenced Segment routes during recovery

### DIFF
--- a/lumabri_segment_discovery.c
+++ b/lumabri_segment_discovery.c
@@ -548,6 +548,48 @@ int lmb_seg_discovery_snapshot(LmbSegDiscovery *d,
     return have;
 }
 
+int lmb_seg_discovery_refresh_now(LmbSegDiscovery *d,
+                                  LmbSegRouteSnapshot *snapshot) {
+    if (!d || !snapshot) return -1;
+    LmbSegRouteSnapshot next;
+    if (lmb_seg_routes_fetch(d->tracker, &d->query, &next)) return -1;
+
+    /* A failover must not wait for direct-connect probes. Preserve observations
+     * for routes already known by the worker and initialize new ones with the
+     * transport prior; the next background pass resumes normal probing. */
+    pthread_mutex_lock(&d->lock);
+    uint64_t now = disc_now_ms();
+    for (uint32_t i = 0; i < next.count; i++) {
+        LmbSegRouteEntry *entry = &next.entries[i];
+        const LmbSegRouteEntry *old = NULL;
+        if (d->have_snapshot)
+            for (uint32_t j = 0; j < d->snapshot.count; j++)
+                if (disc_same_route(entry, &d->snapshot.entries[j])) {
+                    old = &d->snapshot.entries[j];
+                    break;
+                }
+        if (old) {
+            entry->latency = old->latency;
+            entry->last_probe_ms = old->last_probe_ms;
+        } else {
+            lmb_predict_init(&entry->latency,
+                entry->transport & LMB_SEG_TRANSPORT_DIRECT ? 50000u : 120000u);
+        }
+        uint32_t queue = entry->advert.queue_depth + entry->advert.inflight;
+        entry->predicted_us = lmb_predict_score(&entry->latency, queue);
+        if (!lmb_predict_available(&entry->latency, now))
+            entry->predicted_us = UINT64_MAX / 4u;
+    }
+    if (!d->have_snapshot ||
+        next.route_generation >= d->snapshot.route_generation) {
+        d->snapshot = next;
+        d->have_snapshot = 1;
+    }
+    *snapshot = d->snapshot;
+    pthread_mutex_unlock(&d->lock);
+    return 1;
+}
+
 void lmb_seg_discovery_stop(LmbSegDiscovery *d) {
     if (!d) return;
     pthread_mutex_lock(&d->lock);

--- a/lumabri_segment_discovery.h
+++ b/lumabri_segment_discovery.h
@@ -143,6 +143,12 @@ LmbSegDiscovery *lmb_seg_discovery_start(const char *tracker,
  * published, 0 before the first successful tracker response, or -1. */
 int lmb_seg_discovery_snapshot(LmbSegDiscovery *discovery,
                                LmbSegRouteSnapshot *snapshot);
+/* Recovery is the one exceptional data-path operation allowed to contact the
+ * tracker. It publishes and returns a freshly fetched generation so every
+ * member of a reopened stateful chain carries the same current fencing owner.
+ * Returns 1 on success or -1 when the tracker cannot be reached. */
+int lmb_seg_discovery_refresh_now(LmbSegDiscovery *discovery,
+                                  LmbSegRouteSnapshot *snapshot);
 void lmb_seg_discovery_stop(LmbSegDiscovery *discovery);
 
 #endif /* LUMABRI_SEGMENT_DISCOVERY_H */

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -357,8 +357,8 @@ static const char *segment_status_name(uint32_t status) {
     case LMB_SEG_STATUS_EXPIRED:       return "expired";
     case LMB_SEG_STATUS_BUSY:          return "busy";
     case LMB_SEG_STATUS_UNSUPPORTED:   return "unsupported";
-    case LMB_SEG_STATUS_QUOTA:         return "quota — the executor has no "
-        "free session slot";
+    case LMB_SEG_STATUS_QUOTA:         return "quota — the executor resource "
+        "governor or admission limit refused the request";
     case LMB_SEG_STATUS_NEEDS_RESTORE: return "needs restore";
     case LMB_SEG_STATUS_INTERNAL:      return "internal executor failure — "
         "look at that peer's log";
@@ -930,6 +930,7 @@ static int recovery_route_better(const LmbSegRouteEntry *candidate,
 static int conversation_recover_attempt(
     SegmentConversation *conversation, size_t failed_index,
     const LmbSegRouteEntry *candidate,
+    const LmbSegRouteSnapshot *snapshot,
     ColiEdgeEngine *edge, const ColiEdgeCapabilities *cap,
     const uint8_t model_root[32], const uint8_t tokenizer_root[32],
     uint32_t context, uint32_t max_rows,
@@ -940,8 +941,25 @@ static int conversation_recover_attempt(
     RemoteSegment replacement[LMB_SEG_ROUTE_MAX];
     memset(replacement, 0, sizeof replacement);
     for (size_t i = 0; i < conversation->chain_count; i++) {
-        replacement[i].route = i == failed_index
-            ? *candidate : conversation->chain[i].route;
+        const LmbSegRouteEntry *route = candidate;
+        if (i != failed_index) {
+            route = NULL;
+            const LmbSegRouteEntry *current = &conversation->chain[i].route;
+            for (uint32_t j = 0; j < snapshot->count; j++) {
+                const LmbSegRouteEntry *available = &snapshot->entries[j];
+                if (route_same_range(available, current, context, max_rows) &&
+                    recovery_route_better(available, route, current, 1))
+                    route = available;
+            }
+        }
+        if (!route) {
+            snprintf(error, error_size,
+                     "no current Segment recovery route for layers %u:%u",
+                     conversation->chain[i].route.advert.layer_begin,
+                     conversation->chain[i].route.advert.layer_end);
+            return -1;
+        }
+        replacement[i].route = *route;
         replacement[i].fd = -1;
     }
 
@@ -1057,7 +1075,8 @@ recovery_failed:
 
 static int conversation_recover(
     SegmentConversation *conversation,
-    const LmbSegRouteSnapshot *snapshot, size_t failed_index,
+    LmbSegDiscovery *discovery,
+    const LmbSegRouteSnapshot *turn_snapshot, size_t failed_index,
     ColiEdgeEngine *edge, const ColiEdgeCapabilities *cap,
     const uint8_t model_root[32], const uint8_t tokenizer_root[32],
     uint32_t context, uint32_t max_rows,
@@ -1065,8 +1084,19 @@ static int conversation_recover(
     const int32_t *generated, size_t generated_replayed,
     uint8_t *buffer_a, uint8_t *buffer_b,
     char *error, size_t error_size) {
-    if (!conversation || !conversation->active || !snapshot ||
+    if (!conversation || !conversation->active || !turn_snapshot ||
         failed_index >= conversation->chain_count) return -1;
+    LmbSegRouteSnapshot refreshed;
+    const LmbSegRouteSnapshot *snapshot = turn_snapshot;
+    if (discovery &&
+        lmb_seg_discovery_refresh_now(discovery, &refreshed) > 0) {
+        snapshot = &refreshed;
+        if (snapshot->route_generation != turn_snapshot->route_generation)
+            fprintf(stderr, "[lumabri] Segment recovery route generation "
+                            "%llu -> %llu\n",
+                    (unsigned long long)turn_snapshot->route_generation,
+                    (unsigned long long)snapshot->route_generation);
+    }
     char initial_failure[320], last_failure[256] = "";
     snprintf(initial_failure, sizeof initial_failure, "%s",
              conversation->chain[failed_index].operation_error[0]
@@ -1097,7 +1127,7 @@ static int conversation_recover(
         attempts++;
         error[0] = 0;
         if (!conversation_recover_attempt(
-                conversation, failed_index, chosen, edge, cap,
+                conversation, failed_index, chosen, snapshot, edge, cap,
                 model_root, tokenizer_root, context, max_rows,
                 prompt_tokens, prompt_replayed, generated, generated_replayed,
                 buffer_a, buffer_b, error, error_size)) {
@@ -1200,6 +1230,7 @@ static int segment_generate(ColiEdgeEngine *edge,
                             double temperature, double top_p,
                             LmbSampler *sampler,
                             SegmentConversation *conversation,
+                            LmbSegDiscovery *discovery,
                             const LmbSegRouteSnapshot *route_snapshot,
                             uint64_t route_generation,
                             GenerationEventFn event, void *event_opaque,
@@ -1350,7 +1381,7 @@ static int segment_generate(ColiEdgeEngine *edge,
                         active_count, peer, strlen(peer));
         }
         if (failed && (!conversation || !route_snapshot ||
-            conversation_recover(conversation, route_snapshot,
+            conversation_recover(conversation, discovery, route_snapshot,
                                  (size_t)(-failed - 1), edge, cap,
                                  model_root, tokenizer_root, context, max_rows,
                                  prompt_tokens, offset, NULL, 0,
@@ -1433,7 +1464,7 @@ static int segment_generate(ColiEdgeEngine *edge,
                         active_count, peer, strlen(peer));
         }
         if (failed && (!conversation || !route_snapshot ||
-            conversation_recover(conversation, route_snapshot,
+            conversation_recover(conversation, discovery, route_snapshot,
                                  (size_t)(-failed - 1), edge, cap,
                                  model_root, tokenizer_root, context, max_rows,
                                  prompt_tokens, prompt_count,
@@ -1719,6 +1750,7 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
                                    context, max_rows, prompt, prompt_bytes,
                                    NULL, 0, max_tokens,
                                    temperature, top_p, &sampler, &conversation,
+                                   discovery,
                                    &snapshot,
                                    snapshot.route_generation,
                                    serve_generation_event, &stream, &result,
@@ -1951,7 +1983,8 @@ int main(int argc, char **argv) {
                                context, max_rows,
                                prompt, prompt ? strlen(prompt) : 0,
                                prompt_tokens, prompt_count, wanted_tokens,
-                               temperature, top_p, &sampler, NULL, &snapshot, 0,
+                               temperature, top_p, &sampler, NULL, discovery,
+                               &snapshot, 0,
                                NULL, NULL, &generated, error, sizeof error);
     free(prompt_tokens);
     if (bad) {

--- a/segment_failover_test.sh
+++ b/segment_failover_test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Kill the selected non-fallback executor after turn one. Turn two must restore
-# every range at the common checkpoint, replace the dead range with its exact
-# origin replica and replay the token delta without ending the conversation.
+# Change the tracker generation and kill the selected non-fallback executor
+# after turn one. Turn two must refresh every fenced owner, restore every range
+# at the common checkpoint, replace the dead range with its exact origin replica
+# and replay the token delta without ending the conversation.
 set -euo pipefail
 cd "$(dirname "$0")"
 : "${OLMOE_EDGE_MODEL:?set OLMOE_EDGE_MODEL}"
@@ -58,14 +59,31 @@ start_node 0:2 8069 origin-left --fallback
 start_node 2:4 8070 origin-right --fallback
 start_node 0:2 8071 donor-left ""
 DONOR_PID=$LAST_PID
+# This incompatible node is deliberately registered only after turn one. It
+# bumps the tracker's global route generation without entering tiny-failover's
+# placement. The gateway discovery period is 60 seconds, so turn two still has
+# the old immutable snapshot while every live executor has accepted the new
+# generation through its 2-second heartbeat. Recovery must refresh explicitly.
+(
+    while [ ! -f "$TMP/start-generation-bump" ]; do sleep 0.025; done
+    exec "${common[@]}" "$SEGMENT_NODE_BIN" --engine olmoe \
+        --model-dir "$OLMOE_EDGE_MODEL" --model generation-bump \
+        --range 0:1 --port 8072 --tracker 127.0.0.1:8068 \
+        --advertise 127.0.0.1:8072 --name generation-bump \
+        --model-root "$(printf '%064x' 103)" \
+        --tokenizer-root "$(printf '%064x' 104)" --context 64 \
+        --max-rows 16 --sessions 1 >"$TMP/generation-bump.log" 2>&1
+) &
+PIDS+=("$!")
 sleep 1
 
 env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
     LUMABRI_KNOWN_HOSTS="$TMP/known" LUMABRI_SAMPLE_SEED=11 \
     LUMABRI_SEGMENT_DISCOVERY_MS=60000 \
-    python3 - "$DONOR_PID" "$SEGMENT_CHAT_BIN" "$OLMOE_EDGE_MODEL" "$root" "$tok" <<'PY'
-import os, subprocess, sys, time
-donor, binary, model_dir, root, tok = sys.argv[1:]
+    python3 - "$DONOR_PID" "$SEGMENT_CHAT_BIN" "$OLMOE_EDGE_MODEL" \
+        "$root" "$tok" "$TMP" <<'PY'
+import os, socket, subprocess, sys, time
+donor, binary, model_dir, root, tok, tmp = sys.argv[1:]
 p = subprocess.Popen([
     binary, "--serve", "--engine", "olmoe",
     "--model-dir", model_dir, "--model", "tiny-failover",
@@ -74,7 +92,10 @@ p = subprocess.Popen([
 ], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 def line():
     value = p.stdout.readline()
-    if not value: raise RuntimeError("Segment gateway closed")
+    if not value:
+        p.wait(timeout=5)
+        raise RuntimeError("Segment gateway closed:\n"+
+                           p.stderr.read().decode("utf-8", "replace"))
     return value
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("gateway not ready")
@@ -100,6 +121,18 @@ def turn(rid, prompt, kill_after_accept=None):
             raise RuntimeError("unexpected frame: "+repr(frame))
     if not seen_data: raise RuntimeError("no streamed data")
 turn(1, b"hi\n")
+open(os.path.join(tmp, "start-generation-bump"), "wb").close()
+deadline=time.monotonic()+10
+while True:
+    try:
+        with socket.create_connection(("127.0.0.1", 8072), timeout=.1): pass
+        break
+    except OSError:
+        if time.monotonic() >= deadline: raise RuntimeError("generation bump did not start")
+        time.sleep(.05)
+# Existing executors heartbeat every two seconds and now fence the owner's old
+# generation. The chat worker intentionally retains its turn-one snapshot.
+time.sleep(2.5)
 turn(2, b"hi\nthere\n", donor)
 p.stdin.close()
 if p.wait(timeout=30): raise RuntimeError("gateway failed")
@@ -107,5 +140,7 @@ diagnostics=p.stderr.read().decode("utf-8", "replace")
 if ("Segment failover: recovered through origin-left; restored checkpoint"
         not in diagnostics):
     raise RuntimeError("checkpoint failover did not run:\n"+diagnostics)
+if "Segment recovery route generation" not in diagnostics:
+    raise RuntimeError("recovery did not refresh the stale route generation:\n"+diagnostics)
 PY
-echo "SEGMENT FAILOVER: PASS (checkpoint restore + replay after peer death)"
+echo "SEGMENT FAILOVER: PASS (fresh fencing + checkpoint replay after peer death)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -338,7 +338,7 @@ static void *registration_worker(void *opaque) {
     return NULL;
 }
 
-static int open_matches_node(Node *node, const LmbSegOpen *open) {
+static int open_contract_matches_node(Node *node, const LmbSegOpen *open) {
     const LmbSegAdvert *a = &node->advert;
     return !memcmp(open->model_root, a->model_root, sizeof a->model_root) &&
            !memcmp(open->tokenizer_root, a->tokenizer_root,
@@ -352,8 +352,7 @@ static int open_matches_node(Node *node, const LmbSegOpen *open) {
            (open->capabilities & a->capabilities) == open->capabilities &&
            !strcmp(open->engine_id, a->engine_id) &&
            !strcmp(open->state_schema, a->state_schema) &&
-           !strcmp(open->numeric_class, a->numeric_class) &&
-           registration_owner(&node->registration, &open->owner);
+           !strcmp(open->numeric_class, a->numeric_class);
 }
 
 static NodeSession *session_find(Node *node, const LmbSegId *id) {
@@ -576,7 +575,11 @@ static int handle_open(Node *node, int fd, const LmbMsg *msg) {
     if (msg->pay_len || lmb_seg_open_decode(msg->body, msg->body_len, &open))
         return -1;
     LmbSegStatus status = LMB_SEG_STATUS_BAD_REQUEST;
-    if (open_matches_node(node, &open)) {
+    int contract_matches = open_contract_matches_node(node, &open);
+    if (contract_matches &&
+        !registration_owner(&node->registration, &open.owner)) {
+        status = LMB_SEG_STATUS_STALE_OWNER;
+    } else if (contract_matches) {
         pthread_mutex_lock(&node->sessions_lock);
         NodeSession *slot = session_find(node, &open.session_id);
         if (slot) {
@@ -666,6 +669,18 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
             if (admitted != 1) {
                 status = admitted < 0 ? LMB_SEG_STATUS_QUOTA :
                                         LMB_SEG_STATUS_BUSY;
+                if (admitted < 0)
+                    fprintf(stderr, "[segment-node %s %u:%u] RUN admission "
+                                    "cancelled: %s%s (available %.1f GB / "
+                                    "reserve %.1f GB)\n",
+                            node->advert.peer_name, node->advert.layer_begin,
+                            node->advert.layer_end,
+                            g_stop ? "process stopping" :
+                                lmb_governor_reason_name(
+                                    lmb_governor_reason(&node->governor)),
+                            g_stop ? "" : " reached the in-flight safety floor",
+                            (double)available_memory_bytes() / 1e9,
+                            (double)node->ram_reserve_bytes / 1e9);
             }
             ColiSegmentRunRequest request = {
                 .struct_size = sizeof request,


### PR DESCRIPTION
## Outcome

Fixes the live failure where one Segment range returned `QUOTA`, recovery then reopened the whole chain with an old route generation, and an otherwise healthy NAT/relay donor rejected `OPEN` as `bad request`.

The donor response proves the tracker relay reached the machine; the failure was stale fencing after transport, not NAT connectivity.

## Root cause

Segment recovery replaced only the failed range. Every unchanged range retained the conversation's old `LmbSegOwner`, even though the tracker generation may have advanced during the turn and each executor heartbeat had already accepted the newer generation. Reopening the complete stateful chain therefore sent a stale owner to healthy peers.

## Changes

- allow one synchronous tracker refresh only on the exceptional recovery path; ordinary inference remains tracker-free and reads immutable snapshots;
- publish the refreshed generation back into asynchronous discovery;
- rebuild every range of the recovery chain from one current snapshot, preferring the existing peer and choosing an exact-range replica when it disappeared;
- preserve checkpoint restore and token replay across all replaced ranges;
- report owner mismatch as `STALE_OWNER` instead of the generic `BAD_REQUEST`;
- make `QUOTA` diagnostics truthful for RUN admission/governor failures;
- log whether an in-flight RUN was cancelled by shutdown or by the critical RAM/swap safety floor;
- extend the failover gate to bump the global tracker generation while the chat deliberately retains a stale immutable snapshot, then kill the selected donor.

Colibri is unchanged. The behavior is in the universal Lumabri Segment path and therefore applies to every registered adapter/model family.

## Verification

- strict `-Werror` build of `tracker`, `segment_node`, and `segment_chat` against the main release base — PASS;
- all six temporary Colibri Segment/Edge adapters compiled — PASS;
- `segment_failover_test.sh` — PASS (`fresh fencing + checkpoint replay after peer death`);
- `segment_relay_test.sh` — PASS (`relay-only OPEN/RUN/SNAPSHOT/CLOSE`);
- Segment discovery and protocol v2 gates for all six state schemas — PASS;
- machine governor and run-gate tests — PASS;
- general suite completed; two unrelated pre-existing loopback races (CAS/NAT and expert verify-failover) each passed immediately when rerun in isolation.

Based directly on current `main` after #93. Do not merge automatically.
