### PR TITLE
fix: one table decides which adapter runs a checkpoint, and it can refuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -401,6 +401,9 @@ test_accum_order: test_accum_order.c lumabri_client.h lumabri_proto.h lumabri_si
 test_residency_report: test_residency_report.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_residency_report.c -o $@ -lm
 
+test_model_family: test_model_family.c lumabri_families.h
+	$(CC) $(CFLAGS) test_model_family.c -o $@
+
 test_rtt_refresh: test_rtt_refresh.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_rtt_refresh.c -o $@
 
@@ -601,7 +604,7 @@ test-segment-v2: test_segment_v2
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report \
+test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -629,6 +632,8 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_local_fallback
 	./test_accum_order
 	./test_residency_report
+	./test_model_family
+	bash ./model_family_test.sh
 	./test_nat_adopt
 	bash ./rtt_refresh_test.sh
 	./test_segment_v2
@@ -670,6 +675,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
+	      test_model_family \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/lumabri.c
+++ b/lumabri.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_families.h"
 #include "lumabri_machine.h"
 
 #ifdef __linux__
@@ -346,30 +347,58 @@ static void install_chat_signal_handlers(void) {
     sigaction(SIGQUIT, &action, NULL);
 }
 
+/* One table decides the family; the three lookups below only read it.
+ *
+ * LUMABRI_ENGINE_ID names an adapter directly, for a checkpoint whose
+ * model_type nobody has declared yet — the two rows of LMB_FAMILY_UNMAPPED
+ * are reachable only this way, and a name Colibri does not register is
+ * refused instead of ignored. */
+static const LmbModelFamily *lumi_family(const char *model_type) {
+    const char *forced = getenv("LUMABRI_ENGINE_ID");
+    if (forced && forced[0]) {
+        const LmbModelFamily *f = lmb_family_override(forced);
+        if (!f)
+            fprintf(stderr, "[lumabri] LUMABRI_ENGINE_ID=%s is not an adapter "
+                            "Colibri registers; ignoring it\n", forced);
+        else
+            return f;
+    }
+    const LmbModelFamily *f = lmb_family_for(model_type ? model_type : "");
+    /* A model_type nobody claims used to be impossible: every ladder ended in
+     * a substring broad enough to catch anything, so an unknown checkpoint
+     * was executed by whichever engine shared three letters with it. Now it
+     * is a real state, and a real state has to be said out loud — once, with
+     * the string and the way out, rather than a Segment path that silently
+     * never starts. */
+    static int told;
+    if (!f && !told && model_type && model_type[0]) {
+        told = 1;
+        fprintf(stderr,
+                "[lumabri] model_type \"%s\" is not mapped to any Colibri "
+                "adapter, so no engine is chosen for it. Set "
+                "LUMABRI_ENGINE_ID=<adapter> to name one:", model_type);
+        for (size_t i = 0; i < LMB_FAMILY_COUNT; i++)
+            fprintf(stderr, " %s", LMB_FAMILIES[i].segment_id);
+        fprintf(stderr, "\n");
+    }
+    return f;
+}
+
 /* Which expert-node binary can execute this model's experts, or NULL when
  * that engine has no phase-2 build yet. One per engine family: the engines
  * do not share an expert shape, so neither can the peers. */
 static const char *expert_node_for(const char *model_type) {
-    if (strstr(model_type, "olmoe"))    return "expert_node";
-    if (strstr(model_type, "glm"))      return "expert_node_glm";
-    if (strstr(model_type, "inkling"))  return "expert_node_inkling";
-    if (strstr(model_type, "kimi"))     return "expert_node_kimi";
-    if (strstr(model_type, "deepseek")) return "expert_node_deepseek";
-    if (strstr(model_type, "qwen"))     return "expert_node_qwen36";
-    return NULL;
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->expert_node : NULL;
 }
 
 /* Public Colibri Segment adapter ID for the same model family.  Unlike the
  * expert executors, these names are the stable ABI IDs rather than binary
- * basenames. */
+ * basenames. NULL when no family claims this model_type — the caller says so
+ * out loud rather than picking whichever row shares three letters with it. */
 static const char *segment_engine_for(const char *model_type) {
-    if (strstr(model_type, "olmoe"))    return "olmoe";
-    if (strstr(model_type, "glm"))      return "glm";
-    if (strstr(model_type, "inkling")) return "inkling";
-    if (strstr(model_type, "kimi"))     return "kimi";
-    if (strstr(model_type, "deepseek")) return "deepseek_v4";
-    if (strstr(model_type, "qwen"))     return "qwen36";
-    return NULL;
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->segment_id : NULL;
 }
 
 /* model_type from a local config.json; "" when absent or unparseable */
