### PR TITLE
feat: VRAM is the third residency tier, and the tier is a constant offset

### DIFF
--- a/expert_engines/deepseek.h
+++ b/expert_engines/deepseek.h
@@ -141,10 +141,37 @@ static int lmbe_resident_prepare(const uint8_t *holds, int layers,
     if (lmbe_store->ops && lmbe_store->ops->stats)
         lmbe_store->ops->stats(lmbe_store, &stats);
     lmbe_resident_nbytes = stats.resident_bytes;
+#ifdef COLI_V4_GPU_TIER
+    /* Ask the tier which of the assigned experts already carry GPU mirrors.
+     * peek never uploads, so this measures rather than provokes residency. */
+    lmbe_vram_nbytes = 0;
+    if (lmbe_store->gpu)
+        for (int l = 0; l < layers; l++)
+            for (int e = 0; e < experts; e++) {
+                ColiExpertView view = {0};
+                if (!holds[l * experts + e]) continue;
+                if (coli_expert_lookup(lmbe_store, (ColiExpertKey){l, e}, &view))
+                    continue;
+                if (!coli_v4_gpu_expert_peek(lmbe_store, &view) &&
+                    view.gate.gpu && view.up.gpu && view.down.gpu)
+                    lmbe_vram_nbytes += lmbe_expert_bytes();
+                coli_expert_release(lmbe_store, &view);
+            }
+#endif
     return nholds > 0 && stats.resident_bytes > 0 ? 0 : -1;
 }
 
 static uint64_t lmbe_resident_bytes(void) { return lmbe_resident_nbytes; }
+
+/* Experts this node keeps mirrored in VRAM. Colibri's V4 GPU tier attaches
+ * fp4 mirrors to a view on lookup and reports residency through
+ * coli_v4_gpu_expert_peek, so the count is taken once per resident-prepare
+ * over the assigned keys: a peek never uploads, it only answers. Without
+ * the GPU tier compiled in, or without a card, this is zero and the node
+ * advertises RAM residency exactly as before. */
+static uint64_t lmbe_vram_nbytes;
+static uint64_t lmbe_vram_bytes(void) { return lmbe_vram_nbytes; }
+#define LMBE_VRAM_BYTES lmbe_vram_bytes
 
 /* set by lmbe_apply when it could not compute; the node turns it into a
  * refused call instead of a dead process */

--- a/expert_node.c
+++ b/expert_node.c
@@ -1361,6 +1361,18 @@ int main(int argc, char **argv) {
     } else {
         g.resident_flags = LMB_EXPERT_DISK_FALLBACK;
     }
