### PR TITLE
fix(node): the fair gate admits every free slot, not one waiter per completion

### DIFF
--- a/expert_node.c
+++ b/expert_node.c
@@ -273,6 +273,13 @@ static void gate_enter(void) {
     /* no one waiting: the round is over, everybody starts equal again */
     if (g_gate_nwait == 0)
         for (int i = 0; i < g_gate_nsrc; i++) g_gate_granted[i] = 0;
+    /* Slots may still be free and others still queued: only the chosen
+     * waiter left the wait, and a broadcast comes only from a leave. Without
+     * this, a burst of six calls was admitted one per completion — the
+     * origin executor served ~120 calls/s with eight slots and 10 ms of
+     * compute, the same with four, and a token cost 43 × 6 × 8 ms. */
+    else if (g_gate_free > 0)
+        pthread_cond_broadcast(&g_gate_cv);
     pthread_mutex_unlock(&g_gate_lk);
 }
 


### PR DESCRIPTION
The origin executor served ~120 calls/s with four slots and ~120 with eight, at 10 ms of compute and 5 ms queued per call: a token of 258 calls cost 2.1 s whatever the parallelism. The fair gate (#110) admits a waiter only when it is the chosen one, and the only broadcast came from a leave; so a burst of six calls from one layer entered one per completion, and the free slots sat idle.

After a waiter takes a slot, if slots are still free and others still wait, broadcast again, so the next chosen waiter takes the next slot at once. The fairness rule is unchanged: who goes next is still the least served source.

Verified: `relay_exec_test.sh` (concurrency, failover) and `phase2_test.sh` (tokens identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)