### PR TITLE
feat: a node with a cache in front of the disk is neither RAM nor disk

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -311,8 +311,13 @@ spare RAM (the log prints the hit rate and, for DeepSeek, the resulting GB),
 lower it if it swaps. Size it from the expert, not the slot count: a
 DeepSeek V4 Flash expert is ~15 MB with headroom, so `--exec-cache 1800` is
 about 27 GB, and the store keeps at least top-k experts per layer (258 on
-V4-Flash) whatever you pass. `serve` subtracts this figure from the RAM it
-offers the Segment origin slices, and a slice whose layer range does not fit
+V4-Flash) whatever you pass. A caching node is not "a disk node" to the chatters that call it: it reports
+how many experts it keeps hot, out of how many it serves, and how often a
+call is answered without a disk read, and they blend the RAM and disk costs
+by that rate when they choose a replica. So raising `--exec-cache` on a box
+that holds more of the model than fits its RAM buys latency *and* calls,
+where before it bought only latency. `serve` subtracts this figure from the
+RAM it offers the Segment origin slices, and a slice whose layer range does not fit
 its share resident is not started (exit code 3, not restarted): on a box
 smaller than the model you get storage plus the streaming executor, which is
 the honest capacity, instead of five caches of the same experts fighting for
@@ -571,5 +576,5 @@ Two things worth knowing:
 | client says `not signed by the operator key` | server not started with `--key`, or a different key than the client's `LUMABRI_PUBKEY` |
 | `engine not found` after Segment fallback | install the classic Colibri engine or pass `--engines-dir /path/to/colibri/c` |
 | tracker logs `REJECTED: ... unsigned` | a peer joined a signed swarm without signed truth — that is the defence working |
-| expert cache hit rate very low | raise `--exec-cache`; each slot is one expert of RAM (~15 MB on DeepSeek V4 Flash), spread over the layers |
+| expert cache hit rate very low | raise `--exec-cache`; each slot is one expert of RAM (~15 MB on DeepSeek V4 Flash), spread over the layers. The rate is also what chatters route on: the node reports it, and a box that hits often is preferred over one that reads the disk |
 | first start takes minutes | hashing the model; cached afterwards in `.lumabri_hashes/` |

--- a/expert_node.c
+++ b/expert_node.c
@@ -622,11 +622,39 @@ static void manifest_build(LmbBuf *b) {
     lmb_buf_u32(b, (uint32_t)g.hidden);
 }
 