@@ -2660,13 +2689,15 @@ static char *serve2_history_append(Engine *e, char *history, const char *user,
     return c.p ? c.p : calloc(1, 1);
 }
 
+/* The monolithic engine binary for the same family. "colibri" stays the
+ * last resort here — unlike the Segment id, an unknown model_type used to
+ * land on the monolith and sometimes worked, and refusing to launch anything
+ * would be a regression for a checkpoint that runs today. The refusal that
+ * matters is the Segment one, where the wrong adapter is silent corruption
+ * rather than a failed open. */
 static const char *engine_for(const char *model_type) {
-    if (strstr(model_type, "olmoe")) return "olmoe";
-    if (strstr(model_type, "deepseek")) return "deepseek";
-    if (strstr(model_type, "kimi")) return "kimi_k3";
-    if (strstr(model_type, "inkling")) return "inkling";
-    if (strstr(model_type, "qwen")) return "qwen36";
-    return "colibri";
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->engine : "colibri";
 }
 
 /* `local_dir` non-NULL: the model is already on this disk, so no shim, no

--- a/lumabri_families.h
+++ b/lumabri_families.h
@@ -1,0 +1,112 @@
+/* lumabri_families.h — which Colibri adapter runs which checkpoint.
+ *
+ * Colibri does not answer this question. Only DeepSeek V4 checks
+ * `model_type` at all (`require_string(root, "model_type", "deepseek_v4")`);
+ * the other seven adapters never read it, so there is no table in the engine
+ * to consult and the mapping has to be declared here.
+ *
+ * It used to be declared as three separate ladders of strstr(), and that is
+ * not a mapping, it is a guess that always succeeds:
+ *
+ *     if (strstr(model_type, "glm"))  return "glm";
+ *     if (strstr(model_type, "qwen")) return "qwen36";
+ *
+ * A GLM-5.3 checkpoint contains "glm", so it was handed to the GLM adapter.
+ * A Qwen3.8 contains "qwen", so it was handed to qwen36. Not refused, not
+ * warned about: executed by the wrong engine. And since neither `glm53` nor
+ * `qwen38` was ever registered, those two adapters could not be reached at
+ * all, by any spelling.
+ *
+ * So: one table, exact aliases and declared prefixes, longest match wins,
+ * and NO fallback. A checkpoint whose model_type nobody has declared is an
+ * explicit error naming the string, not a silent hand-off to whichever row
+ * happened to share three letters with it.
+ *
+ * The `aliases` of a family may legitimately be empty. That means the
+ * adapter is registered and usable, but we do not yet know what its
+ * checkpoints write in config.json — it is reachable only through an
+ * explicit override. Those families are named in LMB_FAMILY_UNMAPPED, which
+ * the parity test keeps shrink-only: it may never grow without someone
+ * looking at a real checkpoint. */
+#ifndef LUMABRI_FAMILIES_H
+#define LUMABRI_FAMILIES_H
+
+#include <stddef.h>
+#include <string.h>
+
+typedef struct {
+    const char *segment_id;   /* Colibri Segment and Edge adapter id */
+    const char *engine;       /* monolithic engine binary basename */
+    const char *expert_node;  /* phase-2 executor basename, NULL when none */
+    /* exact config.json model_type values, then declared prefixes. Longest
+     * match wins, so a more specific family always beats a broader one. */
+    const char *aliases[6];
+    const char *prefixes[4];
+} LmbModelFamily;
+
+/* Every adapter Colibri registers has a row here. The parity test fails when
+ * Colibri gains one that does not. */
+static const LmbModelFamily LMB_FAMILIES[] = {
+    { "olmoe",       "olmoe",    "expert_node",
+      { "olmoe", NULL }, { NULL } },
+    { "deepseek_v4", "deepseek", "expert_node_deepseek",
+      { "deepseek_v4", NULL }, { NULL } },
+    { "kimi",        "kimi_k3",  "expert_node_kimi",
+      { NULL }, { "kimi", NULL } },
+    { "inkling",     "inkling",  "expert_node_inkling",
+      { NULL }, { "inkling", NULL } },
+    { "qwen36",      "qwen36",   "expert_node_qwen36",
+      { NULL }, { "qwen3_", "qwen36", NULL } },
+    { "glm",         "colibri",  "expert_node_glm",
+      { NULL }, { "glm", NULL } },
+    /* Registered and usable, but no checkpoint of theirs has been read yet,
+     * so nothing is claimed about their model_type. Reachable through the
+     * explicit override until someone looks at one. */
+    { "glm53",       "colibri",  "expert_node_glm",   { NULL }, { NULL } },
+    { "qwen38",      "qwen36",   "expert_node_qwen36", { NULL }, { NULL } },
+};
+#define LMB_FAMILY_COUNT (sizeof LMB_FAMILIES / sizeof *LMB_FAMILIES)
+
+/* Shrink-only. A row belongs here exactly while its aliases and prefixes are
+ * both empty; the parity test enforces both directions, so this list cannot
+ * quietly grow when a new adapter arrives. */
+static const char *const LMB_FAMILY_UNMAPPED[] = { "glm53", "qwen38" };
+#define LMB_FAMILY_UNMAPPED_COUNT \
+    (sizeof LMB_FAMILY_UNMAPPED / sizeof *LMB_FAMILY_UNMAPPED)
+
+static const LmbModelFamily *lmb_family_by_id(const char *segment_id) {
+    if (!segment_id || !segment_id[0]) return NULL;
+    for (size_t i = 0; i < LMB_FAMILY_COUNT; i++)
+        if (!strcmp(LMB_FAMILIES[i].segment_id, segment_id))
+            return &LMB_FAMILIES[i];
+    return NULL;
+}
+
+/* The checkpoint's model_type decides, and the longest declared match wins.
+ * NULL means "no family claims this string" — the caller must say so out
+ * loud rather than pick one. */
+static const LmbModelFamily *lmb_family_for(const char *model_type) {
+    if (!model_type || !model_type[0]) return NULL;
+    const LmbModelFamily *best = NULL;
+    size_t best_len = 0;
+    for (size_t i = 0; i < LMB_FAMILY_COUNT; i++) {
+        const LmbModelFamily *f = &LMB_FAMILIES[i];
+        for (int a = 0; a < 6 && f->aliases[a]; a++)
+            if (!strcmp(model_type, f->aliases[a])) return f;   /* exact wins */
+        for (int p = 0; p < 4 && f->prefixes[p]; p++) {
+            size_t n = strlen(f->prefixes[p]);
+            if (strncmp(model_type, f->prefixes[p], n)) continue;
+            if (n > best_len) { best = f; best_len = n; }
+        }
+    }
+    return best;
+}
+
+/* An operator with a checkpoint we have not mapped names the adapter
+ * directly. Returns NULL when the name is not one Colibri registers, so a
+ * typo is refused instead of silently ignored. */
+static const LmbModelFamily *lmb_family_override(const char *segment_id) {
+    return lmb_family_by_id(segment_id);
+}
+
+#endif /* LUMABRI_FAMILIES_H */

