### PR TITLE
fix: a node that reports nothing is not a node that never misses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -398,6 +398,9 @@ test_local_fallback: test_local_fallback.c lumabri_client.h lumabri_proto.h luma
 test_accum_order: test_accum_order.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_accum_order.c -o $@ -lm
 
+test_residency_report: test_residency_report.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CFLAGS) -pthread test_residency_report.c -o $@ -lm
+
 test_rtt_refresh: test_rtt_refresh.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_rtt_refresh.c -o $@
 
@@ -598,7 +601,7 @@ test-segment-v2: test_segment_v2
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order \
+test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -625,6 +628,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_hedge
 	./test_local_fallback
 	./test_accum_order
+	./test_residency_report
 	./test_nat_adopt
 	bash ./rtt_refresh_test.sh
 	./test_segment_v2
@@ -665,7 +669,8 @@ install: all
 clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
-	      test_local_fallback test_accum_order test_nat_adopt test_rtt_refresh \
+	      test_local_fallback test_accum_order test_residency_report \
+	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \
 	      test_compute_lease test_content_filter test_scheduler test_run_gate \

--- a/expert_engines/deepseek.h
+++ b/expert_engines/deepseek.h
@@ -59,6 +59,11 @@ static int lmbe_effective_bits(int bits) { (void)bits; return 0; }
  * old code multiplied by the layer count instead: `--exec-cache 128` on the
  * 43-layer V4-Flash was 5504 experts (~69 GB) and 1800 was the entire
  * expert set, which is how a 64 GB server filled its RAM and died. */
