### PR TITLE
fix(shim): donated blocks on this machine are read on loopback

### DIFF
--- a/cas_test.sh
+++ b/cas_test.sh
@@ -38,3 +38,26 @@ env "${COMMON[@]}" LUMABRI_STATS=1 LUMABRI_VROOT="$T/vroot-b" \
     LUMABRI_CACHE="$T/cache-b" ./test_shim "$T/vroot-b" "$T/src" \
     >/dev/null 2>"$T/cas.err"
 echo "LOCAL CAS: PASS (fresh mirror rebuilt with origin offline)"
+
+# Hairpin: a donor on THIS machine, advertised at an address the outside
+# world would use but we cannot dial (the broadcast address refuses
+# instantly everywhere). The shim must knock on loopback, adopt it, and pull
+# every byte directly — chat+donor on one box reads its own disk at disk
+# speed, never through the tracker relay.
+mkdir -p "$T/cache-c" "$T/cas-c"
+./maintainer --root "$T/src" --port 7564 --tracker 127.0.0.1:7562 \
+    --name cas-hairpin --model-name cas-test \
+    --advertise 255.255.255.255:7564 >"$T/hairpin.log" 2>&1 & PIDS+=($!)
+for _ in $(seq 1 200); do
+    (exec 3<>/dev/tcp/127.0.0.1/7564) 2>/dev/null && { exec 3<&-; break; }
+    sleep .1
+done
+sleep .3
+env "${COMMON[@]/LUMABRI_CAS=*/LUMABRI_CAS=$T/cas-c}" \
+    LUMABRI_VROOT="$T/vroot-c" LUMABRI_CACHE="$T/cache-c" \
+    ./test_shim "$T/vroot-c" "$T/src" >/dev/null 2>"$T/hairpin.err"
+grep -q "this machine — reading its blocks on loopback" "$T/hairpin.err" || {
+    echo "the hairpinned donor was not adopted on loopback"
+    cat "$T/hairpin.err"; exit 1;
+}
+echo "HAIRPIN CAS: PASS (own donor read on loopback, no relay)"

--- a/deploy/NAT.md
+++ b/deploy/NAT.md
@@ -12,9 +12,9 @@ What changes behind NAT:
 
 - chatters cannot dial you directly, so your answers ride the tracker relay:
   one extra hop of latency, same bytes, same verification;
-- your OWN chat is the exception: a donor node running next to the chat is
-  recognized on loopback and its resident experts are dialed at RAM
-  distance, never through the tracker;
+- your OWN chat is the exception: a donor running next to the chat is
+  recognized on loopback — resident experts are dialed at RAM distance and
+  donated blocks are read at disk distance, never through the tracker;
 - `lumabri doctor --tracker HOST:7300` tells you which side you are on:
   `direct-reachable` (others dial you straight) or `relay-only` (the tunnel
   carries you). Both are full members of the swarm.
@@ -28,6 +28,16 @@ What changes behind NAT:
 
 Or as a system service that survives reboots: see `lumabri-donor.service`
 in this directory.
+
+## If you control every machine: a mesh VPN is a valid turbo
+
+Lumabri needs nothing beyond outbound TCP. But when the same person owns
+all the machines (a home lab, a small team), putting them in one WireGuard
+or Tailscale network makes every peer directly dialable at its mesh
+address — the tracker relay stops carrying any bytes and each pair of
+machines talks at its own bandwidth. Point `--advertise` and `--tracker`
+at the mesh IPs and everything else is unchanged. For strangers on the
+open swarm, the relay remains the zero-configuration path.
 
 ## What to expect in the logs
 

