### PR TITLE
fix(serve): a symlinked checkpoint weighs what it links to, so the Segment fit check runs

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -1610,7 +1610,12 @@ static void tail_file(const char *path, int max) {
 static uint64_t du_bytes(const char *path, int depth) {
     if (depth > 6) return 0;
     struct stat st;
-    if (lstat(path, &st)) return 0;
+    /* stat, not lstat: a checkpoint fetched with huggingface_hub is a
+     * directory of symlinks into its blob cache, and counting the links
+     * made a 167 GB model weigh 0 bytes — which silently disabled the
+     * "does this Segment range fit" check on the origin. The depth cap
+     * above still bounds a symlink loop. */
+    if (stat(path, &st)) return 0;
     if (S_ISREG(st.st_mode)) return (uint64_t)st.st_size;
     if (!S_ISDIR(st.st_mode)) return 0;
     DIR *d = opendir(path);


### PR DESCRIPTION
`serve` measured the model with `lstat` file by file. A checkpoint fetched with `huggingface_hub` is a directory of symlinks into its blob cache, so a 167 GB model weighed 0 bytes, no `--model-bytes` reached the origin slices, and the "does this range fit its budget" check from #107 was silently skipped: four Segment slices started on a 64 GB box exactly as before the fix.

`stat` instead of `lstat`; the existing depth cap still bounds a symlink loop. Proven on a symlinked copy of the fixture: the slices now receive `--model-bytes 681888579`. `lumabri` builds under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