+/* Whatever the store had already counted when it opened, or reopened for a
+ * resident node: those lookups were ours, warming it, not calls anyone made
+ * of us, and they must not be mistaken for a service record. */
+static uint64_t lmbe_stat_base_requests, lmbe_stat_base_hits;
+
 static void lmbe_open_per_layer(const char *dir, int slots_per_layer) {
     char err[512] = "";
     if (coli_v4_config_load(&lmbe_cfg, dir, err, sizeof err)) {
@@ -95,6 +100,13 @@ static void lmbe_open_per_layer(const char *dir, int slots_per_layer) {
             slots, slots == 1 ? "" : "s", lmbe_cfg.num_hidden_layers,
             slots * lmbe_cfg.num_hidden_layers,
             (double)o.cache_bytes / 1e9);
+    lmbe_stat_base_requests = lmbe_stat_base_hits = 0;
+    if (lmbe_store->ops && lmbe_store->ops->stats) {
+        ColiExpertStoreStats st = {0};
+        lmbe_store->ops->stats(lmbe_store, &st);
+        lmbe_stat_base_requests = st.requests;
+        lmbe_stat_base_hits = st.hits;
+    }
 }
 
 /* `cap` is the node's total expert slots (`--cache N`); 0 means a small
@@ -172,6 +184,34 @@ static uint64_t lmbe_resident_bytes(void) { return lmbe_resident_nbytes; }
 static uint64_t lmbe_vram_nbytes;
 static uint64_t lmbe_vram_bytes(void) { return lmbe_vram_nbytes; }
 #define LMBE_VRAM_BYTES lmbe_vram_bytes
+
+/* How often a lookup was answered from RAM, per thousand, since this store
+ * opened.
+ *
+ * This has to come from the store, not from the node's own slot table: on
+ * V4 `lmbe_slot_load` copies a layer and an expert id and loads no weights
+ * at all, because "the store is the cache". The node's LRU is therefore a
+ * shadow — global over N keys — while the one that actually reads the disk
+ * lives here and is sized per layer. Counting misses in the shadow measures
+ * a different cache with a different geometry, and publishing that number
+ * as "calls served without the disk" would be confidently wrong.
+ *
+ * Returns -1 when the store cannot say, or has not been asked enough times
+ * to mean anything; the node then falls back to its opening estimate. */
+static int lmbe_hot_permille(uint32_t *out) {
+    if (!lmbe_store || !lmbe_store->ops || !lmbe_store->ops->stats) return -1;
+    ColiExpertStoreStats st = {0};
+    lmbe_store->ops->stats(lmbe_store, &st);
+    uint64_t reqs = st.requests > lmbe_stat_base_requests
+                  ? st.requests - lmbe_stat_base_requests : 0;
+    uint64_t hits = st.hits > lmbe_stat_base_hits
+                  ? st.hits - lmbe_stat_base_hits : 0;
+    if (reqs < 64) return -1;
+    if (hits > reqs) hits = reqs;
+    *out = (uint32_t)(hits * 1000u / reqs);
+    return 0;
+}
+#define LMBE_HOT_PERMILLE lmbe_hot_permille
 
 /* set by lmbe_apply when it could not compute; the node turns it into a
  * refused call instead of a dead process */

--- a/expert_node.c
+++ b/expert_node.c
@@ -630,14 +630,28 @@ static void manifest_build(LmbBuf *b) {
  * holding none of it, and a chatter that believes the flag then routes
  * around experts this node has warm.
  *
- * The measured rate is the truth once enough calls have gone through. Below
- * that, the slot ratio is the honest floor — a cache cannot hold more than
- * its slots — so a node that has just started is under-promised, never
- * over-promised. */
+ * An engine that owns its own cache answers first, because it is the cache
+ * that actually reads the disk. On V4 the node's slot table loads nothing —
+ * a slot there is a key, and colibri's per-layer store does the reading —
+ * so counting misses in the slot table would measure a different cache with
+ * a different geometry and publish the answer as if it were this one.
+ *
+ * Failing that, the node's own cold count, once enough calls have gone
+ * through to mean something.
+ *
+ * Failing THAT, the slot ratio: an opening estimate, not a floor. A cold
+ * cache hits nothing, and a working set that cycles past the cache keeps
+ * hitting nothing, so the ratio can be optimistic — it is a starting guess
+ * that the measurement replaces within the first minute of traffic, not a
+ * bound. */
 #define NODE_HOT_MIN_CALLS 64u
 
 static uint32_t node_hot_permille(void) {
     if (!g.ncs) return 1000;                  /* fully resident: no cold path */
+#ifdef LMBE_HOT_PERMILLE
+    uint32_t engine = 0;
+    if (!LMBE_HOT_PERMILLE(&engine)) return engine > 1000 ? 1000 : engine;
+#endif
     uint64_t calls = atomic_load(&g.calls), cold = atomic_load(&g.cold);
     if (calls >= NODE_HOT_MIN_CALLS) {
         uint64_t hits = calls > cold ? calls - cold : 0;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -43,6 +43,13 @@
  * the tracker's hop to the peer and back, home-line grade */
 #define LUMI_TUNNEL_PENALTY_US 60000u
 #define LUMI_RTT_REFRESH_S 30.0
+/* How often one peer's residency report is read again. A cache warms, a
+ * measured rate replaces the opening estimate, a node is rebalanced, a
+ * cache starts missing: all of that moves, and reading it once when the
+ * peer joined publishes a dynamic number through a static channel. Slower
+ * than the RTT cadence and on its own connection, so the pooled sockets the
+ * RTT refresh accounts for are left alone. */
+#define LUMI_ERES_REFRESH_S 60.0
 #define LUMI_RTT_SAMPLES   2
 #ifndef LUMI_RTT_PROBE_TIMEOUT_MS
 #define LUMI_RTT_PROBE_TIMEOUT_MS 2000
@@ -81,6 +88,7 @@ typedef struct {
     uint32_t hot_permille;      /* calls served without a disk read, per 1000 */
     uint32_t hot_experts;       /* experts this node keeps hot */
     uint32_t held_experts;      /* experts it serves in all */
+    double eres_read_at;        /* when the residency report was last read */
     /* the bill: what this peer answered, how long it took, and the bytes
      * that crossed the wire each way — the report divides them by rounds */
     unsigned long long ok_calls, bytes_out, bytes_in;
@@ -104,6 +112,7 @@ static struct {
     LmbTrustKeys trust;
     double next_discover, discover_period_s;
     double next_rtt_refresh;  /* one healthy pooled peer per slow cadence */
+    double next_eres_refresh; /* likewise for the residency report */
     int verify_pct;             /* LUMABRI_VERIFY: % of calls double-checked */
     int allow_codegen_skew;     /* LUMABRI_ALLOW_CODEGEN_SKEW: cc/isa -> warn, not refuse */
     int spread;                 /* LUMABRI_SPREAD: near-band replica spreading, not strict argmin */
@@ -365,6 +374,45 @@ static int lumi_refresh_identity(void) {
     return 1;
 }
 
+/* Where this executor keeps the experts it holds, and how much of that it
+ * really keeps hot.
+ *
+ * ERES answers three words on every node, and three more on a node new
+ * enough to count: experts kept hot, experts served, and calls answered per
+ * thousand without a disk read. The silence of an older node is not "it
+ * hits every time" — it is "we do not know", and the only safe reading of
+ * an unknown disk node is the disk price. `held_experts == 0` is what says
+ * the counts never arrived, and it is what the score checks.
+ *
+ * A tunnel-only peer is never asked: the question would be answered by the
+ * tracker's socket, not the executor's. */
+static void lumi_read_residency(LumiPeer *p) {
+    p->resident = -1;
+    p->hot_permille = 1000;
+    p->hot_experts = p->held_experts = 0;
+    p->eres_read_at = lumi_now();
+    if (p->relay_target[0]) return;
+    LmbMsg rm = {0};
+    const char *dial = p->loopback[0] ? p->loopback : p->addr;
+    if (!lmb_request(dial, LMB_ERES, NULL, 0, &rm) && rm.op == LMB_ERES_R) {
+        LmbCur rc = { rm.body, rm.body_len, 0 };
+        uint32_t flags = 0, state = 0, caps = 0;
+        if (!lmb_cur_u32(&rc, &flags))
+            p->resident = (flags & LMB_EXPERT_RESIDENT_VRAM) ? 2 :
+                          (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
+        if (!lmb_cur_u32(&rc, &state) && !lmb_cur_u32(&rc, &caps))
+            p->caps = caps;               /* absent on older nodes: plain EXEC */
+        uint32_t hot = 0, held = 0, permille = 0;
+        if (!lmb_cur_u32(&rc, &hot) && !lmb_cur_u32(&rc, &held) &&
+            !lmb_cur_u32(&rc, &permille) && held > 0) {
+            p->hot_experts = hot;
+            p->held_experts = held;
+            p->hot_permille = permille > 1000 ? 1000 : permille;
+        }
+    }
+    lmb_msg_free(&rm);
+}
+
 /* Learn one peer: manifest, replica claims, distance. Returns 0, or -1 on
  * any failure (already-known addresses are a no-op success). */
 static int lumi_add_peer(const char *addr) {
@@ -558,35 +606,7 @@ static int lumi_add_peer(const char *addr) {
     }
     lmb_predict_observe(&p->latency, (uint64_t)p->rtt_us);
     p->exec_observations_at_probe = p->exec_observations;
-    /* RAM or disk? Asked once, directly (a tunnel-only peer stays unknown,
-     * and a donor behind NAT is a resident donor in practice). */
-    p->resident = -1;
-    p->hot_permille = 1000;       /* no counts: believe the flag, as before */
-    p->hot_experts = p->held_experts = 0;
-    if (!p->relay_target[0]) {
-        LmbMsg rm = {0};
-        const char *dial = p->loopback[0] ? p->loopback : p->addr;
-        if (!lmb_request(dial, LMB_ERES, NULL, 0, &rm) && rm.op == LMB_ERES_R) {
-            LmbCur rc = { rm.body, rm.body_len, 0 };
-            uint32_t flags = 0, state = 0, caps = 0;
-            if (!lmb_cur_u32(&rc, &flags))
-                p->resident = (flags & LMB_EXPERT_RESIDENT_VRAM) ? 2 :
-                              (flags & LMB_EXPERT_DISK_FALLBACK) ? 0 : 1;
-            if (!lmb_cur_u32(&rc, &state) && !lmb_cur_u32(&rc, &caps))
-                p->caps = caps;               /* absent on older nodes: plain EXEC */
-            /* How much of what it serves it actually keeps hot. Absent on a
-             * node that predates the field, and then the flag stands alone
-             * exactly as before. */
-            uint32_t hot = 0, held = 0, permille = 0;
-            if (!lmb_cur_u32(&rc, &hot) && !lmb_cur_u32(&rc, &held) &&
-                !lmb_cur_u32(&rc, &permille)) {
-                p->hot_experts = hot;
-                p->held_experts = held;
-                p->hot_permille = permille > 1000 ? 1000 : permille;
-            }
-        }
-        lmb_msg_free(&rm);
-    }
+    lumi_read_residency(p);
     char tier[96];
     if (p->resident == 0 && p->held_experts)
         snprintf(tier, sizeof tier,
@@ -739,10 +759,27 @@ static void lumi_maybe_refresh_rtt(double now) {
     if (oldest >= 0) lumi_refresh_rtt(&L.peers[oldest]);
 }
 
+/* The same shape for the residency report: one peer per cadence, the one
+ * read longest ago. A dead peer is skipped; a tunnel peer answers instantly
+ * from lumi_read_residency without dialing anything. */
+static void lumi_maybe_refresh_residency(double now) {
+    if (now < L.next_eres_refresh) return;
+    L.next_eres_refresh = now + LUMI_ERES_REFRESH_S;
+    int oldest = -1;
+    for (int i = 0; i < L.npeers; i++) {
+        LumiPeer *p = &L.peers[i];
+        if (p->dead || p->relay_target[0]) continue;
+        if (oldest < 0 || p->eres_read_at < L.peers[oldest].eres_read_at)
+            oldest = i;
+    }
+    if (oldest >= 0) lumi_read_residency(&L.peers[oldest]);
+}
+
 static void lumi_maybe_discover(void) {
     if (!L.initialized) return;
     double now = lumi_now();
     lumi_maybe_refresh_rtt(now);
+    lumi_maybe_refresh_residency(now);
     if (!L.discovery || now < L.next_discover) return;
     L.next_discover = now + L.discover_period_s;
     if (!L.have_identity) lumi_refresh_identity();
@@ -868,6 +905,7 @@ static void lumi_init_ex(int n_layers, int n_experts, int hidden,
     /* Bootstrap probes may themselves be slow; begin the maintenance cadence
      * only after every initial peer has been discovered and measured. */
     L.next_rtt_refresh = lumi_now() + LUMI_RTT_REFRESH_S;
+    L.next_eres_refresh = lumi_now() + LUMI_ERES_REFRESH_S;
 
     int missing = lumi_missing_experts();
     if (missing && !discovery) {
@@ -987,11 +1025,16 @@ static uint64_t lumi_tier_offset(int residency) {
 
 /* A node with a RAM cache in front of on-disk experts pays the RAM price on
  * a hit and the disk price on a miss, so its offset is the two blended by
- * the rate it reports. A node that keeps everything resident reports a
- * thousand out of a thousand and lands exactly where it did before; so does
- * one too old to report anything. And a caching node that genuinely hits
- * every time IS a RAM node for our purposes, which is the point. */
+ * the rate it reports. A caching node that genuinely never misses IS a RAM
+ * node for our purposes, which is the point of asking.
+ *
+ * A node that reported no counts is not blended at all. Its silence used to
+ * be read as "hits every time", which handed an older disk executor the RAM
+ * price — the opposite of the flag it had just sent, and a quiet route to
+ * the slowest replica in the swarm. No counts, no blend: the flag alone,
+ * exactly as it scored before any of this. */
 static uint64_t lumi_blend_offset(const LumiPeer *p) {
+    if (!p->held_experts) return lumi_tier_offset(p->resident);
     /* the cache in front of the disk is RAM, whatever the flag says overall */
     uint64_t warm = lumi_tier_offset(p->resident == 0 ? 1 : p->resident);
     uint64_t cold = p->resident == 0 ? LUMI_TIER_DISK_US : warm;

--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -386,6 +386,31 @@ static int lumi_refresh_identity(void) {
  *
  * A tunnel-only peer is never asked: the question would be answered by the
  * tracker's socket, not the executor's. */
+/* A maintenance question must never be able to hold up a reply.
+ *
+ * lmb_request has no deadline of its own: it connects, sends and then waits.
+ * Against a peer that is wedged rather than gone — registered, socket open,
+ * answering nothing, which is the more dangerous of the two failures and the
+ * one segment_hybrid_test builds on purpose — that wait is unbounded, and
+ * this runs on the generation path. Give it its own short deadline; a
+ * residency report that does not arrive in two seconds is one we can do
+ * without until the next sweep. */
+#define LUMI_ERES_TIMEOUT_MS 2000
+
+static int lumi_request_bounded(const char *addr, uint32_t op, LmbMsg *resp) {
+    int fd = lmb_connect(addr);
+    if (fd < 0) return -1;
+    struct timeval tv = { LUMI_ERES_TIMEOUT_MS / 1000,
+                          (LUMI_ERES_TIMEOUT_MS % 1000) * 1000 };
+    int rc = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv) ||
+             setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof tv);
+    if (!rc) rc = lmb_auth(fd);
+    if (!rc) rc = lmb_send(fd, op, NULL, 0, NULL, 0);
+    if (!rc) rc = lmb_recv(fd, resp);
+    lmb_close(fd);
+    return rc;
+}
+
 static void lumi_read_residency(LumiPeer *p) {
     p->resident = -1;
     p->hot_permille = 1000;
@@ -394,7 +419,7 @@ static void lumi_read_residency(LumiPeer *p) {
     if (p->relay_target[0]) return;
     LmbMsg rm = {0};
     const char *dial = p->loopback[0] ? p->loopback : p->addr;
-    if (!lmb_request(dial, LMB_ERES, NULL, 0, &rm) && rm.op == LMB_ERES_R) {
+    if (!lumi_request_bounded(dial, LMB_ERES, &rm) && rm.op == LMB_ERES_R) {
         LmbCur rc = { rm.body, rm.body_len, 0 };
         uint32_t flags = 0, state = 0, caps = 0;
         if (!lmb_cur_u32(&rc, &flags))

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -281,8 +281,8 @@ enum {
      * of on-disk experts: holding a third of a model hot reads exactly like
      * holding none of it. The three counts say how much is hot, out of how
      * much, and how often a call is actually served without a disk read —
-     * measured once enough calls have gone through, and the slot ratio,
-     * which is the floor, before that. A chatter asks once after the
+     * measured once enough calls have gone through, and an opening
+     * estimate from the slot ratio before that. A chatter asks once after the
      * manifest; an older node answers ERR and is treated as "unknown", or
      * answers the first three fields alone and is read exactly as before.
      * Additive: the manifest itself is unchanged, so old chatters keep

--- a/test_residency_report.c
+++ b/test_residency_report.c
@@ -1,0 +1,161 @@
+/* What a node says about its residency, and what the chatter does with it.
+ *
+ * The flag is binary and most donors are not: a box that keeps a third of a
+ * model hot in RAM and streams the rest is neither "RAM" nor "disk". So the
+ * node also reports how many experts it keeps hot, how many it serves, and
+ * how often a call is answered without a disk read, and the chatter blends
+ * the RAM and disk costs by that rate.
+ *
+ * The case that matters most here is the node that says NOTHING. An
+ * executor built before those fields answers ERES with three words and
+ * stops. Reading that silence as "hits every time" hands a disk node the
+ * RAM price and quietly routes work to the slowest replica in the swarm —
+ * which is exactly what the first version of this feature did, because
+ * nothing exercised it. Hence this file. */
+#define LMBE_ENGINE_ID "residency-report-test"
+#define LMBE_SOURCE_ID "test"
+#define LMBE_EXPECT_BITS 0
+#include <pthread.h>
+#include <stdatomic.h>
+#include <poll.h>
+#include "lumabri_client.h"
+
+typedef struct {
+    int port;
+    uint32_t flags;
+    int with_counts;              /* 0 = an executor that predates the fields */
+    uint32_t hot, held, permille;
+} Node;
+
+static _Atomic int g_listening;
+static _Atomic int g_stop;
+
+static void *node_main(void *arg) {
+    Node *n = (Node *)arg;
+    int lfd = lmb_listen(n->port);
+    if (lfd < 0) return (void *)1;
+    atomic_fetch_add(&g_listening, 1);
+    while (!atomic_load(&g_stop)) {
+        struct pollfd lp = { lfd, POLLIN, 0 };
+        if (poll(&lp, 1, 50) <= 0) continue;
+        int fd = accept(lfd, NULL, NULL);
+        if (fd < 0) continue;
+        for (;;) {
+            struct pollfd cp = { fd, POLLIN, 0 };
+            int pr = poll(&cp, 1, 50);
+            if (pr < 0) break;
+            if (pr == 0) { if (atomic_load(&g_stop)) break; continue; }
+            LmbMsg m = {0};
+            if (lmb_recv(fd, &m)) { lmb_msg_free(&m); break; }
+            int op = m.op;
+            lmb_msg_free(&m);
+            if (op != LMB_ERES) break;
+            LmbBuf b = {0};
+            lmb_buf_u32(&b, n->flags);
+            lmb_buf_u32(&b, LMB_EXPERT_STATE_ACTIVE);
+            lmb_buf_u32(&b, LMB_CAP_EXEC2);
+            if (n->with_counts) {
+                lmb_buf_u32(&b, n->hot);
+                lmb_buf_u32(&b, n->held);
+                lmb_buf_u32(&b, n->permille);
+            }
+            int bad = lmb_send(fd, LMB_ERES_R, b.p, (uint32_t)b.len, NULL, 0);
+            free(b.p);
+            if (bad) break;
+        }
+        close(fd);
+    }
+    close(lfd);
+    return NULL;
+}
+
+/* Ask one node, the way lumi_add_peer does, and score the answer. */
+static uint64_t offset_of(Node *n, LumiPeer *out) {
+    LumiPeer *p = out;
+    memset(p, 0, sizeof *p);
+    snprintf(p->addr, sizeof p->addr, "127.0.0.1:%d", n->port);
+    p->resident = -1;
+    p->hot_permille = 0;
+    lumi_read_residency(p);
+    return lumi_blend_offset(p);
+}
+
+static int check(const char *what, uint64_t got, uint64_t want) {
+    if (got == want) return 0;
+    fprintf(stderr, "%s: offset %llu us, expected %llu\n", what,
+            (unsigned long long)got, (unsigned long long)want);
+    return 1;
+}
+
+int main(void) {
+    /* an executor from before the counts: three words and nothing more */
+    Node old_disk = { 7650, LMB_EXPERT_DISK_FALLBACK, 0, 0, 0, 0 };
+    Node old_ram  = { 7651, LMB_EXPERT_RESIDENT_RAM,  0, 0, 0, 0 };
+    /* and executors that report them */
+    Node cache_cold = { 7652, LMB_EXPERT_DISK_FALLBACK, 1, 1800, 11008, 163 };
+    Node cache_warm = { 7653, LMB_EXPERT_DISK_FALLBACK, 1, 3000, 11008, 450 };
+    Node cache_hot  = { 7654, LMB_EXPERT_DISK_FALLBACK, 1, 3000, 11008, 1000 };
+    Node resident   = { 7655, LMB_EXPERT_RESIDENT_RAM,  1, 9000,  9000, 1000 };
+    Node vram       = { 7656, LMB_EXPERT_RESIDENT_VRAM, 1, 9000,  9000, 1000 };
+    Node *all[] = { &old_disk, &old_ram, &cache_cold, &cache_warm,
+                    &cache_hot, &resident, &vram };
+    int n = (int)(sizeof all / sizeof *all);
+    pthread_t th[7];
+    for (int i = 0; i < n; i++)
+        pthread_create(&th[i], NULL, node_main, all[i]);
+    for (int spins = 0; atomic_load(&g_listening) < n && spins < 500; spins++)
+        usleep(10000);
+
+    LumiPeer p;
+    int bad = 0;
+
+    /* THE regression: silence must keep the flag's own price, not the RAM
+     * price. A node that cannot tell us how often it hits is a node we have
+     * no reason to believe hits at all. */
+    bad |= check("old node, disk", offset_of(&old_disk, &p), LUMI_TIER_DISK_US);
+    if (p.held_experts) {
+        fprintf(stderr, "old node reported counts it never sent\n");
+        bad = 1;
+    }
+    bad |= check("old node, RAM", offset_of(&old_ram, &p), LUMI_TIER_RAM_US);
+
+    /* a cache in front of a disk: the two prices, blended by the rate */
+    uint64_t want_cold = (LUMI_TIER_RAM_US * 163 +
+                          LUMI_TIER_DISK_US * (1000 - 163)) / 1000;
+    bad |= check("cache at 16%", offset_of(&cache_cold, &p), want_cold);
+    if (p.hot_experts != 1800 || p.held_experts != 11008) {
+        fprintf(stderr, "counts not carried: %u of %u\n",
+                p.hot_experts, p.held_experts);
+        bad = 1;
+    }
+    uint64_t want_warm = (LUMI_TIER_RAM_US * 450 +
+                          LUMI_TIER_DISK_US * (1000 - 450)) / 1000;
+    bad |= check("cache at 45%", offset_of(&cache_warm, &p), want_warm);
+    if (!(want_warm < want_cold)) {
+        fprintf(stderr, "a warmer cache did not score better\n");
+        bad = 1;
+    }
+
+    /* a cache that never misses IS RAM, and everything resident is unchanged */
+    bad |= check("cache at 100%", offset_of(&cache_hot, &p), LUMI_TIER_RAM_US);
+    bad |= check("resident RAM", offset_of(&resident, &p), LUMI_TIER_RAM_US);
+    bad |= check("resident VRAM", offset_of(&vram, &p), LUMI_TIER_VRAM_US);
+
+    /* a peer reached only through the tracker tunnel is never asked */
+    memset(&p, 0, sizeof p);
+    snprintf(p.addr, sizeof p.addr, "127.0.0.1:%d", old_disk.port);
+    snprintf(p.relay_target, sizeof p.relay_target, "somewhere");
+    p.resident = -1; p.hot_permille = 0;
+    lumi_read_residency(&p);
+    if (p.resident != -1 || p.hot_permille != 1000) {
+        fprintf(stderr, "a tunnel peer was probed: resident %d, hot %u\n",
+                p.resident, p.hot_permille);
+        bad = 1;
+    }
+    bad |= check("tunnel peer", lumi_blend_offset(&p), LUMI_TIER_RAM_US);
+
+    atomic_store(&g_stop, 1);
+    for (int i = 0; i < n; i++) pthread_join(th[i], NULL);
+    printf("RESIDENCY REPORT: %s\n", bad ? "FAIL" : "PASS");
+    return bad ? 1 : 0;
+}


### PR DESCRIPTION
Three corrections to #134, and the test that would have caught the first one.

## The old node was handed the RAM price

An executor built before the hot counts answers `ERES` with three words and stops. The client set `hot_permille = 1000` before asking and then blended with it regardless, so that silence was read as *hits every time* — and an older node that had just flagged itself `DISK_FALLBACK` scored at 10 ms instead of 48. The comment in that commit claimed "so does one too old to report anything"; the case it named as preserved was the only one it broke, and it was a quiet route to the slowest replica in the swarm.

`held_experts == 0` is what says the counts never arrived, and the score now checks it: **no counts, no blend** — the flag alone, exactly as it scored before any of this.

## The rate was measured on the wrong cache

The rate came from the node's own `cold` counter. On DeepSeek that counter is meaningless:

```c
/* Nothing to load: the store is the cache, with its own LRU and pins. */
static void lmbe_slot_load(int slot, int eid, LmbeSlot *s) {
    s->layer = slot; s->eid = eid;
}
```

The node's LRU loads no weights — it is a shadow, global over N keys — while the cache that actually reads the disk is colibri's store, sized **per layer**: `--exec-cache 1800` over 43 layers is 42 slots per layer there. Two different caches with two different geometries, and we were publishing one as if it were the other.

The glue now reports the store's own `requests` and `hits`, minus whatever warm-up had already counted before any caller arrived, and the node prefers that number wherever an engine owns its cache. Where none does, the node's cold count still answers, and the slot ratio remains the opening guess.

## The report was read once and never again

`ERES` was asked when the peer joined, so the chatter kept the opening estimate for the life of the process: it never learned that a cache had warmed, that the measurement had replaced the guess, that a node had been rebalanced, or that a cache had started missing. A dynamic statistic on a static channel.

It is now re-read on its own slow cadence, one peer per tick, oldest reading first — deliberately *not* folded into the RTT refresh, whose pooled-socket accounting is asserted on and should stay untouched.

## And "floor" was the wrong word

The slot ratio is an opening estimate, not a lower bound. A cold cache hits nothing, and a working set that cycles past the cache keeps hitting nothing. The word mattered because it was what justified using the ratio at all.

## The test

`test_residency_report` stands up seven fake executors and checks: the old node on both flags, the counts carried through, a warmer cache scoring better than a colder one, a cache that never misses scoring as RAM, resident RAM and VRAM unchanged, and a tunnel peer never probed at all.

Checked against the shipped behaviour on a patched copy of the header — it fails on `old node, disk: offset 10000 us, expected 48000`, naming the number.

Verified: `phase2_test.sh` IDENTICI; `rtt_refresh_test.sh` both stages PASS; `test_hedge`, `test_local_fallback`, `test_accum_order` ok; `expert_node_deepseek` builds; client and node under `-Werror`.
