### PR TITLE
fix(segment): the fallback flag outranks probed latency in route choice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,6 @@ jobs:
           OLMOE_EDGE_MODEL=../colibri/c/olmoe_tiny_merged \
           SEGMENT_NODE_BIN=./segment_node SEGMENT_CHAT_BIN=./segment_chat \
             bash ./segment_failover_test.sh
+          OLMOE_EDGE_MODEL=../colibri/c/olmoe_tiny_merged \
+          SEGMENT_NODE_BIN=./segment_node SEGMENT_CHAT_BIN=./segment_chat \
+            bash ./segment_priority_test.sh

--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,9 @@ test-segment-relay-real: tracker segment-direct
 test-segment-failover-real: tracker segment-direct
 	bash ./segment_failover_test.sh
 
+test-segment-priority-real: tracker segment-direct
+	bash ./segment_priority_test.sh
+
 test-relay-exec: tracker expert_node test_relay_exec fixture
 	bash ./relay_exec_test.sh
 

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -204,8 +204,18 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 entry->advert.layer_end > layers ||
                 entry->advert.max_context < required_context ||
                 entry->advert.max_rows < required_rows) continue;
-            uint64_t own_fallback =
-                entry->advert.flags & LMB_SEG_ADVERT_FALLBACK
+            /* --fallback means "my compute streams from disk: use me only
+             * when nothing resident covers these layers". predicted_us
+             * measures the NETWORK, not the compute — ranking by it first
+             * meant a probed disk-streaming origin beat a resident donor
+             * whose relay route keeps an unprobed prior forever, and the
+             * donor never played (observed in the field). Fallback layers
+             * now outrank latency; an unreachable donor (circuit open,
+             * sentinel prediction) counts as fallback so a dead replica
+             * cannot outrank a healthy origin. */
+            int degraded = (entry->advert.flags & LMB_SEG_ADVERT_FALLBACK) ||
+                           entry->predicted_us >= UINT64_MAX / 4u;
+            uint64_t own_fallback = degraded
                     ? entry->advert.layer_end - entry->advert.layer_begin : 0;
             uint64_t own_load = (uint64_t)entry->advert.queue_depth +
                                 entry->advert.inflight;
