### PR TITLE
feat(client): survive the swarm — demote layers to the local mirror instead of dying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_verify_failover test_segment_v2 \
+		test_hedge test_local_fallback test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -386,6 +386,9 @@ test_key_rotation: test_key_rotation.c lumabri_sign.h
 test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_hedge.c -o $@
 
+test_local_fallback: test_local_fallback.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread test_local_fallback.c -o $@
+
 test_verify_failover: test_verify_failover.c lumabri_client.h lumabri_proto.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread test_verify_failover.c -o $@
 
@@ -577,7 +580,7 @@ test-segment-v2: test_segment_v2
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
+test: all test_key_rotation test_hedge test_local_fallback test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -601,6 +604,7 @@ test: all test_key_rotation test_hedge test_verify_failover test_segment_v2 \
 	bash ./verify_failover_test.sh
 	./test_key_rotation
 	./test_hedge
+	./test_local_fallback
 	./test_segment_v2
 	./test_meminfo
 	./test_compute_lease
@@ -639,6 +643,7 @@ install: all
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
+	      test_local_fallback \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \
 	      test_compute_lease test_content_filter test_scheduler test_run_gate \

--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ ranges concurrently. Lumabri deliberately does not fuse rows from unrelated
 sessions: current Colibri adapters own opaque per-session state and can round a
 cross-session batch differently. Calling that continuous batching before an
 engine-neutral multi-session batch ABI exists would break the token oracle.
-When two donors happen to hold the *same* expert, add `LUMABRI_SPREAD=1` on the
-chatter to balance the load between them too. Neither donor needs to know the
-others exist. Expert requests can fail over to another replica. Stateful
+When two donors hold the *same* expert, the chatter spreads the load between
+them by default (set `LUMABRI_SPREAD=0` for strict nearest-replica routing).
+Neither donor needs to know the others exist. Expert requests can fail over to another replica. Stateful
 Segment sessions with compatible replicas checkpoint at turn boundaries; on
 failure the gateway restores an exact-range replica, replays tokens after the
 common checkpoint and retries the interrupted batch. If no compatible replica
@@ -360,7 +360,7 @@ the command, e.g. `LUMABRI_SPREAD=1 lumabri chat …`.
 
 | set | to |
 |---|---|