+    /* A donor with a GPU answers in one or two milliseconds instead of ten
+     * to fifteen, so a chatter must be able to tell it apart. The glue
+     * reports the bytes its engine actually mirrors into VRAM (zero on a
+     * build without a GPU tier); the flag is added, not substituted, since
+     * those experts are resident in RAM as well. */
+#ifdef LMBE_VRAM_BYTES
+    g.resident_vram_bytes = LMBE_VRAM_BYTES();
+    if (g.resident_vram_bytes) g.resident_flags |= LMB_EXPERT_RESIDENT_VRAM;
+#endif
+    if (g.resident_vram_bytes)
+        printf("[%s] %.1f GB of experts mirrored in VRAM\n",
+               g.name, (double)g.resident_vram_bytes / 1e9);
     atomic_store(&g.resident_state,
                  lmb_governor_accepting(&g.governor) ?
                  LMB_EXPERT_STATE_ACTIVE : LMB_EXPERT_STATE_DRAINING);

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -938,32 +938,36 @@ static void lumi_round_done(double t0) {
  * hanging tunnel must still lose to a healthy disk replica 25 ms away. The
  * offset is in microseconds of score, so an unusable RAM replica (dead,
  * circuit open) always loses to a live disk one. */
-/* Residency is a PRIOR on the service time, not a sentence: added while this
- * peer has answered fewer than LUMI_PRIOR_CALLS times, and gone once the
- * measurements speak — an EXEC observation already contains the service, so
- * keeping the offset forever would count it twice, and a healthy disk
- * replica next door would lose to a RAM replica behind a hanging tunnel.
- * The three figures are measured: VRAM one to two ms, RAM ten to fifteen,
- * a cold NVMe read forty to fifty. */
-#define LUMI_PRIOR_CALLS 8u
-#define LUMI_SERVICE_VRAM_US  2000u
-#define LUMI_SERVICE_RAM_US  12000u
-#define LUMI_SERVICE_DISK_US 50000u
+/* Where an executor keeps its experts is worth about an order of magnitude
+ * per call: measured, one to two milliseconds from VRAM, ten to fifteen
+ * from RAM, forty to fifty from a cold NVMe read. The RTT probe is a PING
+ * and cannot see any of it, so the tier enters the score as a RELATIVE
+ * offset — VRAM is the zero, RAM and disk are what they cost more.
+ *
+ * Always applied, never faded. A prior that depends on how many calls a
+ * peer has answered penalises exactly the replica nobody has tried yet: in
+ * CI a freshly refreshed peer took sixteen probes and zero calls while the
+ * busy one kept every one of them. Constant, the offset cancels between two
+ * replicas of the same tier — so their measurements decide, as before — and
+ * survives only where the tiers differ, which is the whole point. */
+#define LUMI_TIER_VRAM_US     0u
+#define LUMI_TIER_RAM_US  10000u
+#define LUMI_TIER_DISK_US 48000u
 
-static uint64_t lumi_service_prior(int residency) {
+static uint64_t lumi_tier_offset(int residency) {
     switch (residency) {
-    case 2:  return LUMI_SERVICE_VRAM_US;
-    case 1:  return LUMI_SERVICE_RAM_US;
-    case 0:  return LUMI_SERVICE_DISK_US;
-    default: return LUMI_SERVICE_RAM_US;      /* unknown: assume the middle */
+    case 2:  return LUMI_TIER_VRAM_US;
+    case 1:  return LUMI_TIER_RAM_US;
+    case 0:  return LUMI_TIER_DISK_US;
+    default: return LUMI_TIER_RAM_US;         /* unknown: assume the middle */
     }
 }
 
 static uint64_t lumi_replica_score(const LumiPeer *p) {
     uint64_t score = lmb_predict_score(&p->latency, p->inflight);
-    if (p->ok_calls >= LUMI_PRIOR_CALLS || score == UINT64_MAX) return score;
-    uint64_t prior = lumi_service_prior(p->resident);
-    return score < UINT64_MAX - prior ? score + prior : score;
+    uint64_t tier = lumi_tier_offset(p->resident);
+    if (score == UINT64_MAX || !tier) return score;
+    return score < UINT64_MAX - tier ? score + tier : score;
 }
 
 static int lumi_pick(int gid, uint32_t tried) {

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -73,9 +73,10 @@ typedef struct {
     LmbLatencyPredictor latency;
     uint32_t inflight;
     uint64_t exec_observations, exec_observations_at_probe;
-    /* 1: its experts are resident in RAM; 0: it streams them from disk (the
-     * origin's --cache executor); -1: not known (older node, or reached only
-     * through the tracker tunnel). Only a known disk replica is penalized. */
+    /* Where this executor keeps the experts it holds: 2 in VRAM, 1 in RAM,
+     * 0 streamed from disk, -1 unknown (older node, or reached only through
+     * the tracker tunnel). A prior on the service time, used until this peer
+     * has answered enough calls for the measurement to speak. */
     int resident;
     /* the bill: what this peer answered, how long it took, and the bytes
      * that crossed the wire each way — the report divides them by rounds */
@@ -564,7 +565,8 @@ static int lumi_add_peer(const char *addr) {
             LmbCur rc = { rm.body, rm.body_len, 0 };
             uint32_t flags = 0, state = 0, caps = 0;
             if (!lmb_cur_u32(&rc, &flags))
-                p->resident = (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
+                p->resident = (flags & LMB_EXPERT_RESIDENT_VRAM) ? 2 :
+                              (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
             if (!lmb_cur_u32(&rc, &state) && !lmb_cur_u32(&rc, &caps))
                 p->caps = caps;               /* absent on older nodes: plain EXEC */
         }
@@ -572,6 +574,7 @@ static int lumi_add_peer(const char *addr) {
     }
     fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms · %s\n",
             p->addr, n, claimed, (double)p->rtt_us / 1000.0,
+            p->resident == 2 ? "experts in VRAM" :
             p->resident == 1 ? "experts in RAM" :
             p->resident == 0 ? "experts streamed from disk (last resort)" :
                                "residency unknown");
@@ -935,13 +938,32 @@ static void lumi_round_done(double t0) {
  * hanging tunnel must still lose to a healthy disk replica 25 ms away. The
  * offset is in microseconds of score, so an unusable RAM replica (dead,
  * circuit open) always loses to a live disk one. */
-#define LUMI_DISK_PENALTY_US 40000u
+/* Residency is a PRIOR on the service time, not a sentence: added while this
+ * peer has answered fewer than LUMI_PRIOR_CALLS times, and gone once the
+ * measurements speak — an EXEC observation already contains the service, so
+ * keeping the offset forever would count it twice, and a healthy disk
+ * replica next door would lose to a RAM replica behind a hanging tunnel.
+ * The three figures are measured: VRAM one to two ms, RAM ten to fifteen,
+ * a cold NVMe read forty to fifty. */
+#define LUMI_PRIOR_CALLS 8u
+#define LUMI_SERVICE_VRAM_US  2000u
+#define LUMI_SERVICE_RAM_US  12000u
+#define LUMI_SERVICE_DISK_US 50000u
+
+static uint64_t lumi_service_prior(int residency) {
+    switch (residency) {
+    case 2:  return LUMI_SERVICE_VRAM_US;
+    case 1:  return LUMI_SERVICE_RAM_US;
+    case 0:  return LUMI_SERVICE_DISK_US;
+    default: return LUMI_SERVICE_RAM_US;      /* unknown: assume the middle */
+    }
+}
 
 static uint64_t lumi_replica_score(const LumiPeer *p) {
     uint64_t score = lmb_predict_score(&p->latency, p->inflight);
-    if (p->resident == 0 && score < UINT64_MAX - LUMI_DISK_PENALTY_US)
-        score += LUMI_DISK_PENALTY_US;
-    return score;
+    if (p->ok_calls >= LUMI_PRIOR_CALLS || score == UINT64_MAX) return score;
+    uint64_t prior = lumi_service_prior(p->resident);
+    return score < UINT64_MAX - prior ? score + prior : score;
 }
 
 static int lumi_pick(int gid, uint32_t tried) {

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -274,7 +274,7 @@ enum {
     LMB_TEXEC = 66,
     LMB_TMAN = 67, LMB_TMAN_FWD = 68, LMB_TMAN_R = 69,
     /* Where an executor's experts live. ERES_R body: u32 resident_flags
-     * (LMB_EXPERT_RESIDENT_RAM / LMB_EXPERT_DISK_FALLBACK), u32 state. A
+     * (LMB_EXPERT_RESIDENT_VRAM / _RAM / LMB_EXPERT_DISK_FALLBACK), u32 state. A
      * chatter asks once after the manifest; an older node answers ERR and is
      * simply treated as "unknown". Additive: the manifest itself is
      * unchanged, so old chatters keep admitting new nodes. */


### PR DESCRIPTION
An expert answered from VRAM costs one to two milliseconds, from RAM ten to fifteen, from a cold NVMe read forty to fifty. The protocol has carried a VRAM flag since the beginning, the tracker stores the bytes and the TUI prints them, but no node ever set it and the chatter knew only two tiers: a donor with a card would have been treated as an ordinary PC.

- The glue reports the experts its engine actually mirrors into VRAM. For DeepSeek that is colibri's GPU tier, asked with `coli_v4_gpu_expert_peek` over the assigned keys at resident-prepare time — a peek measures residency, it never provokes it. Zero without a GPU tier compiled in, and the node then advertises RAM exactly as before.
- The node adds `LMB_EXPERT_RESIDENT_VRAM` to its flags (added, not substituted: those experts are in RAM too) and prints the mirrored GB.
- The chatter reads three tiers from `ERES` and turns them into a constant offset on the predicted service time: VRAM 0, RAM 10 ms, disk 48 ms.

**Why a constant offset and not a prior.** The first version added the tier only while a peer had answered fewer than eight calls, on the argument that an observation already contains the service time and a permanent offset would count it twice. That is true in the arithmetic and wrong in the routing: the peer that has answered fewest calls is precisely the one nobody has tried yet, so the prior fell hardest on the replica that most needed a chance. The staggered-refresh test caught it exactly there — a freshly re-probed replica took sixteen pings and zero calls while the busy one kept them all.

A constant offset does not have that failure. Between two replicas on the same tier it cancels and the measurements decide alone, which is the case the double-counting argument was about. Between different tiers it survives as the intended difference, and a measured RAM peer that is genuinely fast still beats a VRAM peer that is genuinely slow, because the measurements move far more than 10 ms.

Verified: `rtt_refresh_test.sh` both stages PASS; `phase2_test.sh` tokens identical and the per-executor report lines name the tier; `test_local_fallback` ok; `expert_node`, `expert_node_deepseek` and the client header build under `-Werror`.