--- a/lumashim.c
+++ b/lumashim.c
@@ -110,6 +110,12 @@ __attribute__((constructor)) static void shim_ctor(void) {
 
 typedef struct {
     char addr[64];
+    /* Non-empty: the advertised address is this very machine seen from the
+     * outside (a maintainer donated next to this chat, advertised at the
+     * public IP the tracker observed — a NAT rarely hairpins). Sockets dial
+     * this; addr stays the identity. Every fetched block is hash-verified
+     * downstream, so a wrong local service can only fail, never lie. */
+    char dial[64];
     int idle[POOL_SOCKS]; int nidle;
     long rtt_us;          /* measured at init; LONG_MAX = unreachable then */
     pthread_mutex_t lk;
@@ -470,6 +476,7 @@ static int peer_add(const char *addr) {
     if (g.npeers == MAX_RPEERS) return -1;
     RPeer *p = &g.peers[g.npeers];
     snprintf(p->addr, sizeof p->addr, "%s", addr);
+    p->dial[0] = 0;
     p->nidle = 0;
     p->rtt_us = 0;        /* all-equal until probed: FNV spreading as before */
     pthread_mutex_init(&p->lk, NULL);
@@ -734,7 +741,21 @@ static void *probe_thread(void *arg) {
     RPeer *p = (RPeer *)arg;
     p->rtt_us = LONG_MAX;
     int fd = lmb_connect_ms(p->addr, 2000);
-    if (fd < 0) return NULL;
+    if (fd < 0) {
+        /* Hairpin: a donor on THIS machine is advertised at a public IP we
+         * cannot dial from inside the NAT. Its port answers on loopback —
+         * knock there, bounded, before writing the peer off as relay-only.
+         * (chat+donor on one box: the bytes it donated should arrive at
+         * disk speed, not by a round trip through the tracker.) */
+        const char *port_part = strrchr(p->addr, ':');
+        if (port_part && strncmp(p->addr, "127.", 4) != 0) {
+            char here[64];
+            snprintf(here, sizeof here, "127.0.0.1%s", port_part);
+            fd = lmb_connect_ms(here, 500);
+            if (fd >= 0) snprintf(p->dial, sizeof p->dial, "%s", here);
+        }
+        if (fd < 0) return NULL;
+    }
     if (lmb_auth(fd)) { lmb_close(fd); return NULL; }
     for (int i = 0; i < 2; i++) {
         struct timespec a, b;
@@ -1186,6 +1207,10 @@ static void shim_init_impl(void) {
         if (g.peers[i].rtt_us == LONG_MAX)
             fprintf(stderr, "[lumabri] peer %s: unreachable directly (relay or failover)\n",
                     g.peers[i].addr);
+        else if (g.peers[i].dial[0])
+            fprintf(stderr, "[lumabri] peer %s: this machine — reading its "
+                            "blocks on loopback (rtt %.2f ms)\n",
+                    g.peers[i].addr, (double)g.peers[i].rtt_us / 1000.0);
         else
             fprintf(stderr, "[lumabri] peer %s: rtt %.2f ms\n",
                     g.peers[i].addr, (double)g.peers[i].rtt_us / 1000.0);
@@ -1237,7 +1262,7 @@ static uint8_t *peer_fetch(RPeer *p, const char *rel, uint64_t off, uint32_t len
         int fd = p->nidle ? p->idle[--p->nidle] : -1;
         pthread_mutex_unlock(&p->lk);
         if (fd < 0) {
-            fd = lmb_connect_ms(p->addr, 2500);
+            fd = lmb_connect_ms(p->dial[0] ? p->dial : p->addr, 2500);
             if (fd < 0) return NULL;             /* unreachable: relay decides */
             if (lmb_auth(fd)) { lmb_close(fd); return NULL; }
         }


### PR DESCRIPTION
The CAS twin of #103. Role 4 (chat + disk + compute) on one NAT'd machine advertised its maintainer at the public IP; the shim could not dial it from inside (no hairpin), wrote its own donor off as relay-only, and read bytes sitting on its own disk by a round trip through the tracker.

Same recipe as #103: when the advertised address is undialable at probe time, knock on `127.0.0.1:<same port>` (bounded 500 ms); if it answers, the peer gets a loopback dial override. Identity and telemetry keep the advertised address; sockets go to disk distance. CAS blocks are hash-verified against the signed inventory downstream, so a wrong local service can only fail, never lie.

## Verification

- `cas_test` grows a **hairpin stage**: a maintainer advertised at the broadcast address (instant refusal on every platform) with the real listener on loopback — a fresh mirror must adopt it and rebuild with **no relay**: `HAIRPIN CAS: PASS (own donor read on loopback, no relay)`;
- `cas_test` / `donate_test` / `signed_donor_test` green on the branch;
- `deploy/NAT.md`: the shortcut, plus the honest note that a fleet under one owner can put its machines in a WireGuard/Tailscale mesh and skip the relay entirely — lumabri needs nothing beyond outbound TCP either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)