-| `LUMABRI_SPREAD=1` | spread the load across peers that hold the *same* expert (default: the nearest one wins) |
+| `LUMABRI_SPREAD=0` | strict nearest-replica routing (default: spread the load across peers that hold the *same* expert) |
 | `LUMABRI_VERIFY=N` | re-run N% of expert calls on a second peer and demand the same answer — a lie stops the run |
 | `LUMABRI_HEDGE_MS=N` | after N ms with no reply, ask a second peer too and take whichever comes first |
 | `LUMABRI_HEDGE_MS=-1` | never ask a second peer — the only way to get one request per call, which attribution and benchmarking need |

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -82,6 +82,21 @@ static struct {
      * answers and never errors, so only this bound turns it into a failover
      * instead of a stall. LUMABRI_EXEC_WAIT_MS raises it for slow links. */
     int exec_wait_ms;
+    /* Survival policy. A chatter with a mirror must never die because the
+     * swarm did: when every replica of an expert is gone and the tracker
+     * relay cannot serve it either, the layer is DEMOTED — lumi_layer_on()
+     * answers 0 for demote_s seconds, the engine's own local path computes
+     * the layer from the mirror, and the swarm is retried when the window
+     * expires. peer_wait_s is the old patience for a rebooting peer, now
+     * tunable; one expired wait marks the whole swarm sick, so the next
+     * failing layer demotes immediately instead of stalling the generation
+     * for another full wait. */
+    int peer_wait_s;            /* LUMABRI_PEER_WAIT_S, seconds */
+    int demote_s;               /* LUMABRI_DEMOTE_S, seconds */
+    double *demote_until;       /* [n_layers] monotonic deadline; 0 = active */
+    double swarm_sick_until;
+    int swarm_disabled;         /* model identity changed mid-run: local only */
+    unsigned long long demotions, integrity_fails;
     unsigned long long calls, layers_done, failovers, verified, relays;
     unsigned long long hedges, hedge_wins, batch_calls, batch_rows;
     double wait_s;
@@ -185,9 +200,17 @@ static int lumi_refresh_identity(void) {
     if (lmb_model_identity_get(tracker, L.expected_model, &id) ||
         !lumi_identity_valid(L.expected_model, &id)) return 0;
     if (L.have_identity && memcmp(L.identity.root, id.root, 32)) {
-        fprintf(stderr, "[lumabri] model identity changed during this process — "
-                        "refusing to mix checkpoints\n");
-        exit(1);
+        /* Refusing to mix checkpoints is right; killing the engine over it
+         * is not. The mirror still holds the checkpoint this process
+         * started with, so stop trusting peers and finish the run local. */
+        if (!L.swarm_disabled)
+            fprintf(stderr, "[lumabri] model identity changed during this "
+                            "process — refusing to mix checkpoints: swarm "
+                            "off, experts run locally from the mirror for "
+                            "the rest of this run\n");
+        L.swarm_disabled = 1;
+        L.on = 0;
+        return 0;
     }
     L.identity = id; L.have_identity = 1;
     return 1;
@@ -433,6 +456,7 @@ static int lumi_missing_experts(void) {
 }
 
 static void lumi_enable_if_complete(void) {
+    if (L.swarm_disabled) { L.on = 0; return; }
     int missing = lumi_missing_experts();
     L.on = L.ok_layers > 0;
     if (!L.on || L.ok_layers == L.announced_ok) return;
@@ -550,9 +574,19 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
          * unless the operator set LUMABRI_VERIFY themselves. */
         if (!v && L.verify_pct == 0) L.verify_pct = 5;
     }
-    L.spread = getenv("LUMABRI_SPREAD") && atoi(getenv("LUMABRI_SPREAD")) != 0;
+    /* Spreading is the default. Strict argmin sent every call of every
+     * chatter to the single nearest replica — usually the always-on origin
+     * server — so a donor with the same experts resident in RAM received
+     * exactly zero traffic until that origin failed. The canonical-order
+     * band spread keeps cache locality per expert while letting every
+     * near-equal replica carry a share. LUMABRI_SPREAD=0 restores argmin. */
+    const char *spread_env = getenv("LUMABRI_SPREAD");
+    L.spread = spread_env ? atoi(spread_env) != 0 : 1;
     L.hedge_ms = lmb_env_int("LUMABRI_HEDGE_MS", 0, -1, 60000);
     L.exec_wait_ms = lmb_env_int("LUMABRI_EXEC_WAIT_MS", 30000, 100, 3600000);
+    L.peer_wait_s = lmb_env_int("LUMABRI_PEER_WAIT_S", LUMI_WAIT_S, 0, 600);
+    L.demote_s = lmb_env_int("LUMABRI_DEMOTE_S", 120, 1, 3600);
+    L.demote_until = (double *)calloc((size_t)n_layers, sizeof(double));
     L.initialized = 1;
 
     if (discovery) {
@@ -597,8 +631,9 @@ static LMB_MAYBE_UNUSED void lumi_init(int n_layers, int n_experts, int hidden) 
  * before handing a layer over, so an unrouted slot is never a wire error. */
 static LMB_MAYBE_UNUSED int lumi_layer_on(int layer) {
     lumi_maybe_discover();
-    if (!L.on || layer < 0 || layer >= L.n_layers) return 0;
+    if (!L.on || L.swarm_disabled || layer < 0 || layer >= L.n_layers) return 0;
     if (L.routed && !L.routed[layer]) return 0;
+    if (L.demote_until && L.demote_until[layer] > lumi_now()) return 0;
     return !L.layer_ok || L.layer_ok[layer];
 }
 
@@ -794,6 +829,22 @@ static float *lumi_exec_relay(int layer, int eid, const float *x, int D, int nr,
     return out;
 }
 
+/* Every replica of this layer's expert is gone and the relay cannot serve
+ * it. Retire the layer to the engine's own local path for demote_s seconds
+ * and mark the swarm sick, so the next failing layer skips the patience
+ * wait instead of stalling the generation all over again. */
+static void lumi_demote_layer(int layer, int waited) {
+    double now = lumi_now();
+    if (L.demote_until && layer >= 0 && layer < L.n_layers)
+        L.demote_until[layer] = now + (double)(L.demote_s > 0 ? L.demote_s : 120);
+    L.swarm_sick_until = now + (double)(L.demote_s > 0 ? L.demote_s : 120);
+    L.demotions++;
+    fprintf(stderr, "[lumabri] layer %d: nessuna replica viva dopo %d s — "
+                    "eseguo questo layer in locale dal mirror per %d s, poi "
+                    "ritento lo sciame\n",
+            layer, waited, L.demote_s > 0 ? L.demote_s : 120);
+}
+
 /* the failover path: run one expert synchronously on the next replicas.
  * Costs a full extra round trip — it is the price of a peer dying, paid
  * once, instead of the generation dying with it.
@@ -832,11 +883,14 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
              * A swarm with one holder per expert has no redundancy to fall
              * back on, so the only honest thing left is patience: ask the
              * tracker again, and wait, saying so. */
-            if (waited < LUMI_WAIT_S) {
+            int wait_limit = L.initialized ? L.peer_wait_s
+                : lmb_env_int("LUMABRI_PEER_WAIT_S", LUMI_WAIT_S, 0, 600);
+            if (lumi_now() < L.swarm_sick_until) wait_limit = 0;
+            if (waited < wait_limit) {
                 if (!waited)
                     fprintf(stderr, "[lumabri] layer %d expert %d: nessuna replica "
                             "viva — aspetto che torni (fino a %d s)\n",
-                            layer, eid, LUMI_WAIT_S);
+                            layer, eid, wait_limit);
                 tried = 0;                    /* a returning peer deserves a retry */
                 sleep(2);
                 waited += 2;
@@ -849,11 +903,9 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
                     }
                 continue;
             }
-            fprintf(stderr, "[lumabri] layer %d expert %d: nessuna replica viva "
-                    "dopo %d s. Con un solo detentore per esperto qualunque "
-                    "interruzione e' definitiva: serve un secondo peer.\n",
-                    layer, eid, waited);
-            exit(1);
+            lumi_demote_layer(layer, waited);
+            if (tried_io) *tried_io = tried;
+            return NULL;
         }
         tried |= 1u << r;
         LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
@@ -889,34 +941,45 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
  * disagree, so a disagreement IS an attack (or broken hardware) — either
  * way the answer cannot be trusted, and the run stops loudly rather than
  * emit a token nobody can vouch for. */
-static void lumi_spot_check(int layer, int eid, const float *x, int D, int nr,
-                            const float *w, const float *got, LumiPeer *from,
-                            uint32_t tried) {
+static int lumi_spot_check(int layer, int eid, const float *x, int D, int nr,
+                           const float *w, const float *got, LumiPeer *from,
+                           uint32_t tried) {
     int gid = layer * L.n_experts + eid;
     int r2 = lumi_pick(gid, tried);
-    if (r2 < 0) return;                       /* no second replica to ask */
+    if (r2 < 0) return 0;                     /* no second replica to ask */
     LumiPeer *p = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r2]];
     int fd = lumi_take_sock(p);
-    if (fd < 0) return;
+    if (fd < 0) return 0;
     uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
     LmbMsg m = {0};
     if (lumi_send_exec(fd, layer, eid, x, D, nr, w) || lmb_recv(fd, &m) ||
         m.op != LMB_EXEC_R || m.pay_len != want) {
         close(fd);
         lmb_msg_free(&m);
-        return;                               /* checker down ≠ answer wrong */
+        return 0;                             /* checker down ≠ answer wrong */
     }
     L.verified++;
     int same = memcmp(got, m.pay, (size_t)want) == 0;
     lmb_msg_free(&m);
     lumi_put_sock(p, fd);
     if (!same) {
+        /* Two replicas disagreed and there is no majority: neither can be
+         * trusted. Killing the engine punished the victim; quarantine both
+         * suspects instead, discard the answer, and let the caller recompute
+         * on an untainted replica — or on the local mirror, whose bytes are
+         * hash-verified and cannot lie. */
         fprintf(stderr, "[lumabri] INTEGRITY FAILURE on layer %d expert %d: "
                 "%s and %s returned different bytes for the same activation. "
-                "One of them is lying or broken; refusing to continue.\n",
+                "One of them is lying or broken; quarantining both and "
+                "recomputing elsewhere.\n",
                 layer, eid, from ? from->addr : "the tracker relay", p->addr);
-        exit(1);
+        double until = lumi_now() + 600.0;
+        p->dead = 1; p->retry_at = until;
+        if (from) { from->dead = 1; from->retry_at = until; }
+        L.integrity_fails++;
+        return -1;
     }
+    return 0;
 }
 
 /* The sampling gate in front of it. Every answer this client is willing to
@@ -927,13 +990,14 @@ static void lumi_spot_check(int layer, int eid, const float *x, int D, int nr,
  * check, which compares it against any replica that is reachable and is a
  * no-op when none is. */
 static unsigned lumi_vseed = 0x9e3779b9u;