--- a/model_family_test.sh
+++ b/model_family_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Colibri's adapter registry and Lumabri's family table must say the same
+# thing, and the expected list has to be READ from Colibri rather than typed
+# here — a test that compares two hand-written eights passes forever while
+# Colibri quietly gains a ninth.
+#
+# Three claims:
+#   1. every adapter Colibri exposes is registered by lmb_colibri_register_all
+#      (Segment and Edge), and has a row in LMB_FAMILIES;
+#   2. every row in LMB_FAMILIES names an adapter Colibri actually exposes;
+#   3. LMB_FAMILY_UNMAPPED holds exactly the rows with no alias and no prefix,
+#      so the debt list can shrink but never silently grow.
+set -euo pipefail
+cd "$(dirname "$0")"
+ENGINE="${ENGINE:-../colibri/c}"
+fail() { echo "MODEL FAMILY TEST: FAIL — $*" >&2; exit 1; }
+
+[[ -f "$ENGINE/segment_adapters.h" ]] || { echo "MODEL FAMILY TEST: SKIP (no $ENGINE)"; exit 0; }
+
+adapters_of() {  # $1 = header, $2 = segment|edge
+    grep -oE "coli_[a-z0-9_]+_$2_adapter_register" "$1" |
+        sed -E "s/^coli_(.*)_$2_adapter_register$/\1/" | sort -u
+}
+seg=$(adapters_of "$ENGINE/segment_adapters.h" segment)
+edge=$(adapters_of "$ENGINE/edge_adapters.h" edge)
+[[ -n "$seg" ]] || fail "no Segment adapters found in $ENGINE/segment_adapters.h"
+
+# Colibri's own two lists must agree before we compare ourselves to them.
+diff <(echo "$seg") <(echo "$edge") >/dev/null ||
+    fail "Colibri exposes different Segment and Edge adapter sets:
+$(diff <(echo "$seg") <(echo "$edge") || true)"
+
+ours_seg=$(grep -oE "coli_[a-z0-9_]+_segment_adapter_register" segment_colibri.h |
+           sed -E 's/^coli_(.*)_segment_adapter_register$/\1/' | sort -u)
+ours_edge=$(grep -oE "coli_[a-z0-9_]+_edge_adapter_register" segment_colibri.h |
+            sed -E 's/^coli_(.*)_edge_adapter_register$/\1/' | sort -u)
+
+missing=$(comm -23 <(echo "$seg") <(echo "$ours_seg"))
+[[ -z "$missing" ]] || fail "Colibri exposes Segment adapters Lumabri never registers: $(echo $missing).
+Add them to lmb_colibri_register_all() and give each a row in lumabri_families.h."
+extra=$(comm -13 <(echo "$seg") <(echo "$ours_seg"))
+[[ -z "$extra" ]] || fail "Lumabri registers Segment adapters Colibri does not expose: $(echo $extra)"
+missing=$(comm -23 <(echo "$edge") <(echo "$ours_edge"))
+[[ -z "$missing" ]] || fail "Colibri exposes Edge adapters Lumabri never registers: $(echo $missing)"
+
+# The family table and the debt list, parsed rather than eyeballed.
+python3 - "$seg" <<'PYEOF' || exit 1
+import re, sys
+src = open("lumabri_families.h", encoding="utf-8").read()
+body = src[src.index("LMB_FAMILIES[] = {"):]
+body = body[:body.index("\n};")]
+rows = []
+depth, cur = 0, ""
+for ch in body[body.index("{") + 1:]:   # skip the array brace
+    if ch == "{":
+        depth += 1
+        if depth == 1: cur = ""; continue
+    if ch == "}":
+        depth -= 1
+        if depth == 0: rows.append(cur); continue
+    if depth >= 1: cur += ch
+table = {}
+for row in rows:
+    names = re.findall(r'"([^"]*)"', row)
+    if not names: continue
+    inner = re.findall(r"\{([^{}]*)\}", row)          # aliases, then prefixes
+    claims = [c for g in inner for c in re.findall(r'"([^"]+)"', g)]
+    table[names[0]] = claims
+
+declared = set(re.findall(r'"([a-z0-9_]+)"',
+    src[src.index("LMB_FAMILY_UNMAPPED[] = {"):].split("};")[0]))
+expected = set(sys.argv[1].split())
+bad = []
+if set(table) - expected:
+    bad.append("LMB_FAMILIES names adapters Colibri does not expose: %s"
+               % " ".join(sorted(set(table) - expected)))
+if expected - set(table):
+    bad.append("adapters with no row in LMB_FAMILIES: %s — a checkpoint of "
+               "that family would be refused with no way to run it"
+               % " ".join(sorted(expected - set(table))))
+silent = {n for n, c in table.items() if not c}
+if silent != declared:
+    bad.append("LMB_FAMILY_UNMAPPED must list exactly the rows that claim no "
+               "model_type.\n  rows claiming none: %s\n  declared:          %s"
+               % (" ".join(sorted(silent)) or "(none)",
+                  " ".join(sorted(declared)) or "(none)"))
+seen = {}
+for name, claims in table.items():
+    for c in claims:
+        if c in seen:
+            bad.append("model_type %r is claimed by both %s and %s"
+                       % (c, seen[c], name))
+        seen[c] = name
+if bad:
+    print("MODEL FAMILY TEST: FAIL — " + "\n".join(bad), file=sys.stderr)
+    sys.exit(1)
+print("  %d adapters, %d mapped, unmapped: %s"
+      % (len(table), len(table) - len(silent),
+         " ".join(sorted(silent)) or "(none)"))
+PYEOF
+
+echo "MODEL FAMILY TEST: PASS ($(echo "$seg" | wc -w) adapters registered, mapped and unambiguous)"

