### PR TITLE
fix: an executor under RAM pressure keeps serving, and a swarm-fed chatter keeps the smallest expert cache

### DIFF
--- a/engine_patches/deepseek_v4_p2p.py
+++ b/engine_patches/deepseek_v4_p2p.py
@@ -75,6 +75,24 @@ def main():
          '\n'
          '    int key_count = 0;'),
     ]
+    # site 4 — the resource planner: a swarm-fed chatter (LUMABRI_VROOT) never
+    # executes a routed expert locally, so its expert cache stays at the
+    # top-k floor instead of growing into every free byte. On the origin host
+    # that cache reached ~15 GB next to a 27 GB executor and pushed the
+    # machine under its reserve; dense and head residency are untouched.
+    hooks.append((
+        '    int slots = (int)(cache_limit / per_slot);\n'
+        '    if (slots > plan.slots_per_layer) slots = plan.slots_per_layer;\n'
+        '    if (slots < options->experts_per_layer && slots < 6) slots = 6;\n',
+        '    int slots = (int)(cache_limit / per_slot);\n'
+        '    if (slots > plan.slots_per_layer) slots = plan.slots_per_layer;\n'
+        '    if (slots < options->experts_per_layer && slots < 6) slots = 6;\n'
+        '#ifdef LUMABRI_P2P\n'
+        '    if (getenv("LUMABRI_VROOT")) {\n'
+        '        int floor = options->experts_per_layer < 6 ? options->experts_per_layer : 6;\n'
+        '        if (slots > floor) slots = floor;   /* swarm-fed: experts run on peers */\n'
+        '    }\n'
+        '#endif\n'))
     for anchor, repl in hooks:
         if s.count(anchor) != 1:
             sys.exit("deepseek_v4.c: expert-apply anchor found %d times (want 1) — "

--- a/expert_node.c
+++ b/expert_node.c
@@ -352,7 +352,13 @@ static void cache_release(CSlot *s) {
  * with the local path is the entire claim of this project. */
 static int exec_compute(LmbMsg *m, float **outp, uint32_t *out_len, uint32_t *enc_out) {
     if (enc_out) *enc_out = LMB_ENC_F32;
-    if (!lmb_governor_accepting(&g.governor)) return -2;
+    /* PRESSURE means "stop growing", not "stop serving": this process's
+     * experts are already in RAM, bounded by the store budget, and refusing
+     * a call frees nothing — it only stalls every chatter for the patience
+     * window. The origin executor did exactly that when the chat engine
+     * next to it grew and MemAvailable touched the reserve. Only the
+     * critical floor (PAUSED: below half the reserve) refuses. */
+    if (lmb_governor_state(&g.governor) == LMB_GOV_PAUSED) return -2;
     /* Test aid, in the spirit of LUMABRI_RTT_US: a deliberate compute delay
      * lets the relay tests prove concurrency and heartbeat liveness without
      * needing a model slow enough to exhibit them. */


### PR DESCRIPTION
The origin's executor went ACTIVE → PRESSURE ("RAM below reserve", 4.3 GB available) in the middle of a reply and refused every call until the chatter's patience ran out. Refusing freed nothing: its experts were already in RAM, bounded by the 27 GB store budget. What had eaten the machine was the chat engine next to it, 22 GB resident, of which ~15 GB was an expert cache the V4 planner sizes from free memory, for a chatter that never executes a routed expert locally.

1. `exec_compute` refuses only under PAUSED (below half the reserve, the critical floor); PRESSURE means "stop growing", and a bounded store does not grow. The advert still says draining, so new chatters are steered elsewhere while connected ones keep being answered.
2. A fifth hook in the DeepSeek chatter patch: when the model is a swarm mirror (`LUMABRI_VROOT`), the planner's expert slots stay at the top-k floor. Dense and head residency untouched; the chatter's footprint drops by the cache it never used.

Verified: `exec2_test.sh` and `phase2_test.sh` (tokens identical) with the new node; the patched chatter builds with "5 hooks inserted" and the planner hook in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)