### PR TITLE
fix(patches): tolerate whitespace drift in engine hook anchors

### DIFF
--- a/engine_patches/colibri-p2p.diff
+++ b/engine_patches/colibri-p2p.diff
@@ -35,7 +35,7 @@ diff --git a/c/colibri.c b/c/colibri.c
  }
  
  static void model_init(Model *m, const char *snap, int cap,
-@@ -5339,6 +5359,17 @@
+@@ -5391,6 +5411,17 @@
          int e=idxs[(int64_t)s*K+kk];
          if(!seen[e]){ seen[e]=1; uniq[nu++]=e; }
      }

--- a/engine_patches/deepseek-p2p.diff
+++ b/engine_patches/deepseek-p2p.diff
@@ -21,9 +21,9 @@ diff --git a/c/deepseek.c b/c/deepseek.c
      for (int expert_id = 0; !result && expert_id < n; expert_id++) {
 +#ifdef LUMIBRI_P2P
 +    if (!result && lumi_layer_on(weights->plan.layer)) {
-+        lumi_moe_apply_v4(weights->plan.layer, indices, route_weights, topk,
-+                          input, 1, d, output);
-+        n = 0;                        /* the loop below finds no expert left */
++        if (lumi_moe_apply_v4(weights->plan.layer, indices, route_weights,
++                              topk, input, 1, d, output))
++            n = 0;                    /* the loop below finds no expert left */
 +    }
 +#endif
          int rank = -1;
@@ -35,9 +35,9 @@ diff --git a/c/deepseek.c b/c/deepseek.c
  #ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER
 +#ifdef LUMIBRI_P2P
 +    if (!result && lumi_layer_on(weights->plan.layer)) {
-+        lumi_moe_apply_v4(weights->plan.layer, indices, route_weights, topk,
-+                          input, 1, d, output);
-+        selected = 0;                 /* both loader variants walk `selected` */
++        if (lumi_moe_apply_v4(weights->plan.layer, indices, route_weights,
++                              topk, input, 1, d, output))
++            selected = 0;             /* both loader variants walk `selected` */
 +    }
 +#endif
      for (int current = 0; !result && current < selected; current++) {
@@ -49,9 +49,9 @@ diff --git a/c/deepseek.c b/c/deepseek.c
          memset(outputs, 0, (size_t)batch * d * sizeof(*outputs));
 +#ifdef LUMIBRI_P2P
 +    if (!result && lumi_layer_on(weights->plan.layer)) {
-+        lumi_moe_apply_v4(weights->plan.layer, indices, route_weights, topk,
-+                          inputs, batch, d, outputs);
-+        n = 0;                        /* key_count becomes 0: nothing to lease */
++        if (lumi_moe_apply_v4(weights->plan.layer, indices, route_weights,
++                              topk, inputs, batch, d, outputs))
++            n = 0;                    /* key_count becomes 0: nothing to lease */
 +    }
 +#endif
  

--- a/engine_patches/make_patches.py
+++ b/engine_patches/make_patches.py
@@ -28,7 +28,7 @@ The hooks themselves are four, and the same four everywhere:
 Everything is inert without -DLUMIBRI_P2P, and inert at runtime unless a
 tracker or LUMABRI_EXPERTS says otherwise.
 """
-import argparse, difflib, os, shutil, subprocess, sys, tempfile
+import argparse, difflib, os, re, shutil, subprocess, sys, tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -283,18 +283,35 @@ ENGINES = {
 }
 
 
+def find_anchor(text, anchor):
+    """Occurrences of `anchor`, tolerating horizontal-whitespace drift.
+
+    Upstream re-aligning a trailing comment (14 spaces one release, 18 the
+    next) must not break every downstream build: the code is the anchor, the
+    column it sits in is not. Newlines still match exactly — only runs of
+    spaces/tabs are flexible — so anything that moves or edits actual source
+    still fails loudly exactly as before. Returns the literal texts matched,
+    in order, so the caller can splice around what the file really contains."""
+    if text.count(anchor):
+        return [anchor] * text.count(anchor)
+    parts = re.split(r"[ \t]+", anchor)
+    pattern = r"[ \t]+".join(re.escape(part) for part in parts)
+    return [m.group(0) for m in re.finditer(pattern, text)]
+
+
 def apply_hooks(src, hooks, name):
     out = src
     for h in hooks:
-        n = out.count(h["anchor"])
-        if n != h["count"]:
+        found = find_anchor(out, h["anchor"])
+        if len(found) != h["count"]:
             raise SystemExit(
                 "%s: anchor found %d times, expected %d — upstream moved:\n%s"
-                % (name, n, h["count"], h["anchor"][:120]))
+                % (name, len(found), h["count"], h["anchor"][:120]))
+        literal = found[0]
         if h["where"] == "after":
-            out = out.replace(h["anchor"], h["anchor"] + h["add"], 1)
+            out = out.replace(literal, literal + h["add"], 1)
         else:
-            out = out.replace(h["anchor"], h["add"] + h["anchor"], 1)
+            out = out.replace(literal, h["add"] + literal, 1)
     return out
 
 

--- a/engine_patches/qwen36-p2p.diff
+++ b/engine_patches/qwen36-p2p.diff
@@ -15,7 +15,7 @@ diff --git a/c/qwen36.c b/c/qwen36.c
  #ifdef COLI_SEGMENT_ADAPTER
  #include "segment_runtime.h"
  #include "segment_adapters.h"
-@@ -1346,6 +1353,10 @@
+@@ -1363,6 +1370,10 @@
      if (cl < 0.1f) cl = 0.1f; if (cl > 1.0f) cl = 1.0f;
      m->pilot_conf_limit = cl;
      m->dense_load_s = now_s() - t0;
@@ -26,7 +26,7 @@ diff --git a/c/qwen36.c b/c/qwen36.c
  }
  
  static void model_init(Model *m, const char *snap, int cap, int bits) {
-@@ -1851,6 +1862,11 @@
+@@ -1921,6 +1932,11 @@
              for (int kk = 0; kk < K; kk++) if (idx[kk] >= 0) freq_l[idx[kk]]++;
          }
          const float *xs = x + (int64_t)s*D;


### PR DESCRIPTION
## Why

Upstream colibri re-aligned one trailing comment in inkling.c (14 spaces → 18 → back to 14) and every build of the inkling chatter on the mismatched side died with `anchor found 0 times — upstream moved`. The same class of drift will happen again: the **code** is the anchor, the column it sits in is not.

## What

- `make_patches.py`: runs of spaces/tabs inside an anchor now match any run. Newlines still match exactly, so genuinely moved or edited source keeps failing loudly, exactly as designed.
- Refresh the committed reference diffs against current colibri dev (they had drifted).
- The legacy single-file `deepseek-p2p.diff` now honours the return value of `lumi_moe_apply_v4` like the live `deepseek_v4_p2p.py` generator already does — the unconditional `n = 0` silently zeroed the layer when the swarm call failed instead of falling back to the local loop.

## Verification

- `make_patches.py --check` against colibri dev: clean
- `--apply-one inkling.c` against **both** the 14-space and the 18-space vintage: hooks land, 4 macro sites each
- full `make all engines chatters`: green (was broken for inkling/qwen36 against the drifted checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)