@@ -213,13 +223,13 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 (entry->transport & LMB_SEG_TRANSPORT_DIRECT ? 50000u : 120000u) *
                 (own_load + 1u);
             if (entry->advert.layer_end == layers) {
-                if (!viable[i] || own_completion < completion_us[i] ||
-                    (own_completion == completion_us[i] &&
-                     own_fallback < fallback_layers[i]) ||
-                    (own_completion == completion_us[i] &&
-                     own_fallback == fallback_layers[i] && 1 < hops[i]) ||
-                    (own_completion == completion_us[i] &&
-                     own_fallback == fallback_layers[i] && hops[i] == 1 &&
+                if (!viable[i] || own_fallback < fallback_layers[i] ||
+                    (own_fallback == fallback_layers[i] &&
+                     own_completion < completion_us[i]) ||
+                    (own_fallback == fallback_layers[i] &&
+                     own_completion == completion_us[i] && 1 < hops[i]) ||
+                    (own_fallback == fallback_layers[i] &&
+                     own_completion == completion_us[i] && hops[i] == 1 &&
                      own_load < load_cost[i])) {
                     viable[i] = 1;
                     completion_us[i] = own_completion;
@@ -243,14 +253,14 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                     UINT64_MAX - own_completion ? UINT64_MAX :
                     own_completion + completion_us[j];
                 uint32_t candidate_hops = 1 + hops[j];
-                if (!found || candidate_completion < best_completion ||
-                    (candidate_completion == best_completion &&
-                     candidate_fallback < best_fallback) ||
-                    (candidate_completion == best_completion &&
-                     candidate_fallback == best_fallback &&
+                if (!found || candidate_fallback < best_fallback ||
+                    (candidate_fallback == best_fallback &&
+                     candidate_completion < best_completion) ||
+                    (candidate_fallback == best_fallback &&
+                     candidate_completion == best_completion &&
                      candidate_hops < best_hops) ||
-                    (candidate_completion == best_completion &&
-                     candidate_fallback == best_fallback &&
+                    (candidate_fallback == best_fallback &&
+                     candidate_completion == best_completion &&
                      candidate_hops == best_hops &&
                      candidate_load < best_load)) {
                     found = 1;
@@ -261,14 +271,14 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 }
             }
             if (found) {
-                if (!viable[i] || best_completion < completion_us[i] ||
-                    (best_completion == completion_us[i] &&
-                     best_fallback < fallback_layers[i]) ||
-                    (best_completion == completion_us[i] &&
-                     best_fallback == fallback_layers[i] &&
+                if (!viable[i] || best_fallback < fallback_layers[i] ||
+                    (best_fallback == fallback_layers[i] &&
+                     best_completion < completion_us[i]) ||
+                    (best_fallback == fallback_layers[i] &&
+                     best_completion == completion_us[i] &&
                      best_hops < hops[i]) ||
-                    (best_completion == completion_us[i] &&
-                     best_fallback == fallback_layers[i] &&
+                    (best_fallback == fallback_layers[i] &&
+                     best_completion == completion_us[i] &&
                      best_hops == hops[i] && best_load < load_cost[i])) {
                     viable[i] = 1;
                     completion_us[i] = best_completion;
@@ -292,24 +302,24 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
                 candidate->advert.layer_end > layers) continue;
             if (!best) { best = candidate; continue; }
             uint32_t best_index = (uint32_t)(best - snapshot->entries);
-            if (completion_us[i] < completion_us[best_index] ||
-                (completion_us[i] == completion_us[best_index] &&
-                 fallback_layers[i] < fallback_layers[best_index]) ||
-                (completion_us[i] == completion_us[best_index] &&
-                 fallback_layers[i] == fallback_layers[best_index] &&
+            if (fallback_layers[i] < fallback_layers[best_index] ||
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 completion_us[i] < completion_us[best_index]) ||
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 completion_us[i] == completion_us[best_index] &&
                  hops[i] < hops[best_index]) ||
-                (completion_us[i] == completion_us[best_index] &&
-                 fallback_layers[i] == fallback_layers[best_index] &&
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 completion_us[i] == completion_us[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] < load_cost[best_index]) ||
-                (completion_us[i] == completion_us[best_index] &&
-                 fallback_layers[i] == fallback_layers[best_index] &&
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 completion_us[i] == completion_us[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] == load_cost[best_index] &&
                  (candidate->transport & LMB_SEG_TRANSPORT_DIRECT) &&
                  !(best->transport & LMB_SEG_TRANSPORT_DIRECT)) ||
-                (completion_us[i] == completion_us[best_index] &&
-                 fallback_layers[i] == fallback_layers[best_index] &&
+                (fallback_layers[i] == fallback_layers[best_index] &&
+                 completion_us[i] == completion_us[best_index] &&
                  hops[i] == hops[best_index] &&
                  load_cost[i] == load_cost[best_index] &&
                  !!(candidate->transport & LMB_SEG_TRANSPORT_DIRECT) ==
@@ -916,15 +926,22 @@ static int recovery_route_better(const LmbSegRouteEntry *candidate,
                             current->advert.peer_name);
     if (candidate_same != best_same)
         return prefer_same ? candidate_same : !candidate_same;
+    /* Fallback rank above latency, same reasoning as select_chain: the
+     * flag describes the COMPUTE (streams from disk), predicted_us only
+     * the network. An unreachable candidate ranks as fallback so a dead
+     * resident replica cannot outrank a live origin. */
+    int candidate_fallback =
+        !!(candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK) ||
+        candidate->predicted_us >= UINT64_MAX / 4u;
+    int best_fallback = !!(best->advert.flags & LMB_SEG_ADVERT_FALLBACK) ||
+        best->predicted_us >= UINT64_MAX / 4u;
+    if (candidate_fallback != best_fallback)
+        return candidate_fallback < best_fallback;
     if (candidate->predicted_us != best->predicted_us)
         return candidate->predicted_us < best->predicted_us;
     int candidate_direct = !!(candidate->transport & LMB_SEG_TRANSPORT_DIRECT);
     int best_direct = !!(best->transport & LMB_SEG_TRANSPORT_DIRECT);
-    if (candidate_direct != best_direct) return candidate_direct;
-    int candidate_fallback =
-        !!(candidate->advert.flags & LMB_SEG_ADVERT_FALLBACK);
-    int best_fallback = !!(best->advert.flags & LMB_SEG_ADVERT_FALLBACK);
-    return candidate_fallback < best_fallback;
+    return candidate_direct > best_direct;
 }
 
 static int conversation_recover_attempt(

--- a/segment_priority_test.sh
+++ b/segment_priority_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# The --fallback flag must MEAN something: an origin that streams from disk
+# is chosen only when no resident executor covers its layers. Here the
+# origins are direct (probed, low latency) and marked --fallback; the donor
+# covers 0:2 relay-only (never probed, pessimistic prior). The chain must
+# still put the donor on 0:2 — compute rank beats network rank.
+set -euo pipefail
+cd "$(dirname "$0")"
+: "${OLMOE_EDGE_MODEL:?set OLMOE_EDGE_MODEL}"
+SEGMENT_NODE_BIN=${SEGMENT_NODE_BIN:-./segment_node}
+SEGMENT_CHAT_BIN=${SEGMENT_CHAT_BIN:-./segment_chat}
+TRACKER_BIN=${TRACKER_BIN:-./tracker}
+T=$(mktemp -d /tmp/lumabri-seg-priority.XXXXXX)
+PIDS=()
+cleanup() {
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        for log in "$T"/*.log; do
+            [ -f "$log" ] && { echo "--- $log" >&2; tail -40 "$log" >&2; }
+        done
+    fi
+    kill "${PIDS[@]}" 2>/dev/null || true
+    rm -rf "$T"
+}
+trap cleanup EXIT
+export LUMABRI_PEER_BINDINGS="$T/bindings"
+root=$(printf '%064x' 4); tok=$(printf '%064x' 20)
+E=(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY=$T/n.k LUMABRI_KNOWN_HOSTS=$T/n.h)
+
+env LUMABRI_PEER_KEY=$T/t.k LUMABRI_KNOWN_HOSTS=$T/t.h \
+    "$TRACKER_BIN" --port 8086 --peer-bindings $T/b >$T/tracker.log 2>&1 &
+PIDS+=($!)
+sleep 1
+start_node() { # name range port fallback... extra
+    local name=$1 range=$2 port=$3; shift 3
+    "${E[@]}" "$SEGMENT_NODE_BIN" --engine olmoe --model-dir "$OLMOE_EDGE_MODEL" \
+      --model tiny --range $range --port $port --tracker 127.0.0.1:8086 \
+      --name $name --model-root $root --tokenizer-root $tok \
+      --context 64 --max-rows 16 --sessions 4 "$@" >$T/$name.log 2>&1 &
+    PIDS+=($!)
+}
+# origins: direct, probed, marked fallback — they cover everything
+start_node origin-left  0:2 8087 --advertise 127.0.0.1:8087 --fallback
+start_node origin-right 2:4 8088 --advertise 127.0.0.1:8088 --fallback
+# the resident donor: covers 0:2, RELAY-ONLY (advertised address refuses
+# instantly), never probed — the pessimistic-prior case from the field
+start_node donor-left   0:2 8089 --advertise 255.255.255.255:8089
+sleep 5
+
+"${E[@]}" LUMABRI_SEGMENT_DEBUG_ROUTES=1 "$SEGMENT_CHAT_BIN" --engine olmoe \
+  --model-dir "$OLMOE_EDGE_MODEL" --model tiny --tracker 127.0.0.1:8086 \
+  --model-root $root --tokenizer-root $tok \
+  --prompt-ids 3,11,29,7,41,19 --tokens 2 \
+  --context 64 --max-rows 16 >$T/chat.out 2>&1 || {
+    cat $T/chat.out; echo "chat failed"; exit 1; }
+chain=$(grep -a "route generation" $T/chat.out | head -1)
+echo "$chain" | grep -q "donor-left\[0:2\]" || {
+    echo "the chain ignored the resident donor and rode the fallback origin:"
+    echo "$chain"; exit 1
+}
+echo "$chain" | grep -q "origin-left" && {
+    echo "origin-left is in the chain although donor-left is resident:"
+    echo "$chain"; exit 1
+}
+echo "SEGMENT PRIORITY: PASS (resident relay donor outranks direct fallback origin)"


### PR DESCRIPTION
## Observed live on the swarm

A RAM-resident Segment donor behind NAT (layers 10:21 on a 100 GB box) never received a single call, while the disk-streaming `--fallback` origin served every conversation. Root cause: route selection ranks `predicted_us` first, but `predicted_us` measures the **network**, not the compute — and a relay-only route is never probed, so it keeps a pessimistic prior forever. A ~50 ms probed origin with seconds-per-token compute beat a ~250 ms total resident donor, always, and the fallback flag (deliberately last) never fired.

## The change

Fallback-ridden layers now outrank completion time in `select_chain` (all four comparison sites) and in `recovery_route_better`. One guard keeps it safe: an unreachable candidate (circuit open → sentinel prediction) counts as fallback, so a dead resident replica can never outrank a live origin. All-fallback and all-resident swarms are byte-identical in behaviour; only the mixed case — the broken one — changes.

## Honest limits & follow-ups

The flag is a binary proxy for a continuous quantity. Two follow-ups make this principled and are filed as next work:
1. executors advertise their **measured per-RUN compute** so `completion` can rank total cost (network + compute) honestly — then latency-first ordering becomes correct again and the flag returns to tiebreak;
2. segment donors **preload their range before advertising** (expert donors already warm-before-announce), so the first engagement doesn't pay a cold multi-GB load.

A resident donor on a genuinely broken link degrades as before: its RUNs fail, the circuit opens, it ranks as fallback, and the origin takes over.

## Verification

- new `segment_priority_test.sh`: probed direct origins marked `--fallback` vs a resident relay-only donor (advertised at an instantly-refusing address, never probed) → the chain must put the donor on its range. **4/4 green**, and the pre-fix binary **fails** it ('the chain ignored the resident donor') — mutation-checked;
- `segment_failover_test.sh` 3/3 green (no recovery regression);
- gate wired into `make test-segment-priority-real` and the CI failover step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)