### PR TITLE
fix(serve): one RAM budget for the whole server; DeepSeek --exec-cache counts experts, not experts per layer

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -305,9 +305,18 @@ and the Segment origin ranges. A public deployment should advertise direct
 endpoints under `YOUR_SERVER_IP`; a NAT deployment explicitly reports
 `data plane relay` and needs no public Segment endpoint.
 
-`--exec-cache 256` is the RAM/SSD trade: 256 expert slots resident, the
-rest streamed from disk on demand. Raise it if the box has spare RAM (the
-log prints the hit rate), lower it if it swaps.
+`--exec-cache 256` is the RAM/SSD trade: 256 experts resident in the whole
+executor, the rest streamed from disk on demand. Raise it if the box has
+spare RAM (the log prints the hit rate and, for DeepSeek, the resulting GB),
+lower it if it swaps. Size it from the expert, not the slot count: a
+DeepSeek V4 Flash expert is ~15 MB with headroom, so `--exec-cache 1800` is
+about 27 GB, and the store keeps at least top-k experts per layer (258 on
+V4-Flash) whatever you pass. `serve` subtracts this figure from the RAM it
+offers the Segment origin slices, and a slice whose layer range does not fit
+its share resident is not started (exit code 3, not restarted): on a box
+smaller than the model you get storage plus the streaming executor, which is
+the honest capacity, instead of five caches of the same experts fighting for
+one RAM.
 
 ---
 
@@ -562,5 +571,5 @@ Two things worth knowing:
 | client says `not signed by the operator key` | server not started with `--key`, or a different key than the client's `LUMABRI_PUBKEY` |
 | `engine not found` after Segment fallback | install the classic Colibri engine or pass `--engines-dir /path/to/colibri/c` |
 | tracker logs `REJECTED: ... unsigned` | a peer joined a signed swarm without signed truth — that is the defence working |
-| expert cache hit rate very low | raise `--exec-cache`; each slot is one expert of RAM |
+| expert cache hit rate very low | raise `--exec-cache`; each slot is one expert of RAM (~15 MB on DeepSeek V4 Flash), spread over the layers |
 | first start takes minutes | hashing the model; cached afterwards in `.lumabri_hashes/` |

--- a/expert_engines/deepseek.h
+++ b/expert_engines/deepseek.h
@@ -52,12 +52,14 @@ static uint64_t lmbe_resident_nbytes;
 static const char *lmbe_engine_name(void) { return "deepseek_v4"; }
 static int lmbe_effective_bits(int bits) { (void)bits; return 0; }
 