-static void lumi_maybe_spot_check(int layer, int eid, const float *x, int D,
-                                  int nr, const float *w, const float *got,
-                                  LumiPeer *from, uint32_t tried) {
-    if (!L.verify_pct || !got) return;
+static int lumi_maybe_spot_check(int layer, int eid, const float *x, int D,
+                                 int nr, const float *w, const float *got,
+                                 LumiPeer *from, uint32_t tried) {
+    if (!L.verify_pct || !got) return 0;
     lumi_vseed = lumi_vseed * 1664525u + 1013904223u;
     if ((int)(lumi_vseed % 100u) < L.verify_pct)
-        lumi_spot_check(layer, eid, x, D, nr, w, got, from, tried);
+        return lumi_spot_check(layer, eid, x, D, nr, w, got, from, tried);
+    return 0;
 }
 
 /* Run the K selected experts of one layer on their peers and accumulate into
@@ -978,16 +1042,22 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
             LumiPeer *winner = NULL;
             res[k] = lumi_finish_exec(layer, idx[k], x, D, 1, NULL,
                                       fds[k], ps[k], sent[k], &tried[k], &winner);
-            if (res[k]) {
+            if (res[k] &&
                 lumi_maybe_spot_check(layer, idx[k], x, D, 1, NULL, res[k],
-                                      winner, tried[k]);
-                continue;
-            }
-            fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
-                            "trying next replica\n", ps[k]->addr, layer, idx[k]);
+                                      winner, tried[k])) {
+                free(res[k]); res[k] = NULL;  /* mismatch: recompute elsewhere */
+            } else if (!res[k])
+                fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
+                                "trying next replica\n", ps[k]->addr, layer, idx[k]);
+            if (res[k]) continue;
         }
         LumiPeer *rf = NULL;
         res[k] = lumi_exec_retry(layer, idx[k], x, D, 1, NULL, &tried[k], &rf);
