### PR TITLE
fix(node): a DeepSeek expert call with many rows runs colibri's batch kernel once, not the scalar one per row

### DIFF
--- a/expert_engines/deepseek.h
+++ b/expert_engines/deepseek.h
@@ -216,15 +216,32 @@ static void lmbe_apply(const LmbeSlot *s, int slot, const float *x, float *out,
         lmbe_apply_failed = 1;
         return;
     }
-    for (int r = 0; r < nrows; r++)
-        if (coli_v4_expert_forward_ref(out + (size_t)r * d, &view,
-                                       x + (size_t)r * d, w[r],
-                                       lmbe_cfg.swiglu_limit)) {
-            coli_expert_release(lmbe_store, &view);
-            fprintf(stderr, "[lumabri] expert forward failed at layer %d expert %d\n",
-                    slot, s->eid);
-            exit(1);
-        }
+    /* All the rows of one call in one pass: the batch kernel streams each
+     * expert matrix once for every row, where the per-row loop re-read the
+     * 12.6 MB expert for each of them — a layer round with 8 rows cost 7.6×
+     * one with 1 (measured with swarm_rows_bench), so a 64-row prefill call
+     * cost 64 expert reads. It is the kernel the engine itself uses for its
+     * batched prefill (count > 1 → batch_ref), with the same numerical
+     * contract; hot rows16 experts fall back to the scalar path inside it. */
+    int failed = 0;
+    for (int at = 0; at < nrows && !failed; at += 128) {
+        int n = nrows - at < 128 ? nrows - at : 128;
+        if (n == 1)
+            failed = coli_v4_expert_forward_ref(out + (size_t)at * d, &view,
+                                                x + (size_t)at * d, w[at],
+                                                lmbe_cfg.swiglu_limit);
+        else
+            failed = coli_v4_expert_forward_batch_ref(out + (size_t)at * d, &view,
+                                                      x + (size_t)at * d, w + at,
+                                                      n, lmbe_cfg.swiglu_limit);
+    }
+    if (failed) {
+        coli_expert_release(lmbe_store, &view);
+        fprintf(stderr, "[lumabri] expert forward failed at layer %d expert %d: "
+                        "refusing this call\n", slot, s->eid);
+        lmbe_apply_failed = 1;              /* ERR to the chatter, not exit */
+        return;
+    }
     coli_expert_release(lmbe_store, &view);
 }
 


### PR DESCRIPTION
`swarm_rows_bench` (#127) against the origin: a layer round with 8 rows per expert cost 7.6× one with 1 row (14.9 → 112.9 ms), 16 rows 14.6×. Not the network: the glue called `coli_v4_expert_forward_ref` in a loop, and every row re-read the 12.6 MB expert from RAM. A 64-row prefill call was 64 expert reads.

Colibri has `coli_v4_expert_forward_batch_ref`, which streams each matrix once for all rows under the same numerical contract; it is what the engine itself uses for its batched prefill (`count > 1`), and hot rows16 experts fall back to the scalar path inside it. The glue now calls it for every call with more than one row (chunks of 128, its ceiling). A kernel failure refuses the call instead of exiting the executor.

Expected: prefill several times faster on executors; a speculative batch of B rows costs about one row. To verify on the origin: `swarm_rows_bench 148.251.4.122:7302 0 4096` before and after, and `phase2_deepseek_test.sh` (tokens identical) where a real model is available. `expert_node_deepseek` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)