### PR TITLE
feat: fair admission per chatter, per-call telemetry, and a supervisor that backs off

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,12 @@ Lumabri excludes `.coli_*` state such as `.coli_usage`, KV/checkpoint state and
 SSD metadata from storage manifests. These files remain local and mutable;
 only checkpoint/model payloads enter signed CAS identity.
 
+Expert executors admit concurrent chatters fairly: when several wait for the
+compute gate, the next slot goes to the chatter that has been served least
+since the queue last drained, so two chatters on equal networks see the same
+tok/s instead of the busier one starving the other. Each executor's stats
+line reports compute and queue time per call; the chatter's report shows the
+average and the worst layer round, which is what a token actually pays.
 Concurrent chats are admitted FIFO at every Segment range. Queue depth and
 inflight work are published to the predictive scheduler, the queue is bounded,
 and a request that misses its admission deadline returns `BUSY` so an exact

--- a/expert_node.c
+++ b/expert_node.c
@@ -188,18 +188,87 @@ static void gate_init(int forced, int per_expert, int phys) {
     if (g_gate_free < 1) g_gate_free = 1;
 }
 
+/* Fair admission. FIFO let the chatter that issues the most requests take
+ * the most compute: with two chatters one saw its layers served and the
+ * other waited. Under contention the free slot goes to the WAITER whose
+ * source has been granted the least since the queue last drained (ties by
+ * arrival), so every chatter gets the same share of the executor and, with
+ * equal networks, the same tok/s. A source is one remote address; work that
+ * arrives through the tracker relay shares one source. */
+#define GATE_WAITERS_MAX 512
+#define GATE_SOURCES_MAX 64
+typedef struct { uint32_t src; uint64_t seq; } GateWaiter;
+static GateWaiter g_gate_wait[GATE_WAITERS_MAX];
+static int g_gate_nwait;
+static uint64_t g_gate_seq;
+static uint32_t g_gate_src[GATE_SOURCES_MAX];
+static uint64_t g_gate_granted[GATE_SOURCES_MAX];
+static int g_gate_nsrc;
+static __thread uint32_t t_source;          /* set per connection thread */
+static double g_gate_wait_s;                /* total time spent queued */
+
+static int gate_source_slot(uint32_t src) {
+    for (int i = 0; i < g_gate_nsrc; i++) if (g_gate_src[i] == src) return i;
+    if (g_gate_nsrc < GATE_SOURCES_MAX) {
+        g_gate_src[g_gate_nsrc] = src; g_gate_granted[g_gate_nsrc] = 0;
+        return g_gate_nsrc++;
+    }
+    return 0;                                /* table full: share slot 0 */
+}
+
+/* The waiter that should go next: least granted source, then oldest. */
+static int gate_next_locked(void) {
+    int best = -1;
+    for (int i = 0; i < g_gate_nwait; i++) {
+        int bs = gate_source_slot(g_gate_wait[i].src);
+        if (best < 0) { best = i; continue; }
+        int cs = gate_source_slot(g_gate_wait[best].src);
+        if (g_gate_granted[bs] < g_gate_granted[cs] ||
+            (g_gate_granted[bs] == g_gate_granted[cs] &&
+             g_gate_wait[i].seq < g_gate_wait[best].seq))
+            best = i;
+    }
+    return best;
+}
+
 static void gate_enter(void) {
     pthread_mutex_lock(&g_gate_lk);
-    if (g_gate_free <= 0) atomic_fetch_add(&g_gate_waits, 1);
-    while (g_gate_free <= 0) pthread_cond_wait(&g_gate_cv, &g_gate_lk);
+    if (g_gate_free > 0 && g_gate_nwait == 0) {
+        g_gate_free--;
+        g_gate_granted[gate_source_slot(t_source)]++;
+        pthread_mutex_unlock(&g_gate_lk);
+        return;
+    }
+    atomic_fetch_add(&g_gate_waits, 1);
+    double t0 = nowd();
+    uint64_t seq = ++g_gate_seq;
+    if (g_gate_nwait < GATE_WAITERS_MAX)
+        g_gate_wait[g_gate_nwait++] = (GateWaiter){ t_source, seq };
+    for (;;) {
+        int me = -1;
+        for (int i = 0; i < g_gate_nwait; i++)
+            if (g_gate_wait[i].seq == seq) { me = i; break; }
+        if (g_gate_free > 0 && (me < 0 || gate_next_locked() == me)) {
+            if (me >= 0) {
+                g_gate_wait[me] = g_gate_wait[--g_gate_nwait];
+            }
+            break;
+        }
+        pthread_cond_wait(&g_gate_cv, &g_gate_lk);
+    }
     g_gate_free--;
+    g_gate_granted[gate_source_slot(t_source)]++;
+    g_gate_wait_s += nowd() - t0;
+    /* no one waiting: the round is over, everybody starts equal again */
+    if (g_gate_nwait == 0)
+        for (int i = 0; i < g_gate_nsrc; i++) g_gate_granted[i] = 0;
     pthread_mutex_unlock(&g_gate_lk);
 }
 
 static void gate_leave(void) {
     pthread_mutex_lock(&g_gate_lk);
     g_gate_free++;
-    pthread_cond_signal(&g_gate_cv);
+    pthread_cond_broadcast(&g_gate_cv);
     pthread_mutex_unlock(&g_gate_lk);
 }
 
