### PR TITLE
feat: the bill per executor and per layer round, a two-minute expert-call timeout, room for the donor, relay counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ the command, e.g. `LUMABRI_SPREAD=1 lumabri chat …`.
 | `LUMABRI_ENCRYPT=1` | encrypt the transport (see below) |
 | `LUMABRI_ENGINE_LOG=path` | append every line the engine prints to this file (the chat otherwise keeps only the tail `/debug` shows) |
 | `LUMABRI_SWARM_PATIENCE_S=N` | on a swarm-fed chat, how long a reply waits for a vanished executor before failing plainly (default 600); it never downloads experts to run them locally |
+| `LUMABRI_EXEC_TIMEOUT_MS=N` | give up on an expert call that has not answered in N ms and fail over (default 120000; the general I/O timeout is five minutes) |
 | `LUMABRI_READ_TIMEOUT_MS=N` | give up on a peer that has not delivered an 8 MiB block in N ms and ask the next one (default 60000; the general I/O timeout is five minutes) |
 | `RAM_GB=N` | tell a `--local` run how much RAM it may use to keep experts resident |
 

--- a/expert_node.c
+++ b/expert_node.c
@@ -1194,6 +1194,14 @@ int main(int argc, char **argv) {
         long reserve_mb = governor_reserve_mb;
         double avail_b = avail_kb > reserve_mb * 1024L
             ? (double)(avail_kb - reserve_mb * 1024L) * 1024.0 : 0.0;
+        /* Not all of it. A donor that fills every free byte at start is at
+         * the reserve the moment anything else on the machine grows — the
+         * chat engine next to it, a browser — and the governor then flaps
+         * ACTIVE/PRESSURE/PAUSED, refusing calls while its experts sit in
+         * RAM (a real donor did exactly that: 83.6 GB resident, 14 GB free).
+         * Keep a quarter plus two gigabytes as the machine's own room. */
+        avail_b -= avail_b * 0.25 + 2e9;
+        if (avail_b < 0) avail_b = 0;
         double ebytes = node_expert_bytes();
         int total = 0;
         for (int l = 0; l < g.n_slots; l++) if (lmbe_routed(l)) total += g.n_experts;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -74,6 +74,10 @@ typedef struct {
      * origin's --cache executor); -1: not known (older node, or reached only
      * through the tracker tunnel). Only a known disk replica is penalized. */
     int resident;
+    /* the bill: what this peer answered, how long it took, and the bytes
+     * that crossed the wire each way — the report divides them by rounds */
+    unsigned long long ok_calls, bytes_out, bytes_in;
+    double lat_s;
 } LumiPeer;
 
 static struct {
@@ -151,9 +155,12 @@ static void lumi_peer_failed(LumiPeer *peer) {
 }
 
 static void lumi_peer_observed(LumiPeer *peer, double started) {
-    uint64_t elapsed = (uint64_t)((lumi_now() - started) * 1e6);
+    double took = lumi_now() - started;
+    uint64_t elapsed = (uint64_t)(took * 1e6);
     lmb_predict_observe(&peer->latency, elapsed ? elapsed : 1);
     peer->exec_observations++;
+    peer->ok_calls++;
+    peer->lat_s += took;
 }
 
 static void lumi_peer_sent(LumiPeer *peer) { peer->inflight++; }
@@ -194,7 +201,12 @@ static int lumi_take_sock(LumiPeer *p) {
     if (fd < 0) {
         fprintf(stderr, "[lumabri] peer %s unreachable — circuit failure\n", p->addr);
         lumi_peer_failed(p);
+        return fd;
     }
+    /* An expert call that has not answered in two minutes is lost, not slow:
+     * the general five-minute I/O timeout cost a reply 10 minutes twice in
+     * one hour. Long enough for a prefill block on a slow uplink. */
+    lmb_set_io_timeout(fd, lmb_env_int("LUMABRI_EXEC_TIMEOUT_MS", 120000, 1000, 3600000));
     return fd;
 }
 
@@ -979,6 +991,7 @@ static int lumi_send_exec(LumiPeer *p, int fd, int layer, int eid,
     int rc = lmb_send(fd, targeted ? LMB_TEXEC : LMB_EXEC, b.p,
                       (uint32_t)b.len,
                       x, (uint32_t)((size_t)nr * D * sizeof(float)));
+    if (!rc && p) p->bytes_out += 16 + b.len + (size_t)nr * D * sizeof(float);
     free(b.p);
     return rc;
 }
@@ -1041,6 +1054,7 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
                 lumi_peer_done(p[i]);
                 lumi_put_sock(p[i], fd[i]); fd[i] = -1;
                 if (i == 1) L.hedge_wins++;
+                p[i]->bytes_in += 16 + want;
                 lumi_peer_observed(p[i], started[i]);
                 for (int j = 0; j < 2; j++) if (fd[j] >= 0) {
                     close(fd[j]); lumi_peer_done(p[j]);
@@ -1754,6 +1768,28 @@ static LMB_MAYBE_UNUSED void lumi_report(void) {
         fprintf(stderr, "[lumabri] %llu layer demotion(s) to the local mirror"
                         " · %llu integrity quarantine(s)\n",
                 L.demotions, L.integrity_fails);
+    /* The bill per executor, and the bytes a layer round costs: the number
+     * that decides whether a chatter's uplink, not the peers, sets its tok/s. */
+    unsigned long long out = 0, in = 0;
+    for (int i = 0; i < L.npeers; i++) {
+        LumiPeer *p = &L.peers[i];
+        out += p->bytes_out; in += p->bytes_in;
+        if (!p->ok_calls && !p->bytes_out) continue;
+        fprintf(stderr, "[lumabri] executor %s: %llu call(s) answered · %.1f ms each · "
+                        "%.1f MB up · %.1f MB down%s%s\n",
+                p->addr, p->ok_calls,
+                p->ok_calls ? 1000.0 * p->lat_s / (double)p->ok_calls : 0.0,
+                (double)p->bytes_out / 1e6, (double)p->bytes_in / 1e6,
+                p->relay_target[0] ? " · via tracker tunnel" : "",
+                p->resident == 0 ? " · experts from disk" :
+                p->resident == 1 ? " · experts in RAM" : "");
+    }
+    if (L.layers_done)
+        fprintf(stderr, "[lumabri] wire: %.1f MB up · %.1f MB down · per layer round "
+                        "%.0f KB up · %.0f KB down\n",
+                (double)out / 1e6, (double)in / 1e6,
+                (double)out / 1e3 / (double)L.layers_done,
+                (double)in / 1e3 / (double)L.layers_done);
 }
 
 #endif /* LUMABRI_CLIENT_H */

--- a/tracker.c
+++ b/tracker.c
@@ -2207,6 +2207,10 @@ static void peer_unref(Peer *p) {
  * failover is the chatter's own job — it owns the tried-set, the
  * predictors and the spot-check. The reply is a plain LMB_EXEC_R, so the
  * chatter's receive path cannot tell this peer from a dialable one. */
+/* Relayed expert calls, counted: a chatter that reports "peer X failed"
+ * through the tunnel could not be told apart from a tunnel that dropped. */
+static unsigned long long g_relay_exec_ok, g_relay_exec_failed;
+
 static int handle_texec(int fd, LmbMsg *m) {
     LmbCur c = { m->body, m->body_len, 0 };
     char target[64];
@@ -2237,8 +2241,14 @@ static int handle_texec(int fd, LmbMsg *m) {
         p->rexec_fail_at = now_s();
     }
     int rc;
-    if (!ok) { free(resp); send_err(fd, "targeted exec failed"); rc = 0; }
-    else {
+    if (!ok) {
+        free(resp); send_err(fd, "targeted exec failed"); rc = 0;
+        unsigned long long f = ++g_relay_exec_failed;
+        if (f <= 20 || f % 100 == 0)
+            printf("[tracker] targeted exec to %s failed (%llu ok · %llu failed so far)\n",
+                   p->name, g_relay_exec_ok, f);
+    } else {
+        g_relay_exec_ok++;
         rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, resp, resp_len);
         free(resp);
     }
@@ -2364,8 +2374,14 @@ static int handle_rexec(int fd, LmbMsg *m) {
     }
 
     int rc;
-    if (!ok) { free(resp); send_err(fd, "exec relay timeout or peer failure"); rc = 0; }
-    else {
+    if (!ok) {
+        free(resp); send_err(fd, "exec relay timeout or peer failure"); rc = 0;
+        unsigned long long f = ++g_relay_exec_failed;
+        if (f <= 20 || f % 100 == 0)
+            printf("[tracker] relayed exec failed (%llu ok · %llu failed so far)\n",
+                   g_relay_exec_ok, f);
+    } else {
+        g_relay_exec_ok++;
         LmbBuf b = {0}; lmb_buf_u32(&b, 1);
         rc = lmb_send(fd, LMB_REXEC_R, b.p, (uint32_t)b.len, resp, resp_len);
         free(b.p); free(resp);


### PR DESCRIPTION
Tappa 0 of the route: measure before optimizing, and stop two things the first real chats showed.

1. **The bill.** The chatter's end-of-run report lists every executor with calls answered, mean latency, MB up and down, tunnel or direct, RAM or disk, plus one line with the bytes a layer round costs. On a 6.6 Mbit/s uplink a DeepSeek token was 4 MB up (16 KB × 6 experts × 43 layers): the number that set the tok/s, and that nothing printed.
2. **Two-minute expert-call timeout** (`LUMABRI_EXEC_TIMEOUT_MS`, default 120000). The general five-minute I/O timeout cost a one-hour reply eleven minutes in two stalls.
3. **Room for the donor.** `--hold auto` filled every free byte at start; the chat engine next to it then grew, the governor flapped ACTIVE/PRESSURE/PAUSED and the donor refused calls with 83.6 GB of experts in RAM. It now keeps a quarter plus two gigabytes as the machine's own room.
4. **Relay counters.** The tracker counts relayed expert calls that failed and logs them (first 20, then every 100th), so a chatter's "peer X failed" through the tunnel is visible on the server side.

Verified: `phase2_test.sh` (tokens identical; the report shows per-executor lines and `per layer round 17 KB up · 16 KB down` on the fixture); client header, node and tracker build under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
