### PR TITLE
fix(client): a donor on this machine is dialed on loopback, not hairpinned

### DIFF
--- a/deploy/NAT.md
+++ b/deploy/NAT.md
@@ -12,6 +12,9 @@ What changes behind NAT:
 
 - chatters cannot dial you directly, so your answers ride the tracker relay:
   one extra hop of latency, same bytes, same verification;
+- your OWN chat is the exception: a donor node running next to the chat is
+  recognized on loopback and its resident experts are dialed at RAM
+  distance, never through the tracker;
 - `lumabri doctor --tracker HOST:7300` tells you which side you are on:
   `direct-reachable` (others dial you straight) or `relay-only` (the tunnel
   carries you). Both are full members of the swarm.

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -52,6 +52,14 @@ typedef struct {
      * socket layer this peer is indistinguishable from a dialable one:
      * same predictors, same spreading, same hedging, same spot-check. */
     char relay_target[64];
+    /* Non-empty: the advertised address is this very machine seen from the
+     * outside. A donor node spawned next to the chat is advertised at the
+     * public IP the tracker observed, and a NAT rarely lets its own WAN
+     * address be dialed from inside (no hairpin) — so without this, a chat
+     * would reach the experts sitting in its OWN RAM by a round trip
+     * through the tracker. Sockets dial this instead; identity, canonical
+     * ordering and telemetry keep using addr. */
+    char loopback[64];
     int socks[LUMI_MAX_K];
     int nsocks;
     long rtt_us;
@@ -153,7 +161,7 @@ static void lumi_peer_done(LumiPeer *peer) {
  * manifest permanently. */
 static int lumi_take_sock(LumiPeer *p) {
     if (p->nsocks) return p->socks[--p->nsocks];
-    const char *dial = p->addr;
+    const char *dial = p->loopback[0] ? p->loopback : p->addr;
     if (p->relay_target[0]) {
         dial = getenv("LUMABRI_TRACKER");
         if (!dial || !dial[0]) { lumi_peer_failed(p); return -1; }
@@ -328,6 +336,7 @@ static int lumi_add_peer(const char *addr) {
 
     LmbMsg m = {0};
     p->relay_target[0] = 0;
+    p->loopback[0] = 0;
     if (lmb_request(p->addr, LMB_EMANIFEST, NULL, 0, &m) || m.op != LMB_EMANIFEST_R) {
         /* Not dialable — the normal case for a donor behind a home router.
          * Ask the tracker for the same manifest through the peer's own
@@ -335,16 +344,40 @@ static int lumi_add_peer(const char *addr) {
          * whose route happens to run through the tracker. */
         lmb_msg_free(&m);
         memset(&m, 0, sizeof m);
+        /* Hairpin check first: if the unreachable peer is a node on THIS
+         * machine, its port answers on loopback with the same manifest the
+         * advertised address refused — adopt it at RAM distance instead of
+         * tunnel distance. Bounded to 500 ms because a loopback that exists
+         * answers instantly and one that does not must not stall discovery
+         * (some hosts drop instead of refusing). */
+        const char *port_part = strrchr(p->addr, ':');
+        int local = 0;
+        if (port_part && strncmp(p->addr, "127.", 4) != 0) {
+            char here[64];
+            snprintf(here, sizeof here, "127.0.0.1%s", port_part);
+            int fd = lmb_connect_ms(here, 500);
+            if (fd >= 0 && !lmb_auth(fd) &&
+                !lmb_send(fd, LMB_EMANIFEST, NULL, 0, NULL, 0) &&
+                !lmb_recv(fd, &m) && m.op == LMB_EMANIFEST_R) {
+                snprintf(p->loopback, sizeof p->loopback, "%s", here);
+                local = 1;
+            }
+            if (fd >= 0) close(fd);
+            if (!local) { lmb_msg_free(&m); memset(&m, 0, sizeof m); }
+        }
+        if (local)
+            fprintf(stderr, "[lumabri] peer %s is this machine — dialing its "
+                            "experts on loopback\n", p->addr);
         const char *tracker = getenv("LUMABRI_TRACKER");
         int relayed = 0;
-        if (tracker && tracker[0]) {
+        if (!local && tracker && tracker[0]) {
             LmbBuf tb = {0};
             lmb_buf_str(&tb, p->addr);
             relayed = !lmb_request(tracker, LMB_TMAN, tb.p, (uint32_t)tb.len,
                                    &m) && m.op == LMB_EMANIFEST_R;
             free(tb.p);
         }
-        if (!relayed) {
+        if (!local && !relayed) {
             fprintf(stderr, "[lumabri] no expert manifest from %s — skipped\n",
                     p->addr);
             lmb_msg_free(&m);
@@ -352,9 +385,11 @@ static int lumi_add_peer(const char *addr) {
             if (reprobe < 0) L.npeers++;   /* remember NAT-only addresses */
             return -1;
         }
-        snprintf(p->relay_target, sizeof p->relay_target, "%s", p->addr);
-        fprintf(stderr, "[lumabri] peer %s is not directly dialable — "
-                        "adopting it through the tracker tunnel\n", p->addr);
+        if (!local) {
+            snprintf(p->relay_target, sizeof p->relay_target, "%s", p->addr);
+            fprintf(stderr, "[lumabri] peer %s is not directly dialable — "
+                            "adopting it through the tracker tunnel\n", p->addr);
+        }
     }
     LmbCur c = { m.body, m.body_len, 0 };
     uint32_t magic = 0, bits = 0, have_id = 0, has_sig = 0;

--- a/test_nat_adopt.c
+++ b/test_nat_adopt.c
@@ -33,6 +33,44 @@ static void *dead_server(void *arg) {
     return NULL;
 }
 
+/* a local donor node: EMANIFEST + EXEC echo on loopback, the shape of the
+ * hairpin case — the advertised address is unreachable, the port is ours */
+static void *local_node(void *arg) {
+    int lfd = lmb_listen((int)(intptr_t)arg);
+    if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
+    for (;;) {
+        int fd = accept(lfd, NULL, NULL);
+        if (fd < 0) continue;
+        LmbMsg m = {0};
+        while (lmb_recv(fd, &m) == 0) {
+            if (m.op == LMB_EMANIFEST) {
+                LmbBuf b = {0};
+                lmb_buf_u32(&b, LMB_EXPERT_MANIFEST_MAGIC);
+                lmb_buf_str(&b, L.engine_id);
+                lmb_buf_str(&b, L.profile);
+                lmb_buf_str(&b, "tiny");
+                lmb_buf_u32(&b, 0);
+                lmb_buf_u32(&b, 0);
+                lmb_buf_u32(&b, 1);      /* one expert: (0,0) */
+                lmb_buf_u32(&b, 0);
+                lmb_buf_u32(&b, 0);
+                lmb_buf_u32(&b, (uint32_t)L.hidden);
+                lmb_send(fd, LMB_EMANIFEST_R, b.p, (uint32_t)b.len, NULL, 0);
+                free(b.p);
+            } else if (m.op == LMB_EXEC) {
+                lmb_send(fd, LMB_EXEC_R, NULL, 0, m.pay, m.pay_len);
+            } else if (m.op == LMB_PING) {
+                lmb_send(fd, LMB_OK, NULL, 0, NULL, 0);
+            } else break;
+            lmb_msg_free(&m);
+        }
+        lmb_msg_free(&m);
+        close(fd);
+    }
+    return NULL;
+}
+
 /* the tracker: manifest over TMAN, compute over TEXEC */
 static void *tracker_server(void *arg) {
     int lfd = lmb_listen((int)(intptr_t)arg);
@@ -126,7 +164,45 @@ int main(void) {
         if (out[d] != 2.0f * x[d])
             return fail("the tunnelled answer was not accumulated like a direct one");
 
-    printf("nat adopt tests: ok (tunnel manifest, targeted exec, %d TEXEC frame(s))\n",
-           atomic_load(&g_texec_seen));
+    /* --- 3. hairpin: our own node, advertised at an unreachable name ----- */
+    pthread_t ln;
+    pthread_create(&ln, NULL, local_node, (void *)(intptr_t)7593);
+    pthread_detach(ln);
+    for (int spins = 0; atomic_load(&g_listening) < 3 && spins < 500; spins++)
+        usleep(10000);
+    if (atomic_load(&g_listening) < 3)
+        return fail("the local node never came up");
+    int texec_before = atomic_load(&g_texec_seen);
+    /* the broadcast address refuses a connect instantly on every platform:
+     * the advertised address fails, the port answers on loopback — the
+     * shape of chat+donor behind one NAT */
+    if (lumi_add_peer("255.255.255.255:7593"))
+        return fail("the local peer was skipped although loopback answers");
+    LumiPeer *self = NULL;
+    for (int i = 0; i < L.npeers; i++)
+        if (!strcmp(L.peers[i].addr, "255.255.255.255:7593")) self = &L.peers[i];
+    if (!self) return fail("the local peer is not in the table");
+    if (!self->loopback[0])
+        return fail("the local peer was not adopted on loopback");
+    if (self->relay_target[0])
+        return fail("the local peer went through the tunnel instead of loopback");
+
+    /* its expert must run over loopback with a plain EXEC, not a TEXEC */
+    L.own[0] = (int)(self - L.peers);
+    L.own[1] = -1;
+    if (L.demote_until) L.demote_until[0] = 0;
+    L.swarm_sick_until = 0;
+    L.verify_pct = 0;
+    memset(out, 0, sizeof out);
+    if (!lumi_moe_apply(0, idx, val, 1, x, 4, out))
+        return fail("apply failed on the loopback-adopted peer");
+    if (atomic_load(&g_texec_seen) != texec_before)
+        return fail("the loopback peer was reached through the tracker");
+    for (int d = 0; d < 4; d++)
+        if (out[d] != 2.0f * x[d])
+            return fail("the loopback answer was not accumulated correctly");
+
+    printf("nat adopt tests: ok (tunnel manifest, targeted exec, %d TEXEC "
+           "frame(s), hairpin on loopback)\n", atomic_load(&g_texec_seen));
     return 0;
 }


### PR DESCRIPTION
## The gap

Run chat+donor on one machine behind NAT (the TUI's option 3) and the donor node is advertised at the public IP the tracker observed. A NAT rarely lets its own WAN address be dialed from inside (no hairpin), so after #102 the chat adopted its **own** node through the tracker tunnel — reaching the experts sitting in its own RAM by a round trip through the server.

## The fix

When the advertised address refuses the manifest, knock on `127.0.0.1:<same port>` first (bounded to 500 ms — a loopback that exists answers instantly; one that does not must not stall discovery on hosts that drop instead of refusing). Same manifest there → adopt with a **loopback dial override**: identity, canonical ordering and telemetry keep the advertised address, sockets go to RAM distance, frames stay plain `EXEC` (no tunnel). A peer that becomes directly dialable again on a reprobe drops the override, as before.

Worst case if a *different* local lumabri node answers that port: it answered with a matching manifest for the same content-addressed model and every call remains spot-checkable — a valid replica under a mislabelled name, not a wrong answer.

## Verification

- `test_nat_adopt` grows the hairpin scenario: peer advertised at an instantly-refusing address whose port answers on loopback → adopted on loopback, not tunnel, and its expert rides a plain `EXEC` (the TEXEC counter must stay untouched);
- hedge / local-fallback / verify-failover / RTT-refresh gates green; chatters compile against colibri main;
- `deploy/NAT.md` notes the shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)