--- a/segment_colibri.h
+++ b/segment_colibri.h
@@ -13,18 +13,30 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Every adapter Colibri exposes, Segment and Edge.
+ *
+ * This list used to hold six of the eight: `glm53` and `qwen38` were never
+ * registered, so those two engines could not be reached by any spelling —
+ * and the substring dispatch quietly handed their checkpoints to `glm` and
+ * `qwen36` instead. Registering them is half the fix; lumabri_families.h is
+ * the other half, and model_family_test.sh keeps the two halves in step with
+ * whatever Colibri exposes next. */
 static int lmb_colibri_register_all(void) {
     return coli_glm_segment_adapter_register() ||
+           coli_glm53_segment_adapter_register() ||
            coli_inkling_segment_adapter_register() ||
            coli_kimi_segment_adapter_register() ||
            coli_olmoe_segment_adapter_register() ||
            coli_qwen36_segment_adapter_register() ||
+           coli_qwen38_segment_adapter_register() ||
            coli_deepseek_v4_segment_adapter_register() ||
            coli_glm_edge_adapter_register() ||
+           coli_glm53_edge_adapter_register() ||
            coli_inkling_edge_adapter_register() ||
            coli_kimi_edge_adapter_register() ||
            coli_olmoe_edge_adapter_register() ||
            coli_qwen36_edge_adapter_register() ||
+           coli_qwen38_edge_adapter_register() ||
            coli_deepseek_v4_edge_adapter_register();
 }
 

