### PR TITLE
feat: a swarm-fed chat waits for its executors instead of downloading experts, and a donor donates experts first

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ them, so a script never inherits somebody's saved answers.
 
 When you join it also asks how you want to take part — just chat, or **lend your
 machine too**. `disk` receives complete rarest-first files up to the chosen GB
-budget (transferred and verified in MiB blocks). `compute` takes the rarest
-tracker-assigned Segment slice when enough spare RAM is available. It publishes
+budget (transferred and verified in MiB blocks). `compute` holds resident experts assigned by the tracker; it takes a Segment slice only when no expert executor exists for the model. It publishes
 direct P2P when reachable and otherwise uses the signed outbound Segment relay;
 the finer-grained expert donor remains the lower-memory fallback.
 Both run at low priority and die with the TUI. Nothing to configure — Enter
@@ -383,6 +382,7 @@ the command, e.g. `LUMABRI_SPREAD=1 lumabri chat …`.
 | `LUMABRI_HEDGE_MS=-1` | never ask a second peer — the only way to get one request per call, which attribution and benchmarking need |
 | `LUMABRI_ALLOW_CODEGEN_SKEW=1` | let peers built with a different compiler or CPU join (results are then verified, not bit-identical) |
 | `LUMABRI_ENCRYPT=1` | encrypt the transport (see below) |
+| `LUMABRI_SWARM_PATIENCE_S=N` | on a swarm-fed chat, how long a reply waits for a vanished executor before failing plainly (default 600); it never downloads experts to run them locally |
 | `LUMABRI_READ_TIMEOUT_MS=N` | give up on a peer that has not delivered an 8 MiB block in N ms and ask the next one (default 60000; the general I/O timeout is five minutes) |
 | `RAM_GB=N` | tell a `--local` run how much RAM it may use to keep experts resident |
 

--- a/lumabri.c
+++ b/lumabri.c
@@ -3668,7 +3668,14 @@ static void role_start(const Role *r, const char *tracker, const char *model,
                        "dono calcolo saltato%s\n", C_DIM, strerror(errno), C_R);
         } else {
             g_compute_lease_fd = lease;
-            int segment_started = segment_active &&
+            /* Donate what chatters use. The chat runs the expert swarm
+             * whenever an expert executor exists, so a donor that took a
+             * Segment range there served nobody while its RAM could have
+             * held a few hundred resident experts. Segment is the donation
+             * only when no expert executor exists for the model. */
+            int prefer_segment = segment_active &&
+                                 swarm_executors(tracker, model) <= 0;
+            int segment_started = prefer_segment &&
                 role_start_segment(r, tracker, model, model_type, context,
                                    model_bytes);
             if (!segment_started) {

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -1108,12 +1108,22 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
              * LUMABRI_PEER_WAIT_S=0 still yields zero via the re-read. */
             int wait_limit = L.peer_wait_s > 0 ? L.peer_wait_s
                 : lmb_env_int("LUMABRI_PEER_WAIT_S", LUMI_WAIT_S, 0, 600);
-            if (lumi_now() < L.swarm_sick_until) wait_limit = 0;
+            /* A swarm-fed chatter (LUMABRI_VROOT: the model is a mirror, not
+             * a local copy) must never "demote to local": on a 167 GB model
+             * the local path is a 12 MB expert download per call over the
+             * WAN, and a network blip turned into a dead reply after that
+             * download stalled too. Its only honest options are patience
+             * (LUMABRI_SWARM_PATIENCE_S, ten minutes by default) and then a
+             * plain failure that says so. */
+            int swarm_fed = getenv("LUMABRI_VROOT") != NULL;
+            if (swarm_fed)
+                wait_limit = lmb_env_int("LUMABRI_SWARM_PATIENCE_S", 600, 2, 86400);
+            else if (lumi_now() < L.swarm_sick_until) wait_limit = 0;
             if (waited < wait_limit) {
-                if (!waited)
+                if (!waited || (swarm_fed && waited % 30 == 0))
                     fprintf(stderr, "[lumabri] layer %d expert %d: nessuna replica "
-                            "viva — aspetto che torni (fino a %d s)\n",
-                            layer, eid, wait_limit);
+                            "viva — aspetto che torni (%d/%d s)\n",
+                            layer, eid, waited, wait_limit);
                 tried = 0;                    /* a returning peer deserves a retry */
                 sleep(2);
                 waited += 2;
@@ -1125,6 +1135,13 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
                         lumi_add_peer(addr);   /* revalidates manifest before reuse */
                     }
                 continue;
+            }
+            if (swarm_fed) {
+                char why[200];
+                snprintf(why, sizeof why, "layer %d expert %d: nessun esecutore "
+                         "raggiungibile per %d s; non scarico gli esperti in "
+                         "locale, la risposta si ferma qui", layer, eid, waited);
+                lumi_die(why);
             }
             lumi_demote_layer(layer, waited);
             if (tried_io) *tried_io = tried;


### PR DESCRIPTION
## What the first real DeepSeek chat over the WAN showed

1. **A network blip killed the reply** after 500 s with `hybrid batched block failed in MoE`. Executor calls failed, the client waited 30 s, then *demoted* the layer to the engine's local path, which on a 167 GB model behind the shim means a 12 MB expert download per call. That download stalled on the same bad network, the shim gave up, the engine aborted. Demotion is right for a model the chatter has on disk; for a swarm-fed chatter the honest options are patience and a plain failure. With `LUMABRI_VROOT` set the client now waits `LUMABRI_SWARM_PATIENCE_S` (default 600 s, logging every 30 s) and then stops the engine with a message naming the layer and the wait. It never pulls expert weights. Local-copy chats keep the old demote policy.
2. **A compute donor took a Segment range** whenever the origin published one, and served nobody, because the chat runs the expert swarm whenever an expert executor exists. The donor now starts the expert node first; Segment only when no expert executor exists for the model.

## Verified

- `phase2_test.sh` tokens identical; `test_local_fallback` (demote semantics for local copies) unchanged and passing; `donate_test.sh` pass.
- `lumabri` builds under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
