### PR TITLE
feat: the expert swarm comes first, RAM beats disk, and a joining machine donates by itself

### DIFF
--- a/PROTOCOL_COMPATIBILITY.md
+++ b/PROTOCOL_COMPATIBILITY.md
@@ -13,6 +13,7 @@ Changing one payload never permits silently reinterpreting another.
 | Segment assignment | `GSA1` / 2 | release/retry assignment, never guess a range |
 | Expert stats capability | `ECAP` / 1, `EST1` / 2 | fall back to legacy registration without stats |
 | swarm execution/detail | `SWX1` / 1, detail 2 | omit unavailable telemetry, not compute identity |
+| executor residency (`LMB_ERES` 70/71) | additive op | older node answers `ERR`; chatter treats residency as unknown, no penalty |
 
 The model root, engine ID, source/build profile, numeric class, state schema,
 dtype and width are compatibility data rather than decoration. A peer with a

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ tracker-assigned Segment slice when enough spare RAM is available. It publishes
 direct P2P when reachable and otherwise uses the signed outbound Segment relay;
 the finer-grained expert donor remains the lower-memory fallback.
 Both run at low priority and die with the TUI. Nothing to configure — Enter
-picks "just chat".
+picks what this machine can afford: with at least 2 GB of RAM free beyond
+the system reserve it chats **and** donates compute, otherwise it just
+chats. The menu says which before you press it; `1` always means chat only.
 
 `lumabri machine` shows the quick startup profile used for donation: CPU
 model/ISA, physical and logical cores, NUMA, RAM/swap, visible GPU/VRAM, disk,
@@ -221,9 +223,11 @@ the engines your colibri checkout actually has.
 
 The Segment path keeps whole contiguous layer ranges and their sequence state
 resident on peers, reducing the network boundary from one request per
-layer/expert to one request per segment. It is the preferred path of ordinary
-`lumabri chat` when the matching Colibri ABI and a complete compatible route
-exist. GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4 are all release
+layer/expert to one request per segment. Ordinary `lumabri chat` uses it only
+when nobody in the swarm executes experts for the model (or under
+`LUMABRI_SEGMENT_REQUIRED=1`): the expert swarm is the primary data plane,
+because a machine that donates a few hundred resident experts speeds it up,
+while it cannot help a Segment chain at all. GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4 are all release
 gates; OLMoE is not a special-case definition of complete. Build details,
 relay/failover semantics and the remaining operational boundaries are in
 **[SEGMENT_DIRECT.md](SEGMENT_DIRECT.md)**.
@@ -334,8 +338,12 @@ ranges concurrently. Lumabri deliberately does not fuse rows from unrelated
 sessions: current Colibri adapters own opaque per-session state and can round a
 cross-session batch differently. Calling that continuous batching before an
 engine-neutral multi-session batch ABI exists would break the token oracle.
-When two donors hold the *same* expert, the chatter spreads the load between
-them by default (set `LUMABRI_SPREAD=0` for strict nearest-replica routing).
+A replica that holds the expert in RAM is always preferred to one that
+streams it from disk, whatever their RTTs: the origin's `--exec-cache`
+executor is the last resort, so a donor that loaded an expert receives its
+calls the moment it is visible. When two donors hold the *same* expert, the
+chatter spreads the load between them by default (set `LUMABRI_SPREAD=0`
+for strict nearest-replica routing).
 Neither donor needs to know the others exist. Expert requests can fail over to another replica. Stateful
 Segment sessions with compatible replicas checkpoint at turn boundaries; on
 failure the gateway restores an exact-range replica, replays tokens after the

