### PR TITLE
fix(client): a pooled socket the executor already closed is dialed fresh, not charged as a peer failure

### DIFF
--- a/lumabri.c
+++ b/lumabri.c
@@ -1477,7 +1477,13 @@ static void render_experts(const char *tracker) {
 /* distinct model names on the swarm; returns count */
 static int swarm_models(const char *tracker, char names[][64], int cap) {
     SwarmRow rows[64];
-    int n = swarm_stats(tracker, rows, 64, NULL, 0, NULL), out = 0;
+    /* One lost packet at startup used to print "no swarm" and exit while
+     * the tracker was answering everyone else. Ask a few times first. */
+    int n = -1, out = 0;
+    for (int attempt = 0; attempt < 4 && n < 0; attempt++) {
+        if (attempt) sleep(1);
+        n = swarm_stats(tracker, rows, 64, NULL, 0, NULL);
+    }
     if (n < 0) return 0;
     for (int i = 0; i < n; i++) {
         int seen = 0;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -28,6 +28,7 @@
 #define LUMABRI_CLIENT_H
 
 #include <limits.h>
+#include <poll.h>
 
 #include "lumabri_proto.h"
 #include "lumabri_sign.h"
@@ -164,8 +165,25 @@ static void lumi_peer_done(LumiPeer *peer) {
  * layer must see them as two concurrent requests, not a queue of one. A
  * transport failure feeds the circuit breaker; it does not erase a valid
  * manifest permanently. */
+/* A pooled socket may have been closed by the executor while it sat idle
+ * (its I/O timeout is minutes; a slow reply leaves sockets idle longer).
+ * Reusing it means a send that succeeds into the kernel and a recv that
+ * finds EOF: a "failed" call charged to a healthy peer, a retry, and after
+ * a few of those an open circuit and a patience wait. A closed socket is
+ * readable (EOF) before we write to it, so ask, and dial fresh instead. */
+static int lumi_sock_alive(int fd) {
+    struct pollfd pfd = { fd, POLLIN, 0 };
+    int r = poll(&pfd, 1, 0);
+    if (r < 0) return 1;                       /* cannot tell: use it */
+    return r == 0;                             /* nothing pending = idle and open */
+}
+
 static int lumi_take_sock(LumiPeer *p) {
-    if (p->nsocks) return p->socks[--p->nsocks];
+    while (p->nsocks) {
+        int fd = p->socks[--p->nsocks];
+        if (lumi_sock_alive(fd)) return fd;
+        close(fd);                             /* stale: the peer hung up */
+    }
     const char *dial = p->loopback[0] ? p->loopback : p->addr;
     if (p->relay_target[0]) {
         dial = getenv("LUMABRI_TRACKER");


### PR DESCRIPTION
A chatter keeps a pool of sockets per executor. The executor's I/O timeout closes an idle one after minutes, and a slow reply leaves them idle for longer than that. Reusing a closed socket meant a send that succeeded into the kernel and a recv that found EOF: a `failed on layer` charged to a healthy peer, a retry on the next replica, and after a few of those an open circuit and a `nessuna replica viva — aspetto` pause. The engine log of a one-hour reply showed exactly that loop.

A closed socket is readable (EOF) before anything is written to it, so `lumi_take_sock` now polls a pooled socket and discards it if the peer hung up, dialing fresh instead. `phase2_test.sh` passes (tokens identical); the client header builds under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)