+/* How often a call is served without touching the disk, per thousand.
+ *
+ * A node with a RAM cache in front of on-disk experts is neither "RAM" nor
+ * "disk": it is both, in a proportion only it can know. Reporting the flag
+ * alone makes a box holding a third of a model hot look exactly like one
+ * holding none of it, and a chatter that believes the flag then routes
+ * around experts this node has warm.
+ *
+ * The measured rate is the truth once enough calls have gone through. Below
+ * that, the slot ratio is the honest floor — a cache cannot hold more than
+ * its slots — so a node that has just started is under-promised, never
+ * over-promised. */
+#define NODE_HOT_MIN_CALLS 64u
+
+static uint32_t node_hot_permille(void) {
+    if (!g.ncs) return 1000;                  /* fully resident: no cold path */
+    uint64_t calls = atomic_load(&g.calls), cold = atomic_load(&g.cold);
+    if (calls >= NODE_HOT_MIN_CALLS) {
+        uint64_t hits = calls > cold ? calls - cold : 0;
+        return (uint32_t)(hits * 1000u / calls);
+    }
+    return g.nholds > 0
+         ? (uint32_t)((uint64_t)g.ncs * 1000u / (uint64_t)g.nholds) : 1000u;
+}
+
 static int handle_eres(int fd) {
     LmbBuf b = {0};
     lmb_buf_u32(&b, g.resident_flags);
     lmb_buf_u32(&b, atomic_load(&g.resident_state));
     lmb_buf_u32(&b, LMB_CAP_EXEC2);           /* what this node speaks beyond EXEC */
+    lmb_buf_u32(&b, (uint32_t)(g.ncs ? g.ncs : g.nholds));   /* experts kept hot */
+    lmb_buf_u32(&b, (uint32_t)g.nholds);                     /* experts served */
+    lmb_buf_u32(&b, node_hot_permille());
     int rc = lmb_send(fd, LMB_ERES_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -78,6 +78,9 @@ typedef struct {
      * the tracker tunnel). A prior on the service time, used until this peer
      * has answered enough calls for the measurement to speak. */
     int resident;
+    uint32_t hot_permille;      /* calls served without a disk read, per 1000 */
+    uint32_t hot_experts;       /* experts this node keeps hot */
+    uint32_t held_experts;      /* experts it serves in all */
     /* the bill: what this peer answered, how long it took, and the bytes
      * that crossed the wire each way — the report divides them by rounds */
     unsigned long long ok_calls, bytes_out, bytes_in;
@@ -558,6 +561,8 @@ static int lumi_add_peer(const char *addr) {
     /* RAM or disk? Asked once, directly (a tunnel-only peer stays unknown,
      * and a donor behind NAT is a resident donor in practice). */
     p->resident = -1;
+    p->hot_permille = 1000;       /* no counts: believe the flag, as before */
+    p->hot_experts = p->held_experts = 0;
     if (!p->relay_target[0]) {
         LmbMsg rm = {0};
         const char *dial = p->loopback[0] ? p->loopback : p->addr;
@@ -569,15 +574,32 @@ static int lumi_add_peer(const char *addr) {
                               (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
             if (!lmb_cur_u32(&rc, &state) && !lmb_cur_u32(&rc, &caps))
                 p->caps = caps;               /* absent on older nodes: plain EXEC */
+            /* How much of what it serves it actually keeps hot. Absent on a
+             * node that predates the field, and then the flag stands alone
+             * exactly as before. */
+            uint32_t hot = 0, held = 0, permille = 0;
+            if (!lmb_cur_u32(&rc, &hot) && !lmb_cur_u32(&rc, &held) &&
+                !lmb_cur_u32(&rc, &permille)) {
+                p->hot_experts = hot;
+                p->held_experts = held;
+                p->hot_permille = permille > 1000 ? 1000 : permille;
+            }
         }
         lmb_msg_free(&rm);
     }
+    char tier[96];
+    if (p->resident == 0 && p->held_experts)
+        snprintf(tier, sizeof tier,
+                 "%u of %u experts hot, %u%% of calls served without the disk",
+                 p->hot_experts, p->held_experts, p->hot_permille / 10);
+    else
+        snprintf(tier, sizeof tier, "%s",
+                 p->resident == 2 ? "experts in VRAM" :
+                 p->resident == 1 ? "experts in RAM" :
+                 p->resident == 0 ? "experts streamed from disk (last resort)" :
+                                    "residency unknown");
     fprintf(stderr, "[lumabri] peer %s: %u experts (%d first-holder) · rtt %.2f ms · %s\n",
-            p->addr, n, claimed, (double)p->rtt_us / 1000.0,
-            p->resident == 2 ? "experts in VRAM" :
-            p->resident == 1 ? "experts in RAM" :
-            p->resident == 0 ? "experts streamed from disk (last resort)" :
-                               "residency unknown");
+            p->addr, n, claimed, (double)p->rtt_us / 1000.0, tier);
     if (reprobe < 0) L.npeers++;
     return 0;
 }
@@ -963,9 +985,23 @@ static uint64_t lumi_tier_offset(int residency) {
     }
 }
 
+/* A node with a RAM cache in front of on-disk experts pays the RAM price on
+ * a hit and the disk price on a miss, so its offset is the two blended by
+ * the rate it reports. A node that keeps everything resident reports a
+ * thousand out of a thousand and lands exactly where it did before; so does
+ * one too old to report anything. And a caching node that genuinely hits
+ * every time IS a RAM node for our purposes, which is the point. */
+static uint64_t lumi_blend_offset(const LumiPeer *p) {
+    /* the cache in front of the disk is RAM, whatever the flag says overall */
+    uint64_t warm = lumi_tier_offset(p->resident == 0 ? 1 : p->resident);
+    uint64_t cold = p->resident == 0 ? LUMI_TIER_DISK_US : warm;
+    uint64_t hot = p->hot_permille > 1000 ? 1000 : p->hot_permille;
+    return (warm * hot + cold * (1000 - hot)) / 1000;
+}
+
 static uint64_t lumi_replica_score(const LumiPeer *p) {
     uint64_t score = lmb_predict_score(&p->latency, p->inflight);
-    uint64_t tier = lumi_tier_offset(p->resident);
+    uint64_t tier = lumi_blend_offset(p);
     if (score == UINT64_MAX || !tier) return score;
     return score < UINT64_MAX - tier ? score + tier : score;
 }

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -274,10 +274,19 @@ enum {
     LMB_TEXEC = 66,
     LMB_TMAN = 67, LMB_TMAN_FWD = 68, LMB_TMAN_R = 69,
     /* Where an executor's experts live. ERES_R body: u32 resident_flags
-     * (LMB_EXPERT_RESIDENT_VRAM / _RAM / LMB_EXPERT_DISK_FALLBACK), u32 state. A
-     * chatter asks once after the manifest; an older node answers ERR and is
-     * simply treated as "unknown". Additive: the manifest itself is
-     * unchanged, so old chatters keep admitting new nodes. */
+     * (LMB_EXPERT_RESIDENT_VRAM / _RAM / LMB_EXPERT_DISK_FALLBACK), u32 state,
+     * u32 caps, then u32 hot_experts, u32 held_experts, u32 hot_permille.
+     *
+     * The flag alone cannot describe a node that keeps a RAM cache in front
+     * of on-disk experts: holding a third of a model hot reads exactly like
+     * holding none of it. The three counts say how much is hot, out of how
+     * much, and how often a call is actually served without a disk read —
+     * measured once enough calls have gone through, and the slot ratio,
+     * which is the floor, before that. A chatter asks once after the
+     * manifest; an older node answers ERR and is treated as "unknown", or
+     * answers the first three fields alone and is read exactly as before.
+     * Additive: the manifest itself is unchanged, so old chatters keep
+     * admitting new nodes. */
     LMB_ERES = 70, LMB_ERES_R = 71,
     /* EXEC with an explicit encoding. Body: u32 layer, eid, D, nrows,
      * enc_in, then the router weights when the engine wants them applied
@@ -288,7 +297,7 @@ enum {
      * round their MoE input and expert output to bf16 (DeepSeek V4 does)
      * pay half the bytes, others keep floats, and nothing is approximated.
      * Advertised by an executor as bit 0 of the caps word ERES_R carries
-     * after residency and state; an older node never receives EXEC2. */
+     * third, after residency and state; an older node never receives EXEC2. */
     LMB_EXEC2 = 72, LMB_EXEC2_R = 73,
 };
 #define LMB_CAP_EXEC2 (1u << 0)


### PR DESCRIPTION
The residency flag is binary, and most donors are not.

A 64 GB server holding DeepSeek V4-Flash serves **11008 experts** — 43 routed layers of 256 — at roughly 15 MB each. That is 165 GB. No cache size fits them, so the node runs in streaming mode and reports `LMB_EXPERT_DISK_FALLBACK`, and it reports it whether its RAM cache holds 1800 experts, 3000, or none at all. To a chatter, a box keeping a third of the model hot is indistinguishable from one keeping nothing.

That was survivable while the flag only broke ties. With #131 merged it is not: the disk tier is a constant 48 ms offset applied to every one of that node's experts, including the ones it has warm in RAM. Raising `--exec-cache` made its calls faster and made it no likelier to be asked — the two moved in opposite directions, which is the wrong shape for a knob operators are told to turn.

**What the node now says.** `ERES_R` gains three fields after the caps word: how many experts it keeps hot, how many it serves in all, and how often a call is actually answered without a disk read. The last one is measured from the counters the node already keeps for its own log, once sixty-four calls have gone through. Before that it is the slot ratio — a cache cannot hold more than its slots, so the floor is honest and a node that has just started is under-promised rather than over-promised.

**What the chatter does with it.** It blends the two costs by that rate instead of trusting the flag: RAM price on a hit, disk price on a miss. For the server above at `--exec-cache 1800` that is ~42 ms instead of a flat 48; at 3000 with a measured 45% hit rate it is ~27 ms, and it starts winning calls against a distant RAM replica, correctly.

Everything that reported nothing keeps its old score exactly:

- a fully resident node reports 1000 of 1000 and lands on the RAM tier, unchanged;
- a node too old to carry the fields is parsed as before and treated as before;
- a tunnel-only peer is never asked and stays unknown, as before;
- a caching node that genuinely hits every time scores as a RAM node — which is not a regression, it is the point.

The peer line now reads `1800 of 11008 experts hot, 46% of calls served without the disk` instead of `experts streamed from disk (last resort)`, so the operator can see what the knob did.

Verified: `phase2_test.sh` — IDENTICI, the network changed no token; `rtt_refresh_test.sh` both stages PASS; `test_hedge`, `test_local_fallback` ok; node and client build under `-Werror`.