--- a/expert_engines/deepseek.h
+++ b/expert_engines/deepseek.h
@@ -123,6 +123,25 @@ static int lmbe_resident_prepare(const uint8_t *holds, int layers,
 
 static uint64_t lmbe_resident_bytes(void) { return lmbe_resident_nbytes; }
 
+/* Warm one expert into the store's RAM cache (its own LRU, pins included)
+ * so the compute gate is never held across a disk read. A miss here is
+ * not fatal: apply will look it up again and report the real error. */
+static void lmbe_touch(int layer, int eid) {
+    ColiExpertView view = {0};
+    if (!lmbe_store) return;
+    if (coli_expert_lookup(lmbe_store, (ColiExpertKey){layer, eid}, &view)) return;
+    coli_expert_release(lmbe_store, &view);
+}
+
+/* fp4 expert: three moe_intermediate × hidden matrices at half a byte plus
+ * block scales; the same figure lmbe_open budgets with. */
+static uint64_t lmbe_expert_bytes(void) {
+    uint64_t per_expert = (uint64_t)lmbe_cfg.moe_intermediate_size *
+                          (uint64_t)lmbe_cfg.hidden_size * 3 / 2;
+    return per_expert + per_expert / 5;
+}
+#define LMBE_EXPERT_BYTES lmbe_expert_bytes
+
 static int lmbe_n_slots(void)   { return lmbe_cfg.num_hidden_layers; }
 static int lmbe_n_experts(void) { return lmbe_cfg.n_routed_experts; }
 static int lmbe_hidden(void)    { return lmbe_cfg.hidden_size; }

--- a/expert_node.c
+++ b/expert_node.c
@@ -319,6 +319,14 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
      * Keep it visible through configured response delays as those calls still
      * consume end-to-end executor capacity from the chatter's perspective. */
     atomic_fetch_add(&g.in_flight, 1);
+    /* Bring the weights in BEFORE taking the compute gate: a cold expert is a
+     * disk read of tens of milliseconds, and holding the gate across it
+     * turned every cache miss into a stall for every other chatter. The gate
+     * protects the cores, not the SSD. */
+    CSlot *cs = g.ncs ? cache_acquire((int)layer, (int)eid) : NULL;
+#ifdef LMBE_STORE_OWNS_RESIDENCY
+    lmbe_touch((int)layer, (int)eid);
+#endif
     gate_enter();
 
     /* one scratch per connection thread: the kernels are called concurrently */
@@ -331,10 +339,9 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
     size_t obytes = (size_t)want;
     float *out = node_falloc((size_t)nrows * g.hidden);
     double t0 = nowd();
-    if (g.ncs) {
-        CSlot *s = cache_acquire((int)layer, (int)eid);
-        lmbe_apply(&s->slot, (int)layer, (const float *)m->pay, out, (int)nrows, rw, t_scratch);
-        cache_release(s);
+    if (cs) {
+        lmbe_apply(&cs->slot, (int)layer, (const float *)m->pay, out, (int)nrows, rw, t_scratch);
+        cache_release(cs);
     } else {
         lmbe_apply(&g.held[g.index[gid]].slot, (int)layer,
                    (const float *)m->pay, out, (int)nrows, rw, t_scratch);
@@ -485,6 +492,15 @@ static void manifest_build(LmbBuf *b) {
     lmb_buf_u32(b, (uint32_t)g.hidden);
 }
 
+static int handle_eres(int fd) {
+    LmbBuf b = {0};
+    lmb_buf_u32(&b, g.resident_flags);
+    lmb_buf_u32(&b, atomic_load(&g.resident_state));
+    int rc = lmb_send(fd, LMB_ERES_R, b.p, (uint32_t)b.len, NULL, 0);
+    free(b.p);
+    return rc;
+}
+
 static int handle_emanifest(int fd) {
     LmbBuf b = {0};
     manifest_build(&b);
@@ -520,6 +536,7 @@ static void *conn_thread(void *arg) {
         }
         case LMB_EXEC:      rc = handle_exec(fd, &m); break;
         case LMB_EMANIFEST: rc = handle_emanifest(fd); break;
+        case LMB_ERES: rc = handle_eres(fd); break;
         default:            send_err(fd, "unknown op"); rc = -1; break;
         }
         lmb_msg_free(&m);
@@ -1024,6 +1041,21 @@ int main(int argc, char **argv) {
         fprintf(stderr, "[OMP] lumabri: %d physical-core threads instead of %d logical\n",
                 runtime_phys, logical);
     }
+    /* One expert call is one small matmul (a 12 MB fp4 expert on DeepSeek,
+     * a few MB elsewhere); a full-machine OpenMP team spends more time
+     * forking than multiplying, and the admission gate then admits exactly
+     * ONE expert at a time: 258 serialized calls per DeepSeek token, and two
+     * chatters queued behind each other. A small team per call lets several
+     * experts run at once, which is what a layer's top-k arrive as. The
+     * operator's explicit OMP_NUM_THREADS or --parallel still wins. */
+    if (!getenv("OMP_NUM_THREADS") && !getenv("COLI_NO_OMP_TUNE") &&
+        parallel <= 0 && runtime_phys >= 4) {
+        int team = runtime_phys >= 16 ? 4 : 2;
+        omp_set_num_threads(team);
+        fprintf(stderr, "[OMP] lumabri: %d-thread team per expert, %d experts "
+                        "at a time on %d physical cores\n",
+                team, runtime_phys / team, runtime_phys);
+    }
     if (resident && cache > 0) {
         fprintf(stderr, "--resident and --cache are mutually exclusive\n");
         return 2;
@@ -1058,6 +1090,9 @@ int main(int argc, char **argv) {
         double avail_b = avail_kb > reserve_mb * 1024L
             ? (double)(avail_kb - reserve_mb * 1024L) * 1024.0 : 0.0;
         double ebytes = 3.0 * g.inter * g.hidden;     /* same width the cache MB uses */
+#ifdef LMBE_EXPERT_BYTES
+        ebytes = (double)LMBE_EXPERT_BYTES();        /* the glue knows its format */
+#endif
         int total = 0;
         for (int l = 0; l < g.n_slots; l++) if (lmbe_routed(l)) total += g.n_experts;
         long n = ebytes > 0 ? (long)(avail_b / ebytes) : total;

--- a/lumabri.c
+++ b/lumabri.c
@@ -3180,7 +3180,24 @@ static int role_unknown(const char *arg, char *out, size_t cap) {
     return 0;
 }
 
+/* What this machine can donate without being asked: RAM beyond the system
+ * reserve is the only input, read at startup like `serve` reads it. Below
+ * two spare gigabytes a donor would hold too few experts to matter and only
+ * cost the tracker a peer. */
+static double spare_ram_gb(void) {
+    LmbMachineProfile profile;
+    if (lmb_machine_probe(&profile, ".", NULL)) return 0.0;
+    uint64_t reserve = (uint64_t)lmb_env_int(
+        getenv("LUMABRI_EXPERT_RAM_RESERVE_MB") ?
+        "LUMABRI_EXPERT_RAM_RESERVE_MB" : "LUMABRI_RAM_RESERVE_MB",
+        4096, 256, 262144) << 20;
+    if (profile.ram_available_bytes <= reserve) return 0.0;
+    return (double)(profile.ram_available_bytes - reserve) / 1e9;
+}
+
 static int role_pick(Role *r, const char *model, int have_model_dir) {
+    double spare = spare_ram_gb();
+    int auto_compute = spare >= 2.0;
     printf("  %scome entri nello sciame?%s\n\n", C_BOLD, C_R);
     printf("    %s1%s  solo chattare        %snon condividi niente%s\n",
            C_CORAL, C_R, C_DIM, C_R);
@@ -3193,13 +3210,19 @@ static int role_pick(Role *r, const char *model, int have_model_dir) {
         printf("    %s3%s  chatti e doni calcolo %sla tua fetta di esperti "
                "arriva dallo sciame%s\n", C_CORAL, C_R, C_DIM, C_R);
     printf("    %s4%s  tutti e due%s\n", C_CORAL, C_R, C_R);
-    printf("\n  %sinvio = solo chattare%s\n", C_DIM, C_R);
+    if (auto_compute)
+        printf("\n  %sinvio = chatti e doni calcolo: %.0f GB di RAM liberi oltre "
+               "la riserva, ogni esperto che tieni rende lo sciame piu' veloce%s\n",
+               C_DIM, spare, C_R);
+    else
+        printf("\n  %sinvio = solo chattare (%.1f GB liberi oltre la riserva, "
+               "troppo pochi per tenere esperti)%s\n", C_DIM, spare, C_R);
     printf("\n%s\xe2\x94\x82%s %s%s\xe2\x80\xba%s ", C_GRAY, C_R, C_CORAL, C_BOLD, C_R);
     fflush(stdout);
 
     char line[256];
     if (prompt_line(line, sizeof line)) return -1;
-    int c = line[0] ? line[0] : '1';
+    int c = line[0] ? line[0] : (auto_compute ? '3' : '1');
     if (c == 'q') return -1;
     if (c == '2' || c == '4') r->disk = 1;
     if (c == '3' || c == '4') r->compute = 1;
@@ -3241,6 +3264,24 @@ static int free_port(int from) {
         if (fd >= 0) { close(fd); return p; }
     }
     return 0;
+}
+
+/* How many expert executors the tracker knows for this model right now
+ * (origin's --cache executor and resident donors alike). -1 = no answer. */
+static int swarm_executors(const char *tracker, const char *model) {
+    LmbMsg em = {0};
+    LmbBuf eb = {0};
+    lmb_buf_str(&eb, model);
+    int nexec = -1;
+    if (!lmb_request(tracker, LMB_EPEERS, eb.p, (uint32_t)eb.len, &em) &&
+        em.op == LMB_EPEERS_R) {
+        LmbCur ec = { em.body, em.body_len, 0 };
+        uint32_t n = 0;
+        if (!lmb_cur_u32(&ec, &n)) nexec = (int)n;
+    }
+    free(eb.p);
+    lmb_msg_free(&em);
+    return nexec;
 }
 
 /* Prefer one tracker-assigned Segment slice when this chat is already using
@@ -3640,14 +3681,28 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
      * signed mirror, then discovery either publishes READY or exits.  Exiting
      * before READY is an ordinary coverage miss, not a chat failure; the
      * unchanged expert/local engine starts immediately afterwards. */
-    if (!local_dir && !getenv("LUMABRI_NO_SEGMENT")) {
+    /* The expert swarm is the data plane of this project: dense weights and
+     * the KV cache stay here, every routed expert runs on whichever peer
+     * holds it in RAM, and each machine that joins adds resident experts and
+     * therefore speed. A Segment chain keeps whole layer ranges and their
+     * state on a few large peers instead, where a small donor cannot help
+     * at all. So Segment is tried only when nobody executes experts for this
+     * model (or when the operator insists with LUMABRI_SEGMENT_REQUIRED);
+     * otherwise the expert path starts at once. */
+    int executors = local_dir ? -1 : swarm_executors(tracker, model);
+    if (executors > 0 && !getenv("LUMABRI_SEGMENT_REQUIRED"))
+        printf("  %s%d esecutor%s di esperti nello sciame: dense e KV restano "
+               "qui, gli esperti girano sui peer%s\n", C_DIM, executors,
+               executors == 1 ? "e" : "i", C_R);
+    if (!local_dir && !getenv("LUMABRI_NO_SEGMENT") &&
+        (executors <= 0 || getenv("LUMABRI_SEGMENT_REQUIRED"))) {
         char self[1024], segment_bin[1200];
         exe_dir(self, sizeof self);
         snprintf(segment_bin, sizeof segment_bin, "%s/segment_chat", self);
         if (access(segment_bin, X_OK) == 0 &&
             segment_engine_for(mtype) != NULL) {
-            printf("  %sprovo una catena Segment completa; se manca uso "
-                   "automaticamente expert/CAS%s\n", C_DIM, C_R);
+            printf("  %snessun esecutore di esperti: provo una catena Segment "
+                   "completa, altrimenti expert/CAS%s\n", C_DIM, C_R);
             if (!segment_engine_spawn(segment_bin, shim, tracker, model,
                                       mtype, ctx, e)) {
                 g_eng.booting = 1;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -69,6 +69,10 @@ typedef struct {
     LmbLatencyPredictor latency;
     uint32_t inflight;
     uint64_t exec_observations, exec_observations_at_probe;
+    /* 1: its experts are resident in RAM; 0: it streams them from disk (the
+     * origin's --cache executor); -1: not known (older node, or reached only
+     * through the tracker tunnel). Only a known disk replica is penalized. */
+    int resident;
 } LumiPeer;
 
 static struct {
@@ -508,8 +512,25 @@ static int lumi_add_peer(const char *addr) {
     }
     lmb_predict_observe(&p->latency, (uint64_t)p->rtt_us);
     p->exec_observations_at_probe = p->exec_observations;
-    fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms\n",
-            p->addr, n, claimed, (double)p->rtt_us / 1000.0);
+    /* RAM or disk? Asked once, directly (a tunnel-only peer stays unknown,
+     * and a donor behind NAT is a resident donor in practice). */
+    p->resident = -1;
+    if (!p->relay_target[0]) {
+        LmbMsg rm = {0};
+        const char *dial = p->loopback[0] ? p->loopback : p->addr;
+        if (!lmb_request(dial, LMB_ERES, NULL, 0, &rm) && rm.op == LMB_ERES_R) {
+            LmbCur rc = { rm.body, rm.body_len, 0 };
+            uint32_t flags = 0;
+            if (!lmb_cur_u32(&rc, &flags))
+                p->resident = (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
+        }
+        lmb_msg_free(&rm);
+    }
+    fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms · %s\n",
+            p->addr, n, claimed, (double)p->rtt_us / 1000.0,
+            p->resident == 1 ? "experts in RAM" :
+            p->resident == 0 ? "experts streamed from disk (last resort)" :
+                               "residency unknown");
     if (reprobe < 0) L.npeers++;
     return 0;
 }
@@ -825,6 +846,22 @@ static uint32_t lumi_hash_gid(int gid) {   /* fnv1a over the (layer,expert) id *
  * whenever the band has one member, nothing is near-equal, or the best is still
  * unprobed (LONG_MAX), which also keeps the percentage arithmetic from
  * overflowing. Never returns a dead, tried, or absent replica. */
+/* A replica that streams its experts from disk costs a disk read per call
+ * that no RTT estimate sees until it has happened, and it is usually the
+ * origin: the one machine with the lowest RTT and the least spare RAM. Rank
+ * it behind every replica that holds the expert in RAM, however far; this
+ * is what makes a joining donor actually receive the calls for the experts
+ * it loaded. The penalty is a score offset in microseconds, so an unusable
+ * RAM replica (dead, circuit open) still loses to a live disk one. */
+#define LUMI_DISK_PENALTY_US 250000u
+
+static uint64_t lumi_replica_score(const LumiPeer *p) {
+    uint64_t score = lmb_predict_score(&p->latency, p->inflight);
+    if (p->resident == 0 && score < UINT64_MAX - LUMI_DISK_PENALTY_US)
+        score += LUMI_DISK_PENALTY_US;
+    return score;
+}
+
 static int lumi_pick(int gid, uint32_t tried) {
     const int *own = &L.own[(size_t)gid * LUMI_MAX_REP];
     int best = -1;
@@ -834,8 +871,7 @@ static int lumi_pick(int gid, uint32_t tried) {
         int pi = own[r];
         if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead ||
             !lmb_predict_available(&L.peers[pi].latency, now)) continue;
-        uint64_t score = lmb_predict_score(&L.peers[pi].latency,
-                                            L.peers[pi].inflight);
+        uint64_t score = lumi_replica_score(&L.peers[pi]);
         if (best < 0 || score < best_score)
             { best = r; best_score = score; }
     }
@@ -847,8 +883,7 @@ static int lumi_pick(int gid, uint32_t tried) {
         int pi = own[r];
         if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead ||
             !lmb_predict_available(&L.peers[pi].latency, now)) continue;
-        uint64_t score = lmb_predict_score(&L.peers[pi].latency,
-                                            L.peers[pi].inflight);
+        uint64_t score = lumi_replica_score(&L.peers[pi]);
         if (score <= band) cand[nc++] = r;
     }
     if (nc <= 1) return best;

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -273,6 +273,12 @@ enum {
      * the same way. */
     LMB_TEXEC = 66,
     LMB_TMAN = 67, LMB_TMAN_FWD = 68, LMB_TMAN_R = 69,
+    /* Where an executor's experts live. ERES_R body: u32 resident_flags
+     * (LMB_EXPERT_RESIDENT_RAM / LMB_EXPERT_DISK_FALLBACK), u32 state. A
+     * chatter asks once after the manifest; an older node answers ERR and is
+     * simply treated as "unknown". Additive: the manifest itself is
+     * unchanged, so old chatters keep admitting new nodes. */
+    LMB_ERES = 70, LMB_ERES_R = 71,
 };
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,


### PR DESCRIPTION
## Why

The founder's rule: every machine that joins must make the swarm faster, with nothing to configure. The expert swarm (dense + KV on the chatter, experts on peers, only activations on the wire) is the path where that rule can hold, and four defaults kept it from being used:

1. **Chat tried Segment first** and, when the origin published a chain, never started the expert path. Now the expert path starts as soon as the tracker knows an executor; Segment only when nobody executes experts (or `LUMABRI_SEGMENT_REQUIRED=1`).
2. **Replica choice was RTT-only**, so the origin's disk-streaming executor beat every home donor holding the expert in RAM. New additive op `LMB_ERES` (70/71): the chatter asks once whether an executor's experts are resident; a known disk replica gets a 250 ms score penalty. Old nodes answer `ERR` → unknown, no penalty. `PROTOCOL_COMPATIBILITY.md` updated.
3. **The executor admitted one expert at a time** (gate = cores / OMP team, team = all cores) and held the gate across the cold disk read. Default team is now 2 threads (4 on 16+ cores) so a layer's top-k run together; the cache/store lookup happens before the gate. `OMP_NUM_THREADS` / `--parallel` still win.
4. **`--hold auto` sized fp4 experts at int8 width** on DeepSeek; the glue now reports its real expert size, so a donor holds twice as many.
5. **Enter in the join menu meant chat only.** It now donates compute when ≥ 2 GB are free beyond the reserve, and says so before the keypress.

## Verified

- `phase2_test.sh`: tokens identical; nodes log `3 experts at a time, 2 threads each`; chatter logs `experts in RAM` per peer.
- `relay_exec_test.sh`, `swarm_fed_exec_test.sh`, `donate_test.sh`, `serve_failfast_test.sh` pass; `make check-warnings` clean.

Independent of #107 (both branch from main; they touch different lines of `lumabri.c` and `deepseek.h`).
