### PR TITLE
feat: activations and expert outputs cross the wire as bf16 when they already are bf16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -386,6 +386,9 @@ test_key_rotation: test_key_rotation.c lumabri_sign.h
 test_hedge: test_hedge.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_hedge.c -o $@
 
+test_exec2: test_exec2.c lumabri_proto.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread test_exec2.c -o $@ -lm
+
 test_local_fallback: test_local_fallback.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_local_fallback.c -o $@
 
@@ -599,6 +602,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	bash ./hot_cache_integrity_test.sh
 	bash ./role_test.sh
 	bash ./serve_failfast_test.sh
+	bash ./exec2_test.sh
 	bash ./security_test.sh
 	bash ./expert_input_test.sh
 	bash ./prefetch_policy_test.sh

--- a/PROTOCOL_COMPATIBILITY.md
+++ b/PROTOCOL_COMPATIBILITY.md
@@ -14,6 +14,7 @@ Changing one payload never permits silently reinterpreting another.
 | Expert stats capability | `ECAP` / 1, `EST1` / 2 | fall back to legacy registration without stats |
 | swarm execution/detail | `SWX1` / 1, detail 2 | omit unavailable telemetry, not compute identity |
 | executor residency (`LMB_ERES` 70/71) | additive op | older node answers `ERR`; chatter treats residency as unknown, no penalty |
+| encoded expert call (`LMB_EXEC2` 72/73, caps word in `ERES_R`) | additive op | a chatter sends `EXEC2` only to a node whose `ERES_R` carries `LMB_CAP_EXEC2`; the tunnel keeps `EXEC`; bf16 only for values that are exactly bf16 |
 
 The model root, engine ID, source/build profile, numeric class, state schema,
 dtype and width are compatibility data rather than decoration. A peer with a

--- a/README.md
+++ b/README.md
@@ -353,8 +353,13 @@ ranges concurrently. Lumabri deliberately does not fuse rows from unrelated
 sessions: current Colibri adapters own opaque per-session state and can round a
 cross-session batch differently. Calling that continuous batching before an
 engine-neutral multi-session batch ABI exists would break the token oracle.