+        if (res[k] &&
+            lumi_maybe_spot_check(layer, idx[k], x, D, 1, NULL, res[k], rf,
+                                  tried[k])) {
+            free(res[k]); res[k] = NULL;  /* second disagreement: go local */
+        }
         if (!res[k]) {
             for (int j = k + 1; j < K; j++) if (fds[j] >= 0) {
                 close(fds[j]); lumi_peer_done(ps[j]);
@@ -995,7 +1065,6 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
             for (int j = 0; j < K; j++) free(res[j]);
             return 0;
         }
-        lumi_maybe_spot_check(layer, idx[k], x, D, 1, NULL, res[k], rf, tried[k]);
     }
     /* accumulate in the router's order, exactly as the local path does */
     for (int k = 0; k < K; k++) {
@@ -1101,10 +1170,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
                 res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
                                        fds[j], ps[j], sent[j], &tried[j], &winner);
                 fds[j] = -1;
-                if (res) {
+                if (res &&
                     lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res,
-                                          winner, tried[j]);
-                } else {
+                                          winner, tried[j])) {
+                    free(res); res = NULL;  /* mismatch: recompute elsewhere */
+                } else if (!res) {
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
@@ -1112,6 +1182,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
             if (!res) {
                 LumiPeer *rf = NULL;
                 res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, &tried[j], &rf);
+                if (res &&
+                    lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res, rf,
+                                          tried[j])) {
+                    free(res); res = NULL;  /* second disagreement: go local */
+                }
                 if (!res) {
                     for (int q = j + 1; q < nb; q++)
                         if (fds[q] >= 0) {
@@ -1121,7 +1196,6 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
                     free(seen); free(uniq); free(rows); free(rw); free(xg); free(saved);
                     return 0;
                 }
-                lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res, rf, tried[j]);
             }
             if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             int *rj = rows + (size_t)j * S;
@@ -1205,10 +1279,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
                 res = lumi_finish_exec(layer, eid, xj, D, nr, NULL,
                                        fds[j], ps[j], sent[j], &tried[j], &winner);
                 fds[j] = -1;