-/* `cap` is expert slots; the store wants bytes, so it is scaled by the
- * record size the store itself reports back through its stats. Before that
- * is known, ask for cap × a generous per-expert estimate and let the store
- * clamp: it refuses anything under its own minimum and says so. */
-static void lmbe_open(const char *dir, int cap, int bits) {
-    (void)bits;                       /* V4 experts are fp4 on disk, as shipped */
+/* The store wants bytes and thinks per layer: colibri turns `cache_bytes`
+ * into `cache_bytes / (layers * record)` slots for EVERY layer. Lumabri's
+ * `--cache N` (and `serve --exec-cache N`) means N experts for the whole
+ * node, like every other glue, so N is spread over the layers here. The
+ * old code multiplied by the layer count instead: `--exec-cache 128` on the
+ * 43-layer V4-Flash was 5504 experts (~69 GB) and 1800 was the entire
+ * expert set, which is how a 64 GB server filled its RAM and died. */
+static void lmbe_open_per_layer(const char *dir, int slots_per_layer) {
     char err[512] = "";
     if (coli_v4_config_load(&lmbe_cfg, dir, err, sizeof err)) {
         fprintf(stderr, "[lumabri] %s\n", err[0] ? err : "cannot read the V4 config");
@@ -68,12 +70,13 @@ static void lmbe_open(const char *dir, int cap, int bits) {
     /* One fp4 expert is three matrices of moe_intermediate × hidden at half a
      * byte, plus the block scales — a fifth over is enough headroom, and the
      * store refuses anything under six live experts per layer (top-k), so
-     * that is the floor `--cache` cannot go below. */
+     * that is the floor the budget cannot go below. */
     uint64_t per_expert = (uint64_t)lmbe_cfg.moe_intermediate_size *
                           (uint64_t)lmbe_cfg.hidden_size * 3 / 2;
     per_expert += per_expert / 5;
-    int slots = cap > 0 ? cap : 8;
+    int slots = slots_per_layer > 0 ? slots_per_layer : 8;
     if (slots < lmbe_cfg.num_experts_per_tok) slots = lmbe_cfg.num_experts_per_tok;
+    if (slots > lmbe_cfg.n_routed_experts) slots = lmbe_cfg.n_routed_experts;
     ColiDeepSeekV4ExpertStoreOptions o = {
         .model_dir = dir,
         .layers = lmbe_cfg.num_hidden_layers,
@@ -87,6 +90,26 @@ static void lmbe_open(const char *dir, int cap, int bits) {
         fprintf(stderr, "[lumabri] expert store: %s\n", err);
         exit(1);
     }
+    fprintf(stderr, "[lumabri] expert store: %d slot%s per layer × %d layers "
+                    "= %d experts, up to %.1f GB of RAM\n",
+            slots, slots == 1 ? "" : "s", lmbe_cfg.num_hidden_layers,
+            slots * lmbe_cfg.num_hidden_layers,
+            (double)o.cache_bytes / 1e9);
+}
+
+/* `cap` is the node's total expert slots (`--cache N`); 0 means a small
+ * default. It is divided over the layers, rounding up, and the top-k floor
+ * per layer means a V4-Flash node holds at least 6 × 43 = 258 experts. */
+static void lmbe_open(const char *dir, int cap, int bits) {
+    (void)bits;                       /* V4 experts are fp4 on disk, as shipped */
+    char err[512] = "";
+    if (coli_v4_config_load(&lmbe_cfg, dir, err, sizeof err)) {
+        fprintf(stderr, "[lumabri] %s\n", err[0] ? err : "cannot read the V4 config");
+        exit(1);
+    }
+    int layers = lmbe_cfg.num_hidden_layers > 0 ? lmbe_cfg.num_hidden_layers : 1;
+    int per_layer = cap > 0 ? (cap + layers - 1) / layers : 0;
+    lmbe_open_per_layer(dir, per_layer);
 }
 
 /* READY means every assigned key already has a RAM slot. Re-open Colibri's
@@ -105,7 +128,7 @@ static int lmbe_resident_prepare(const uint8_t *holds, int layers,
     if (lmbe_store && lmbe_store->ops && lmbe_store->ops->destroy)
         lmbe_store->ops->destroy(lmbe_store);
     lmbe_store = NULL;
-    lmbe_open(lmbe_model_dir, max_per_layer, 0);
+    lmbe_open_per_layer(lmbe_model_dir, max_per_layer);
     for (int l = 0; l < layers; l++)
         for (int e = 0; e < experts; e++) {
             if (!holds[l * experts + e]) continue;

--- a/lumabri.c
+++ b/lumabri.c
@@ -419,6 +419,32 @@ static int local_model_layers(const char *model_dir, uint32_t *layers) {
     return local_model_u32(model_dir, "num_hidden_layers", layers);
 }
 
+/* RAM the classic expert executor will grow into. It is spawned before the
+ * Segment slices and sized by --exec-cache alone, so unless its residency is
+ * subtracted here the Segment budget is computed against memory the executor
+ * is about to fill: two caches of the same experts, both sized to "all the
+ * free RAM", on one box. DeepSeek V4 is the family whose executor holds no
+ * dense weights and whose expert size is fixed by config.json, so it can be
+ * estimated exactly; the other glues run a full engine and are left at 0
+ * (unknown), which keeps the old behaviour rather than inventing a number. */
+static uint64_t expert_executor_ram_estimate(const char *model_dir,
+                                             const char *model_type,
+                                             int cache_slots) {
+    uint32_t inter = 0, hidden = 0, layers = 0, topk = 0;
+    if (!model_type || !strstr(model_type, "deepseek")) return 0;
+    if (local_model_u32(model_dir, "moe_intermediate_size", &inter) ||
+        local_model_u32(model_dir, "hidden_size", &hidden) ||
+        local_model_layers(model_dir, &layers))
+        return 0;
+    if (local_model_u32(model_dir, "num_experts_per_tok", &topk)) topk = 6;
+    uint64_t per_expert = (uint64_t)inter * hidden * 3 / 2;
+    per_expert += per_expert / 5;                 /* the glue's own headroom */
+    uint64_t slots = cache_slots > 0 ? (uint64_t)cache_slots : 8;
+    uint64_t floor = (uint64_t)topk * layers;     /* the store's per-layer minimum */
+    if (slots < floor) slots = floor;
+    return per_expert * slots + ((uint64_t)1 << 30);   /* + 1 GiB of workspace */
+}
+
 /* A server with a real public IPv4 should need no networking flag. Private,
  * loopback, link-local and CGNAT addresses are deliberately not guessed:
  * publishing one to an Internet swarm would create a "complete" Segment
@@ -504,6 +530,8 @@ static int serve_port_available(int port) {
 }
 
 static void serve_watch_start(const char *tracker, const char *model);
+
+static uint64_t du_bytes(const char *path, int depth);
 
 static int cmd_serve(int argc, char **argv) {
     const char *model = NULL, *join = NULL, *mname = NULL, *donate = NULL;
@@ -612,6 +640,16 @@ static int cmd_serve(int argc, char **argv) {
     uint64_t segment_available = serve_profile.ram_available_bytes;
     uint64_t segment_min_free = (uint64_t)lmb_env_int(
         "LUMABRI_SEGMENT_MIN_FREE_MB", 8192, 1024, 262144) << 20;
+    uint64_t exec_estimate = 0;
+    if (!disk_donor && !no_exec && node && access(exec_bin, X_OK) == 0)
+        exec_estimate = expert_executor_ram_estimate(model, mtype, cache_slots);
+    if (exec_estimate && segment_available) {
+        printf("  %sl'esecutore di esperti crescera' fino a ~%.1f GB "
+               "(--exec-cache %d): li tolgo dal budget Segment%s\n", C_DIM,
+               (double)exec_estimate / 1e9, cache_slots, C_R);
+        segment_available = segment_available > exec_estimate
+                          ? segment_available - exec_estimate : 1;
+    }
     int segment_candidate = !disk_donor && !no_exec && segment_engine &&
         segment_model && access(segment_bin, X_OK) == 0 &&
         local_model_layers(model, &segment_layers) == 0 &&
@@ -808,6 +846,12 @@ static int cmd_serve(int argc, char **argv) {
         snprintf(run_wait_text, sizeof run_wait_text, "%d", run_wait_ms);
         uint64_t total_budget = segment_available > segment_min_free
                               ? segment_available - segment_min_free : 0;
+        uint64_t origin_model_bytes = du_bytes(model, 0);
+        char origin_model_text[32], origin_layers_text[16];
+        snprintf(origin_model_text, sizeof origin_model_text, "%llu",
+                 (unsigned long long)origin_model_bytes);
+        snprintf(origin_layers_text, sizeof origin_layers_text, "%u",
+                 segment_layers);
         uint64_t slice_budget_mb = (total_budget / (uint64_t)chunks) >> 20;
         if (!slice_budget_mb) slice_budget_mb = 1;
         snprintf(memory_text, sizeof memory_text, "%llu",
@@ -851,6 +895,15 @@ static int cmd_serve(int argc, char **argv) {
             sargv[a++] = "--run-queue";    sargv[a++] = run_queue_text;
             sargv[a++] = "--run-wait-ms";  sargv[a++] = run_wait_text;
             sargv[a++] = "--memory-limit-mb"; sargv[a++] = memory_text;
+            /* A donor is refused a range it cannot hold resident; the origin
+             * used to skip that check and open the engine anyway, which on a
+             * model larger than the box meant every slice streamed experts
+             * from disk into a cache that outgrew its budget, went DRAINING
+             * and stayed there. Same check, same exit code 3, no restart. */
+            if (origin_model_bytes) {
+                sargv[a++] = "--model-bytes";  sargv[a++] = origin_model_text;
+                sargv[a++] = "--model-layers"; sargv[a++] = origin_layers_text;
+            }
             sargv[a++] = "--advertise";    sargv[a++] = sadv;
             sargv[a] = NULL;
             char slog[1200];
@@ -914,7 +967,18 @@ static int cmd_serve(int argc, char **argv) {
         if (p < 0) break;
         int idx = -1;
         for (int i = 0; i < g_nchildren; i++) if (g_children[i] == p) idx = i;
-        if (idx >= 0 && g_cargv[idx] && !g_stopping) {
+        if (idx >= 0 && g_cargv[idx] && !g_stopping &&
+            WIFEXITED(status) && WEXITSTATUS(status) == 3) {
+            /* segment_node exit 3: the assigned range does not fit the RAM
+             * budget. Restarting it every 5 s would only repeat the refusal
+             * (and, before the check existed, reload a slice into a box that
+             * is already full). The expert executor and storage stay up. */
+            printf("\n%s%s non parte: la fetta non entra nel budget RAM di "
+                   "questa macchina (vedi il suo log). Non lo riavvio; "
+                   "storage ed esperti restano attivi.%s\n",
+                   C_RED, g_cwhat[idx], C_R);
+            fflush(stdout);
+        } else if (idx >= 0 && g_cargv[idx] && !g_stopping) {
             /* Losing a child silently is the expensive failure: with the
              * executor gone every chatter falls back to downloading experts
              * and nothing anywhere says why. Name it, and bring it back. */


### PR DESCRIPTION
## Why

A 64 GB server holding a 167 GB DeepSeek V4 Flash fills its RAM and dies, faster with two chatters than one. Three verified causes, all on the server side:

1. **`--exec-cache N` meant N experts *per layer* on DeepSeek only.** `expert_engines/deepseek.h` handed colibri `cache_bytes = per_expert × N × layers`; colibri's store divides by `layers × record` to get slots per layer. So the default `128` was ~5500 experts (~69 GB) and `1800` was the entire 137 GB expert set. Every other glue counts experts for the whole node. Now N is spread over the layers (top-k floor per layer, 258 on V4-Flash) and the store logs the resulting GB at open.
2. **`serve` sized two caches of the same experts against the same free RAM.** It probed MemAvailable once, spawned the expert executor without counting it, then split `(available − 8 GB) / 4` between the Segment origin slices. The executor's expected residency (exact for DeepSeek from `config.json`; 0 = unknown for the full-engine glues, i.e. unchanged) is now subtracted first, and printed.
3. **Origin slices skipped the "does this range fit resident" check** that donors get (`--model-bytes` / `--model-layers`, exit 3). On a model larger than the box each slice streamed experts from disk into a cache that outgrew its budget (the DeepSeek Segment adapter spends the whole `memory_limit` on expert slots), tripped `process_budget_exhausted`, and advertised DRAINING for good; the supervisor restarted anything that died every 5 s. Origin slices now get the same check, and a child exiting 3 is reported once and **not restarted**; storage and the streaming executor stay up.

## Verified

- `serve_failfast_test.sh`, `swarm_fed_exec_test.sh`, `phase2_test.sh` pass; `make check-warnings` clean.
- `serve` on the fixture still starts the four origin slices.
- With `LUMABRI_SEGMENT_MIN_FREE_MB` squeezing the budget, the four slices exit 3 once ("assigned range 0:4 needs about 0.2 GB but the donor budget is 0.1 GB") and are not respawned; `/swarm` shows storage + expert executor.

## Operator impact

On 148.251.4.122 (64 GB, V4-Flash) after this: `--exec-cache 1800` ≈ 27 GB instead of "everything"; the Segment origin will (correctly) decline to start because a quarter of a 167 GB model does not fit a ~10 GB slice budget, so the box serves storage + the SSD-streaming expert executor until donors with RAM take the ranges. DEPLOY.md updated accordingly.