-A replica that holds the expert in RAM is always preferred to one that
-streams it from disk, whatever their RTTs: the origin's `--exec-cache`
+An activation crosses the wire as bf16 when every one of its values already
+is a bf16 (DeepSeek V4 rounds its MoE input and every expert's output to
+bf16, so always there; other engines whenever it happens), and an executor
+answers in bf16 the same way: half the bytes in each direction on the uplink
+that sets a home chatter's tok/s, with the arithmetic untouched, because a
+value is never rounded to fit. A replica that holds the expert in RAM is
+always preferred to one that streams it from disk, whatever their RTTs: the origin's `--exec-cache`
 executor is the last resort, so a donor that loaded an expert receives its
 calls the moment it is visible. When two donors hold the *same* expert, the
 chatter spreads the load between them by default (set `LUMABRI_SPREAD=0`

--- a/exec2_test.sh
+++ b/exec2_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# The bf16 wire dialect against a real OLMoE node: same bytes back.
+set -euo pipefail
+cd "$(dirname "$0")"
+make -s expert_node test_exec2
+MODEL="${MODEL:-$PWD/tiny_olmoe}"
+[ -f "$MODEL/config.json" ] || make -s fixture
+T=$(mktemp -d /tmp/lumabri-exec2.XXXXXX)
+OMP_NUM_THREADS=2 COLI_NO_OMP_TUNE=1 ./expert_node --model "$MODEL" --port 7631 --name exec2-node >"$T/node.log" 2>&1 &
+PID=$!
+trap 'kill $PID 2>/dev/null || true; rm -rf "$T"' EXIT
+for _ in $(seq 1 600); do (exec 3<>/dev/tcp/127.0.0.1/7631) 2>/dev/null && break; sleep .1; done
+HIDDEN=$(python3 -c "import json;print(json.load(open('$MODEL/config.json'))['hidden_size'])")
+sleep 1
+./test_exec2 127.0.0.1:7631 0 3 "$HIDDEN" || { cat "$T/node.log"; exit 1; }
+./test_exec2 127.0.0.1:7631 1 5 "$HIDDEN" || { cat "$T/node.log"; exit 1; }

--- a/expert_node.c
+++ b/expert_node.c
@@ -350,7 +350,8 @@ static void cache_release(CSlot *s) {
  * to be all of them at once: an engine that computes nr rows in one call
  * does not produce the same floats as nr calls of one row, and byte identity
  * with the local path is the entire claim of this project. */
-static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
+static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len, uint32_t *enc_out) {
+    if (enc_out) *enc_out = LMB_ENC_F32;
     if (!lmb_governor_accepting(&g.governor)) return -2;
     /* Test aid, in the spirit of LUMABRI_RTT_US: a deliberate compute delay
      * lets the relay tests prove concurrency and heartbeat liveness without
@@ -364,6 +365,11 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
         return -1;
     }
     lmb_cur_u32(&cur, &nrows);            /* absent in the single-row dialect */
+    uint32_t enc_in = LMB_ENC_F32, hdr = 16;
+    if (m->op == LMB_EXEC2) {
+        if (lmb_cur_u32(&cur, &enc_in) || enc_in > LMB_ENC_BF16) return -1;
+        hdr = 20;
+    }
     /* The cap is not decoration. The size check below used to be computed in
      * 32 bits, so on a model with a large hidden size a caller could pick a
      * row count whose byte length wrapped to something small, match it with a
@@ -378,13 +384,22 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
      * projection, so it is not something the chatter can multiply back. The
      * body length says which dialect this is. */
     const float *rw = NULL;
-    if (m->body_len == 16 + (uint64_t)nrows * sizeof(float))
-        rw = (const float *)(m->body + 16);
-    else if (m->body_len != 16) return -1;
+    if (m->body_len == hdr + (uint64_t)nrows * sizeof(float))
+        rw = (const float *)(m->body + hdr);
+    else if (m->body_len != hdr) return -1;
     uint64_t want = (uint64_t)nrows * dim * sizeof(float);
+    uint64_t pay_want = enc_in == LMB_ENC_BF16 ? want / 2 : want;
     if (!expert_index_ok(layer, eid) || dim != (uint32_t)g.hidden ||
-        want > LMB_MAX_PAY || m->pay_len != want) {
+        want > LMB_MAX_PAY || m->pay_len != pay_want) {
         return -1;
+    }
+    /* bf16 in: widen to the floats the kernel takes; exact by construction */
+    float *x_bf16 = NULL;
+    const float *x = (const float *)m->pay;
+    if (enc_in == LMB_ENC_BF16) {
+        x_bf16 = node_falloc((size_t)nrows * dim);
+        lmb_bf16_unpack(x_bf16, (const uint16_t *)m->pay, (size_t)nrows * dim);
+        x = x_bf16;
     }
     size_t gid = (size_t)layer * (size_t)g.n_experts + eid;
     if (!g.holds[gid]) return -1;
@@ -420,15 +435,24 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
     float *out = node_falloc((size_t)nrows * g.hidden);
     double t0 = nowd();
     if (cs) {
-        lmbe_apply(&cs->slot, (int)layer, (const float *)m->pay, out, (int)nrows, rw, t_scratch);
+        lmbe_apply(&cs->slot, (int)layer, x, out, (int)nrows, rw, t_scratch);
         cache_release(cs);
     } else {
         lmbe_apply(&g.held[g.index[gid]].slot, (int)layer,
-                   (const float *)m->pay, out, (int)nrows, rw, t_scratch);
+                   x, out, (int)nrows, rw, t_scratch);
     }
     double dt = nowd() - t0;
     gate_leave();
+    free(x_bf16);
     maybe_corrupt_out(out);
+    /* bf16 out when every value already is one: half the bytes down, same
+     * numbers. The chatter asked with EXEC2, so it can read either. */
+    if (enc_out && m->op == LMB_EXEC2 &&
+        lmb_bf16_exact(out, (size_t)nrows * g.hidden)) {
+        lmb_bf16_pack((uint16_t *)out, out, (size_t)nrows * g.hidden);
+        obytes = want / 2;
+        *enc_out = LMB_ENC_BF16;
+    }
     { const char *slow = getenv("LUMABRI_EXEC_DELAY_MS");
       if (slow && atoi(slow) > 0) usleep((useconds_t)atoi(slow) * 1000u); }
     lmb_emu_delay();   /* the reply's flight time, when one is being emulated */
@@ -440,14 +464,19 @@ static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len) {
 }
 
 static int handle_exec(int fd, LmbMsg *m) {
-    float *out = NULL; uint32_t out_len = 0;
-    int status = exec_compute(m, &out, &out_len);
+    float *out = NULL; uint32_t out_len = 0, enc = LMB_ENC_F32;
+    int status = exec_compute(m, &out, &out_len, m->op == LMB_EXEC2 ? &enc : NULL);
     if (status) {
         send_err(fd, status == -2 ? "executor draining under machine pressure" :
                                     "bad exec request or expert not held");
         return -1;
     }
-    int rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, out, out_len);
+    int rc;
+    if (m->op == LMB_EXEC2) {
+        uint8_t body[4]; lmb_put32(body, enc);
+        rc = lmb_send(fd, LMB_EXEC2_R, body, 4, out, out_len);
+    } else
+        rc = lmb_send(fd, LMB_EXEC_R, NULL, 0, out, out_len);
     free(out);
     return rc;
 }
