### PR TITLE
feat(swarm): a NAT'd donor is a first-class replica, not a last resort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,11 +37,12 @@ deepseek_p2p
 build/
 artifacts/
 
-# compiled unit-test binaries
-test_hedge
-test_key_rotation
-test_relay_exec
-test_verify_failover
+# compiled unit-test binaries — the glob, because listing them one by one is
+# exactly how test_local_fallback and test_nat_adopt slipped into a commit
+test_*
+!test_*.c
+!test_*.py
+!test_*.sh
 
 # Build outputs. These were tracked by accident in 67e0b73 (#88): `git add -A`
 # in a built tree picked up every binary the Makefile had just produced.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_verify_failover test_segment_v2 \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -389,6 +389,9 @@ test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECUR
 test_local_fallback: test_local_fallback.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_local_fallback.c -o $@
 
+test_nat_adopt: test_nat_adopt.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread test_nat_adopt.c -o $@
+
 test_verify_failover: test_verify_failover.c lumabri_client.h lumabri_proto.h lumabri_sign.h
 	$(CC) $(CFLAGS) -pthread test_verify_failover.c -o $@
 
@@ -580,7 +583,7 @@ test-segment-v2: test_segment_v2
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_verify_failover test_segment_v2 \
+test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_segment_v2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -605,6 +608,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_verify_failover 
 	./test_key_rotation
 	./test_hedge
 	./test_local_fallback
+	./test_nat_adopt
 	./test_segment_v2
 	./test_meminfo
 	./test_compute_lease
@@ -643,7 +647,7 @@ install: all
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
-	      test_local_fallback \
+	      test_local_fallback test_nat_adopt \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \
 	      test_compute_lease test_content_filter test_scheduler test_run_gate \

--- a/expert_node.c
+++ b/expert_node.c
@@ -454,7 +454,7 @@ static void node_refresh_identity(void) {
     pthread_mutex_unlock(&g.identity_lk);
 }
 