@@ -509,8 +578,24 @@ static int handle_emanifest(int fd) {
     return rc;
 }
 
+static uint32_t peer_source(int fd) {
+    struct sockaddr_storage ss;
+    socklen_t len = sizeof ss;
+    if (getpeername(fd, (struct sockaddr *)&ss, &len)) return 1;
+    const uint8_t *bytes = NULL; size_t n = 0;
+    if (ss.ss_family == AF_INET) {
+        bytes = (const uint8_t *)&((struct sockaddr_in *)&ss)->sin_addr; n = 4;
+    } else if (ss.ss_family == AF_INET6) {
+        bytes = (const uint8_t *)&((struct sockaddr_in6 *)&ss)->sin6_addr; n = 16;
+    } else return 1;
+    uint32_t h = 2166136261u;
+    for (size_t i = 0; i < n; i++) { h ^= bytes[i]; h *= 16777619u; }
+    return h ? h : 1;
+}
+
 static void *conn_thread(void *arg) {
     int fd = (int)(intptr_t)arg;
+    t_source = peer_source(fd);
     if (lmb_secure_server(fd)) { close(fd); lmb_conn_gate_leave(&g_conn_gate); return NULL; }
     int authed = g.token[0] ? 0 : 1;
     LmbMsg m;
@@ -844,11 +929,20 @@ static void *stats_thread(void *arg) {
              * most), so clamp the difference instead of letting the unsigned
              * subtraction wrap to a monstrous percentage. */
             uint64_t hits = calls > cold ? calls - cold : 0;
-            printf("[%s] %llu exec calls · %llu cold loads · %.1f%% RAM hit\n",
+            printf("[%s] %llu exec calls · %llu cold loads · %.1f%% RAM hit",
                    g.name, (unsigned long long)calls, (unsigned long long)cold,
                    calls ? 100.0 * (double)hits / (double)calls : 0.0);
         } else
-            printf("[%s] %llu exec calls\n", g.name, (unsigned long long)calls);
+            printf("[%s] %llu exec calls", g.name, (unsigned long long)calls);
+        /* Where a call's time goes, on this side of the wire: queued behind
+         * other experts, or multiplying. A chatter sees only the sum. */
+        double busy, queued;
+        pthread_mutex_lock(&g.stat_lk); busy = g.busy_s; pthread_mutex_unlock(&g.stat_lk);
+        pthread_mutex_lock(&g_gate_lk); queued = g_gate_wait_s; pthread_mutex_unlock(&g_gate_lk);
+        printf(" · %.2f ms compute · %.2f ms queued per call · %llu waited\n",
+               calls ? 1000.0 * busy / (double)calls : 0.0,
+               calls ? 1000.0 * queued / (double)calls : 0.0,
+               (unsigned long long)atomic_load(&g_gate_waits));
         fflush(stdout);
         last = calls;
     }

--- a/lumabri.c
+++ b/lumabri.c
@@ -253,6 +253,9 @@ static const char *g_cwhat[MAX_CHILDREN];
 /* Children that must not share the operator's terminal keep their own log,
  * and keep it across a supervised restart. */
 static char *g_clog[MAX_CHILDREN];