-                if (res) {
+                if (res &&
                     lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res,
-                                          winner, tried[j]);
-                } else {
+                                          winner, tried[j])) {
+                    free(res); res = NULL;  /* mismatch: recompute elsewhere */
+                } else if (!res) {
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
@@ -1216,6 +1291,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
             if (!res) {
                 LumiPeer *rf = NULL;
                 res = lumi_exec_retry(layer, eid, xj, D, nr, NULL, &tried[j], &rf);
+                if (res &&
+                    lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res, rf,
+                                          tried[j])) {
+                    free(res); res = NULL;  /* second disagreement: go local */
+                }
                 if (!res) {
                     for (int q = j + 1; q < nb; q++)
                         if (fds[q] >= 0) {
@@ -1225,7 +1305,6 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
                     free(xg); free(saved);
                     return 0;
                 }
-                lumi_maybe_spot_check(layer, eid, xj, D, nr, NULL, res, rf, tried[j]);
             }
             if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             for (int r = 0; r < nr; r++) {
@@ -1333,10 +1412,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
                 res = lumi_finish_exec(layer, eid, xj, D, nr, wj,
                                        fds[j], ps[j], sent[j], &tried[j], &winner);
                 fds[j] = -1;
-                if (res) {
+                if (res &&
                     lumi_maybe_spot_check(layer, eid, xj, D, nr, wj, res,
-                                          winner, tried[j]);
-                } else {
+                                          winner, tried[j])) {
+                    free(res); res = NULL;  /* mismatch: recompute elsewhere */
+                } else if (!res) {
                     fprintf(stderr, "[lumabri] peer %s failed on layer %d expert %d — "
                                     "trying next replica\n", ps[j]->addr, layer, eid);
                 }
@@ -1344,6 +1424,11 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
             if (!res) {
                 LumiPeer *rf = NULL;
                 res = lumi_exec_retry(layer, eid, xj, D, nr, wj, &tried[j], &rf);
+                if (res &&
+                    lumi_maybe_spot_check(layer, eid, xj, D, nr, wj, res, rf,
+                                          tried[j])) {
+                    free(res); res = NULL;  /* second disagreement: go local */
+                }
                 if (!res) {
                     for (int q = j + 1; q < nb; q++)
                         if (fds[q] >= 0) {
@@ -1353,7 +1438,6 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
                     free(used); free(uid); free(rows); free(rw); free(xg); free(saved);
                     return 0;
                 }
-                lumi_maybe_spot_check(layer, eid, xj, D, nr, wj, res, rf, tried[j]);
             }
             if (nr > 1) { L.batch_calls++; L.batch_rows += (unsigned long long)nr; }
             for (int r = 0; r < nr; r++) {       /* already weighted by the peer */
@@ -1372,16 +1456,21 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
 }
 
 static LMB_MAYBE_UNUSED void lumi_report(void) {
-    if (!L.on) return;
+    if (!L.on && !L.calls) return;
     fprintf(stderr, "[lumabri] %llu remote expert calls in %llu layer rounds · "
                     "%.2fs waiting on peers (%.2f ms per layer round) · "
                     "%llu batched call(s)/%llu rows · %llu hedge(s), %llu won · "
                     "%llu failover(s) · %llu tracker relay call(s) · "
-                    "%llu spot-check(s), all agreed\n",
+                    "%llu spot-check(s)%s\n",
             L.calls, L.layers_done, L.wait_s,
             L.layers_done ? 1000.0 * L.wait_s / (double)L.layers_done : 0.0,
             L.batch_calls, L.batch_rows, L.hedges, L.hedge_wins,
-            L.failovers, L.relays, L.verified);
+            L.failovers, L.relays, L.verified,
+            L.integrity_fails ? "" : ", all agreed");
+    if (L.demotions || L.integrity_fails)
+        fprintf(stderr, "[lumabri] %llu layer demotion(s) to the local mirror"
+                        " · %llu integrity quarantine(s)\n",
+                L.demotions, L.integrity_fails);
 }
 
 #endif /* LUMABRI_CLIENT_H */

--- a/test_hedge.c
+++ b/test_hedge.c
@@ -2,14 +2,18 @@
 #define LMBE_SOURCE_ID "test"
 #define LMBE_EXPECT_BITS 0
 #include <pthread.h>
+#include <stdatomic.h>
 #include "lumabri_client.h"
 
 typedef struct { int port, delay_ms; } Echo;
+
+static _Atomic int g_listening;
 
 static void *echo_server(void *arg) {
     Echo *e = (Echo *)arg;
     int lfd = lmb_listen(e->port);
     if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
     int fd = accept(lfd, NULL, NULL);
     LmbMsg m = {0};
     int bad = fd < 0 || lmb_recv(fd, &m) || m.op != LMB_EXEC || m.body_len < 16;
@@ -33,7 +37,9 @@ int main(void) {
     pthread_t a, b;
     pthread_create(&a, NULL, echo_server, &slow);
     pthread_create(&b, NULL, echo_server, &fast);
-    usleep(100000);
+    /* a fixed sleep loses on a loaded box: wait for the actual binds */
+    for (int spins = 0; atomic_load(&g_listening) < 2 && spins < 500; spins++)
+        usleep(10000);
 
     L.n_layers = 1; L.n_experts = 1; L.hidden = 4; L.npeers = 2;
     L.hedge_ms = 20;
@@ -67,7 +73,8 @@ int main(void) {
     pthread_t c, d;
     pthread_create(&c, NULL, echo_server, &slow_off);
     pthread_create(&d, NULL, echo_server, &fast_off);
-    usleep(100000);
+    for (int spins = 0; atomic_load(&g_listening) < 4 && spins < 500; spins++)
+        usleep(10000);
     for (int i = 0; i < 2; i++)
         while (L.peers[i].nsocks > 0) close(L.peers[i].socks[--L.peers[i].nsocks]);
     snprintf(L.peers[0].addr, sizeof L.peers[0].addr,

--- a/test_local_fallback.c
+++ b/test_local_fallback.c
@@ -1,0 +1,159 @@
+/* The survival contract: a chatter with a local mirror must never die
+ * because the swarm did.
+ *
+ * 1. Every replica gone → lumi_moe_apply returns 0 (the engine's local path
+ *    runs the layer), the layer is demoted for LUMABRI_DEMOTE_S seconds and
+ *    the NEXT failing layer demotes immediately instead of waiting again.
+ * 2. A spot-check disagreement quarantines both suspects and recomputes —
+ *    it no longer kills the engine that was the victim of the lie.
+ *
+ * Both regressions used to be exit(1) inside the client library, so the
+ * strongest assertion this test makes is simply still being alive to print
+ * its own verdict. */
+#define LMBE_ENGINE_ID "fallback-test"
+#define LMBE_SOURCE_ID "test"
+#define LMBE_EXPECT_BITS 0
+#include <pthread.h>
+#include <stdatomic.h>
+#include "lumabri_client.h"
+
+/* One EXEC request, echoed back — optionally with the payload corrupted, so
+ * a 100% spot-check sees two "replicas" disagree on the same activation. */
+typedef struct { int port, corrupt; } Exec;
+
+static _Atomic int g_listening;
+
+static void *exec_server(void *arg) {
+    Exec *e = (Exec *)arg;
+    int lfd = lmb_listen(e->port);
+    if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
+    int fd = accept(lfd, NULL, NULL);
+    LmbMsg m = {0};
+    int bad = fd < 0 || lmb_recv(fd, &m) || m.op != LMB_EXEC;
+    if (!bad) {
+        if (e->corrupt && m.pay_len) ((uint8_t *)m.pay)[0] ^= 0x55;
+        bad = lmb_send(fd, LMB_EXEC_R, NULL, 0, m.pay, m.pay_len) != 0;
+    }
+    lmb_msg_free(&m);
+    if (fd >= 0) close(fd);
+    close(lfd);
+    return (void *)(intptr_t)(bad != 0);
+}
+
+/* A "dead" peer that fails FAST on every dialect of dead. On WSL2 (and any
+ * firewall that drops instead of refusing) a closed port eats the full
+ * connect timeout, which would turn this test into a half-minute stall: so
+ * the dead peer LISTENS and slams every connection shut, exactly like a
+ * crashed executor whose port is still in the kernel backlog. */
+static void *dead_server(void *arg) {
+    int lfd = lmb_listen((int)(intptr_t)arg);
+    if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
+    for (;;) {
+        int fd = accept(lfd, NULL, NULL);
+        if (fd >= 0) close(fd);
+    }
+    return NULL;
+}
+
+static void wire_replicas(int gid, int a, int b) {
+    L.own[(size_t)gid * LUMI_MAX_REP + 0] = a;
+    L.own[(size_t)gid * LUMI_MAX_REP + 1] = b;
+}
+
+static int fail(const char *what) {
+    fprintf(stderr, "test_local_fallback: FAIL — %s\n", what);
+    return 1;
+}
+
+int main(void) {
+    setenv("LUMABRI_PEER_WAIT_S", "2", 1);
+    setenv("LUMABRI_DEMOTE_S", "2", 1);
+    unsetenv("LUMABRI_EXPERTS");
+    pthread_t dt, dp1, dp2;
+    pthread_create(&dt, NULL, dead_server, (void *)(intptr_t)7580);
+    pthread_create(&dp1, NULL, dead_server, (void *)(intptr_t)7583);
+    pthread_create(&dp2, NULL, dead_server, (void *)(intptr_t)7584);
+    pthread_detach(dt); pthread_detach(dp1); pthread_detach(dp2);
+    for (int spins = 0; atomic_load(&g_listening) < 3 && spins < 500; spins++)
+        usleep(10000);
+    if (atomic_load(&g_listening) < 3)
+        return fail("the dead-peer listeners never came up");
+    /* a dead tracker keeps init on the discovery path (which allocates the
+     * maps and reads the knobs) without ever finding a peer to trust */
+    setenv("LUMABRI_TRACKER", "127.0.0.1:7580", 1);
+    setenv("LUMABRI_DISCOVERY_MS", "600000", 1);
+    lumi_init(2, 1, 4);          /* 2 layers, 1 expert each, hidden = 4 */
+    if (!L.own) return fail("init did not allocate the expert map");
+    if (!L.spread)
+        return fail("replica spreading must be the default (LUMABRI_SPREAD=0 opts out)");
+
+    /* --- 1. all replicas dead: demote, do not die ------------------------ */
+    L.npeers = 2;
+    snprintf(L.peers[0].addr, sizeof L.peers[0].addr, "127.0.0.1:7583");
+    snprintf(L.peers[1].addr, sizeof L.peers[1].addr, "127.0.0.1:7584");
+    lmb_predict_init(&L.peers[0].latency, 1000);
+    lmb_predict_init(&L.peers[1].latency, 1000);
+    wire_replicas(0, 0, 1);
+    wire_replicas(1, 0, 1);
+    L.on = 1;
+    if (L.layer_ok) { L.layer_ok[0] = 1; L.layer_ok[1] = 1; }
+
+    float x[4] = { 1, 2, 3, 4 }, out[4] = { 0 };
+    int idx[1] = { 0 };
+    float val[1] = { 1.0f };
+
+    double t0 = lumi_now();
+    if (lumi_moe_apply(0, idx, val, 1, x, 4, out))
+        return fail("apply reported success with every replica dead");
+    if (lumi_now() - t0 > 15.0)
+        return fail("first failure took longer than the patience window");
+    if (L.demotions != 1) return fail("layer 0 was not demoted");
+    if (lumi_layer_on(0)) return fail("demoted layer 0 still claims the swarm");
+
+    /* the swarm is now known sick: the second layer must give up at once */
+    t0 = lumi_now();
+    if (lumi_moe_apply(1, idx, val, 1, x, 4, out))
+        return fail("second apply reported success with every replica dead");
+    if (lumi_now() - t0 > 1.5)
+        return fail("swarm-sick fast path did not skip the patience wait");
+    if (lumi_layer_on(1)) return fail("demoted layer 1 still claims the swarm");
+
+    sleep(3);                    /* the demotion window expires */
+    if (!lumi_layer_on(0))
+        return fail("layer 0 did not re-enable after the demotion window");
+
+    /* --- 2. spot-check mismatch: quarantine, do not die ------------------ */
+    Exec honest = { 7581, 0 }, liar = { 7582, 1 };
+    pthread_t a, b;
+    pthread_create(&a, NULL, exec_server, &honest);
+    pthread_create(&b, NULL, exec_server, &liar);
+    for (int spins = 0; atomic_load(&g_listening) < 5 && spins < 500; spins++)
+        usleep(10000);
+    if (atomic_load(&g_listening) < 5)
+        return fail("the exec servers never came up");
+    snprintf(L.peers[0].addr, sizeof L.peers[0].addr, "127.0.0.1:%d", honest.port);
+    snprintf(L.peers[1].addr, sizeof L.peers[1].addr, "127.0.0.1:%d", liar.port);
+    L.peers[0].dead = L.peers[1].dead = 0;
+    L.peers[0].retry_at = L.peers[1].retry_at = 0;
+    lmb_predict_init(&L.peers[0].latency, 1000);
+    lmb_predict_init(&L.peers[1].latency, 1000);
+    L.swarm_sick_until = 0;
+    if (L.demote_until) { L.demote_until[0] = 0; L.demote_until[1] = 0; }
+    L.verify_pct = 100;
+
+    memset(out, 0, sizeof out);
+    int r = lumi_moe_apply(0, idx, val, 1, x, 4, out);
+    pthread_join(a, NULL); pthread_join(b, NULL);
+    if (L.integrity_fails != 1)
+        return fail("the disagreement was not counted as an integrity failure");
+    if (!L.peers[0].dead || !L.peers[1].dead)
+        return fail("the two disagreeing replicas were not both quarantined");
+    if (r)
+        return fail("apply trusted an answer after an unresolved disagreement");
+
+    printf("local fallback tests: ok (demote %llus, quarantine, still alive)\n",
+           (unsigned long long)L.demote_s);
+    return 0;
+}

--- a/test_verify_failover.c
+++ b/test_verify_failover.c
@@ -10,7 +10,9 @@
  * double-checked, whichever path produced it. So:
  *
  *   liar    the failover answer disagrees with replica 3 → the client must
- *           print INTEGRITY FAILURE and exit 1, never return the bytes
+ *           print INTEGRITY FAILURE, quarantine both suspects, refuse the
+ *           bytes — and SURVIVE: the apply reports failure so the engine's
+ *           local path recomputes the layer from the mirror
  *   honest  the failover answer agrees → the run completes, and the check
  *           must have actually run (L.verified > 0), so a spot-check that
  *           silently did nothing cannot pass as a success
@@ -22,6 +24,7 @@
 #define LMBE_SOURCE_ID "test"
 #define LMBE_EXPECT_BITS 0
 #include <pthread.h>
+#include <stdatomic.h>
 #include "lumabri_client.h"
 
 typedef struct {
@@ -33,10 +36,13 @@ typedef struct {
 
 /* An honest expert here echoes the activation back unchanged: deterministic,
  * so two honest nodes always agree and any disagreement is the lie. */
+static _Atomic int g_listening;
+
 static void *node_thread(void *arg) {
     Node *n = (Node *)arg;
     int lfd = lmb_listen(n->port);
     if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
     for (;;) {
         int fd = accept(lfd, NULL, NULL);
         if (fd < 0) break;
@@ -70,7 +76,13 @@ int main(int argc, char **argv) {
     pthread_create(&t[0], NULL, node_thread, &refuse);
     pthread_create(&t[1], NULL, node_thread, &second);
     pthread_create(&t[2], NULL, node_thread, &third);
-    usleep(200000);
+    /* a fixed sleep loses on a loaded box: wait for the actual binds */
+    for (int spins = 0; atomic_load(&g_listening) < 3 && spins < 500; spins++)
+        usleep(10000);
+    if (atomic_load(&g_listening) < 3) {
+        printf("FAIL: the three fake replicas never came up\n");
+        return 1;
+    }
 
     L.n_layers = 1; L.n_experts = 1; L.hidden = 4;
     L.npeers = 3;
@@ -88,13 +100,28 @@ int main(int argc, char **argv) {
     int idx[1] = { 0 };
     float val[1] = { 1.0f };
 
-    /* In the liar case the client detects the disagreement inside this call
-     * and exits(1); nothing below runs. */
-    lumi_moe_apply(0, idx, val, 1, x, 4, out);
+    int used = lumi_moe_apply(0, idx, val, 1, x, 4, out);
 
     if (lie) {
-        printf("FAIL: the corrupted failover answer was accepted "
-               "(checker served %d call(s))\n", third.served);
+        if (used) {
+            printf("FAIL: the corrupted failover answer was accepted "
+                   "(checker served %d call(s))\n", third.served);
+            return 1;
+        }
+        if (!L.integrity_fails) {
+            printf("FAIL: the disagreement was refused but never counted\n");
+            return 1;
+        }
+        if (!L.peers[1].dead || !L.peers[2].dead) {
+            printf("FAIL: the two disagreeing replicas were not quarantined\n");
+            return 1;
+        }
+        printf("VERIFIED FAILOVER: PASS (lie caught, both suspects "
+               "quarantined, the run survives to recompute locally)\n");
+        return 0;
+    }
+    if (!used) {
+        printf("FAIL: the honest failover run reported failure\n");
         return 1;
     }
     if (!L.verified) {

--- a/verify_failover_test.sh
+++ b/verify_failover_test.sh
@@ -9,22 +9,27 @@ cd "$(dirname "$0")"
 
 make -s test_verify_failover
 
-echo "· a lying replica reached through failover is caught"
+echo "· a lying replica reached through failover is caught — and survived"
 set +e
-OUT=$(./test_verify_failover liar 2>&1)
+OUT=$(env LUMABRI_PEER_WAIT_S=2 ./test_verify_failover liar 2>&1)
 RC=$?
 set -e
-if [ "$RC" -eq 0 ]; then
-    echo "   the corrupted failover answer was accepted"
+if [ "$RC" -ne 0 ]; then
+    echo "   the liar case failed (a dead engine is the old, wrong outcome)"
     echo "$OUT"
     exit 1
 fi
 grep -q "INTEGRITY FAILURE" <<<"$OUT" || {
-    echo "   the run stopped, but not with the integrity error"
+    echo "   the lie was never reported as an integrity error"
     echo "$OUT"
     exit 1
 }
-echo "   ✓ INTEGRITY FAILURE, and the bytes never reached the model"
+grep -q "quarantined" <<<"$OUT" || {
+    echo "   the disagreeing replicas were not quarantined"
+    echo "$OUT"
+    exit 1
+}
+echo "   ✓ INTEGRITY FAILURE, bytes refused, both suspects quarantined, run alive"
 
 echo "· an honest failover is checked and not mistaken for an attack"
 ./test_verify_failover honest


### PR DESCRIPTION
## The bug this kills

Last night's field failure, end to end: the origin executor wedged on one cold expert, the tracker relay kept timing out against the same peer, and after 30 s the client library called `exit(1)` — killing the engine and the chat — while the process sat on 11.6 GB of verified local mirror that could have computed that expert. **A chatter with a mirror must never die because the swarm did.**

## What changes

Three `exit(1)` sites become survival paths:

1. **Every replica of an expert gone** → the layer **demotes**: `lumi_moe_apply` reports failure, the engine's own local path (already wired at every patched call site — each one honours the return value) runs the layer from the mirror, and the swarm is retried after `LUMABRI_DEMOTE_S` (default 120 s). One expired wait marks the whole swarm sick, so the next failing layer demotes immediately instead of adding its own 30 s stall. `LUMABRI_PEER_WAIT_S` tunes the patience window.
2. **Spot-check disagreement** → both suspects quarantined 10 minutes (two replicas, no majority), answer discarded, recompute on an untainted replica or locally. The victim of the lie no longer dies for it.
3. **Model identity change mid-run** → swarm off for the rest of the run, mirror finishes the job. Refusing to mix checkpoints never required dying.

Plus one default flip: **replica spreading is now on** (`LUMABRI_SPREAD=0` restores argmin). Strict argmin sent every call of every chatter to the single nearest replica — the always-on origin — so a donor with the same experts resident in RAM received exactly zero traffic until that origin failed.

## Verification

- new `test_local_fallback`: demote → local, sick fast-path (second layer gives up in <1.5 s), re-enable after the window, quarantine-not-death — each assertion mutation-checked;
- `test_verify_failover` liar case now asserts survival (caught, quarantined, recomputed) instead of asserting death;
- listen barrier in the three fake-peer harnesses kills a load-dependent connect-before-bind flake (test_hedge failed 3/12 under load before, 15/15 + 8×-trio green after);
- full `make test` suite, check-warnings, sanitizers: green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)