-static int handle_emanifest(int fd) {
+static void manifest_build(LmbBuf *b) {
     LmbModelIdentity id = {0};
     pthread_mutex_lock(&g.identity_lk);
     int have_id = g.have_identity;
@@ -464,26 +464,30 @@ static int handle_emanifest(int fd) {
     have_id = g.have_identity;
     if (have_id) id = g.identity;
     pthread_mutex_unlock(&g.identity_lk);
-    LmbBuf b = {0};
-    lmb_buf_u32(&b, LMB_EXPERT_MANIFEST_MAGIC);
-    lmb_buf_str(&b, lmbe_engine_name());
-    lmb_buf_str(&b, g.profile);
-    lmb_buf_str(&b, g.model);
-    lmb_buf_u32(&b, (uint32_t)g.bits);
-    lmb_buf_u32(&b, have_id ? 1u : 0u);
+    lmb_buf_u32(b, LMB_EXPERT_MANIFEST_MAGIC);
+    lmb_buf_str(b, lmbe_engine_name());
+    lmb_buf_str(b, g.profile);
+    lmb_buf_str(b, g.model);
+    lmb_buf_u32(b, (uint32_t)g.bits);
+    lmb_buf_u32(b, have_id ? 1u : 0u);
     if (have_id) {
-        lmb_buf_bytes(&b, id.root, sizeof id.root);
-        lmb_buf_u32(&b, id.has_sig ? 1u : 0u);
-        if (id.has_sig) lmb_buf_bytes(&b, id.sig, sizeof id.sig);
+        lmb_buf_bytes(b, id.root, sizeof id.root);
+        lmb_buf_u32(b, id.has_sig ? 1u : 0u);
+        if (id.has_sig) lmb_buf_bytes(b, id.sig, sizeof id.sig);
     }
-    lmb_buf_u32(&b, (uint32_t)g.nholds);
+    lmb_buf_u32(b, (uint32_t)g.nholds);
     for (int l = 0; l < g.n_slots; l++)
         for (int e = 0; e < g.n_experts; e++)
             if (g.holds[l * g.n_experts + e]) {
-                lmb_buf_u32(&b, (uint32_t)l);
-                lmb_buf_u32(&b, (uint32_t)e);
+                lmb_buf_u32(b, (uint32_t)l);
+                lmb_buf_u32(b, (uint32_t)e);
             }
-    lmb_buf_u32(&b, (uint32_t)g.hidden);
+    lmb_buf_u32(b, (uint32_t)g.hidden);
+}
+
+static int handle_emanifest(int fd) {
+    LmbBuf b = {0};
+    manifest_build(&b);
     int rc = lmb_send(fd, LMB_EMANIFEST_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
@@ -763,7 +767,24 @@ static void *control_thread(void *arg) {
                 break;
             }
             int rc = 0;
+            if (getenv("LUMABRI_RELAY_TRACE"))
+                fprintf(stderr, "[%s] ctrl frame op=%u body=%u\n",
+                        g.name, m.op, m.body_len);
             if (m.op == LMB_REXEC_FWD) rc = dispatch_rexec_fwd(fd, &m);
+            else if (m.op == LMB_TMAN_FWD && m.body_len >= 4) {
+                /* the manifest through the tunnel: what makes a NAT-only
+                 * donor a first-class replica instead of a bitmap of last
+                 * resort */
+                uint32_t id = lmb_get32(m.body);
+                LmbBuf mb = {0}, hb = {0};
+                manifest_build(&mb);
+                lmb_buf_u32(&hb, id); lmb_buf_u32(&hb, 1u);
+                pthread_mutex_lock(&g_ctrl_wr);
+                rc = lmb_send(fd, LMB_TMAN_R, hb.p, (uint32_t)hb.len,
+                              mb.p, (uint32_t)mb.len);
+                pthread_mutex_unlock(&g_ctrl_wr);
+                free(hb.p); free(mb.p);
+            }
             else if (m.op == LMB_ERR) {
                 LmbCur ec = { m.body, m.body_len, 0 };
                 char why[128] = "";

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -41,6 +41,12 @@
 
 typedef struct {
     char addr[64];
+    /* Non-empty: this peer cannot be dialed at addr (NAT); every socket for
+     * it goes to the TRACKER instead and each EXEC travels as a targeted
+     * LMB_TEXEC naming addr. The reply is a plain LMB_EXEC_R, so above the
+     * socket layer this peer is indistinguishable from a dialable one:
+     * same predictors, same spreading, same hedging, same spot-check. */
+    char relay_target[64];
     int socks[LUMI_MAX_K];
     int nsocks;
     long rtt_us;
@@ -138,7 +144,12 @@ static void lumi_peer_done(LumiPeer *peer) {
  * manifest permanently. */
 static int lumi_take_sock(LumiPeer *p) {
     if (p->nsocks) return p->socks[--p->nsocks];
-    int fd = lmb_connect(p->addr);
+    const char *dial = p->addr;
+    if (p->relay_target[0]) {
+        dial = getenv("LUMABRI_TRACKER");
+        if (!dial || !dial[0]) { lumi_peer_failed(p); return -1; }
+    }
+    int fd = lmb_connect(dial);
     if (fd >= 0 && lmb_auth(fd)) { close(fd); fd = -1; }
     if (fd < 0) {
         fprintf(stderr, "[lumabri] peer %s unreachable — circuit failure\n", p->addr);
@@ -236,12 +247,34 @@ static int lumi_add_peer(const char *addr) {
     p->nsocks = 0;
 
     LmbMsg m = {0};
+    p->relay_target[0] = 0;
     if (lmb_request(p->addr, LMB_EMANIFEST, NULL, 0, &m) || m.op != LMB_EMANIFEST_R) {
-        fprintf(stderr, "[lumabri] no expert manifest from %s — skipped\n", p->addr);
+        /* Not dialable — the normal case for a donor behind a home router.
+         * Ask the tracker for the same manifest through the peer's own
+         * tunnel; if it answers, this peer joins the table as a replica
+         * whose route happens to run through the tracker. */
         lmb_msg_free(&m);
-        p->dead = 1; p->retry_at = lumi_now() + 30.0;
-        if (reprobe < 0) L.npeers++;       /* remember NAT-only addresses */
-        return -1;
+        memset(&m, 0, sizeof m);
+        const char *tracker = getenv("LUMABRI_TRACKER");
+        int relayed = 0;
+        if (tracker && tracker[0]) {
+            LmbBuf tb = {0};
+            lmb_buf_str(&tb, p->addr);
+            relayed = !lmb_request(tracker, LMB_TMAN, tb.p, (uint32_t)tb.len,
+                                   &m) && m.op == LMB_EMANIFEST_R;
+            free(tb.p);
+        }
+        if (!relayed) {
+            fprintf(stderr, "[lumabri] no expert manifest from %s — skipped\n",
+                    p->addr);
+            lmb_msg_free(&m);
+            p->dead = 1; p->retry_at = lumi_now() + 30.0;
+            if (reprobe < 0) L.npeers++;   /* remember NAT-only addresses */
+            return -1;
+        }
+        snprintf(p->relay_target, sizeof p->relay_target, "%s", p->addr);
+        fprintf(stderr, "[lumabri] peer %s is not directly dialable — "
+                        "adopting it through the tracker tunnel\n", p->addr);
     }
     LmbCur c = { m.body, m.body_len, 0 };
     uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0;
@@ -704,15 +737,18 @@ static int lumi_pick(int gid, uint32_t tried) {
  * before the down projection and rounds the result to bf16, so it is not a
  * scale at all and a chatter-side multiply would quietly differ. The body
  * says which: 16 bytes = no weights, 16 + nr*4 = weights follow. */
-static int lumi_send_exec(int fd, int layer, int eid, const float *x, int D, int nr,
-                          const float *w) {
+static int lumi_send_exec(LumiPeer *p, int fd, int layer, int eid,
+                          const float *x, int D, int nr, const float *w) {
     LmbBuf b = {0};
+    int targeted = p && p->relay_target[0];
+    if (targeted) lmb_buf_str(&b, p->relay_target);
     lmb_buf_u32(&b, (uint32_t)layer);
     lmb_buf_u32(&b, (uint32_t)eid);
     lmb_buf_u32(&b, (uint32_t)D);
     lmb_buf_u32(&b, (uint32_t)nr);
     if (w) lmb_buf_bytes(&b, w, (size_t)nr * sizeof(float));
-    int rc = lmb_send(fd, LMB_EXEC, b.p, (uint32_t)b.len,
+    int rc = lmb_send(fd, targeted ? LMB_TEXEC : LMB_EXEC, b.p,
+                      (uint32_t)b.len,
                       x, (uint32_t)((size_t)nr * D * sizeof(float)));
     free(b.p);
     return rc;
@@ -746,7 +782,7 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
                 p[1] = &L.peers[L.own[(size_t)gid * LUMI_MAX_REP + r]];
                 fd[1] = lumi_take_sock(p[1]);
                 started[1] = lumi_now();
-                if (fd[1] >= 0 && lumi_send_exec(fd[1], layer, eid, x, D, nr, w)) {
+                if (fd[1] >= 0 && lumi_send_exec(p[1], fd[1], layer, eid, x, D, nr, w)) {
                     close(fd[1]); lumi_peer_failed(p[1]); fd[1] = -1;
                 }
                 if (fd[1] >= 0) { lumi_peer_sent(p[1]); L.hedges++; }
@@ -917,7 +953,7 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
         if (fd < 0) continue;
         double started = lumi_now();
         LmbMsg m = {0};
-        int send_bad = lumi_send_exec(fd, layer, eid, x, D, nr, w);
+        int send_bad = lumi_send_exec(p, fd, layer, eid, x, D, nr, w);
         if (!send_bad) lumi_peer_sent(p);
         if (send_bad || lmb_recv(fd, &m) ||
             m.op != LMB_EXEC_R || m.pay_len != want) {
@@ -956,7 +992,7 @@ static int lumi_spot_check(int layer, int eid, const float *x, int D, int nr,
     if (fd < 0) return 0;
     uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
     LmbMsg m = {0};
-    if (lumi_send_exec(fd, layer, eid, x, D, nr, w) || lmb_recv(fd, &m) ||
+    if (lumi_send_exec(p, fd, layer, eid, x, D, nr, w) || lmb_recv(fd, &m) ||
         m.op != LMB_EXEC_R || m.pay_len != want) {
         close(fd);
         lmb_msg_free(&m);
@@ -1030,7 +1066,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
             int fd = lumi_take_sock(p);
             if (fd < 0) continue;
             sent[k] = lumi_now();
-            if (lumi_send_exec(fd, layer, idx[k], x, D, 1, NULL)) {
+            if (lumi_send_exec(p, fd, layer, idx[k], x, D, 1, NULL)) {
                 close(fd);
                 lumi_peer_failed(p);
                 continue;
@@ -1158,7 +1194,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
                 int fd = lumi_take_sock(p);
                 if (fd < 0) continue;
                 sent[j] = lumi_now();
-                if (lumi_send_exec(fd, layer, eid, xj, D, nr, NULL)) {
+                if (lumi_send_exec(p, fd, layer, eid, xj, D, nr, NULL)) {
                     close(fd); lumi_peer_failed(p); continue;
                 }
                 lumi_peer_sent(p);
@@ -1267,7 +1303,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
                 int fd = lumi_take_sock(p);
                 if (fd < 0) continue;
                 sent[j] = lumi_now();
-                if (lumi_send_exec(fd, layer, eid, xj, D, nr, NULL)) {
+                if (lumi_send_exec(p, fd, layer, eid, xj, D, nr, NULL)) {
                     close(fd); lumi_peer_failed(p); continue;
                 }
                 lumi_peer_sent(p);
@@ -1398,7 +1434,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
                 int fd = lumi_take_sock(p);
                 if (fd < 0) continue;
                 sent[j] = lumi_now();
-                if (lumi_send_exec(fd, layer, eid, xj, D, nr, wj)) {
+                if (lumi_send_exec(p, fd, layer, eid, xj, D, nr, wj)) {
                     close(fd); lumi_peer_failed(p); continue;
                 }
                 lumi_peer_sent(p);

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -265,6 +265,14 @@ enum {
      * placement promise immediately, so another READY-capable machine need
      * not wait for its timeout. This grants no lease or execution authority. */
     LMB_SEG_ASSIGN_RELEASE = 62,
+    /* Targeted tunnel dialects, for peers that only the tracker can reach.
+     * TEXEC carries one ordinary EXEC to ONE named holder and answers with
+     * a plain LMB_EXEC_R, so a chatter can treat "peer behind the tracker"
+     * exactly like any other replica: same sockets, same predictors, same
+     * hedging, same spot-check. TMAN fetches that peer's expert manifest
+     * the same way. */
+    LMB_TEXEC = 66,
+    LMB_TMAN = 67, LMB_TMAN_FWD = 68, LMB_TMAN_R = 69,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
@@ -356,6 +364,8 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
     case LMB_HASHES_R:
     case LMB_EXEC_R:
     case LMB_REXEC_R:
+    case LMB_TEXEC:
+    case LMB_TMAN_R:
     case LMB_SEG_RUN:
     case LMB_SEG_RUN_R:
     case LMB_SEG_SNAPSHOT_R:

--- a/relay_exec_test.sh
+++ b/relay_exec_test.sh
@@ -39,7 +39,7 @@ grep -q "expert nat-expert" "$T/tracker.log" || {
     cat "$T/tracker.log" "$T/node.log"; exit 1;
 }
 
-./test_relay_exec 127.0.0.1:7560 127.0.0.1:7561 tiny_olmoe 8 1024 0
+./test_relay_exec 127.0.0.1:7560 127.0.0.1:7561 tiny_olmoe 8 1024 0 127.0.0.1:1
 
 echo "· concurrency: four relayed calls to one delayed node finish together"
 # a fresh tracker: the delayed node is its only holder, no staleness dance

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1106,6 +1106,7 @@ static int conversation_recover(
     int prefer_same = !conversation->chain[failed_index].failure_transport;
     uint8_t attempted[LMB_SEG_ROUTE_MAX] = {0};
     size_t attempts = 0;
+    int stale_refreshes = 0;
     for (;;) {
         uint32_t chosen_index = UINT32_MAX;
         const LmbSegRouteEntry *chosen = NULL;
@@ -1136,6 +1137,24 @@ static int conversation_recover(
         }
         snprintf(last_failure, sizeof last_failure, "%s",
                  error[0] ? error : "recovery route failed");
+        /* The tracker can move again BETWEEN our refresh and the OPENs — a
+         * peer dies or joins, every executor heartbeat accepts the newer
+         * generation, and a healthy range answers STALE_OWNER to fencing we
+         * fetched milliseconds ago. One refresh per rejection, bounded: the
+         * race window is heartbeat-sized, not unbounded. */
+        if (discovery && stale_refreshes < 2 &&
+            strstr(last_failure, "stale owner") &&
+            lmb_seg_discovery_refresh_now(discovery, &refreshed) > 0) {
+            stale_refreshes++;
+            fprintf(stderr, "[lumabri] Segment recovery route generation "
+                            "%llu -> %llu (stale-owner retry %d)\n",
+                    (unsigned long long)snapshot->route_generation,
+                    (unsigned long long)refreshed.route_generation,
+                    stale_refreshes);
+            snapshot = &refreshed;
+            memset(attempted, 0, sizeof attempted);
+            attempts = 0;
+        }
     }
     if (!attempts)
         snprintf(error, error_size,

--- a/test_hedge.c
+++ b/test_hedge.c
@@ -54,7 +54,7 @@ int main(void) {
     int fd = lumi_take_sock(&L.peers[0]);
     uint32_t tried = 1;
     double started = lumi_now();
-    int bad = fd < 0 || lumi_send_exec(fd, 0, 0, x, 4, 3, NULL);
+    int bad = fd < 0 || lumi_send_exec(&L.peers[0], fd, 0, 0, x, 4, 3, NULL);
     LumiPeer *from = NULL;
     float *out = bad ? NULL : lumi_finish_exec(0, 0, x, 4, 3, NULL, fd,
                                                 &L.peers[0], started,
@@ -100,7 +100,7 @@ int main(void) {
     int off_fd = lumi_take_sock(&L.peers[0]);
     uint32_t off_tried = 1;
     double off_started = lumi_now();
-    bad |= off_fd < 0 || lumi_send_exec(off_fd, 0, 0, x, 4, 3, NULL);
+    bad |= off_fd < 0 || lumi_send_exec(&L.peers[0], off_fd, 0, 0, x, 4, 3, NULL);
     LumiPeer *off_from = NULL;
     float *off_out = bad ? NULL
                          : lumi_finish_exec(0, 0, x, 4, 3, NULL, off_fd,

--- a/test_nat_adopt.c
+++ b/test_nat_adopt.c
@@ -1,0 +1,132 @@
+/* A donor behind NAT must be a REPLICA, not a coverage bit of last resort.
+ *
+ * The peer's advertised address refuses every dial (a dead listener — the
+ * honest shape of a home router). The fake tracker serves the peer's
+ * manifest through LMB_TMAN and executes targeted LMB_TEXEC calls in its
+ * place. The client must:
+ *
+ *   1. adopt the peer through the tunnel (relay_target set, experts in the
+ *      table) instead of skipping it;
+ *   2. run an ordinary lumi_moe_apply through it — the TEXEC frame names
+ *      exactly that peer, and the reply is used like any direct answer.
+ */
+#define LMBE_ENGINE_ID "nat-test"
+#define LMBE_SOURCE_ID "test"
+#define LMBE_EXPECT_BITS 0
+#include <pthread.h>
+#include <stdatomic.h>
+#include "lumabri_client.h"
+
+static _Atomic int g_listening;
+static _Atomic int g_texec_seen;
+static char g_expect_target[64];
+
+/* the NAT'd peer: every dial dies instantly */
+static void *dead_server(void *arg) {
+    int lfd = lmb_listen((int)(intptr_t)arg);
+    if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
+    for (;;) {
+        int fd = accept(lfd, NULL, NULL);
+        if (fd >= 0) close(fd);
+    }
+    return NULL;
+}
+
+/* the tracker: manifest over TMAN, compute over TEXEC */
+static void *tracker_server(void *arg) {
+    int lfd = lmb_listen((int)(intptr_t)arg);
+    if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
+    for (;;) {
+        int fd = accept(lfd, NULL, NULL);
+        if (fd < 0) continue;
+        LmbMsg m = {0};
+        while (lmb_recv(fd, &m) == 0) {
+            if (m.op == LMB_TMAN) {
+                LmbBuf b = {0};
+                lmb_buf_u32(&b, LMB_EXPERT_MANIFEST_MAGIC);
+                lmb_buf_str(&b, L.engine_id);
+                lmb_buf_str(&b, L.profile);   /* byte-compatible by construction */
+                lmb_buf_str(&b, "tiny");
+                lmb_buf_u32(&b, 0);           /* bits */
+                lmb_buf_u32(&b, 0);           /* no identity */
+                lmb_buf_u32(&b, 1);           /* one expert: (0,0) */
+                lmb_buf_u32(&b, 0);
+                lmb_buf_u32(&b, 0);
+                lmb_buf_u32(&b, (uint32_t)L.hidden);
+                lmb_send(fd, LMB_EMANIFEST_R, b.p, (uint32_t)b.len, NULL, 0);
+                free(b.p);
+            } else if (m.op == LMB_TEXEC) {
+                LmbCur c = { m.body, m.body_len, 0 };
+                char target[64] = "";
+                lmb_cur_str(&c, target, sizeof target);
+                if (!strcmp(target, g_expect_target))
+                    atomic_fetch_add(&g_texec_seen, 1);
+                /* echo the activations back, like an honest expert */
+                lmb_send(fd, LMB_EXEC_R, NULL, 0, m.pay, m.pay_len);
+            } else if (m.op == LMB_PING) {
+                lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
+            } else break;
+            lmb_msg_free(&m);
+        }
+        lmb_msg_free(&m);
+        close(fd);
+    }
+    return NULL;
+}
+
+static int fail(const char *what) {
+    fprintf(stderr, "test_nat_adopt: FAIL — %s\n", what);
+    return 1;
+}
+
+int main(void) {
+    unsetenv("LUMABRI_EXPERTS");
+    unsetenv("LUMABRI_MODEL");
+    setenv("LUMABRI_TRACKER", "127.0.0.1:7591", 1);
+    setenv("LUMABRI_DISCOVERY_MS", "600000", 1);
+    snprintf(g_expect_target, sizeof g_expect_target, "127.0.0.1:7592");
+
+    lumi_init(1, 1, 4);
+    if (!L.own) return fail("init did not allocate the expert map");
+
+    pthread_t dt, dn;
+    pthread_create(&dt, NULL, tracker_server, (void *)(intptr_t)7591);
+    pthread_create(&dn, NULL, dead_server, (void *)(intptr_t)7592);
+    pthread_detach(dt); pthread_detach(dn);
+    for (int spins = 0; atomic_load(&g_listening) < 2 && spins < 500; spins++)
+        usleep(10000);
+    if (atomic_load(&g_listening) < 2)
+        return fail("the fake tracker/peer never came up");
+
+    /* 1. adoption through the tunnel */
+    if (lumi_add_peer("127.0.0.1:7592"))
+        return fail("the NAT peer was skipped although the tunnel had its manifest");
+    LumiPeer *peer = NULL;
+    for (int i = 0; i < L.npeers; i++)
+        if (!strcmp(L.peers[i].addr, "127.0.0.1:7592")) peer = &L.peers[i];
+    if (!peer) return fail("the adopted peer is not in the table");
+    if (!peer->relay_target[0])
+        return fail("the adopted peer has no relay target");
+    if (L.own[0] < 0)
+        return fail("the adopted peer's expert never entered the replica table");
+
+    /* 2. an ordinary apply rides the tunnel */
+    L.on = 1;
+    if (L.layer_ok) L.layer_ok[0] = 1;
+    float x[4] = { 1, 2, 3, 4 }, out[4] = { 0 };
+    int idx[1] = { 0 };
+    float val[1] = { 2.0f };
+    if (!lumi_moe_apply(0, idx, val, 1, x, 4, out))
+        return fail("apply failed although the tunnel executes for the peer");
+    if (!atomic_load(&g_texec_seen))
+        return fail("no TEXEC frame named the adopted peer");
+    for (int d = 0; d < 4; d++)
+        if (out[d] != 2.0f * x[d])
+            return fail("the tunnelled answer was not accumulated like a direct one");
+
+    printf("nat adopt tests: ok (tunnel manifest, targeted exec, %d TEXEC frame(s))\n",
+           atomic_load(&g_texec_seen));
+    return 0;
+}

--- a/test_relay_exec.c
+++ b/test_relay_exec.c
@@ -1,12 +1,17 @@
-/* One real expert call, direct and through the tracker's NAT tunnel. */
+/* One real expert call, direct and through the tracker's NAT tunnel —
+ * anonymous (REXEC: any holder) and targeted (TEXEC: exactly this peer),
+ * plus the peer's manifest over the same tunnel (TMAN). Every answer must
+ * be byte-identical to the direct one. */
 #include "lumabri_proto.h"
 
 int main(int argc, char **argv) {
-    if (argc != 7) {
-        fprintf(stderr, "usage: %s TRACKER NODE MODEL NEXPERTS DIM EID\n", argv[0]);
+    if (argc != 7 && argc != 8) {
+        fprintf(stderr, "usage: %s TRACKER NODE MODEL NEXPERTS DIM EID "
+                        "[ADVERTISED]\n", argv[0]);
         return 2;
     }
     const char *tracker = argv[1], *node = argv[2], *model = argv[3];
+    const char *advertised = argc == 8 ? argv[7] : NULL;
     uint32_t nexp = (uint32_t)atoi(argv[4]), dim = (uint32_t)atoi(argv[5]);
     uint32_t eid = (uint32_t)atoi(argv[6]), layer = 0, rows = 3;
     float *x = (float *)malloc((size_t)rows * dim * sizeof(float));
@@ -32,8 +37,37 @@ int main(int argc, char **argv) {
               memcmp(direct.pay, relayed.pay, pay_len);
         free(b.p);
     }
+    if (!bad && advertised) {
+        /* targeted: the tunnel must reach exactly the named peer */
+        LmbBuf b = {0};
+        LmbMsg targeted = {0};
+        lmb_buf_str(&b, advertised);
+        lmb_buf_bytes(&b, exec.p, exec.len);
+        bad = lmb_request_pay(tracker, LMB_TEXEC, b.p, (uint32_t)b.len,
+                              x, pay_len, &targeted) ||
+              targeted.op != LMB_EXEC_R || targeted.pay_len != pay_len ||
+              memcmp(direct.pay, targeted.pay, pay_len);
+        free(b.p); lmb_msg_free(&targeted);
+        if (bad) { fprintf(stderr, "targeted TEXEC differs from direct EXEC\n"); }
+    }
+    if (!bad && advertised) {
+        /* and the manifest arrives through the same tunnel, byte-identical */
+        LmbMsg dman = {0}, tman = {0};
+        LmbBuf b = {0};
+        lmb_buf_str(&b, advertised);
+        bad = lmb_request(node, LMB_EMANIFEST, NULL, 0, &dman) ||
+              dman.op != LMB_EMANIFEST_R ||
+              lmb_request(tracker, LMB_TMAN, b.p, (uint32_t)b.len, &tman) ||
+              tman.op != LMB_EMANIFEST_R ||
+              dman.body_len != tman.body_len ||
+              memcmp(dman.body, tman.body, dman.body_len);
+        free(b.p); lmb_msg_free(&dman); lmb_msg_free(&tman);
+        if (bad) { fprintf(stderr, "tunnelled manifest differs from direct\n"); }
+    }
     free(exec.p); free(x); lmb_msg_free(&direct); lmb_msg_free(&relayed);
     if (bad) { fprintf(stderr, "relayed EXEC differs from direct EXEC\n"); return 1; }
-    puts("EXEC RELAY: PASS (3-row batch, byte-identical to direct)");
+    puts(advertised
+         ? "EXEC RELAY: PASS (anonymous + targeted + manifest, byte-identical)"
+         : "EXEC RELAY: PASS (3-row batch, byte-identical to direct)");
     return 0;
 }

--- a/tracker.c
+++ b/tracker.c
@@ -37,6 +37,7 @@
 
 /* A fully built control-channel frame, queued for the peer's conn thread. */
 typedef struct OutFrame {
+    uint32_t op;
     uint8_t *body; uint32_t body_len;
     uint8_t *pay; uint32_t pay_len;
     struct OutFrame *next;
@@ -2118,7 +2119,8 @@ static int handle_rread(int fd, LmbMsg *m) {
  * takes one of the peer's REXEC_INFLIGHT slots, so several chatters (and
  * several experts of one layer) ride the tunnel concurrently; a timed-out
  * slot is abandoned in place and a late reply for it is dropped by id. */
-static int rexec_forward(Peer *p, const uint8_t *body, uint32_t body_len,
+static int relay_forward(Peer *p, uint32_t fwd_op,
+                         const uint8_t *body, uint32_t body_len,
                          const uint8_t *pay, uint32_t pay_len, int wait_s,
                          uint8_t **resp, uint32_t *resp_len) {
     *resp = NULL; *resp_len = 0;
@@ -2150,6 +2152,7 @@ static int rexec_forward(Peer *p, const uint8_t *body, uint32_t body_len,
     f->body = b.p; f->body_len = (uint32_t)b.len;
     if (pay_len) memcpy(pcopy, pay, pay_len);
     f->pay = pcopy; f->pay_len = pay_len;
+    f->op = fwd_op;
     if (p->outq_tail) p->outq_tail->next = f; else p->outq_head = f;
     p->outq_tail = f;
     pthread_mutex_unlock(&p->rq_lk);
@@ -2169,6 +2172,102 @@ static int rexec_forward(Peer *p, const uint8_t *body, uint32_t body_len,
     }
     pthread_mutex_unlock(&p->rq_lk);
     return ok;
+}
+
+/* Find one fresh expert registrant by its advertised address. The address
+ * is identity here, not a route: for a NAT-only peer nobody can dial it,
+ * but every EREG carries it and the chatter names it to mean THAT peer. */
+static Peer *expert_by_addr(const char *addr) {
+    double now = now_s();
+    Peer *p = NULL;
+    pthread_mutex_lock(&g_lk);
+    for (int i = 0; i < MAX_PEERS && !p; i++) {
+        Peer *q = &g_peers[i];
+        if (getenv("LUMABRI_RELAY_TRACE") && q->used)
+            fprintf(stderr, "[tracker] by_addr? used=%d is_e=%d has_e=%d stale=%.1f ctrl=%d ev=%d addr='%s' want='%s'\n",
+                    q->used, q->is_expert, q->has_expert, now - q->expert_ts,
+                    q->ctrl_fd, q->evfd, q->addr, addr);
+        if (!q->used || !q->is_expert || !q->has_expert ||
+            now - q->expert_ts > g_stale_s ||
+            q->ctrl_fd < 0 || q->evfd < 0 || strcmp(q->addr, addr)) continue;
+        p = q; p->refs++;
+    }
+    pthread_mutex_unlock(&g_lk);
+    return p;
+}
+
+static void peer_unref(Peer *p) {
+    pthread_mutex_lock(&g_lk);
+    if (p->refs) p->refs--;
+    pthread_mutex_unlock(&g_lk);
+}
+
+/* Targeted EXEC through the tunnel. Unlike REXEC this does NOT fail over:
+ * the chatter chose this replica exactly as it chooses a direct one, and
+ * failover is the chatter's own job — it owns the tried-set, the
+ * predictors and the spot-check. The reply is a plain LMB_EXEC_R, so the
+ * chatter's receive path cannot tell this peer from a dialable one. */
+static int handle_texec(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    char target[64];
+    uint32_t layer = 0, eid = 0, dim = 0, nrows = 0;
+    if (lmb_cur_str(&c, target, sizeof target) ||
+        lmb_cur_u32(&c, &layer) || lmb_cur_u32(&c, &eid) ||
+        lmb_cur_u32(&c, &dim) || lmb_cur_u32(&c, &nrows)) {
+        send_err(fd, "malformed texec header"); return -1;
+    }
+    size_t exec_at = c.off - 16;
+    if (!dim || nrows < 1 || nrows > LMB_MAX_EXEC_ROWS ||
+        (m->body_len - c.off != 0 && m->body_len - c.off != (uint64_t)nrows * 4) ||
+        (uint64_t)nrows * dim * 4 != m->pay_len) {
+        send_err(fd, "bad texec shape"); return -1;
+    }
+    Peer *p = expert_by_addr(target);
+    if (!p) { send_err(fd, "no such expert peer"); return 0; }
+    uint8_t *resp = NULL; uint32_t resp_len = 0;
+    int ok = relay_forward(p, LMB_REXEC_FWD, m->body + exec_at,
+                           m->body_len - (uint32_t)exec_at, m->pay, m->pay_len,
+                           lmb_env_int("LUMABRI_RELAY_TRY_S", 25, 1, RELAY_WAIT_S),
+                           &resp, &resp_len);
+    if (ok) {
+        p->rexec_fails = 0;
+    } else {
+        /* the anonymous-relay candidate ordering learns from this too */
+        if (p->rexec_fails < 1000) p->rexec_fails++;
+        p->rexec_fail_at = now_s();
+    }
+    int rc;
+    if (!ok) { free(resp); send_err(fd, "targeted exec failed"); rc = 0; }
+    else {
+        rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, resp, resp_len);
+        free(resp);
+    }
+    peer_unref(p);
+    return rc;
+}
+
+/* Targeted manifest through the tunnel: what makes a NAT-only donor a
+ * first-class replica in the chatter's table instead of an anonymous
+ * coverage bit of last resort. */
+static int handle_tman(int fd, LmbMsg *m) {
+    LmbCur c = { m->body, m->body_len, 0 };
+    char target[64];
+    if (m->pay_len || lmb_cur_str(&c, target, sizeof target) || c.off != c.len) {
+        send_err(fd, "bad tman"); return -1;
+    }
+    Peer *p = expert_by_addr(target);
+    if (!p) { send_err(fd, "no such expert peer"); return 0; }
+    uint8_t *resp = NULL; uint32_t resp_len = 0;
+    int ok = relay_forward(p, LMB_TMAN_FWD, NULL, 0, NULL, 0, 10,
+                           &resp, &resp_len);
+    int rc;
+    if (!ok || !resp_len) { free(resp); send_err(fd, "manifest relay failed"); rc = 0; }
+    else {
+        rc = lmb_send(fd, LMB_EMANIFEST_R, resp, resp_len, NULL, 0);
+        free(resp);
+    }
+    peer_unref(p);
+    return rc;
 }
 
 /* EXEC relay: same one-request mailbox as byte relay, but the expert node's
@@ -2252,7 +2351,8 @@ static int handle_rexec(int fd, LmbMsg *m) {
         if (getenv("LUMABRI_RELAY_TRACE"))
             fprintf(stderr, "[tracker] rexec try %d/%d %s gid=%llu\n",
                     ci + 1, ncand, p->name, (unsigned long long)gid64);
-        ok = rexec_forward(p, m->body + exec_at, body_len, m->pay, m->pay_len,
+        ok = relay_forward(p, LMB_REXEC_FWD, m->body + exec_at, body_len,
+                           m->pay, m->pay_len,
                            ncand > 1 ? try_s : RELAY_WAIT_S,
                            &resp, &resp_len);
         if (ok) {
@@ -2490,7 +2590,7 @@ static void relay_complete(Peer *p, LmbMsg *m) {
         fprintf(stderr, "[tracker] relay complete op=%u id=%u ok=%u pay=%u\n",
                 m->op, id, ok, m->pay_len);
     pthread_mutex_lock(&p->rq_lk);
-    if (m->op == LMB_REXEC_R) {
+    if (m->op == LMB_REXEC_R || m->op == LMB_TMAN_R) {
         for (int r = 0; r < REXEC_INFLIGHT; r++)
             if (p->rex[r].used && !p->rex[r].done && p->rex[r].id == id) {
                 p->rex[r].ok = ok && m->pay_len > 0;
@@ -2630,7 +2730,7 @@ static void *conn_thread(void *arg) {
                     }
                     pthread_mutex_unlock(&ctrl->rq_lk);
                     if (!frame) break;
-                    int rc = lmb_send(fd, LMB_REXEC_FWD, frame->body,
+                    int rc = lmb_send(fd, frame->op, frame->body,
                                       frame->body_len, frame->pay, frame->pay_len);
                     free(frame->body); free(frame->pay); free(frame);
                     if (rc) { send_bad = 1; break; }
@@ -2684,6 +2784,7 @@ static void *conn_thread(void *arg) {
         }
         case LMB_RREAD_R:
         case LMB_REXEC_R:
+        case LMB_TMAN_R:
         case LMB_RSEG_R:    if (ctrl) relay_complete(ctrl, &m); break;
         case LMB_EREG: {
             Peer *p = handle_ereg(fd, &m, have_nonce ? nonce : NULL);
@@ -2733,6 +2834,8 @@ static void *conn_thread(void *arg) {
         case LMB_SWARM_DETAIL: rc = handle_swarm_detail(fd); break;
         case LMB_RREAD:     rc = handle_rread(fd, &m); break;
         case LMB_REXEC:     rc = handle_rexec(fd, &m); break;
+        case LMB_TEXEC:     rc = handle_texec(fd, &m); break;
+        case LMB_TMAN:      rc = handle_tman(fd, &m); break;
         case LMB_RSEG:      rc = handle_rseg(fd, &m); break;
         case LMB_ASSIGN:    rc = handle_assign(fd, &m); break;
         default:            send_err(fd, "unknown op"); rc = -1; break;


### PR DESCRIPTION
## The gap this closes

A donor behind a home router could never serve its manifest (`no expert manifest — skipped`, retried forever) and its experts existed only as an anonymous coverage bitmap consulted after every direct replica was already dead. Donated RAM sat idle — the exact 'dono RAM ma il donor non lavora' from the field.

## What changes

- **`LMB_TMAN`** (67-69): the peer's expert manifest through its own control tunnel. When the direct fetch fails and a tracker exists, `lumi_add_peer` adopts the peer with `relay_target` set: it enters `L.own` as a **real replica** — predictors, spreading, hedging and spot-check all apply unchanged.
- **`LMB_TEXEC`** (66): one ordinary EXEC to ONE named holder, answered with a plain `LMB_EXEC_R`. `lumi_take_sock` dials the tracker for such peers, `lumi_send_exec` prefixes the target; above the socket layer a tunnelled peer is indistinguishable from a dialable one. No tracker-side failover for targeted calls — the chatter owns the tried-set, exactly as for direct replicas. Outcomes feed the same relay-health ordering as the anonymous path.
- **Recovery hardening**: `conversation_recover` re-refreshes its tracker snapshot (bounded, twice) when a healthy range answers `STALE_OWNER` — the tracker can legitimately move again between the refresh and the OPENs.

Old trackers answer the new ops with `LMB_ERR` and the client degrades to exactly the old behaviour.

## Deliberately NOT included

Feeding realized Segment RUN latencies into the discovery predictor: wiring it made the Segment failover gate fail 2-3/6 from timing perturbation alone. Until that interaction with the serve-loop recovery is understood, it stays out (details in the commit message).

## Verification

- new `test_nat_adopt`: fake tracker + undialable peer — adoption through the tunnel, the TEXEC frame names exactly that peer, byte-correct accumulation;
- `relay_exec_test.sh` grows a targeted+manifest stage against a **real** expert node advertising an unreachable address — anonymous, targeted and manifest all byte-identical to direct;
- Segment failover gate **6/6** on a loaded host; hedge / local-fallback / verify-failover / full relay gate green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)