### PR TITLE
feat(chat): dense weights before "ready" with a bar and an ETA; a donor sees itself being used; a typo is not a prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ On a machine that wants to chat:
 ./lumabri chat --tracker <server-ip>:7300
 ```
 
-That is all. The first answer is slower while the Edge working set crosses the
-network. If no complete compatible Segment route exists, the same command
+That is all. On a swarm-fed model the dense weights (everything but the
+routed experts) are pulled into the mirror before the chat says ready, with
+a bar, the rate and an ETA; the first answer then costs only the network
+round trips, not a layer-by-layer download. If no complete compatible Segment route exists, the same command
 automatically falls back to the existing expert/CAS engine, then to local
 execution as coverage permits; there is no separate `segment_chat` command for
 an end user.
@@ -76,6 +78,11 @@ binaries, CAS state, model readability, tracker reachability and the complete
 serving port block. The reproducible local, sanitizer, multi-host and soak
 release gates are documented in **[PRODUCTION.md](PRODUCTION.md)**.
 
+While you donate, the frame above the idle prompt shows what your machine is
+doing for the swarm and refreshes every few seconds: experts held (and how
+many are resident in RAM), calls served and their rate, work in flight, and
+bytes your storage served. A line starting with `/` that is not a known
+command is refused with a hint instead of being sent to the model.
 Inside the chat, `/swarm` (or `/hosts`) shows stable human-readable machine
 names, storage served, expert calls and live Segment ranges. `/experts` answers
 how often each executor has actually been used; `/model`, `/debug`, `/storage`
@@ -382,6 +389,7 @@ the command, e.g. `LUMABRI_SPREAD=1 lumabri chat …`.
 | `LUMABRI_HEDGE_MS=-1` | never ask a second peer — the only way to get one request per call, which attribution and benchmarking need |
 | `LUMABRI_ALLOW_CODEGEN_SKEW=1` | let peers built with a different compiler or CPU join (results are then verified, not bit-identical) |
 | `LUMABRI_ENCRYPT=1` | encrypt the transport (see below) |
+| `LUMABRI_ENGINE_LOG=path` | append every line the engine prints to this file (the chat otherwise keeps only the tail `/debug` shows) |
 | `LUMABRI_SWARM_PATIENCE_S=N` | on a swarm-fed chat, how long a reply waits for a vanished executor before failing plainly (default 600); it never downloads experts to run them locally |
 | `LUMABRI_READ_TIMEOUT_MS=N` | give up on a peer that has not delivered an 8 MiB block in N ms and ask the next one (default 60000; the general I/O timeout is five minutes) |
 | `RAM_GB=N` | tell a `--local` run how much RAM it may use to keep experts resident |

--- a/lumabri.c
+++ b/lumabri.c
@@ -151,11 +151,22 @@ static const char *WORDMARK[6] = {
 };
 static const int WORD_TINT[6] = { 203, 209, 209, 215, 216, 223 };
 
+static int vis_len(const char *s);
 static void hline(const char *l, const char *r, int w) {
     printf("%s%s", C_GRAY, l);
     for (int i = 0; i < w - 2; i++) printf("\xe2\x94\x80");
     printf("%s%s\n", r, C_R);
 }
+
+/* the same frame edge carrying a short text: "╭─ text ──────╮" */
+static void hline_text(const char *l, const char *r, int w, const char *text) {
+    int tw = text && text[0] ? vis_len(text) + 2 : 0;
+    printf("%s%s", C_GRAY, l);
+    if (tw) { printf("\xe2\x94\x80 %s%s%s ", C_DIM, text, C_GRAY); tw += 1; }
+    for (int i = 0; i < w - 2 - tw; i++) printf("\xe2\x94\x80");
+    printf("%s%s", r, C_R);
+}
+
 
 /* visible width of a string carrying ANSI escapes and UTF-8 */
 static int vis_len(const char *s) {
@@ -1495,6 +1506,8 @@ static struct {
     volatile double rate_mbs;
     volatile double total_gb;        /* the whole model, from the shim */
     volatile double local_gb;        /* already in the mirror when we started */
+    volatile double dense_mb, dense_total_mb, dense_rate; /* the dense warm-up */
+    volatile int    dense_ready;     /* 1 ready · 2 incomplete (engine will retry) */
     volatile int    spinning;
     volatile int    booting;
     volatile int    streaming;       /* a reply is being echoed token by token */
@@ -1527,11 +1540,15 @@ static void tail_dump(int max) {
 static void *stderr_thread(void *arg) {
     FILE *f = fdopen((int)(intptr_t)arg, "r");
     if (!f) return NULL;
+    /* LUMABRI_ENGINE_LOG=path keeps every engine line, not just the tail
+     * /debug shows: the only way to read a slow reply after the fact. */
+    FILE *keep = getenv("LUMABRI_ENGINE_LOG") ? fopen(getenv("LUMABRI_ENGINE_LOG"), "a") : NULL;
     char line[512];
     while (fgets(line, sizeof line, f)) {
         size_t n = strlen(line);
         while (n && (line[n-1] == '\n' || line[n-1] == '\r')) line[--n] = 0;
         if (!n) continue;
+        if (keep) { fputs(line, keep); fputc('\n', keep); fflush(keep); }
         tail_push(line);
         g_eng.last_out = nowd();
 
@@ -1540,6 +1557,14 @@ static void *stderr_thread(void *arg) {
         if (!strncmp(line, "[segment-route]", 15)) continue;
 
         double mb, rate, gb, pct;
+        double d1, d2, d3;
+        if (sscanf(line, "[lumabri] dense %lf/%lf MB (%lf MB/s)", &d1, &d2, &d3) == 3) {
+            g_eng.dense_mb = d1; g_eng.dense_total_mb = d2; g_eng.dense_rate = d3;
+        } else if (!strncmp(line, "[lumabri] dense ready", 21)) {
+            g_eng.dense_ready = 1;
+        } else if (!strncmp(line, "[lumabri] dense warm-up incomplete", 34)) {
+            g_eng.dense_ready = 2;
+        }
         if (sscanf(line, "[lumabri] net %lf MB", &mb) == 1) {
             g_eng.net_mb = mb;
             if (sscanf(strstr(line, "(") ? strstr(line, "(") : "", "(%lf MB/s", &rate) == 1)
@@ -2080,6 +2105,40 @@ static int live_take_pending(char *out, size_t cap) {
 }
 
 /* one line, rewritten in place: the star, what it is doing, how far along */
+/* The engine is up, but on a swarm-fed model its dense weights may still be
+ * crossing the network: "ready" only after the warm-up says so, with the
+ * bar meanwhile. Bounded: a warm-up that has not moved for two minutes is
+ * left to the engine's own on-demand reads (the shim retries them). */
+static void *spinner_thread(void *arg);
+static void wait_dense_ready(void) {
+    if (g_eng.dense_ready || g_eng.dense_total_mb <= 0) {
+        /* no progress line yet: give the warm-up a moment to size itself */
+        for (int i = 0; i < 30 && !g_eng.dense_ready && g_eng.dense_total_mb <= 0; i++)
+            usleep(100 * 1000);
+        if (g_eng.dense_ready || g_eng.dense_total_mb <= 0) return;
+    }
+    g_eng.booting = 1; g_eng.spinning = 1;
+    pthread_t sp;
+    int spun = g_tty && pthread_create(&sp, NULL, spinner_thread,
+                                       (void *)"parte densa nel mirror") == 0;
+    double last_mb = g_eng.dense_mb, last_move = nowd();
+    while (!g_eng.dense_ready) {
+        usleep(200 * 1000);
+        if (g_eng.dense_mb != last_mb) { last_mb = g_eng.dense_mb; last_move = nowd(); }
+        else if (nowd() - last_move > 120) break;
+    }
+    g_eng.spinning = 0;
+    if (spun) pthread_join(sp, NULL);
+    g_eng.booting = 0;
+    if (g_eng.dense_ready == 1)
+        printf("  %s\xe2\x9c\x93 parte densa nel mirror: %.2f GB%s\n", C_DIM,
+               g_eng.dense_total_mb / 1000.0, C_R);
+    else
+        printf("  %s\xe2\x9a\xa0 parte densa incompleta (%.2f/%.2f GB): il motore "
+               "scarica il resto al primo uso%s\n", C_DIM,
+               g_eng.dense_mb / 1000.0, g_eng.dense_total_mb / 1000.0, C_R);
+}
+
 static void *spinner_thread(void *arg) {
     const char *verb = arg ? (const char *)arg : "thinking";
     const char *star[] = { "\xe2\x9c\xbb", "\xe2\x9c\xb2", "\xe2\x9c\xb3", "\xe2\x9c\xb2" };
@@ -2096,9 +2155,28 @@ static void *spinner_thread(void *arg) {
         } else
             snprintf(what, sizeof what, "%s", verb);
 
-        char prog[160] = "";
+        char prog[200] = "";
         double got = g_eng.local_gb + g_eng.net_mb / 1000.0;
-        if (g_eng.booting && g_eng.total_gb > 0)
+        if (g_eng.booting && g_eng.dense_total_mb > 0 && !g_eng.dense_ready) {
+            double frac = g_eng.dense_mb / g_eng.dense_total_mb;
+            if (frac > 1) frac = 1;
+            int cells = 20, full = (int)(frac * cells + 0.5);
+            char bar[128] = "";
+            for (int k = 0; k < cells; k++)
+                strncat(bar, k < full ? "\xe2\x96\x88" : "\xe2\x96\x91", sizeof bar - strlen(bar) - 1);
+            double left_mb = g_eng.dense_total_mb - g_eng.dense_mb;
+            char eta[40] = "";
+            if (g_eng.dense_rate > 0.05 && left_mb > 0) {
+                double sec = left_mb / g_eng.dense_rate;
+                if (sec >= 3600) snprintf(eta, sizeof eta, " \xc2\xb7 ETA %d h %d min", (int)(sec / 3600), ((int)sec % 3600) / 60);
+                else if (sec >= 60) snprintf(eta, sizeof eta, " \xc2\xb7 ETA %.0f min", sec / 60);
+                else snprintf(eta, sizeof eta, " \xc2\xb7 ETA %.0f s", sec);
+            }
+            snprintf(prog, sizeof prog, " %s\xe2\x96\x95%s\xe2\x96\x8f %.2f/%.2f GB \xc2\xb7 %.1f MB/s%s%s",
+                     C_DIM, bar, g_eng.dense_mb / 1000.0, g_eng.dense_total_mb / 1000.0,
+                     g_eng.dense_rate, eta, C_R);
+            snprintf(what, sizeof what, "parte densa nel mirror");
+        } else if (g_eng.booting && g_eng.total_gb > 0)
             snprintf(prog, sizeof prog, " %s\xc2\xb7 %.1f/%.0f GB \xc2\xb7 %.0f MB/s%s",
                      C_DIM, got, g_eng.total_gb, g_eng.rate_mbs, C_R);
         else if (g_eng.booting && g_eng.net_mb > 0)
@@ -2641,6 +2719,9 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
          * switch, not V4's. */
         if (!local_dir) { setenv("COLI_V4_AUTOPIN", "0", 0);
                           setenv("COLI_V4_PREWARM", "0", 0); }
+        /* and pull the dense weights NOW, with a bar, instead of letting the
+         * first reply discover them layer by layer over the WAN */
+        if (!local_dir) setenv("LUMABRI_PREFETCH_DENSE", "1", 0);
         /* Same split for the expert cache. A swarm chatter caches almost nothing
          * (experts run on peers), so its cap stays at the small default. But a
          * --local run holds its own experts, and there the cap IS the resident
@@ -3062,6 +3143,50 @@ static void le_set(char *buf, size_t cap, int *len, int *pos, const char *text) 
     fwrite(buf, 1, (size_t)*len, stdout);
 }
 
+/* This machine as a donor, for the frame above the idle prompt: experts
+ * held, calls served and the rate since the last look, work in flight,
+ * bytes served by its storage. Read from the tracker's nominative counters
+ * (the donor children never talk to the TUI directly). */
+static char g_donor_base[48];
+static uint64_t g_donor_last_calls;
+static double g_donor_last_at;
+static int donor_status_line(char *out, size_t cap) {
+    if (!g_donor_base[0] || !g_live.tracker[0]) return 0;
+    SwarmDetailRow rows[64];
+    int n = swarm_detail(g_live.tracker, rows, 64);
+    if (n <= 0) return 0;
+    uint64_t calls = 0, inflight = 0, resident = 0, resident_bytes = 0, served = 0;
+    int mine = 0, nexperts = 0;
+    for (int i = 0; i < n; i++) {
+        if (strncmp(rows[i].name, g_donor_base, strlen(g_donor_base))) continue;
+        mine++;
+        if (rows[i].roles & LMB_SWARM_ROLE_EXPERT) {
+            nexperts += (int)rows[i].nexperts;
+            calls += rows[i].exec_calls; inflight += rows[i].exec_inflight;
+            resident += rows[i].resident_experts;
+            resident_bytes += rows[i].expert_resident_bytes;
+        }
+        if (rows[i].roles & LMB_SWARM_ROLE_STORAGE) served += rows[i].served_bytes;
+    }
+    if (!mine) return 0;
+    double now = nowd(), rate = 0;
+    if (g_donor_last_at > 0 && now > g_donor_last_at && calls >= g_donor_last_calls)
+        rate = (double)(calls - g_donor_last_calls) / (now - g_donor_last_at);
+    g_donor_last_calls = calls; g_donor_last_at = now;
+    int len = snprintf(out, cap, "donor: %d esperti", nexperts);
+    if (resident)
+        len += snprintf(out + len, cap - (size_t)len, " (%llu in RAM, %.1f GB)",
+                        (unsigned long long)resident, (double)resident_bytes / 1e9);
+    len += snprintf(out + len, cap - (size_t)len, " \xc2\xb7 %llu chiamate",
+                    (unsigned long long)calls);
+    if (rate > 0) len += snprintf(out + len, cap - (size_t)len, " (%.1f/s)", rate);
+    if (inflight) len += snprintf(out + len, cap - (size_t)len, " \xc2\xb7 %llu in corso",
+                                  (unsigned long long)inflight);
+    if (served) len += snprintf(out + len, cap - (size_t)len, " \xc2\xb7 disco %.1f GB serviti",
+                                (double)served / 1e9);
+    return len > 0;
+}
+
 static int line_edit(char *buf, size_t cap) {
     struct termios old, raw;
     if (g_chat_term_valid) old = g_chat_term;
@@ -3088,6 +3213,24 @@ static int line_edit(char *buf, size_t cap) {
 
     for (;;) {
         unsigned char c;
+        if (g_donor_base[0]) {
+            /* a donor refreshes the frame above the prompt every 3 s while
+             * the user is idle: calls served, experts held, work in flight */
+            struct pollfd pfd = { 0, POLLIN, 0 };
+            int pr = poll(&pfd, 1, 3000);
+            if (pr < 0 && errno != EINTR) { rc = -1; break; }
+            if (pr == 0) {
+                char status[200] = "";
+                if (donor_status_line(status, sizeof status)) {
+                    printf("\x1b" "7\x1b[1A\r\x1b[2K");
+                    hline_text("\xe2\x95\xad", "\xe2\x95\xae", term_w() - 2, status);
+                    printf("\x1b" "8");
+                    fflush(stdout);
+                }
+                continue;
+            }
+            if (pr < 0) { if (g_stopping) { rc = -1; break; } continue; }
+        }
         ssize_t rn = read(0, &c, 1);
         if (rn < 0 && errno == EINTR) {
             if (g_stopping) { rc = -1; break; }
@@ -3747,6 +3890,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
             }
             char portstr[16], name[64], base[48];
             donor_base_name(r, base, sizeof base);
+            snprintf(g_donor_base, sizeof g_donor_base, "%s", base);
             snprintf(portstr, sizeof portstr, "%d", port);
             snprintf(name, sizeof name, "%s-exec-%d", base, port);
             char *argv[20];
@@ -3961,6 +4105,7 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
         engine_stop(e);
         return -1;
     }
+    if (!local_dir) wait_dense_ready();
     printf("  %s\xe2\x9c\x93 %s pronto in %.1fs%s%s · net %.0f MB · "
            "/swarm /experts /model /debug /storage /reset /quit%s\n",
            C_GRN, model, nowd() - t0, C_R, C_DIM, g_eng.net_mb, C_R);
@@ -4171,8 +4316,10 @@ static int cmd_chat(int argc, char **argv) {
         int w = term_w() - 2;
         if (g_tty) {
             printf("\n");
-            hline("\xe2\x95\xad", "\xe2\x95\xae", w);
-            printf("%s\xe2\x94\x82%s %s%s\xe2\x80\xba%s ", C_GRAY, C_R, C_CORAL, C_BOLD, C_R);
+            char status[200] = "";
+            if (g_donor_base[0]) donor_status_line(status, sizeof status);
+            hline_text("\xe2\x95\xad", "\xe2\x95\xae", w, status);
+            printf("\n%s\xe2\x94\x82%s %s%s\xe2\x80\xba%s ", C_GRAY, C_R, C_CORAL, C_BOLD, C_R);
         } else
             printf("\n> ");
         fflush(stdout);
@@ -4219,6 +4366,11 @@ static int cmd_chat(int argc, char **argv) {
             continue;
         }
 
+        if (line[0] == '/' && strcmp(line, "/reset")) {
+            printf("  %scomando sconosciuto: %.40s \xc2\xb7 Tab completa i comandi, "
+                   "/help li elenca. Non l'ho mandato al modello.%s\n", C_RED, line, C_R);
+            continue;
+        }
         int is_reset = !strcmp(line, "/reset");
         if (eng.proto == PROTO_SERVE2) {
             /* the serve codec has no reset command; dropping the local history

--- a/lumashim.c
+++ b/lumashim.c
@@ -158,6 +158,10 @@ static struct {
     LmbTrustKeys trust;                    /* old+new keys during rotation */
     RFile *_Atomic fdmap[FD_LIMIT];
     _Atomic uint64_t net_bytes, net_blocks, warm_reads, cas_hits, cas_bytes;
+    /* the dense warm-up: bytes of non-expert tensors, and how many of them
+     * are in the mirror (already there, or fetched by the warm-up thread) */
+    _Atomic uint64_t dense_total, dense_done;
+    _Atomic int dense_state;        /* 0 off · 1 running · 2 ready · 3 failed */
     pthread_once_t once;
 } g = { .cache_lock_fd = -1, .reset_lock_fd = -1, .once = PTHREAD_ONCE_INIT };
 
@@ -829,6 +833,7 @@ static pthread_mutex_t pf_lk = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t pf_cv = PTHREAD_COND_INITIALIZER;
 
 static int ensure_block(RFile *f, uint32_t blk);      /* fwd */
+static int ensure_range(RFile *f, uint64_t off, uint64_t len);   /* fwd */
 
 static void *prefetch_thread(void *arg) {
     (void)arg;
@@ -867,11 +872,131 @@ static void prefetch_after(RFile *f, uint64_t off, uint64_t len) {
 
 /* ---- stats -------------------------------------------------------------- */
 
+/* ---- the dense warm-up ----------------------------------------------------
+ *
+ * A MoE engine loads its dense weights layer by layer, on the first forward:
+ * behind a cold mirror that made the FIRST REPLY a 7 GB download spread over
+ * 43 layers, while "ready" had been printed half an hour earlier. The warm-up
+ * reads every safetensors header, keeps the tensors that are not routed
+ * experts (name without ".experts." — shared_experts stay, they run here),
+ * and pulls their blocks through the ordinary verified path while the engine
+ * boots. The engine's own reads of the same blocks dedup on the in-flight
+ * map, so nothing is fetched twice. Progress is published as bytes so the
+ * chatter can draw a bar with an ETA; "ready" then means ready. */
+static int dense_is_expert(const char *name) {
+    return strstr(name, ".experts.") != NULL;
+}
+
+/* one shard: header → tensor ranges → blocks to have; returns needed blocks */
+static uint32_t dense_plan_file(RFile *f, uint8_t *need) {
+    char cpath[LMB_CACHE_PATH_MAX];
+    if (ensure_range(f, 0, 8) || data_path(cpath, sizeof cpath, f->rel)) return 0;
+    int fd = real_open(cpath, O_RDONLY, 0);
+    if (fd < 0) return 0;
+    uint8_t hdr[8];
+    uint64_t hlen = 0;
+    if (real_pread(fd, hdr, 8, 0) != 8) { real_close(fd); return 0; }
+    for (int i = 7; i >= 0; i--) hlen = (hlen << 8) | hdr[i];
+    if (!hlen || hlen > (64u << 20) || 8 + hlen > f->size) { real_close(fd); return 0; }
+    if (ensure_range(f, 8, hlen)) { real_close(fd); return 0; }
+    char *json = (char *)malloc((size_t)hlen + 1);
+    if (!json) { real_close(fd); return 0; }
+    size_t got = 0;
+    while (got < hlen) {
+        ssize_t r = real_pread(fd, json + got, (size_t)hlen - got, (off_t)(8 + got));
+        if (r <= 0) break;
+        got += (size_t)r;
+    }
+    real_close(fd);
+    if (got != hlen) { free(json); return 0; }
+    json[hlen] = 0;
+    uint32_t needed = 0;
+    for (char *p = strstr(json, "\"data_offsets\""); p; p = strstr(p + 1, "\"data_offsets\"")) {
+        /* the tensor's object starts at the previous '{'; its name is the
+         * quoted key right before it */
+        char *ob = p;
+        while (ob > json && *ob != '{') ob--;
+        char *q2 = ob;
+        while (q2 > json && *q2 != '"') q2--;           /* closing quote of the name */
+        char *q1 = q2 > json ? q2 - 1 : json;
+        while (q1 > json && *q1 != '"') q1--;
+        if (q2 <= q1) continue;
+        char name[256];
+        size_t nl = (size_t)(q2 - q1 - 1);
+        if (nl >= sizeof name) nl = sizeof name - 1;
+        memcpy(name, q1 + 1, nl); name[nl] = 0;
+        if (dense_is_expert(name)) continue;
+        unsigned long long a = 0, b = 0;
+        char *br = strchr(p, '[');
+        if (!br || sscanf(br, "[%llu,%llu]", &a, &b) != 2 || b <= a) continue;
+        uint64_t off = 8 + hlen + a, end = 8 + hlen + b;
+        if (end > f->size) end = f->size;
+        if (off >= end) continue;
+        for (uint32_t blk = (uint32_t)(off / g.block);
+             blk <= (uint32_t)((end - 1) / g.block) && blk < f->nblocks; blk++)
+            if (!need[blk]) { need[blk] = 1; needed++; }
+    }
+    free(json);
+    return needed;
+}
+
+static void *dense_prefetch_thread(void *arg) {
+    (void)arg;
+    uint8_t **plans = (uint8_t **)calloc((size_t)g.nfiles, sizeof *plans);
+    if (!plans) { atomic_store(&g.dense_state, 3); return NULL; }
+    uint64_t total = 0, done = 0;
+    for (int i = 0; i < g.nfiles; i++) {
+        RFile *f = &g.files[i];
+        size_t n = strlen(f->rel);
+        if (n < 12 || strcmp(f->rel + n - 12, ".safetensors")) continue;
+        plans[i] = (uint8_t *)calloc(f->nblocks ? f->nblocks : 1, 1);
+        if (!plans[i]) continue;
+        uint32_t needed = dense_plan_file(f, plans[i]);
+        if (!needed) { free(plans[i]); plans[i] = NULL; continue; }
+        for (uint32_t b = 0; b < f->nblocks; b++)
+            if (plans[i][b]) {
+                uint64_t bytes = (uint64_t)b + 1 == f->nblocks
+                    ? f->size - (uint64_t)b * g.block : g.block;
+                total += bytes;
+                if (f->map[b]) done += bytes;
+            }
+    }
+    atomic_store(&g.dense_total, total);
+    atomic_store(&g.dense_done, done);
+    int failed = 0;
+    for (int i = 0; i < g.nfiles; i++) {
+        if (!plans[i]) continue;
+        RFile *f = &g.files[i];
+        for (uint32_t b = 0; b < f->nblocks; b++) {
+            if (!plans[i][b] || f->map[b]) continue;
+            uint64_t bytes = (uint64_t)b + 1 == f->nblocks
+                ? f->size - (uint64_t)b * g.block : g.block;
+            if (ensure_block(f, b)) { failed = 1; continue; }
+            atomic_fetch_add(&g.dense_done, bytes);
+        }
+        free(plans[i]);
+    }
+    free(plans);
+    atomic_store(&g.dense_state, failed ? 3 : 2);
+    fprintf(stderr, "[lumabri] dense %s: %.0f MB of non-expert weights in the mirror%s\n",
+            failed ? "warm-up incomplete" : "ready",
+            (double)atomic_load(&g.dense_done) / 1e6,
+            failed ? " (some blocks could not be fetched; the engine will retry them)" : "");
+    return NULL;
+}
+
 static void *stats_thread(void *arg) {
     int period = (int)(intptr_t)arg;
-    uint64_t last_bytes = 0, last_cas = 0;
+    uint64_t last_bytes = 0, last_cas = 0, last_dense = 0;
     for (;;) {
         sleep((unsigned)period);
+        if (atomic_load(&g.dense_state) == 1) {
+            uint64_t dt = atomic_load(&g.dense_total), dd = atomic_load(&g.dense_done);
+            fprintf(stderr, "[lumabri] dense %.1f/%.1f MB (%.1f MB/s)\n",
+                    (double)dd / 1e6, (double)dt / 1e6,
+                    (double)(dd > last_dense ? dd - last_dense : 0) / 1e6 / period);
+            last_dense = dd;
+        }
         uint64_t nb = atomic_load(&g.net_bytes);
         uint64_t blk = atomic_load(&g.net_blocks);
         uint64_t warm = atomic_load(&g.warm_reads);
@@ -1240,6 +1365,15 @@ static void shim_init_impl(void) {
         pthread_t t;
         if (pthread_create(&t, NULL, stats_thread, (void *)(intptr_t)atoi(stats)) == 0)
             pthread_detach(t);
+    }
+    /* The chatter asks for the dense warm-up on a swarm-fed model: it needs
+     * peers (or a CAS) to pull from, and it must not run for a local copy. */
+    if (getenv("LUMABRI_PREFETCH_DENSE") && (g.npeers || g.cas_dir[0])) {
+        pthread_t t;
+        atomic_store(&g.dense_state, 1);
+        if (pthread_create(&t, NULL, dense_prefetch_thread, NULL) == 0)
+            pthread_detach(t);
+        else atomic_store(&g.dense_state, 3);
     }
     fprintf(stderr, "[lumabri] %d files · %.1f GB · %.1f%% already local · "
                     "%d peer(s) · block %u MiB · prefetch %d%s\n",


### PR DESCRIPTION
Three things the first real chats asked for, in one PR.

1. **Dense weights before "ready", with a bar.** "Ready" was printed while 7 GB of dense weights were still on the server: a MoE engine loads them layer by layer on the first forward, so the first reply became a 35-minute download. The shim now runs a dense warm-up on every swarm-fed chat (`LUMABRI_PREFETCH_DENSE`): it reads each safetensors header, keeps the tensors that are not routed experts (name without `.experts.`; shared experts stay), and pulls their blocks through the ordinary verified path while the engine boots, deduped against the engine's own reads. Progress is published as bytes; the boot spinner draws a bar with GB, MB/s and an ETA, and "ready" waits for the warm-up (bounded: two minutes without progress hands over to the engine's on-demand reads).
2. **A donor sees itself being used.** The frame above the idle prompt carries `donor: N esperti (M in RAM, X GB) · calls (rate) · in corso · disco served`, read from the tracker's nominative counters and refreshed every 3 s while the prompt is idle. The line editor polls with a timeout so the refresh never touches what is being typed.
3. **A typo is not a prompt.** A line starting with `/` that is not a known command is refused with a hint (Tab completes, `/help` lists) and never reaches the engine.

Also `LUMABRI_ENGINE_LOG=path` appends every engine line to a file: `/debug` keeps only a tail, and a slow reply could not be read after the fact.

## Verified

- `selftest.sh` (cold, warm, offline, NAT relay, replaced checkpoint) passes with the new shim.
- On the fixture the warm-up reports `dense N/411.0 MB (MB/s)` and excludes the fused expert tensors.
- Chat and shim build under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
