### PR TITLE
feat(chat): speculative decoding on by default for a swarm-fed DeepSeek chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ the command, e.g. `LUMABRI_SPREAD=1 lumabri chat …`.
 | `LUMABRI_ENCRYPT=1` | encrypt the transport (see below) |
 | `LUMABRI_ENGINE_LOG=path` | append every line the engine prints to this file (the chat otherwise keeps only the tail `/debug` shows) |
 | `LUMABRI_SWARM_PATIENCE_S=N` | on a swarm-fed chat, how long a reply waits for a vanished executor before failing plainly (default 600); it never downloads experts to run them locally |
+| `V4_DRAFT=N` | on a swarm-fed DeepSeek chat, candidate tokens verified per network round (default 8; `0` turns speculation off); tokens are identical to the one-by-one path, only the number of rounds changes |
 | `LUMABRI_EXEC_TIMEOUT_MS=N` | give up on an expert call that has not answered in N ms and fail over (default 120000; the general I/O timeout is five minutes) |
 | `LUMABRI_READ_TIMEOUT_MS=N` | give up on a peer that has not delivered an 8 MiB block in N ms and ask the next one (default 60000; the general I/O timeout is five minutes) |
 | `RAM_GB=N` | tell a `--local` run how much RAM it may use to keep experts resident |

--- a/lumabri.c
+++ b/lumabri.c
@@ -2728,6 +2728,16 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
         /* and pull the dense weights NOW, with a bar, instead of letting the
          * first reply discover them layer by layer over the WAN */
         if (!local_dir) setenv("LUMABRI_PREFETCH_DENSE", "1", 0);
+        /* Speculative decoding on a swarm-fed DeepSeek chat: every token is
+         * 43 network rounds, and the only way to amortize them without
+         * moving state off this machine is to verify several candidate
+         * tokens per round. Colibri's V4 n-gram drafter proposes up to
+         * V4_DRAFT tokens from the context and the full model verifies them
+         * in one batched pass (greedy: the tokens are exactly those of the
+         * one-by-one path). The batched MoE rows travel as one multi-row
+         * call per expert, which the client already speaks. An explicit
+         * V4_DRAFT (0 to turn it off) still wins. */
+        if (!local_dir && strstr(engine, "deepseek")) setenv("V4_DRAFT", "8", 0);
         /* Same split for the expert cache. A swarm chatter caches almost nothing
          * (experts run on peers), so its cap stays at the small default. But a
          * --local run holds its own experts, and there the cap IS the resident


### PR DESCRIPTION
Every token is 43 network rounds, and the only way to amortize them without moving the conversation state off the chatter is to verify several candidate tokens per round. Colibri's V4 n-gram drafter proposes up to `V4_DRAFT` tokens from the context and the full model verifies them in one batched pass; greedy verification keeps the tokens exactly those of the one-by-one path, only the number of rounds changes. The batched MoE rows travel as one multi-row call per expert, which the client already speaks (and, since #120, in bf16 when exact).

A swarm-fed DeepSeek chat now starts its engine with `V4_DRAFT=8`; an explicit value (`0` turns it off) still wins. Local runs are untouched. Builds under `-Werror`. The gain depends on how often the n-gram draft is right on the text at hand: to be measured with the prefill/decode split of #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)