--- a/test_model_family.c
+++ b/test_model_family.c
@@ -1,0 +1,79 @@
+/* The table decides, and it decides the same way every time.
+ *
+ * The dispatch this replaces was three ladders of strstr(), and its failure
+ * was not that it refused things — it was that it never did. "glm53_moe"
+ * contains "glm", so a GLM-5.3 checkpoint was handed to the GLM adapter and
+ * executed. That is worse than an error: an error stops, a wrong adapter
+ * produces numbers.
+ *
+ * So the claims here are about what the table REFUSES as much as what it
+ * resolves. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "lumabri_families.h"
+
+static int bad;
+
+static void want(const char *model_type, const char *expect_id) {
+    const LmbModelFamily *f = lmb_family_for(model_type);
+    const char *got = f ? f->segment_id : NULL;
+    if (!expect_id && !got) return;
+    if (expect_id && got && !strcmp(got, expect_id)) return;
+    fprintf(stderr, "model_type \"%s\": got %s, expected %s\n", model_type,
+            got ? got : "(refused)", expect_id ? expect_id : "(refused)");
+    bad = 1;
+}
+
+int main(void) {
+    /* the two the table knows exactly */
+    want("olmoe", "olmoe");
+    want("deepseek_v4", "deepseek_v4");
+
+    /* the families that still match by declared prefix, unchanged */
+    want("kimi_k2", "kimi");
+    want("inkling", "inkling");
+    want("qwen3_moe", "qwen36");
+    want("glm4_moe", "glm");
+
+    /* the refusals. Nothing here shares enough with a declared prefix to be
+     * claimed, and every one of them used to be swallowed silently. */
+    want("", NULL);
+    want("llama", NULL);
+    want("mixtral", NULL);
+    want("deepseek_v3", NULL);   /* "deepseek" was a prefix once: not any more */
+
+    /* a family with no declared model_type is unreachable by detection... */
+    const LmbModelFamily *f;
+    for (size_t i = 0; i < LMB_FAMILY_UNMAPPED_COUNT; i++) {
+        const char *id = LMB_FAMILY_UNMAPPED[i];
+        f = lmb_family_by_id(id);
+        if (!f) { fprintf(stderr, "unmapped family %s has no row\n", id); bad = 1; continue; }
+        if (f->aliases[0] || f->prefixes[0]) {
+            fprintf(stderr, "%s is listed as unmapped but claims a model_type\n", id);
+            bad = 1;
+        }
+        /* ...and reachable by explicit name, which is the whole point of
+         * registering it. */
+        if (lmb_family_override(id) != f) {
+            fprintf(stderr, "%s cannot be selected explicitly\n", id);
+            bad = 1;
+        }
+    }
+
+    /* a name Colibri does not register is refused, not ignored */
+    if (lmb_family_override("qwen39")) {
+        fprintf(stderr, "an unknown adapter name was accepted\n");
+        bad = 1;
+    }
+
+    /* the longest declared match wins, so a more specific family can always
+     * be added later without disturbing the broader one */
+    if (lmb_family_for("qwen36_moe") != lmb_family_by_id("qwen36")) {
+        fprintf(stderr, "longest-match did not prefer the specific family\n");
+        bad = 1;
+    }
+
+    printf("MODEL FAMILY TABLE: %s\n", bad ? "FAIL" : "PASS");
+    return bad ? 1 : 0;
+}


