### PR TITLE
fix: residency decides between replicas the measurements do not separate

### DIFF
--- a/lumabri_client.h
+++ b/lumabri_client.h
@@ -1067,11 +1067,30 @@ static uint64_t lumi_blend_offset(const LumiPeer *p) {
     return (warm * hot + cold * (1000 - hot)) / 1000;
 }
 
+/* The score is what we measured, and nothing else.
+ *
+ * An EXEC observation is the whole call — transport, queue and compute — so
+ * residency is already inside every sample the predictor holds. Adding the
+ * tier on top of that counts the same cost twice, and once a peer has been
+ * observed enough it can lose the call for belonging to the wrong class
+ * while genuinely being the faster machine. That is #121 in reverse, and
+ * #121 was a real incident on this network.
+ *
+ * The two other shapes we tried both trade the double count for starvation.
+ * A prior that fades while a peer is unmeasured falls hardest on the
+ * replica nobody has tried yet, which is how #131 first failed CI. Seeding
+ * the predictor with the tier and folding it back on every idle refresh
+ * does the same thing more slowly: the peer that has been called sheds the
+ * tier through its observations, the peer that has not keeps it forever,
+ * and it is never called again. Measured, that is not a hypothetical — it
+ * reproduces the same test failure.
+ *
+ * So the tier does not enter the score at all. It decides between replicas
+ * the measurements do not separate, in lumi_pick. A peer that is genuinely
+ * faster still wins outright; a peer nobody has measured still gets its
+ * turn whenever its transport says it should. */
 static uint64_t lumi_replica_score(const LumiPeer *p) {
-    uint64_t score = lmb_predict_score(&p->latency, p->inflight);
-    uint64_t tier = lumi_blend_offset(p);
-    if (score == UINT64_MAX || !tier) return score;
-    return score < UINT64_MAX - tier ? score + tier : score;
+    return lmb_predict_score(&p->latency, p->inflight);
 }
 
 static int lumi_pick(int gid, uint32_t tried) {
@@ -1087,18 +1106,41 @@ static int lumi_pick(int gid, uint32_t tried) {
         if (best < 0 || score < best_score)
             { best = r; best_score = score; }
     }
-    if (best < 0 || !L.spread || best_score == UINT64_MAX) return best;
+    if (best < 0 || best_score == UINT64_MAX) return best;
 
+    /* The band: replicas the measurements do not meaningfully separate.
+     * Within it, and only within it, where the experts live decides — an
+     * expert answered from VRAM costs one to two milliseconds, from RAM ten
+     * to fifteen, from a cold NVMe read forty to fifty, and a PING cannot
+     * see any of that. Outside the band the measurement has already spoken
+     * and is not overruled. */
     uint64_t band = best_score + best_score / 4 + 2000;
     int cand[LUMI_MAX_REP], nc = 0;
+    uint64_t best_tier = UINT64_MAX;
     for (int r = 0; r < LUMI_MAX_REP; r++) {
         int pi = own[r];
         if (pi < 0 || ((tried >> r) & 1) || L.peers[pi].dead ||
             !lmb_predict_available(&L.peers[pi].latency, now)) continue;
-        uint64_t score = lumi_replica_score(&L.peers[pi]);
-        if (score <= band) cand[nc++] = r;
+        if (lumi_replica_score(&L.peers[pi]) > band) continue;
+        uint64_t tier = lumi_blend_offset(&L.peers[pi]);
+        if (tier < best_tier) best_tier = tier;
+        cand[nc++] = r;
     }
     if (nc <= 1) return best;
+    int keep = 0;
+    for (int i = 0; i < nc; i++)
+        if (lumi_blend_offset(&L.peers[own[cand[i]]]) == best_tier)
+            cand[keep++] = cand[i];
+    nc = keep;
+    if (nc == 1) return cand[0];
+    if (!L.spread) {
+        /* No spreading: the best-scoring replica of the best tier. */
+        int pick = cand[0];
+        for (int i = 1; i < nc; i++)
+            if (lumi_replica_score(&L.peers[own[cand[i]]]) <
+                lumi_replica_score(&L.peers[own[pick]])) pick = cand[i];
+        return pick;
+    }
     for (int i = 1; i < nc; i++)            /* canonical: sort the band by address */
         for (int j = i; j > 0 &&
              strcmp(L.peers[own[cand[j]]].addr, L.peers[own[cand[j-1]]].addr) < 0; j--) {

--- a/test_residency_report.c
+++ b/test_residency_report.c
@@ -154,6 +154,47 @@ int main(void) {
     }
     bad |= check("tunnel peer", lumi_blend_offset(&p), LUMI_TIER_RAM_US);
 
+    /* ---- and what the routing does with it -----------------------------
+     *
+     * Two claims, and they pull in opposite directions. Where the
+     * measurements do not separate two replicas, the tier decides — that is
+     * the whole reason to ask. Where they DO separate them, the tier must
+     * not overrule the measurement: an EXEC observation already contains
+     * the residency, so charging it again can hand the call to the slower
+     * machine for belonging to the favoured class. */
+    L.n_layers = 1; L.n_experts = 1; L.npeers = 2; L.spread = 0;
+    L.own = (int *)malloc(LUMI_MAX_REP * sizeof(int));
+    for (int i = 0; i < LUMI_MAX_REP; i++) L.own[i] = -1;
+    L.own[0] = 0; L.own[1] = 1;
+
+    /* same measured cost, different residency: residency decides */
+    memset(&L.peers[0], 0, sizeof L.peers[0]);
+    memset(&L.peers[1], 0, sizeof L.peers[1]);
+    snprintf(L.peers[0].addr, sizeof L.peers[0].addr, "a:1");
+    snprintf(L.peers[1].addr, sizeof L.peers[1].addr, "b:1");
+    L.peers[0].resident = 0; L.peers[0].hot_permille = 0;
+    L.peers[0].hot_experts = 1; L.peers[0].held_experts = 1000;
+    L.peers[1].resident = 1; L.peers[1].hot_permille = 1000;
+    L.peers[1].hot_experts = 1000; L.peers[1].held_experts = 1000;
+    lmb_predict_init(&L.peers[0].latency, 20000);
+    lmb_predict_init(&L.peers[1].latency, 20000);
+    if (lumi_pick(0, 0) != 1) {
+        fprintf(stderr, "tied on measurement: the disk replica was chosen\n");
+        bad = 1;
+    }
+
+    /* now the disk replica is measurably four times faster. The measurement
+     * already contains its disk reads; charging the tier again would lose
+     * the call to a slower machine. */
+    lmb_predict_init(&L.peers[0].latency, 5000);
+    lmb_predict_init(&L.peers[1].latency, 20000);
+    if (lumi_pick(0, 0) != 0) {
+        fprintf(stderr, "measured four times faster and still not chosen: "
+                        "the residency cost is being counted twice\n");
+        bad = 1;
+    }
+    free(L.own);
+
     atomic_store(&g_stop, 1);
     for (int i = 0; i < n; i++) pthread_join(th[i], NULL);
     printf("RESIDENCY REPORT: %s\n", bad ? "FAIL" : "PASS");


### PR DESCRIPTION
Stacked on #136.

An `EXEC` observation is the whole call — transport, queue and compute — so where a peer keeps its experts is already inside every sample the predictor holds. Adding the tier to the score on top of that charges the same cost twice, and once a peer has been observed enough it can lose the call for belonging to the wrong class while genuinely being the faster machine. That is **#121 in reverse**, and #121 was a real incident on this network.

## Two other shapes, both measured rather than argued about

**A prior that fades while a peer is unmeasured.** This is what #131 shipped first, and CI rejected it: the peer with fewest calls is exactly the one nobody has tried, so the prior falls hardest on the replica that most needs a chance. A freshly re-probed peer took sixteen pings and zero calls.

**Seeding the predictor with the tier**, and folding it back on each idle refresh, so the tier is the starting estimate rather than a standing penalty. This is the obvious repair and it does not work. The peer that gets called sheds the tier through its observations; the peer that does not keeps it forever and is therefore never called. Implemented and run, it reproduces the same failure: `parked peer refresh (named A/B=8/0, pings A/B=4/26, observations A/B=8/0)`. Same deadlock, slower road.

The reason is structural: an untried peer's service time has to be *guessed*, and any guess large enough to be useful is large enough to keep it untried. No arrangement of the tier as a term in the score escapes that.

## So it stops being a term in the score

The tier decides **inside the band** — among replicas whose measurements do not meaningfully separate them — and nowhere else.

- A peer that is genuinely faster wins outright. The measurement is never overruled.
- A peer nobody has measured still gets its turn whenever its transport says it should. Nothing can starve.
- Where the measurements are level, an expert from VRAM beats one from RAM beats one from a cold read — which is the whole reason to ask a node where its experts live.

The band already existed, for spreading, and only ran when spreading was on. It now always runs: narrow to the best tier present, then either spread across it as before or take its best-scoring member.

## Test

`test_residency_report` gains both directions, because one without the other is half a claim:

- two replicas tied on measurement → the resident one is chosen;
- a disk replica measured four times faster → chosen anyway.

Checked against the shipped scoring: it fails the second with `measured four times faster and still not chosen: the residency cost is being counted twice`.

Verified: `phase2_test.sh` IDENTICI; `rtt_refresh_test.sh` both stages PASS; `test_hedge`, `test_local_fallback`, `test_accum_order` ok; `-Werror` clean.