@@ -476,7 +505,7 @@ static int handle_rexec_fwd(int fd, LmbMsg *m) {
                      .body_len = m->body_len - 4,
                      .pay = m->pay, .pay_len = m->pay_len };
     float *out = NULL; uint32_t out_len = 0;
-    int ok = exec_compute(&inner, &out, &out_len) == 0;
+    int ok = exec_compute(&inner, &out, &out_len, NULL) == 0;
     if (getenv("LUMABRI_RELAY_TRACE"))
         fprintf(stderr, "[%s] relay exec id=%u %s out=%u\n",
                 g.name, id, ok ? "ok" : "refused", out_len);
@@ -576,6 +605,7 @@ static int handle_eres(int fd) {
     LmbBuf b = {0};
     lmb_buf_u32(&b, g.resident_flags);
     lmb_buf_u32(&b, atomic_load(&g.resident_state));
+    lmb_buf_u32(&b, LMB_CAP_EXEC2);           /* what this node speaks beyond EXEC */
     int rc = lmb_send(fd, LMB_ERES_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
@@ -630,7 +660,8 @@ static void *conn_thread(void *arg) {
             } else { send_err(fd, "bad token"); rc = -1; }
             break;
         }
-        case LMB_EXEC:      rc = handle_exec(fd, &m); break;
+        case LMB_EXEC:
+        case LMB_EXEC2:     rc = handle_exec(fd, &m); break;
         case LMB_EMANIFEST: rc = handle_emanifest(fd); break;
         case LMB_ERES: rc = handle_eres(fd); break;
         default:            send_err(fd, "unknown op"); rc = -1; break;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -78,6 +78,7 @@ typedef struct {
      * that crossed the wire each way — the report divides them by rounds */
     unsigned long long ok_calls, bytes_out, bytes_in;
     double lat_s;
+    uint32_t caps;              /* LMB_CAP_* the executor advertised (ERES) */
 } LumiPeer;
 
 static struct {
@@ -551,9 +552,11 @@ static int lumi_add_peer(const char *addr) {
         const char *dial = p->loopback[0] ? p->loopback : p->addr;
         if (!lmb_request(dial, LMB_ERES, NULL, 0, &rm) && rm.op == LMB_ERES_R) {
             LmbCur rc = { rm.body, rm.body_len, 0 };
-            uint32_t flags = 0;
+            uint32_t flags = 0, state = 0, caps = 0;
             if (!lmb_cur_u32(&rc, &flags))
                 p->resident = (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
+            if (!lmb_cur_u32(&rc, &state) && !lmb_cur_u32(&rc, &caps))
+                p->caps = caps;               /* absent on older nodes: plain EXEC */
         }
         lmb_msg_free(&rm);
     }
@@ -982,18 +985,56 @@ static int lumi_send_exec(LumiPeer *p, int fd, int layer, int eid,
                           const float *x, int D, int nr, const float *w) {
     LmbBuf b = {0};
     int targeted = p && p->relay_target[0];
+    /* EXEC2 to a node that speaks it, directly: the activation goes as
+     * bf16 when every value already is one (DeepSeek rounds its MoE input
+     * to bf16, so always there; other engines when it happens), which is
+     * half the bytes on the uplink that sets a home chatter's tok/s, with
+     * the arithmetic untouched. The tunnel keeps the plain dialect. */
+    int exec2 = p && !targeted && (p->caps & LMB_CAP_EXEC2);
+    size_t n = (size_t)nr * D;
+    int bf16 = exec2 && lmb_bf16_exact(x, n);
     if (targeted) lmb_buf_str(&b, p->relay_target);
     lmb_buf_u32(&b, (uint32_t)layer);
     lmb_buf_u32(&b, (uint32_t)eid);
     lmb_buf_u32(&b, (uint32_t)D);
     lmb_buf_u32(&b, (uint32_t)nr);
+    if (exec2) lmb_buf_u32(&b, bf16 ? LMB_ENC_BF16 : LMB_ENC_F32);
     if (w) lmb_buf_bytes(&b, w, (size_t)nr * sizeof(float));
-    int rc = lmb_send(fd, targeted ? LMB_TEXEC : LMB_EXEC, b.p,
-                      (uint32_t)b.len,
-                      x, (uint32_t)((size_t)nr * D * sizeof(float)));
-    if (!rc && p) p->bytes_out += 16 + b.len + (size_t)nr * D * sizeof(float);
+    const void *pay = x;
+    uint32_t pay_len = (uint32_t)(n * sizeof(float));
+    uint16_t *packed = NULL;
+    if (bf16) {
+        packed = (uint16_t *)malloc(n * sizeof *packed);
+        if (packed) { lmb_bf16_pack(packed, x, n); pay = packed; pay_len = (uint32_t)(n * 2); }
+        else { bf16 = 0; b.p[b.len - (w ? nr * 4 : 0) - 4] = LMB_ENC_F32; }
+    }
+    int rc = lmb_send(fd, targeted ? LMB_TEXEC : exec2 ? LMB_EXEC2 : LMB_EXEC,
+                      b.p, (uint32_t)b.len, pay, pay_len);
+    if (!rc && p) p->bytes_out += 16 + b.len + pay_len;
+    free(packed);
     free(b.p);
     return rc;
+}
+
+/* The reply of EXEC or EXEC2 as the floats the engine expects, or NULL
+ * when it is not one. A bf16 reply is widened here; it was exact. */
+static float *lumi_exec_take(LmbMsg *m, int nr, int D) {
+    size_t n = (size_t)nr * D;
+    if (m->op == LMB_EXEC_R) {
+        if (m->pay_len != n * sizeof(float)) return NULL;
+        return (float *)lmb_msg_take_pay(m);
+    }
+    if (m->op != LMB_EXEC2_R || m->body_len < 4) return NULL;
+    uint32_t enc = lmb_get32(m->body);
+    if (enc == LMB_ENC_F32 && m->pay_len == n * sizeof(float))
+        return (float *)lmb_msg_take_pay(m);
+    if (enc == LMB_ENC_BF16 && m->pay_len == n * 2) {
+        float *res = (float *)malloc(n * sizeof(float));
+        if (!res) return NULL;
+        lmb_bf16_unpack(res, (const uint16_t *)m->pay, n);
+        return res;
+    }
+    return NULL;
 }
 
 /* Adaptive p95 hedging, with LUMABRI_HEDGE_MS as an explicit fixed override.
@@ -1007,7 +1048,6 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
     if (primary_fd < 0 || !primary) return NULL;
     int fd[2] = { primary_fd, -1 };
     LumiPeer *p[2] = { primary, NULL };
-    uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
     double started[2] = { primary_started, 0.0 };
     uint32_t hedge_ms = L.hedge_ms < 0 ? 0u :
                         L.hedge_ms > 0 ? (uint32_t)L.hedge_ms :
@@ -1049,12 +1089,13 @@ static float *lumi_finish_exec(int layer, int eid, const float *x, int D, int nr
         for (int q = 0; q < np; q++) if (pf[q].revents) {
             int i = map[q];
             LmbMsg m = {0};
-            if (lmb_recv(fd[i], &m) == 0 && m.op == LMB_EXEC_R && m.pay_len == want) {
-                float *res = (float *)lmb_msg_take_pay(&m); lmb_msg_free(&m);
+            float *res = lmb_recv(fd[i], &m) == 0 ? lumi_exec_take(&m, nr, D) : NULL;
+            if (res) {
+                uint32_t got = m.pay_len; lmb_msg_free(&m);
                 lumi_peer_done(p[i]);
                 lumi_put_sock(p[i], fd[i]); fd[i] = -1;
                 if (i == 1) L.hedge_wins++;
-                p[i]->bytes_in += 16 + want;
+                p[i]->bytes_in += 16 + got;
                 lumi_peer_observed(p[i], started[i]);
                 for (int j = 0; j < 2; j++) if (fd[j] >= 0) {
                     close(fd[j]); lumi_peer_done(p[j]);
@@ -1136,7 +1177,6 @@ static void lumi_demote_layer(int layer, int waited) {
 static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
                               const float *w, uint32_t *tried_io, LumiPeer **from) {
     int gid = layer * L.n_experts + eid;
-    uint32_t want = (uint32_t)((size_t)nr * D * sizeof(float));
     uint32_t tried = tried_io ? *tried_io : 0;
     int waited = 0;
     if (from) *from = NULL;
@@ -1215,8 +1255,8 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
         LmbMsg m = {0};
         int send_bad = lumi_send_exec(p, fd, layer, eid, x, D, nr, w);
         if (!send_bad) lumi_peer_sent(p);
-        if (send_bad || lmb_recv(fd, &m) ||
-            m.op != LMB_EXEC_R || m.pay_len != want) {
+        float *res = (!send_bad && lmb_recv(fd, &m) == 0) ? lumi_exec_take(&m, nr, D) : NULL;
+        if (!res) {
             close(fd);
             if (!send_bad) lumi_peer_done(p);
             lumi_peer_failed(p);
@@ -1224,7 +1264,7 @@ static float *lumi_exec_retry(int layer, int eid, const float *x, int D, int nr,
             fprintf(stderr, "[lumabri] peer %s failed — trying next replica\n", p->addr);
             continue;
         }
-        float *res = (float *)lmb_msg_take_pay(&m);
+        p->bytes_in += 16 + m.pay_len;
         lmb_msg_free(&m);
         lumi_peer_done(p);
         lumi_put_sock(p, fd);

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -279,7 +279,42 @@ enum {
      * simply treated as "unknown". Additive: the manifest itself is
      * unchanged, so old chatters keep admitting new nodes. */
     LMB_ERES = 70, LMB_ERES_R = 71,
+    /* EXEC with an explicit encoding. Body: u32 layer, eid, D, nrows,
+     * enc_in, then the router weights when the engine wants them applied
+     * remotely (body_len == 20 + nrows*4); pay is nrows*D floats when
+     * enc_in == 0, nrows*D bf16 halves when enc_in == 1. Reply body: u32
+     * enc_out; pay likewise. A value travels as bf16 only when it IS a
+     * bf16 (low 16 bits zero), so the arithmetic is unchanged: engines that
+     * round their MoE input and expert output to bf16 (DeepSeek V4 does)
+     * pay half the bytes, others keep floats, and nothing is approximated.
+     * Advertised by an executor as bit 0 of the caps word ERES_R carries
+     * after residency and state; an older node never receives EXEC2. */
+    LMB_EXEC2 = 72, LMB_EXEC2_R = 73,
 };
+#define LMB_CAP_EXEC2 (1u << 0)
+#define LMB_ENC_F32  0u
+#define LMB_ENC_BF16 1u
+
+/* bf16 on the wire, exact or not at all */
+static LMB_MAYBE_UNUSED int lmb_bf16_exact(const float *v, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        uint32_t bits; memcpy(&bits, &v[i], 4);
+        if (bits & 0xFFFFu) return 0;
+    }
+    return 1;
+}
+static LMB_MAYBE_UNUSED void lmb_bf16_pack(uint16_t *dst, const float *src, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        uint32_t bits; memcpy(&bits, &src[i], 4);
+        dst[i] = (uint16_t)(bits >> 16);
+    }
+}
+static LMB_MAYBE_UNUSED void lmb_bf16_unpack(float *dst, const uint16_t *src, size_t n) {
+    for (size_t i = 0; i < n; i++) {
+        uint32_t bits = (uint32_t)src[i] << 16;
+        memcpy(&dst[i], &bits, 4);
+    }
+}
 
 /* REGISTER body: str name, str addr, str model, u64 held_bytes,
  *                u64 served_bytes, u64 served_reads, u32 n { str path, u64 size }
@@ -369,6 +404,7 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
     case LMB_RREAD_R:
     case LMB_HASHES_R:
     case LMB_EXEC_R:
+    case LMB_EXEC2_R:
     case LMB_REXEC_R:
     case LMB_TEXEC:
     case LMB_TMAN_R:
@@ -385,6 +421,7 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
         break;
     case LMB_RREAD_FWD:
     case LMB_EXEC:
+    case LMB_EXEC2:
     case LMB_REXEC:
     case LMB_REXEC_FWD:
         *body_cap = LMB_MAX_CONTROL_BODY;

--- a/test_exec2.c
+++ b/test_exec2.c
@@ -1,0 +1,70 @@
+/* EXEC2 against a real expert node: the same bf16-exact activation sent as
+ * plain EXEC (floats) and as EXEC2 (bf16 halves) must come back identical,
+ * and the EXEC2 reply must be bf16 when the engine's output is. */
+#include "lumabri_proto.h"
+#include <math.h>
+
+static float *ask(const char *addr, int op, int layer, int eid, int D,
+                  const float *x, uint32_t *enc_out, uint32_t *pay_len) {
+    int fd = lmb_connect(addr);
+    if (fd < 0 || lmb_auth(fd)) { fprintf(stderr, "connect %s failed\n", addr); return NULL; }
+    LmbBuf b = {0};
+    lmb_buf_u32(&b, (uint32_t)layer); lmb_buf_u32(&b, (uint32_t)eid);
+    lmb_buf_u32(&b, (uint32_t)D); lmb_buf_u32(&b, 1u);
+    uint16_t *packed = NULL;
+    const void *pay = x; uint32_t plen = (uint32_t)D * 4;
+    if (op == LMB_EXEC2) {
+        int bf16 = lmb_bf16_exact(x, (size_t)D);
+        lmb_buf_u32(&b, bf16 ? LMB_ENC_BF16 : LMB_ENC_F32);
+        if (bf16) { packed = malloc((size_t)D * 2); lmb_bf16_pack(packed, x, (size_t)D); pay = packed; plen = (uint32_t)D * 2; }
+    }
+    LmbMsg m = {0};
+    float *res = NULL;
+    if (!lmb_send(fd, op, b.p, (uint32_t)b.len, pay, plen) && !lmb_recv(fd, &m)) {
+        *pay_len = m.pay_len;
+        if (op == LMB_EXEC && m.op == LMB_EXEC_R && m.pay_len == (uint32_t)D * 4) {
+            *enc_out = LMB_ENC_F32; res = (float *)lmb_msg_take_pay(&m);
+        } else if (op == LMB_EXEC2 && m.op == LMB_EXEC2_R && m.body_len >= 4) {
+            *enc_out = lmb_get32(m.body);
+            if (*enc_out == LMB_ENC_F32 && m.pay_len == (uint32_t)D * 4) res = (float *)lmb_msg_take_pay(&m);
+            else if (*enc_out == LMB_ENC_BF16 && m.pay_len == (uint32_t)D * 2) {
+                res = malloc((size_t)D * 4); lmb_bf16_unpack(res, (const uint16_t *)m.pay, (size_t)D);
+            }
+        } else {
+            char why[256] = "";
+            if (m.op == LMB_ERR) { LmbCur c = { m.body, m.body_len, 0 }; lmb_cur_str(&c, why, sizeof why); }
+            fprintf(stderr, "op %d: unexpected reply op=%u body=%u pay=%u %s\n", op, m.op, m.body_len, m.pay_len, why);
+        }
+    }
+    lmb_msg_free(&m); free(b.p); free(packed); close(fd);
+    return res;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 5) { fprintf(stderr, "usage: %s ADDR LAYER EID HIDDEN\n", argv[0]); return 2; }
+    const char *addr = argv[1];
+    int layer = atoi(argv[2]), eid = atoi(argv[3]), D = atoi(argv[4]);
+    float *x = malloc((size_t)D * 4);
+    /* a bf16-exact activation: random floats rounded to bf16 */
+    for (int i = 0; i < D; i++) {
+        float v = (float)((i * 7919) % 2000 - 1000) / 333.0f;
+        uint32_t bits; memcpy(&bits, &v, 4); bits &= 0xFFFF0000u; memcpy(&x[i], &bits, 4);
+    }
+    if (!lmb_bf16_exact(x, (size_t)D)) { fprintf(stderr, "test input is not bf16-exact\n"); return 1; }
+    uint32_t enc1 = 9, enc2 = 9, len1 = 0, len2 = 0;
+    float *a = ask(addr, LMB_EXEC, layer, eid, D, x, &enc1, &len1);
+    float *b = ask(addr, LMB_EXEC2, layer, eid, D, x, &enc2, &len2);
+    if (!a || !b) { fprintf(stderr, "EXEC2 TEST: FAIL (no reply: exec=%p exec2=%p)\n", (void *)a, (void *)b); return 1; }
+    if (memcmp(a, b, (size_t)D * 4)) {
+        int first = -1; for (int i = 0; i < D; i++) if (a[i] != b[i]) { first = i; break; }
+        fprintf(stderr, "EXEC2 TEST: FAIL (results differ at %d: %g vs %g)\n", first, a[first], b[first]);
+        return 1;
+    }
+    int out_exact = lmb_bf16_exact(a, (size_t)D);
+    printf("EXEC2 TEST: PASS · %d floats · request %u bytes as bf16 vs %u as f32 · reply %s (%u bytes)%s\n",
+           D, (unsigned)D * 2, (unsigned)D * 4,
+           enc2 == LMB_ENC_BF16 ? "bf16" : "f32", len2,
+           out_exact && enc2 != LMB_ENC_BF16 ? " · WARNING: output was bf16-exact but came back as f32" : "");
+    free(a); free(b); free(x);
+    return 0;
+}


