### PR TITLE
feat(segment): print who served each turn

### DIFF
--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1794,6 +1794,15 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
             if (!bad && !stream.emitted_bytes)
                 (void)serve_generation_event(&stream, GEN_EVENT_DATA,
                                              0, 0, NULL, 0);
+            /* Who actually served this turn — printed EVERY turn, from the
+             * conversation's live chain (recovery may have moved it mid-
+             * generation). Users kept having to play detective across
+             * /swarm and node logs to learn where their tokens went; the
+             * answer belongs in the engine tail, one line per turn. */
+            if (!bad && conversation.active)
+                route_print(stderr, "[segment-route] turn served by",
+                            &snapshot, conversation.chain,
+                            conversation.chain_count);
         }
         free(prompt);
         if (bad) {


### PR DESCRIPTION
The route line printed once at chain open and scrolled out of the /debug tail within seconds; knowing where your tokens went required /swarm timing tricks and pidstat on the donor. Every completed turn now ends with one line built from the conversation's **live** chain (recovery may have moved it mid-generation):

```
[segment-route] turn served by …: host[0:10](fallback) -> donor-poweredget430[10:21] -> …
```

Print-only change. Failover and priority gates green (the new line coexists with the diagnostics they grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)