### PR TITLE
feat(ops): donor systemd unit, NAT guide, doctor reachability probe

### DIFF
--- a/deploy/NAT.md
+++ b/deploy/NAT.md
@@ -1,0 +1,40 @@
+# Donating from behind a home router (NAT)
+
+Nothing to configure. No port forwarding, no UPnP, no VPN.
+
+A Lumabri donor only ever makes **outbound** connections: it dials the
+tracker, keeps that connection open, and the swarm's traffic to you travels
+back through it (the tracker relays expert calls, byte reads and Segment
+frames over the tunnel your own machine opened). A home router that allows
+outbound TCP — all of them — is enough.
+
+What changes behind NAT:
+
+- chatters cannot dial you directly, so your answers ride the tracker relay:
+  one extra hop of latency, same bytes, same verification;
+- `lumabri doctor --tracker HOST:7300` tells you which side you are on:
+  `direct-reachable` (others dial you straight) or `relay-only` (the tunnel
+  carries you). Both are full members of the swarm.
+
+## The two ways to donate
+
+| you give | command | what happens |
+|---|---|---|
+| RAM + CPU | `lumabri serve --model ./donated --model-name NAME --join TRACKER:7300` | the tracker assigns a slice of experts; they load into RAM **before** the node is advertised, then execute for the swarm |
+| disk | the same, plus `--donate GB` | the rarest signed blocks land on your disk and serve chatters |
+
+Or as a system service that survives reboots: see `lumabri-donor.service`
+in this directory.
+
+## What to expect in the logs
+
+- `auto-hold resident: up to N experts (~X GB)` — the tracker's assignment,
+  sized to your free RAM;
+- `holding N experts (X MB resident) loaded in Ys` — the slice is warm; only
+  now does the first heartbeat go out;
+- `N exec calls · M cold loads · Z% RAM hit` — you are serving traffic.
+
+If the exec-call counter stays at zero while chats are running, the swarm's
+chatters are reaching a nearer replica first — you are the failover. That
+changes as more chats arrive: load spreads across every near-equal replica
+by default.

--- a/deploy/lumabri-donor.service
+++ b/deploy/lumabri-donor.service
@@ -1,0 +1,35 @@
+# Lumabri donor as a system service: survives reboots, crashes and closed
+# laptops-turned-servers. Install:
+#
+#   sudo cp deploy/lumabri-donor.service /etc/systemd/system/
+#   sudo systemctl edit lumabri-donor      # set the four variables below
+#   sudo systemctl enable --now lumabri-donor
+#
+# The unit runs `lumabri serve --join`, the donor form that outlives a chat
+# session. RAM/CPU pressure is governed by lumabri itself (the machine
+# governor pauses donation before the box starts swapping), so the unit sets
+# no MemoryMax: a hard systemd kill is exactly the ungraceful death the
+# governor exists to prevent.
+[Unit]
+Description=Lumabri swarm donor (disk/compute)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Override these four in `systemctl edit`:
+Environment=LUMABRI_DIR=/opt/lumabri
+Environment=LUMABRI_TRACKER=203.0.113.1:7300
+Environment=LUMABRI_MODEL_NAME=DeepSeek-V4-Flash
+# Empty LUMABRI_DONATE_GB donates COMPUTE (the node holds a slice of experts
+# resident in RAM and executes them); a number donates that many GB of DISK.
+Environment=LUMABRI_DONATE_GB=
+ExecStart=/bin/sh -c 'exec "$LUMABRI_DIR/lumabri" serve --model "$LUMABRI_DIR/donated" --model-name "$LUMABRI_MODEL_NAME" --join "$LUMABRI_TRACKER" ${LUMABRI_DONATE_GB:+--donate "$LUMABRI_DONATE_GB"}'
+Restart=on-failure
+RestartSec=10
+# A donor is a guest on this machine: lowest scheduling priority.
+Nice=10
+IOSchedulingClass=idle
+
+[Install]
+WantedBy=multi-user.target