### PR DESCRIPTION
Stacked on #119 (base `feat/tappa0-measure`); retarget to `main` after it merges.

A DeepSeek token was **4 MB up** on a home uplink: 16 KB of float32 activation × 6 experts × 43 layers. DeepSeek V4 rounds its MoE input to bf16 (`normalized_hc_pre`) and every expert's output to bf16 (`coli_v4_expert_forward_ref`), so half of every one of those bytes was zero.

**EXEC2 (72/73)**, additive: an explicit encoding per request and per reply. A value travels as bf16 only when it *is* a bf16 (low 16 bits zero), checked per request on the chatter and per reply on the executor, so the arithmetic is untouched: engines that round get half the bytes each way, others keep floats, and nothing is ever rounded to fit. An executor advertises the dialect as a caps word after residency in `ERES_R`; a chatter sends EXEC2 only to a node that advertised it, and only directly (the tracker tunnel keeps plain EXEC). Older nodes never see it. `PROTOCOL_COMPATIBILITY.md` updated.

## Verified
- New `test_exec2` / `exec2_test.sh` (added to `make test`): the same bf16-exact activation to a real OLMoE node as EXEC and as EXEC2 returns identical bytes; the request went as 2048 bytes instead of 4096.
- `phase2_test.sh` tokens identical (on OLMoE the activations are not bf16, so the dialect keeps floats, as designed).
- Client header, node and the test build under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