### PR DESCRIPTION
Step 0 of the roadmap, first half: the adapter registry and an exact dispatch.

## Two adapters nothing could reach

Colibri exposes eight Segment adapters — `glm`, `glm53`, `inkling`, `kimi`, `olmoe`, `qwen36`, `qwen38`, `deepseek_v4`. `lmb_colibri_register_all()` registered six: `glm53` and `qwen38` were never registered, so those two engines could not be reached by any spelling.

## And a dispatch that could not refuse

Worse than the omission was how the choice was made. Three separate ladders of `strstr()` answered "which engine runs this model_type", and a substring ladder is not a mapping — it is a guess that always succeeds:

```c
if (strstr(model_type, "glm"))  return "glm";
if (strstr(model_type, "qwen")) return "qwen36";
```

A GLM-5.3 checkpoint contains "glm", so it was handed to the GLM adapter and **executed**. A Qwen3.8 contains "qwen", so it went to `qwen36`. Not refused, not warned about: run by the wrong engine — which is worse than an error, because an error stops and a wrong adapter produces numbers.

## One table

`lumabri_families.h` is now the only place that answers the question: exact aliases, declared prefixes, longest match wins, and **no fallback** for the Segment id. The three lookups (`segment_engine_for`, `expert_node_for`, `engine_for`) only read it.

A `model_type` nobody claims is now a real state, said out loud once with the string and the list of adapters, plus `LUMABRI_ENGINE_ID` to name one directly. The monolithic engine keeps `colibri` as its last resort: there an unknown type used to launch something that sometimes worked, and removing that would be a regression. The refusal that matters is the Segment one, where the wrong adapter is silent corruption rather than a failed open.

**Colibri does not answer this itself:** only DeepSeek V4 reads `model_type` (`require_string(root, "model_type", "deepseek_v4")`); the other seven never look at it. So `glm53` and `qwen38` are registered and selectable, but claim no `model_type` until someone reads a real checkpoint of theirs. `LMB_FAMILY_UNMAPPED` names them, and the test keeps that list **shrink-only**.

## The test derives the expected set from Colibri

`model_family_test.sh` reads the expected adapters out of Colibri's own headers instead of comparing two hand-written eights, which would pass forever while Colibri gained a ninth. It catches five breakages, each verified against a deliberately patched copy:

- a new Colibri adapter we do not register → *"Colibri exposes Segment adapters Lumabri never registers: newmodel"*;
- an adapter with no row in the table → *"a checkpoint of that family would be refused with no way to run it"*;
- a row for an adapter Colibri does not expose;
- a stale debt list when a family starts claiming a `model_type`;
- two families claiming the same string → *"model_type 'glm' is claimed by both qwen36 and glm"*.

`test_model_family` covers the runtime side: the families that resolve, the ones reachable only by explicit name, a name Colibri does not register being refused rather than ignored, and the four model types now refused instead of swallowed — including `deepseek_v3`, which the old ladder would have handed to the V4 adapter.

Verified: `selftest.sh`, `role_test.sh`, `serve_failfast_test.sh` PASS; `-Werror` clean; both new tests wired into `make test` and `check-warnings`.