--- a/expert_node.c
+++ b/expert_node.c
@@ -1027,9 +1027,11 @@ int main(int argc, char **argv) {
     g.inter     = lmbe_inter();
     if (hold_auto) {
         /* Hold as many experts as this machine's free RAM can keep resident, and
-         * ask the tracker for exactly that many: it hands back the least-covered
-         * slice, so several "donate compute" machines auto-spread into disjoint
-         * shares instead of every one holding the whole model. */
+         * ask the tracker for exactly that many: it completes the least-covered
+         * layers first and then grows second replicas (keep limit 2), so
+         * several "donate compute" machines spread across the model AND give
+         * every expert a failover copy, instead of every one holding the
+         * whole model or none overlapping. */
         long avail_kb = meminfo_avail_kb();
         long reserve_mb = governor_reserve_mb;
         double avail_b = avail_kb > reserve_mb * 1024L

--- a/lumabri.c
+++ b/lumabri.c
@@ -3557,7 +3557,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             argv[a++] = "--tracker";    argv[a++] = (char *)tracker;
             argv[a++] = "--name";       argv[a++] = name;
             argv[a++] = "--model-name"; argv[a++] = (char *)model;
-            argv[a++] = "--hold";       argv[a++] = "auto";   /* the tracker hands us a disjoint slice; the node sizes it to free RAM */
+            argv[a++] = "--hold";       argv[a++] = "auto";   /* the tracker completes the least-covered layers first, then grows replicas (keep limit 2); the node sizes the slice to free RAM */
             argv[a] = NULL;
             { char lp[1200];
               pid_t np = spawn_argv_logged(argv, local ? NULL : envv,

--- a/lumabri.c
+++ b/lumabri.c
@@ -4427,11 +4427,42 @@ static int cmd_doctor(int argc, char **argv) {
                    access(config, R_OK) == 0 ? "config.json is readable" :
                                               "model directory has no readable config.json");
     }
-    if (tracker)
+    if (tracker) {
         doctor_add(checks, &count, "tracker", machine_ok &&
                    profile.tracker_rtt_ms >= 0.0, 1,
                    machine_ok && profile.tracker_rtt_ms >= 0.0 ?
                    "tracker TCP endpoint is reachable" : "tracker is unreachable");
+        /* Which side of the NAT am I on? Bind an ephemeral port, ask the
+         * tracker to dial it back. Purely informational: a relay-only donor
+         * is a full member of the swarm, it just rides the tunnel. */
+        static char nat_note[160];
+        snprintf(nat_note, sizeof nat_note,
+                 "tracker too old for the reach probe — assume relay");
+        int lfd = lmb_listen(0);
+        if (lfd >= 0) {
+            struct sockaddr_in me; socklen_t ml = sizeof me;
+            if (getsockname(lfd, (struct sockaddr *)&me, &ml) == 0) {
+                LmbBuf b = {0};
+                lmb_buf_u32(&b, (uint32_t)ntohs(me.sin_port));
+                LmbMsg reply = {0};
+                if (!lmb_request(tracker, LMB_REACH, b.p, (uint32_t)b.len,
+                                 &reply) && reply.op == LMB_REACH_R) {
+                    LmbCur c = { reply.body, reply.body_len, 0 };
+                    uint32_t direct = 0; char observed[96] = "";
+                    if (!lmb_cur_u32(&c, &direct) &&
+                        !lmb_cur_str(&c, observed, sizeof observed))
+                        snprintf(nat_note, sizeof nat_note, direct ?
+                                 "directly dialable at %s" :
+                                 "behind NAT/firewall (%s): the tracker "
+                                 "relay will carry this peer", observed);
+                }
+                lmb_msg_free(&reply);
+                free(b.p);
+            }
+            close(lfd);
+        }
+        doctor_add(checks, &count, "nat-reachability", 1, 0, nat_note);
+    }
     if (serve_port) {
         int topology_ok = 1, failed_port = 0;
         for (int offset = 0; offset < 10; offset++)

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -258,6 +258,9 @@ enum {
      * keys: the TUI can explain who is doing work without leaking how to
      * reach a private donor. The body is versioned independently. */
     LMB_SWARM_DETAIL = 60, LMB_SWARM_DETAIL_R = 61,
+    /* NAT probe: "dial me back at this port". The tracker connects to the
+     * requester's OBSERVED address, so a caller can only ever probe itself. */
+    LMB_REACH = 64, LMB_REACH_R = 65,
     /* A donor that cannot fit its assigned range releases the short-lived
      * placement promise immediately, so another READY-capable machine need
      * not wait for its timeout. This grants no lease or execution authority. */

--- a/tracker.c
+++ b/tracker.c
@@ -2019,6 +2019,33 @@ static int handle_eassign(int fd, LmbMsg *m) {
     return rc;
 }
 
+/* Answers "can the swarm dial me back?" for lumabri doctor. The tracker
+ * connects to the requester's observed source address at the port it names:
+ * TCP means the caller provably owns that address, the port floor and the
+ * two-second bound keep this from being anyone's port scanner. */
+static int handle_reach(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    uint32_t port = 0;
+    if (m->pay_len || lmb_cur_u32(&c, &port) || c.off != c.len ||
+        port < 1024 || port > 65535) {
+        send_err(fd, "bad reach probe"); return -1;
+    }
+    struct sockaddr_in sin; socklen_t sl = sizeof sin;
+    char addr[80] = ""; uint32_t reachable = 0;
+    if (getpeername(fd, (struct sockaddr *)&sin, &sl) == 0 &&
+        sin.sin_family == AF_INET) {
+        snprintf(addr, sizeof addr, "%s:%u", inet_ntoa(sin.sin_addr), port);
+        int probe = lmb_connect_ms(addr, 2000);
+        if (probe >= 0) { reachable = 1; close(probe); }
+    }
+    LmbBuf b = {0};
+    lmb_buf_u32(&b, reachable);
+    lmb_buf_str(&b, addr);
+    int rc = lmb_send(fd, LMB_REACH_R, b.p, (uint32_t)b.len, NULL, 0);
+    free(b.p);
+    return rc;
+}
+
 /* ---- RREAD: the relay --------------------------------------------------- */
 
 static int handle_rread(int fd, LmbMsg *m) {
@@ -2702,6 +2729,7 @@ static void *conn_thread(void *arg) {
         case LMB_MODEL_ID:  rc = handle_model_id(fd, &m); break;
         case LMB_PLACEMENT: rc = handle_placement(fd, &m); break;
         case LMB_SWARM:     rc = handle_swarm(fd); break;
+        case LMB_REACH:     rc = handle_reach(fd, &m); break;
         case LMB_SWARM_DETAIL: rc = handle_swarm_detail(fd); break;
         case LMB_RREAD:     rc = handle_rread(fd, &m); break;
         case LMB_REXEC:     rc = handle_rexec(fd, &m); break;


### PR DESCRIPTION
Three pieces that turn 'a donor on a home connection' from folklore into a supported path:

1. **`deploy/lumabri-donor.service`** — donation as a system service: survives reboots, restarts on failure, runs at idle priority; one variable switches disk vs compute donation. No MemoryMax on purpose: the machine governor pauses donation *before* the box swaps, and a hard systemd kill is exactly the ungraceful death the governor exists to prevent.
2. **`deploy/NAT.md`** — the actual NAT contract, stated: a donor only ever dials out, the tracker tunnel carries everything back, zero router configuration; what the logs of a healthy donor look like, and why an exec counter at zero just means you are the failover (until load spreads).
3. **`lumabri doctor` NAT probe** — new `nat-reachability` line: doctor binds an ephemeral port and asks the tracker to dial it back (new `LMB_REACH` op). Reports *directly dialable at ip:port* or *behind NAT/firewall: the relay will carry this peer*. The tracker dials only the connection's **observed** source address (TCP ownership proven), port ≥1024, 2-second bound — it can probe you, and only you. Old trackers answer with an error and doctor says 'tracker too old for the reach probe' instead of guessing.

Verified: doctor against a live local tracker reports `directly dialable at 127.0.0.1:PORT`; strict build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)