### PR TITLE
fix(patch): a delegated layer asks for one view, not zero

### DIFF
--- a/engine_patches/deepseek_v4_p2p.py
+++ b/engine_patches/deepseek_v4_p2p.py
@@ -65,8 +65,16 @@ def main():
         # not the loop. selected=0 stays correct on the CPU build we compile:
         # the GPU batch path is #ifdef'd out, so the only tail that runs is
         # `output = round(output + shared)` — identical to sites 1 and 3, with
-        # the routed partial already written remotely. (views = malloc(0) is a
-        # valid non-NULL pointer on glibc; selected==topk>0 in every local run.)
+        # the routed partial already written remotely.
+        #
+        # The same `selected = 0` reaches colibri's own
+        #     ColiExpertView *views = malloc((size_t)selected * sizeof(*views));
+        #     if (!views) result = -1;
+        # and malloc(0) is allowed by the standard to return NULL, which would
+        # turn a correctly delegated layer into a failed forward. glibc happens
+        # to return a non-null pointer, so this never fired here; that is a
+        # property of one allocator, not of the code. Ask for one element when
+        # there is nothing to select — the loop below is skipped either way.
         ('    if (!result) memset(output, 0, (size_t)d * sizeof(*output));\n'
          '\n'
          '#ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER\n'
@@ -80,7 +88,8 @@ def main():
          '#endif\n'
          '\n'
          '#ifdef COLI_V4_EXPERIMENTAL_DUAL_EXPERT_LOADER\n'
-         '    ColiExpertView *views = malloc((size_t)selected * sizeof(*views));'),
+         '    ColiExpertView *views =\n'
+         '        malloc((size_t)(selected > 0 ? selected : 1) * sizeof(*views));'),
         # site 3 — v4_moe_batch_union: batch, reset n
         ('    if (!result)\n'
          '        memset(outputs, 0, (size_t)batch * d * sizeof(*outputs));\n'


### PR DESCRIPTION
When #130 decides a layer remotely it sets `selected = 0`, so no local expert loader ever starts — that is the whole point of the fix, and it is what stopped a swarm-fed chatter from downloading the very experts it had just delegated.

That zero also reaches colibri's own code, a few lines further down:

```c
ColiExpertView *views = malloc((size_t)selected * sizeof(*views));
int gpu_compute = 0;
if (!views) result = -1;
```

`malloc(0)` is allowed by the C standard to return `NULL`. Where it does, a layer that was delegated *correctly* is reported as a failed forward. glibc returns a non-null pointer, so this has never fired on any machine we run — but that is a property of one allocator, not of the code, and the patch's comment said as much out loud while relying on it anyway.

The patch now emits `malloc((size_t)(selected > 0 ? selected : 1) * sizeof(*views))`. One element instead of none; the loop that follows is skipped when `selected` is zero either way, so nothing else changes. Colibri itself is untouched — the guard lives in the generated copy, like every other hook.

Verified: the patcher still reports `deepseek_v4 p2p: 6 hooks inserted (1 engine-open tail)`, the guard is present in `build/deepseek_v4_p2p.c`, and `expert_node_deepseek` builds.