+/* restart history per slot, for the supervisor's backoff */
+static int g_crestarts[MAX_CHILDREN];
+static double g_cstarted[MAX_CHILDREN];
 
 static void child_publish(int idx, pid_t pid) {
     g_children[idx] = pid;
@@ -988,10 +991,22 @@ static int cmd_serve(int argc, char **argv) {
             else
                 printf("\n%s⚠ %s e' uscito (codice %d)%s\n",
                        C_RED, g_cwhat[idx], WEXITSTATUS(status), C_R);
-            printf("  %slo riavvio fra 5 s — finche' manca, i chatter si "
-                   "scaricano gli esperti invece di farli eseguire%s\n", C_DIM, C_R);
+            /* Backoff: a child that dies right after starting (OOM, a port
+             * taken, a corrupt model) used to be relaunched every 5 s
+             * forever, reloading gigabytes into a box that is already
+             * full. The delay doubles up to two minutes and resets once the
+             * child has lived ten minutes. */
+            double alive = nowd() - g_cstarted[idx];
+            if (alive >= 600.0) g_crestarts[idx] = 0;
+            int delay = 5 << (g_crestarts[idx] < 5 ? g_crestarts[idx] : 5);
+            if (delay > 120) delay = 120;
+            g_crestarts[idx]++;
+            printf("  %slo riavvio fra %d s — finche' manca, i chatter si "
+                   "scaricano gli esperti invece di farli eseguire%s\n",
+                   C_DIM, delay, C_R);
             fflush(stdout);
-            sleep(5);
+            sleep((unsigned)delay);
+            g_cstarted[idx] = nowd();
             pid_t np = g_clog[idx]
                 ? spawn_argv_logged(g_cargv[idx], NULL, g_clog[idx])
                 : spawn_argv(g_cargv[idx]);

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -124,6 +124,7 @@ static struct {
     int swarm_disabled;         /* model identity changed mid-run: local only */
     unsigned long long demotions, integrity_fails;
     unsigned long long calls, layers_done, failovers, verified, relays;
+    double wait_max_s;          /* the slowest layer round so far: the tail a token pays */
     unsigned long long hedges, hedge_wins, batch_calls, batch_rows;
     double wait_s;
 } L = {0};
@@ -836,6 +837,15 @@ static uint32_t lumi_hash_gid(int gid) {   /* fnv1a over the (layer,expert) id *
     return h;
 }
 
+/* One layer round is over: the token paid max(...) over its experts, so
+ * the worst round is what the network really costs, not the mean. */
+static void lumi_round_done(double t0) {
+    double dt = lumi_now() - t0;
+    L.wait_s += dt;
+    if (dt > L.wait_max_s) L.wait_max_s = dt;
+    L.layers_done++;
+}
+
 /* Which replica of `gid` to send to. Default: the nearest live, untried one
  * (strict argmin — deliberate, and what a single-holder-per-expert swarm wants).
  * With LUMABRI_SPREAD on and this expert held by several near-equal replicas,
@@ -1286,9 +1296,8 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply(int layer, const int *idx,
         for (int d = 0; d < D; d++) out[d] += w * h[d];
         free(res[k]);
     }
-    L.wait_s += lumi_now() - t0;
     L.calls += (unsigned long long)K;
-    L.layers_done++;
+    lumi_round_done(t0);
     return 1;
 }
 
@@ -1422,8 +1431,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_batch(int layer, const int *idxs,
             L.calls++;
         }
     }
-    L.wait_s += lumi_now() - t0;
-    L.layers_done++;
+    lumi_round_done(t0);
     free(seen); free(uniq); free(rows); free(rw); free(xg); free(saved);
     return 1;
 }
@@ -1529,8 +1537,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_union(int layer, int nu,
             L.calls++;
         }
     }
-    L.wait_s += lumi_now() - t0;
-    L.layers_done++;
+    lumi_round_done(t0);
     free(xg); free(saved);
     return 1;
 }
@@ -1662,8 +1669,7 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
             L.calls++;
         }
     }
-    L.wait_s += lumi_now() - t0;
-    L.layers_done++;
+    lumi_round_done(t0);
     free(used); free(uid); free(rows); free(rw); free(xg); free(saved);
     return 1;
 }
@@ -1671,12 +1677,13 @@ static LMB_MAYBE_UNUSED int lumi_moe_apply_v4(int layer, const int *indices,
 static LMB_MAYBE_UNUSED void lumi_report(void) {
     if (!L.on && !L.calls) return;
     fprintf(stderr, "[lumabri] %llu remote expert calls in %llu layer rounds · "
-                    "%.2fs waiting on peers (%.2f ms per layer round) · "
+                    "%.2fs waiting on peers (%.2f ms per layer round, worst %.1f ms) · "
                     "%llu batched call(s)/%llu rows · %llu hedge(s), %llu won · "
                     "%llu failover(s) · %llu tracker relay call(s) · "
                     "%llu spot-check(s)%s\n",
             L.calls, L.layers_done, L.wait_s,
             L.layers_done ? 1000.0 * L.wait_s / (double)L.layers_done : 0.0,
+            1000.0 * L.wait_max_s,
             L.batch_calls, L.batch_rows, L.hedges, L.hedge_wins,
             L.failovers, L.relays, L.verified,
             L.integrity_fails ? "" : ", all agreed");


### PR DESCRIPTION
Replaces #109, which GitHub closed when its base branch (#108) was merged and deleted. Same single commit, rebased onto main after #107 and #108.

## What

1. **Fair compute gate in `expert_node`.** FIFO let the busiest chatter starve the others. Under contention the next slot goes to the waiting source (remote address; tracker-relayed work shares one) with the fewest grants since the queue last drained, ties by arrival. This is the mechanism behind "everyone at the same tok/s".
2. **Telemetry.** Executor stats line: `… · X ms compute · Y ms queued per call · N waited`. Chatter report: `(… ms per layer round, worst N ms)` — a token pays the max over its experts, so the worst round is the real network cost. Step 1 of the speed phase in the roadmap: measure before optimizing.
3. **Supervisor backoff in `serve`.** Restart delay 5 s → 10 → 20 → … → 120 s, reset after ten minutes of child life. No more reloading a 30 GB executor every 5 s into a box that just OOM-killed it.

## Verified (on the pre-rebase commit; the rebase applied cleanly and the tree builds)

- `phase2_test.sh` tokens identical; report shows the worst round.
- `relay_exec_test.sh` (four clients through one delayed node, failover) pass.
- `concurrency_test.sh` 1/2/4 chatters on one executor: all complete, nobody starved.
- `serve_failfast_test.sh` pass; `expert_node_deepseek` builds; `make check-warnings` clean.

