### PR TITLE
feat: a planner that says what fits, and a preflight that believes it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -401,6 +401,9 @@ test_accum_order: test_accum_order.c lumabri_client.h lumabri_proto.h lumabri_si
 test_residency_report: test_residency_report.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_residency_report.c -o $@ -lm
 
+test_model_family: test_model_family.c lumabri_families.h
+	$(CC) $(CFLAGS) test_model_family.c -o $@
+
 test_rtt_refresh: test_rtt_refresh.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_rtt_refresh.c -o $@
 
@@ -601,7 +604,7 @@ test-segment-v2: test_segment_v2
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report \
+test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -629,6 +632,8 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_local_fallback
 	./test_accum_order
 	./test_residency_report
+	./test_model_family
+	bash ./model_family_test.sh
 	./test_nat_adopt
 	bash ./rtt_refresh_test.sh
 	./test_segment_v2
@@ -670,6 +675,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
+	      test_model_family \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate \
@@ -404,6 +404,15 @@ test_residency_report: test_residency_report.c lumabri_client.h lumabri_proto.h 
 test_model_family: test_model_family.c lumabri_families.h
 	$(CC) $(CFLAGS) test_model_family.c -o $@
 
+test_planner: test_planner.c lumabri_planner.h lumabri_families.h
+	$(CC) $(CFLAGS) test_planner.c -o $@
+
+test_cluster: test_cluster.c lumabri_cluster.h lumabri_planner.h lumabri_families.h lumabri_machine.h
+	$(CC) $(CFLAGS) test_cluster.c -o $@
+
+segment_budget_probe: segment_budget_probe.c lumabri_planner.h lumabri_families.h
+	$(CC) $(CFLAGS) segment_budget_probe.c -o $@
+
 test_rtt_refresh: test_rtt_refresh.c lumabri_client.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CFLAGS) -pthread test_rtt_refresh.c -o $@
 
@@ -604,7 +613,7 @@ test-segment-v2: test_segment_v2
 test-segment-discovery: tracker test_segment_discovery
 	bash ./segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family \
+test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -634,6 +643,8 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_residency_report
 	./test_model_family
 	bash ./model_family_test.sh
+	./test_planner
+	./test_cluster
 	./test_nat_adopt
 	bash ./rtt_refresh_test.sh
 	./test_segment_v2
@@ -675,7 +686,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
-	      test_model_family \
+	      test_model_family test_planner test_cluster segment_budget_probe \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/adapter_conformance_test.sh
+++ b/adapter_conformance_test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# "Supported" has to mean "proved", not "compiles".
+#
+# Every adapter Colibri exposes gets the same battery, and an adapter that
+# has not passed it is reported as experimental rather than supported. The
+# list of adapters comes from Colibri's headers, so a new one shows up here
+# as untested the moment it appears — the same rule model_family_test.sh
+# enforces for the registry.
+#
+# A family with no fixture checkpoint on this machine is SKIPPED, and skipped
+# is not passed: the summary says so, and the exit status stays zero only
+# because a laptop cannot be expected to hold a 167 GB checkpoint. The real
+# matrix runs where the checkpoints live.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ENGINE="${ENGINE:-../colibri/c}"
+[[ -f "$ENGINE/segment_adapters.h" ]] ||
+    { echo "ADAPTER CONFORMANCE: SKIP (no $ENGINE)"; exit 0; }
+
+adapters=$(grep -oE "coli_[a-z0-9_]+_segment_adapter_register" \
+           "$ENGINE/segment_adapters.h" |
+           sed -E 's/^coli_(.*)_segment_adapter_register$/\1/' | sort -u)
+
+# Where a fixture for each family lives, when one does. LUMABRI_FIXTURE_<id>
+# overrides, so an operator with the real checkpoints can run the whole
+# matrix without editing this file.
+fixture_for() {
+    local id=$1 var
+    var="LUMABRI_FIXTURE_${id^^}"
+    if [[ -n "${!var:-}" ]]; then echo "${!var}"; return; fi
+    case "$id" in
+        olmoe) [[ -d tiny_olmoe ]] && echo tiny_olmoe ;;
+        *)     ;;
+    esac
+}
+
+pass=0 skip=0 fail=0
+declare -a untested=()
+for id in $adapters; do
+    dir=$(fixture_for "$id")
+    if [[ -z "$dir" || ! -f "$dir/config.json" ]]; then
+        printf '  %-14s experimental — no checkpoint on this machine\n' "$id"
+        untested+=("$id"); skip=$(( skip + 1 ))
+        continue
+    fi
+    name=$(python3 -c "import json;print(json.load(open('$dir/config.json')).get('model_type','$id'))")
+    if SPLIT_MODEL_DIR="$dir" SPLIT_ENGINE="$id" SPLIT_MODEL="conf-$id" \
+       PORT=$(( 8200 + RANDOM % 200 )) bash ./segment_split_test.sh >"/tmp/conf-$id.log" 2>&1; then
+        printf '  %-14s supported (%s)\n' "$id" "$name"
+        pass=$(( pass + 1 ))
+    else
+        printf '  %-14s FAILED — see /tmp/conf-%s.log\n' "$id" "$id"
+        tail -n 20 "/tmp/conf-$id.log" >&2
+        fail=$(( fail + 1 ))
+    fi
+done
+
+echo "ADAPTER CONFORMANCE: $pass supported, $skip experimental, $fail failed"
+if (( fail > 0 )); then exit 1; fi
+if (( pass == 0 )); then
+    echo "  nothing was actually exercised: this run proves nothing" >&2
+fi
+exit 0

--- a/lumabri.c
+++ b/lumabri.c
@@ -43,6 +43,7 @@
 #include <unistd.h>
 
 #include "lumabri_proto.h"
+#include "lumabri_families.h"
 #include "lumabri_machine.h"
 
 #ifdef __linux__
@@ -346,30 +347,58 @@ static void install_chat_signal_handlers(void) {
     sigaction(SIGQUIT, &action, NULL);
 }
 
+/* One table decides the family; the three lookups below only read it.
+ *
+ * LUMABRI_ENGINE_ID names an adapter directly, for a checkpoint whose
+ * model_type nobody has declared yet — the two rows of LMB_FAMILY_UNMAPPED
+ * are reachable only this way, and a name Colibri does not register is
+ * refused instead of ignored. */
+static const LmbModelFamily *lumi_family(const char *model_type) {
+    const char *forced = getenv("LUMABRI_ENGINE_ID");
+    if (forced && forced[0]) {
+        const LmbModelFamily *f = lmb_family_override(forced);
+        if (!f)
+            fprintf(stderr, "[lumabri] LUMABRI_ENGINE_ID=%s is not an adapter "
+                            "Colibri registers; ignoring it\n", forced);
+        else
+            return f;
+    }
+    const LmbModelFamily *f = lmb_family_for(model_type ? model_type : "");
+    /* A model_type nobody claims used to be impossible: every ladder ended in
+     * a substring broad enough to catch anything, so an unknown checkpoint
+     * was executed by whichever engine shared three letters with it. Now it
+     * is a real state, and a real state has to be said out loud — once, with
+     * the string and the way out, rather than a Segment path that silently
+     * never starts. */
+    static int told;
+    if (!f && !told && model_type && model_type[0]) {
+        told = 1;
+        fprintf(stderr,
+                "[lumabri] model_type \"%s\" is not mapped to any Colibri "
+                "adapter, so no engine is chosen for it. Set "
+                "LUMABRI_ENGINE_ID=<adapter> to name one:", model_type);
+        for (size_t i = 0; i < LMB_FAMILY_COUNT; i++)
+            fprintf(stderr, " %s", LMB_FAMILIES[i].segment_id);
+        fprintf(stderr, "\n");
+    }
+    return f;
+}
+
 /* Which expert-node binary can execute this model's experts, or NULL when
  * that engine has no phase-2 build yet. One per engine family: the engines
  * do not share an expert shape, so neither can the peers. */
 static const char *expert_node_for(const char *model_type) {
-    if (strstr(model_type, "olmoe"))    return "expert_node";
-    if (strstr(model_type, "glm"))      return "expert_node_glm";
-    if (strstr(model_type, "inkling"))  return "expert_node_inkling";
-    if (strstr(model_type, "kimi"))     return "expert_node_kimi";
-    if (strstr(model_type, "deepseek")) return "expert_node_deepseek";
-    if (strstr(model_type, "qwen"))     return "expert_node_qwen36";
-    return NULL;
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->expert_node : NULL;
 }
 
 /* Public Colibri Segment adapter ID for the same model family.  Unlike the
  * expert executors, these names are the stable ABI IDs rather than binary
- * basenames. */
+ * basenames. NULL when no family claims this model_type — the caller says so
+ * out loud rather than picking whichever row shares three letters with it. */
 static const char *segment_engine_for(const char *model_type) {
-    if (strstr(model_type, "olmoe"))    return "olmoe";
-    if (strstr(model_type, "glm"))      return "glm";
-    if (strstr(model_type, "inkling")) return "inkling";
-    if (strstr(model_type, "kimi"))     return "kimi";
-    if (strstr(model_type, "deepseek")) return "deepseek_v4";
-    if (strstr(model_type, "qwen"))     return "qwen36";
-    return NULL;
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->segment_id : NULL;
 }
 
 /* model_type from a local config.json; "" when absent or unparseable */
@@ -2660,13 +2689,15 @@ static char *serve2_history_append(Engine *e, char *history, const char *user,
     return c.p ? c.p : calloc(1, 1);
 }
 
+/* The monolithic engine binary for the same family. "colibri" stays the
+ * last resort here — unlike the Segment id, an unknown model_type used to
+ * land on the monolith and sometimes worked, and refusing to launch anything
+ * would be a regression for a checkpoint that runs today. The refusal that
+ * matters is the Segment one, where the wrong adapter is silent corruption
+ * rather than a failed open. */
 static const char *engine_for(const char *model_type) {
-    if (strstr(model_type, "olmoe")) return "olmoe";
-    if (strstr(model_type, "deepseek")) return "deepseek";
-    if (strstr(model_type, "kimi")) return "kimi_k3";
-    if (strstr(model_type, "inkling")) return "inkling";
-    if (strstr(model_type, "qwen")) return "qwen36";
-    return "colibri";
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->engine : "colibri";
 }
 
 /* `local_dir` non-NULL: the model is already on this disk, so no shim, no

--- a/lumabri_cluster.h
+++ b/lumabri_cluster.h
@@ -1,0 +1,233 @@
+/* lumabri_cluster.h — what this collection of computers can actually run.
+ *
+ * The catalogue's whole job is to answer three questions about every model,
+ * and to keep them apart:
+ *
+ *   can it run at all?      resident, from disk, or not at all
+ *   what is missing?        gigabytes, and how many machines that is
+ *   how would it be split?  a range per node, and who runs Edge
+ *
+ * A fourth question — how fast — is deliberately NOT answered here. A plan
+ * knows what fits; only a calibration knows what it does, and the two must
+ * never be printed in the same voice.
+ *
+ * The placement has two objectives and they pull apart, so the caller says
+ * which one it wants. One session is a chain: the layers are sequential, so
+ * what matters is the SUM of the stages plus the hops between them, and
+ * fewer machines can be better because every boundary is another hop. Many
+ * sessions are a pipeline: different chats occupy different stages at once,
+ * so what matters is the SLOWEST stage. Optimising one while reporting the
+ * other is how a plan looks good and feels wrong. */
+#ifndef LUMABRI_CLUSTER_H
+#define LUMABRI_CLUSTER_H
+
+#include "lumabri_machine.h"   /* LMB_GPU_* : the backends an engine can use */
+#include "lumabri_planner.h"
+
+#define LMB_CLUSTER_MAX_NODES 32
+
+typedef struct {
+    char name[64];
+    char addr[64];
+    uint64_t ram_budget_bytes;   /* what this machine offers, reserve removed */
+    uint64_t vram_budget_bytes;
+    uint64_t disk_read_bps;      /* 0 = unmeasured: disk mode cannot be judged */
+    uint64_t lan_bps;            /* to the node running Edge; 0 = unmeasured */
+    double rtt_ms;               /* to the node running Edge */
+    uint32_t gpu_backends;       /* what the ENGINE can use, not what is fitted */
+    uint32_t threads;
+    int has_checkpoint;          /* the weights are already on this machine */
+} LmbClusterNode;
+
+typedef struct {
+    uint32_t node;               /* index into the node array */
+    uint32_t layer_begin, layer_end;
+    LmbPlanState state;
+    uint64_t bytes_resident;     /* what it will actually hold */
+    uint64_t bytes_to_fetch;     /* what it must receive first */
+} LmbSlice;
+
+typedef enum {
+    LMB_GOAL_ONE_SESSION = 0,    /* minimise the sum: a chain */
+    LMB_GOAL_THROUGHPUT,         /* minimise the slowest stage: a pipeline */
+} LmbPlanGoal;
+
+typedef struct {
+    LmbPlanState state;
+    LmbPlanGoal goal;
+    uint32_t nslices;
+    LmbSlice slices[LMB_CLUSTER_MAX_NODES];
+    uint32_t edge_node;          /* who holds embedding and head */
+    uint64_t missing_bytes;      /* 0 when it fits */
+    uint32_t missing_nodes;      /* machines of the median size that would fix it */
+    uint64_t fetch_bytes;        /* total that must cross the network first */
+    double ready_seconds;        /* download and distribution, NOT speed */
+    int ready_known;             /* 0 when no bandwidth was measured */
+    uint32_t sessions;
+} LmbClusterPlan;
+
+/* Give each node a share of the layers proportional to what it can hold, so
+ * a 32 GB machine takes twice the range of a 16 GB one instead of the same.
+ * Equal splits are the obvious thing and they are wrong on the hardware a
+ * house actually has, where one box is always the big one. */
+static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
+                                       const LmbClusterNode *nodes, uint32_t n,
+                                       uint32_t context, uint32_t sessions,
+                                       LmbPlanGoal goal,
+                                       LmbClusterPlan *out) {
+    memset(out, 0, sizeof *out);
+    out->goal = goal;
+    out->sessions = sessions ? sessions : 1;
+    out->state = LMB_PLAN_UNRUNNABLE;
+    if (!m->layers || !n || n > LMB_CLUSTER_MAX_NODES) return -1;
+
+    /* Edge goes where it fits and the engine is fastest: a machine whose
+     * engine can use its GPU beats one that merely has a card in it. */
+    LmbRangeCost edge = lmb_estimate_edge(m, context, sessions);
+    uint32_t best_edge = UINT32_MAX;
+    uint64_t best_edge_room = 0;
+    for (uint32_t i = 0; i < n; i++) {
+        uint64_t room = nodes[i].ram_budget_bytes + nodes[i].vram_budget_bytes;
+        if (edge.ok && room < edge.resident_bytes + edge.state_bytes) continue;
+        uint64_t score = room + (nodes[i].gpu_backends ? room : 0);
+        if (best_edge == UINT32_MAX || score > best_edge_room) {
+            best_edge = i; best_edge_room = score;
+        }
+    }
+    if (best_edge == UINT32_MAX) return -1;      /* nobody can hold Edge */
+    out->edge_node = best_edge;
+
+    uint64_t total_budget = 0;
+    for (uint32_t i = 0; i < n; i++)
+        total_budget += nodes[i].ram_budget_bytes + nodes[i].vram_budget_bytes;
+    if (!total_budget) return -1;
+
+    /* Hand out layers in proportion to budget, in one pass, never leaving a
+     * layer unassigned: the last node takes whatever rounding left over. */
+    uint32_t assigned = 0;
+    uint64_t whole_resident = 0;
+    for (uint32_t i = 0; i < n && assigned < m->layers; i++) {
+        uint64_t budget = nodes[i].ram_budget_bytes + nodes[i].vram_budget_bytes;
+        uint32_t take = (uint32_t)((uint64_t)m->layers * budget / total_budget);
+        if (i + 1 == n) take = m->layers - assigned;
+        if (!take) continue;
+        if (assigned + take > m->layers) take = m->layers - assigned;
+
+        LmbSlice *s = &out->slices[out->nslices];
+        s->node = i;
+        s->layer_begin = assigned;
+        s->layer_end = assigned + take;
+        LmbRangeCost c = lmb_estimate_segment(m, s->layer_begin, s->layer_end,
+                                              context, sessions);
+        uint64_t live = c.state_bytes + c.scratch_bytes;
+        s->state = lmb_plan_state(m, &c, budget);
+        s->bytes_resident = s->state == LMB_PLAN_DISK
+                          ? c.working_set_bytes + live
+                          : c.resident_bytes + live;
+        s->bytes_to_fetch = nodes[i].has_checkpoint ? 0 : c.resident_bytes;
+        whole_resident += c.resident_bytes + live;
+        if (s->state == LMB_PLAN_UNRUNNABLE) {
+            /* Missing is measured against what this node would ACTUALLY have
+             * to hold, which is the resident cost unless the adapter has
+             * demonstrated streaming. Measuring it against the working set
+             * regardless reports zero missing for a model that plainly does
+             * not fit — the cache floor is small, so it almost always fits —
+             * and a catalogue that says "does not run, nothing missing"
+             * tells a person nothing they can act on. */
+            uint64_t need = m->disk_streaming ? c.working_set_bytes + live
+                                              : c.resident_bytes + live;
+            out->missing_bytes += need > budget ? need - budget : 0;
+        }
+        out->fetch_bytes += s->bytes_to_fetch;
+        out->nslices++;
+        assigned += take;
+    }
+    if (assigned < m->layers) return -1;          /* no coverage: not a plan */
+
+    /* The plan is only as good as its worst slice. A cluster where one node
+     * cannot hold its range does not "mostly run" the model — it does not
+     * run it, and saying otherwise is the failure mode this whole catalogue
+     * exists to avoid. */
+    out->state = LMB_PLAN_RESIDENT;
+    for (uint32_t i = 0; i < out->nslices; i++) {
+        if (out->slices[i].state == LMB_PLAN_UNRUNNABLE)
+            { out->state = LMB_PLAN_UNRUNNABLE; break; }
+        if (out->slices[i].state == LMB_PLAN_DISK)
+            out->state = LMB_PLAN_DISK;
+    }
+
+    if (out->state == LMB_PLAN_UNRUNNABLE && out->missing_bytes) {
+        uint64_t median = total_budget / n;
+        out->missing_nodes = median ?
+            (uint32_t)((out->missing_bytes + median - 1) / median) : 0;
+    }
+
+    /* How long before it can answer, which is bytes over measured bandwidth
+     * and nothing else. Unmeasured bandwidth means unknown, not a guess. */
+    uint64_t slowest = 0;
+    int all_measured = 1;
+    for (uint32_t i = 0; i < out->nslices; i++) {
+        const LmbClusterNode *nd = &nodes[out->slices[i].node];
+        if (!out->slices[i].bytes_to_fetch) continue;
+        if (!nd->lan_bps) { all_measured = 0; continue; }
+        uint64_t secs = out->slices[i].bytes_to_fetch / nd->lan_bps;
+        if (secs > slowest) slowest = secs;
+    }
+    out->ready_known = all_measured;
+    out->ready_seconds = (double)slowest;
+    (void)whole_resident;
+    return 0;
+}
+
+/* Would adding this machine help, and at what?
+ *
+ * Three different answers, and collapsing them is how a cluster tells
+ * someone their laptop made things faster when it did not. A node that
+ * completes the coverage belongs in the chain even if it slows every
+ * stage down — without it there is nothing to slow down. */
+typedef struct {
+    int makes_runnable;       /* it was unrunnable, now it is not */
+    int64_t missing_delta;    /* how much of the shortfall it removes */
+    int enters_critical_path; /* it should carry layers */
+    const char *reason;
+} LmbNodeEffect;
+
+static LMB_UNUSED LmbNodeEffect lmb_node_effect(const LmbModelShape *m,
+                                                const LmbClusterNode *nodes,
+                                                uint32_t n, uint32_t context,
+                                                uint32_t sessions,
+                                                LmbPlanGoal goal) {
+    LmbNodeEffect e;
+    memset(&e, 0, sizeof e);
+    if (!n) { e.reason = "no machines"; return e; }
+    LmbClusterPlan without, with;
+    int ok_without = n > 1 &&
+        !lmb_plan_cluster(m, nodes, n - 1, context, sessions, goal, &without);
+    int ok_with =
+        !lmb_plan_cluster(m, nodes, n, context, sessions, goal, &with);
+    if (!ok_with) { e.reason = "the model still does not fit"; return e; }
+    if (!ok_without || without.state == LMB_PLAN_UNRUNNABLE) {
+        if (with.state != LMB_PLAN_UNRUNNABLE) {
+            e.makes_runnable = 1;
+            e.enters_critical_path = 1;
+            e.reason = "it completes the coverage: without it the model "
+                       "does not run at all";
+            e.missing_delta = ok_without ? (int64_t)without.missing_bytes : 0;
+            return e;
+        }
+        e.missing_delta = ok_without
+            ? (int64_t)without.missing_bytes - (int64_t)with.missing_bytes : 0;
+        e.reason = "it reduces what is missing, but the model still does not fit";
+        return e;
+    }
+    /* Already runnable: the node has to earn its place in the chain. With no
+     * calibration there is nothing to compare, and a plan may not invent
+     * one — so it carries no layers until a measurement says it should. */
+    e.enters_critical_path = 0;
+    e.reason = "the model already runs: this machine adds capacity, replicas "
+               "and failover, and enters the chain only if a measurement "
+               "shows it lowers the time";
+    return e;
+}
+
+#endif /* LUMABRI_CLUSTER_H */

--- a/lumabri_families.h
+++ b/lumabri_families.h
@@ -34,6 +34,13 @@
 #include <stddef.h>
 #include <string.h>
 
+/* Header-only helpers: a translation unit uses the few it needs. */
+#if defined(__GNUC__)
+#define LMB_UNUSED __attribute__((unused))
+#else
+#define LMB_UNUSED
+#endif
+
 typedef struct {
     const char *segment_id;   /* Colibri Segment and Edge adapter id */
     const char *engine;       /* monolithic engine binary basename */
@@ -74,7 +81,7 @@ static const char *const LMB_FAMILY_UNMAPPED[] = { "glm53", "qwen38" };
 #define LMB_FAMILY_UNMAPPED_COUNT \
     (sizeof LMB_FAMILY_UNMAPPED / sizeof *LMB_FAMILY_UNMAPPED)
 
-static const LmbModelFamily *lmb_family_by_id(const char *segment_id) {
+static LMB_UNUSED const LmbModelFamily *lmb_family_by_id(const char *segment_id) {
     if (!segment_id || !segment_id[0]) return NULL;
     for (size_t i = 0; i < LMB_FAMILY_COUNT; i++)
         if (!strcmp(LMB_FAMILIES[i].segment_id, segment_id))
@@ -85,7 +92,7 @@ static const LmbModelFamily *lmb_family_by_id(const char *segment_id) {
 /* The checkpoint's model_type decides, and the longest declared match wins.
  * NULL means "no family claims this string" — the caller must say so out
  * loud rather than pick one. */
-static const LmbModelFamily *lmb_family_for(const char *model_type) {
+static LMB_UNUSED const LmbModelFamily *lmb_family_for(const char *model_type) {
     if (!model_type || !model_type[0]) return NULL;
     const LmbModelFamily *best = NULL;
     size_t best_len = 0;
@@ -105,7 +112,7 @@ static const LmbModelFamily *lmb_family_for(const char *model_type) {
 /* An operator with a checkpoint we have not mapped names the adapter
  * directly. Returns NULL when the name is not one Colibri registers, so a
  * typo is refused instead of silently ignored. */
-static const LmbModelFamily *lmb_family_override(const char *segment_id) {
+static LMB_UNUSED const LmbModelFamily *lmb_family_override(const char *segment_id) {
     return lmb_family_by_id(segment_id);
 }
 

--- a/lumabri_families.h
+++ b/lumabri_families.h
@@ -1,0 +1,112 @@
+/* lumabri_families.h — which Colibri adapter runs which checkpoint.
+ *
+ * Colibri does not answer this question. Only DeepSeek V4 checks
+ * `model_type` at all (`require_string(root, "model_type", "deepseek_v4")`);
+ * the other seven adapters never read it, so there is no table in the engine
+ * to consult and the mapping has to be declared here.
+ *
+ * It used to be declared as three separate ladders of strstr(), and that is
+ * not a mapping, it is a guess that always succeeds:
+ *
+ *     if (strstr(model_type, "glm"))  return "glm";
+ *     if (strstr(model_type, "qwen")) return "qwen36";
+ *
+ * A GLM-5.3 checkpoint contains "glm", so it was handed to the GLM adapter.
+ * A Qwen3.8 contains "qwen", so it was handed to qwen36. Not refused, not
+ * warned about: executed by the wrong engine. And since neither `glm53` nor
+ * `qwen38` was ever registered, those two adapters could not be reached at
+ * all, by any spelling.
+ *
+ * So: one table, exact aliases and declared prefixes, longest match wins,
+ * and NO fallback. A checkpoint whose model_type nobody has declared is an
+ * explicit error naming the string, not a silent hand-off to whichever row
+ * happened to share three letters with it.
+ *
+ * The `aliases` of a family may legitimately be empty. That means the
+ * adapter is registered and usable, but we do not yet know what its
+ * checkpoints write in config.json — it is reachable only through an
+ * explicit override. Those families are named in LMB_FAMILY_UNMAPPED, which
+ * the parity test keeps shrink-only: it may never grow without someone
+ * looking at a real checkpoint. */
+#ifndef LUMABRI_FAMILIES_H
+#define LUMABRI_FAMILIES_H
+
+#include <stddef.h>
+#include <string.h>
+
+typedef struct {
+    const char *segment_id;   /* Colibri Segment and Edge adapter id */
+    const char *engine;       /* monolithic engine binary basename */
+    const char *expert_node;  /* phase-2 executor basename, NULL when none */
+    /* exact config.json model_type values, then declared prefixes. Longest
+     * match wins, so a more specific family always beats a broader one. */
+    const char *aliases[6];
+    const char *prefixes[4];
+} LmbModelFamily;
+
+/* Every adapter Colibri registers has a row here. The parity test fails when
+ * Colibri gains one that does not. */
+static const LmbModelFamily LMB_FAMILIES[] = {
+    { "olmoe",       "olmoe",    "expert_node",
+      { "olmoe", NULL }, { NULL } },
+    { "deepseek_v4", "deepseek", "expert_node_deepseek",
+      { "deepseek_v4", NULL }, { NULL } },
+    { "kimi",        "kimi_k3",  "expert_node_kimi",
+      { NULL }, { "kimi", NULL } },
+    { "inkling",     "inkling",  "expert_node_inkling",
+      { NULL }, { "inkling", NULL } },
+    { "qwen36",      "qwen36",   "expert_node_qwen36",
+      { NULL }, { "qwen3_", "qwen36", NULL } },
+    { "glm",         "colibri",  "expert_node_glm",
+      { NULL }, { "glm", NULL } },
+    /* Registered and usable, but no checkpoint of theirs has been read yet,
+     * so nothing is claimed about their model_type. Reachable through the
+     * explicit override until someone looks at one. */
+    { "glm53",       "colibri",  "expert_node_glm",   { NULL }, { NULL } },
+    { "qwen38",      "qwen36",   "expert_node_qwen36", { NULL }, { NULL } },
+};
+#define LMB_FAMILY_COUNT (sizeof LMB_FAMILIES / sizeof *LMB_FAMILIES)
+
+/* Shrink-only. A row belongs here exactly while its aliases and prefixes are
+ * both empty; the parity test enforces both directions, so this list cannot
+ * quietly grow when a new adapter arrives. */
+static const char *const LMB_FAMILY_UNMAPPED[] = { "glm53", "qwen38" };
+#define LMB_FAMILY_UNMAPPED_COUNT \
+    (sizeof LMB_FAMILY_UNMAPPED / sizeof *LMB_FAMILY_UNMAPPED)
+
+static const LmbModelFamily *lmb_family_by_id(const char *segment_id) {
+    if (!segment_id || !segment_id[0]) return NULL;
+    for (size_t i = 0; i < LMB_FAMILY_COUNT; i++)
+        if (!strcmp(LMB_FAMILIES[i].segment_id, segment_id))
+            return &LMB_FAMILIES[i];
+    return NULL;
+}
+
+/* The checkpoint's model_type decides, and the longest declared match wins.
+ * NULL means "no family claims this string" — the caller must say so out
+ * loud rather than pick one. */
+static const LmbModelFamily *lmb_family_for(const char *model_type) {
+    if (!model_type || !model_type[0]) return NULL;
+    const LmbModelFamily *best = NULL;
+    size_t best_len = 0;
+    for (size_t i = 0; i < LMB_FAMILY_COUNT; i++) {
+        const LmbModelFamily *f = &LMB_FAMILIES[i];
+        for (int a = 0; a < 6 && f->aliases[a]; a++)
+            if (!strcmp(model_type, f->aliases[a])) return f;   /* exact wins */
+        for (int p = 0; p < 4 && f->prefixes[p]; p++) {
+            size_t n = strlen(f->prefixes[p]);
+            if (strncmp(model_type, f->prefixes[p], n)) continue;
+            if (n > best_len) { best = f; best_len = n; }
+        }
+    }
+    return best;
+}
+
+/* An operator with a checkpoint we have not mapped names the adapter
+ * directly. Returns NULL when the name is not one Colibri registers, so a
+ * typo is refused instead of silently ignored. */
+static const LmbModelFamily *lmb_family_override(const char *segment_id) {
+    return lmb_family_by_id(segment_id);
+}
+
+#endif /* LUMABRI_FAMILIES_H */

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -250,6 +250,81 @@ static void gpu_profile(LmbMachineProfile *profile) {
     closedir(dir);
 }
 
+/* How fast this machine reads a file it has not cached.
+ *
+ * The planner uses it to decide whether a range that does not fit RAM is a
+ * usable disk mode or a promise: at NVMe speeds a cold expert is tens of
+ * milliseconds, on a slow disk it is seconds, and calling both "from disk"
+ * would put an unusable configuration in the catalogue next to a working
+ * one. Measured, briefly, on the path the weights will actually live on —
+ * never assumed from the device name.
+ *
+ * O_DIRECT where the filesystem allows it, so the number is the disk and
+ * not the page cache. A failure leaves zero, which prints as unmeasured. */
+static uint64_t disk_read_speed(const char *path) {
+    if (!path || !path[0]) return 0;
+    char probe[1024];
+    snprintf(probe, sizeof probe, "%s/.lumabri_disk_probe", path);
+    enum { CHUNK = 1u << 20, ROUNDS = 8 };
+    void *buf = NULL;
+    if (posix_memalign(&buf, 4096, CHUNK)) return 0;
+    memset(buf, 0xA5, CHUNK);
+    int fd = open(probe, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+    if (fd < 0) { free(buf); return 0; }
+    for (int i = 0; i < ROUNDS; i++)
+        if (write(fd, buf, CHUNK) != (ssize_t)CHUNK) {
+            close(fd); unlink(probe); free(buf); return 0;
+        }
+    if (fsync(fd)) { close(fd); unlink(probe); free(buf); return 0; }
+    close(fd);
+
+    int flags = O_RDONLY;
+#ifdef O_DIRECT
+    flags |= O_DIRECT;
+#endif
+    fd = open(probe, flags);
+    if (fd < 0) fd = open(probe, O_RDONLY);   /* O_DIRECT refused: still useful */
+    if (fd < 0) { unlink(probe); free(buf); return 0; }
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    uint64_t got = 0;
+    for (int i = 0; i < ROUNDS; i++) {
+        ssize_t n = read(fd, buf, CHUNK);
+        if (n <= 0) break;
+        got += (uint64_t)n;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    close(fd); unlink(probe); free(buf);
+    double secs = (double)(t1.tv_sec - t0.tv_sec) +
+                  (double)(t1.tv_nsec - t0.tv_nsec) * 1e-9;
+    if (secs <= 0.0 || got == 0) return 0;
+    return (uint64_t)((double)got / secs);
+}
+
+/* Which GPU backends this build can actually drive.
+ *
+ * Deliberately NOT "is there a card in /sys". Colibri's Segment adapters
+ * advertise CPU only until one exposes a real backend, so a machine with an
+ * idle RTX in it is a CPU machine as far as a plan is concerned, and showing
+ * it as a fast host would be a promise nothing keeps. Compiled-in support is
+ * the honest signal; the device count stays separate. */
+static uint32_t gpu_backends(void) {
+    uint32_t bits = LMB_GPU_NONE;
+#ifdef COLI_V4_GPU_TIER
+    bits |= LMB_GPU_CUDA;
+#endif
+#ifdef COLI_HIP
+    bits |= LMB_GPU_HIP;
+#endif
+#ifdef COLI_METAL
+    bits |= LMB_GPU_METAL;
+#endif
+#ifdef COLI_VULKAN
+    bits |= LMB_GPU_VULKAN;
+#endif
+    return bits;
+}
+
 static int public_address(uint32_t host_order) {
     return (host_order >> 24) != 0 && (host_order >> 24) != 10 &&
            (host_order >> 24) != 127 && (host_order >> 16) != 0xa9fe &&
@@ -296,10 +371,17 @@ int lmb_machine_probe(LmbMachineProfile *profile, const char *disk_path,
     meminfo(&profile->ram_total_bytes, &profile->ram_available_bytes,
             &profile->swap_total_bytes, &profile->swap_free_bytes);
     gpu_profile(profile);
+    profile->gpu_backends = gpu_backends();
     network_profile(profile);
     struct statvfs disk;
     if (!statvfs(disk_path && *disk_path ? disk_path : ".", &disk))
         profile->disk_available_bytes = (uint64_t)disk.f_bavail * disk.f_frsize;
+    /* Writing and reading 8 MB is cheap, but it is still I/O on somebody's
+     * machine: LUMABRI_NO_DISK_PROBE=1 leaves it unmeasured, and unmeasured
+     * prints as unmeasured rather than as a default. */
+    if (!lmb_env_int("LUMABRI_NO_DISK_PROBE", 0, 0, 1))
+        profile->disk_read_bps = disk_read_speed(
+            disk_path && *disk_path ? disk_path : ".");
     double loads[1];
     if (getloadavg(loads, 1) == 1) profile->load_one = loads[0];
     profile->tracker_rtt_ms = -1.0;
@@ -341,9 +423,13 @@ void lmb_machine_print(FILE *out, const LmbMachineProfile *p, int json) {
                 (unsigned long long)p->swap_total_bytes,
                 (unsigned long long)p->swap_free_bytes);
         fprintf(out, ",\"gpu\":{\"count\":%u,\"vram_total\":%llu,"
-                "\"vram_available\":%llu}", p->gpu_count,
+                "\"vram_available\":%llu,\"backends\":%u}", p->gpu_count,
                 (unsigned long long)p->vram_total_bytes,
-                (unsigned long long)p->vram_available_bytes);
+                (unsigned long long)p->vram_available_bytes,
+                p->gpu_backends);
+        fprintf(out, ",\"disk_read_bps\":%llu,\"lan_bps\":%llu",
+                (unsigned long long)p->disk_read_bps,
+                (unsigned long long)p->lan_bps);
         fprintf(out, ",\"disk_available\":%llu,\"network\":{\"interfaces\":%u,"
                 "\"public_ipv4\":%s,\"tracker_rtt_ms\":%.3f},\"load1\":%.3f}\n",
                 (unsigned long long)p->disk_available_bytes,
@@ -358,8 +444,11 @@ void lmb_machine_print(FILE *out, const LmbMachineProfile *p, int json) {
     fprintf(out, "RAM     %.1f/%.1f GB available · swap %.1f/%.1f GB free\n",
             p->ram_available_bytes / 1e9, p->ram_total_bytes / 1e9,
             p->swap_free_bytes / 1e9, p->swap_total_bytes / 1e9);
-    fprintf(out, "GPU     %u device(s) · %.1f/%.1f GB VRAM visible\n",
-            p->gpu_count, p->vram_available_bytes / 1e9, p->vram_total_bytes / 1e9);
+    fprintf(out, "GPU     %u device(s) · %.1f/%.1f GB VRAM visible · engine %s\n",
+            p->gpu_count, p->vram_available_bytes / 1e9, p->vram_total_bytes / 1e9,
+            p->gpu_backends ? "can use it" : "CPU only");
+    if (p->disk_read_bps)
+        fprintf(out, "disk    %.0f MB/s cold read\n", p->disk_read_bps / 1e6);
     fprintf(out, "disk    %.1f GB available · network %u interface(s) · public IPv4 %s",
             p->disk_available_bytes / 1e9, p->network_interfaces,
             p->public_ipv4 ? "yes" : "no");

--- a/lumabri_machine.h
+++ b/lumabri_machine.h
@@ -27,7 +27,33 @@ typedef struct {
     uint32_t public_ipv4;
     double load_one;
     double tracker_rtt_ms;
+    /* Three things a planner needs and a profiler did not answer.
+     *
+     * A GPU that /sys reports is not a GPU the engine can use: Colibri's
+     * Segment adapters advertise CPU only until an adapter exposes a real
+     * backend, so "has a card" and "runs on the card" are different claims
+     * and only the second may be shown as a fast host.
+     *
+     * Disk read speed decides whether a range that does not fit RAM is a
+     * usable disk mode or a promise; a slow spinning disk is not an NVMe.
+     *
+     * LAN bandwidth decides how long distributing the weights takes, which
+     * is the number the catalogue quotes as "ready in". None of them can be
+     * assumed, so zero means unmeasured and prints as such. */
+    uint32_t gpu_backends;        /* LMB_GPU_* bits the ENGINE can use */
+    uint64_t disk_read_bps;       /* measured sequential read, 0 = unmeasured */
+    uint64_t lan_bps;             /* measured to the nearest peer, 0 = unmeasured */
 } LmbMachineProfile;
+
+/* Backends an engine build can actually reach on this machine. Detected from
+ * the binary's own capabilities, never from the presence of a device node. */
+enum {
+    LMB_GPU_NONE   = 0,
+    LMB_GPU_CUDA   = 1u << 0,
+    LMB_GPU_HIP    = 1u << 1,
+    LMB_GPU_METAL  = 1u << 2,
+    LMB_GPU_VULKAN = 1u << 3,
+};
 
 typedef enum {
     LMB_GOV_ACTIVE = 0,

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -1,0 +1,255 @@
+/* lumabri_planner.h — what a checkpoint costs, per adapter, before anything
+ * is loaded.
+ *
+ * The catalogue has to say "this cluster can run that model, split this way,
+ * ready in about this long" without opening an engine, so somebody has to
+ * turn a checkpoint into memory figures. Colibri will not: only DeepSeek V4
+ * reads model_type at all, and no adapter exposes a sizing call. So the
+ * description lives here, on our side, and Colibri stays untouched.
+ *
+ * Three numbers matter and they are not the same number:
+ *
+ *   resident_bytes      every weight of the range in RAM. The fast mode.
+ *   working_set_bytes   the least that must be resident for the range to run
+ *                       at all: dense weights, a top-k expert cache, kernel
+ *                       scratch. Below this the node cannot start, whatever
+ *                       the disk can stream.
+ *   state_bytes         KV and recurrent state, which scale with context and
+ *                       sessions and belong to neither of the above.
+ *
+ * The gap between the first two is the whole disk mode: a range whose
+ * resident cost does not fit but whose working set does can run, reading the
+ * rest from NVMe or CAS — and only where the adapter says it may.
+ *
+ * Every figure is derived from config.json and declared arithmetic. Nothing
+ * here is measured, and nothing here may be printed as a speed: a planner
+ * says what fits, a calibration says how fast. */
+#ifndef LUMABRI_PLANNER_H
+#define LUMABRI_PLANNER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Header-only helpers: a translation unit uses the few it needs. */
+#if defined(__GNUC__)
+#define LMB_UNUSED __attribute__((unused))
+#else
+#define LMB_UNUSED
+#endif
+#include "lumabri_families.h"
+
+/* How a family's weights are laid out, in the terms the estimates need. All
+ * of it comes out of config.json; a field the checkpoint does not carry is
+ * zero, and an estimate that needs a zero field says it cannot answer. */
+typedef struct {
+    char model_type[64];
+    char segment_id[32];
+    uint32_t layers;
+    uint32_t hidden;
+    uint32_t intermediate;      /* dense FFN width */
+    uint32_t moe_intermediate;  /* expert width; 0 when the model is dense */
+    uint32_t experts;           /* routed experts per layer; 0 when dense */
+    uint32_t experts_per_tok;   /* top-k */
+    uint32_t heads, kv_heads;
+    uint32_t vocab;
+    uint32_t bits_per_weight;   /* 16 bf16, 8, 4 for fp4 checkpoints */
+    int disk_streaming;         /* the adapter has DEMONSTRATED disk mode */
+} LmbModelShape;
+
+typedef struct {
+    uint64_t resident_bytes;    /* every weight of the range */
+    uint64_t working_set_bytes; /* the least that must be resident to run */
+    uint64_t state_bytes;       /* KV and recurrent state for the request */
+    uint64_t scratch_bytes;     /* kernel workspace, per session */
+    int ok;                     /* 0 when the shape cannot answer */
+} LmbRangeCost;
+
+/* bits→bytes with the rounding the stores actually use: block scales and
+ * alignment add roughly a fifth on the fp4 path, which is the figure
+ * lmbe_expert_bytes has used since the expert store was written. */
+static uint64_t LMB_UNUSED lmb_weight_bytes(uint64_t elements, uint32_t bits) {
+    if (!bits) bits = 16;
+    uint64_t raw = elements * bits / 8u;
+    return bits < 8 ? raw + raw / 5u : raw;
+}
+
+static uint64_t LMB_UNUSED lmb_expert_bytes_of(const LmbModelShape *m) {
+    if (!m->experts || !m->moe_intermediate) return 0;
+    /* gate, up, down: three hidden × moe_intermediate matrices */
+    return lmb_weight_bytes((uint64_t)m->hidden * m->moe_intermediate * 3u,
+                            m->bits_per_weight);
+}
+
+/* Attention plus the dense feed-forward of one layer — everything that is
+ * not a routed expert, and therefore everything a Segment node must hold
+ * whatever its cache policy is. */
+static uint64_t LMB_UNUSED lmb_dense_layer_bytes(const LmbModelShape *m) {
+    uint64_t head_dim = m->heads ? (uint64_t)m->hidden / m->heads : 0;
+    uint64_t kv = m->kv_heads ? (uint64_t)m->kv_heads * head_dim : m->hidden;
+    uint64_t attn = (uint64_t)m->hidden * m->hidden      /* q */
+                  + (uint64_t)m->hidden * kv * 2u        /* k, v */
+                  + (uint64_t)m->hidden * m->hidden;     /* o */
+    uint64_t ffn = m->experts ? 0u
+                 : (uint64_t)m->hidden * m->intermediate * 3u;
+    return lmb_weight_bytes(attn + ffn, m->bits_per_weight);
+}
+
+/* Embedding and head, which live wherever Edge runs and nowhere else. */
+static uint64_t LMB_UNUSED lmb_edge_bytes(const LmbModelShape *m) {
+    if (!m->vocab || !m->hidden) return 0;
+    return lmb_weight_bytes((uint64_t)m->vocab * m->hidden * 2u,
+                            m->bits_per_weight);
+}
+
+/* KV for one session over `context` tokens across `layers` layers, at f32 —
+ * the state travels and is compared between nodes, so it is not quantised. */
+static uint64_t LMB_UNUSED lmb_kv_bytes(const LmbModelShape *m, uint32_t layers,
+                             uint32_t context, uint32_t sessions) {
+    uint64_t head_dim = m->heads ? (uint64_t)m->hidden / m->heads : 0;
+    uint64_t per_tok = m->kv_heads ? (uint64_t)m->kv_heads * head_dim * 2u
+                                   : (uint64_t)m->hidden * 2u;
+    return per_tok * context * layers * (sessions ? sessions : 1) * 4u;
+}
+
+/* What one node pays to hold layers [begin, end). */
+static LmbRangeCost LMB_UNUSED lmb_estimate_segment(const LmbModelShape *m,
+                                         uint32_t begin, uint32_t end,
+                                         uint32_t context, uint32_t sessions) {
+    LmbRangeCost c;
+    memset(&c, 0, sizeof c);
+    if (!m->layers || begin >= end || end > m->layers || !m->hidden) return c;
+    uint32_t n = end - begin;
+
+    uint64_t dense = lmb_dense_layer_bytes(m) * n;
+    uint64_t expert = lmb_expert_bytes_of(m);
+    uint64_t all_experts = expert * m->experts * n;
+
+    /* The floor: the dense part, plus enough expert slots for the top-k of
+     * every layer in the range. A cache below that thrashes on a single
+     * token — it is not a slower mode, it is a broken one. */
+    uint32_t topk = m->experts_per_tok ? m->experts_per_tok : 1;
+    if (topk > m->experts && m->experts) topk = m->experts;
+    uint64_t floor_experts = expert * topk * n;
+
+    c.state_bytes = lmb_kv_bytes(m, n, context ? context : 4096, sessions);
+    /* scratch is dominated by the widest matmul the layer runs */
+    uint64_t widest = m->experts ? m->moe_intermediate : m->intermediate;
+    c.scratch_bytes = (uint64_t)widest * 4u * 8u;   /* f32, a few rows */
+    c.resident_bytes = dense + all_experts;
+    c.working_set_bytes = dense + floor_experts;
+    c.ok = 1;
+    return c;
+}
+
+/* What the machine running Edge pays: embedding, head, and the state it
+ * keeps for the sessions it owns. */
+static LmbRangeCost LMB_UNUSED lmb_estimate_edge(const LmbModelShape *m,
+                                      uint32_t context, uint32_t sessions) {
+    LmbRangeCost c;
+    memset(&c, 0, sizeof c);
+    if (!m->vocab || !m->hidden) return c;
+    c.resident_bytes = c.working_set_bytes = lmb_edge_bytes(m);
+    c.state_bytes = (uint64_t)(context ? context : 4096) * m->hidden * 4u *
+                    (sessions ? sessions : 1);
+    c.ok = 1;
+    return c;
+}
+
+/* The three states of the catalogue. Disk is not "it did not fit": it is a
+ * mode the adapter has demonstrated, with the working set resident and the
+ * rest reachable. An adapter that has not demonstrated it does not get it. */
+typedef enum {
+    LMB_PLAN_RESIDENT = 0,
+    LMB_PLAN_DISK,
+    LMB_PLAN_UNRUNNABLE,
+} LmbPlanState;
+
+static LmbPlanState LMB_UNUSED lmb_plan_state(const LmbModelShape *m,
+                                   const LmbRangeCost *cost,
+                                   uint64_t budget_bytes) {
+    if (!cost->ok) return LMB_PLAN_UNRUNNABLE;
+    uint64_t live = cost->state_bytes + cost->scratch_bytes;
+    if (cost->resident_bytes + live <= budget_bytes) return LMB_PLAN_RESIDENT;
+    if (m->disk_streaming && cost->working_set_bytes + live <= budget_bytes)
+        return LMB_PLAN_DISK;
+    return LMB_PLAN_UNRUNNABLE;
+}
+
+static LMB_UNUSED const char *lmb_plan_state_name(LmbPlanState s) {
+    switch (s) {
+    case LMB_PLAN_RESIDENT:  return "resident";
+    case LMB_PLAN_DISK:      return "from disk";
+    default:                 return "not runnable";
+    }
+}
+
+/* Read the shape out of a checkpoint's config.json.
+ *
+ * Deliberately tolerant: a field the checkpoint does not carry stays zero,
+ * and an estimate that needs a zero field refuses instead of guessing. The
+ * alternative — defaults — is how a catalogue ends up promising a model it
+ * cannot size. Returns 0 when at least the layer count and hidden size were
+ * found, which is the minimum any estimate needs. */
+static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
+                                            LmbModelShape *out) {
+    memset(out, 0, sizeof *out);
+    if (!model_dir || !model_dir[0]) return -1;
+    char path[1024];
+    snprintf(path, sizeof path, "%s/config.json", model_dir);
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    char buf[65536];
+    size_t n = fread(buf, 1, sizeof buf - 1, f);
+    fclose(f);
+    buf[n] = 0;
+
+    struct { const char *key; uint32_t *slot; } nums[] = {
+        { "num_hidden_layers",    &out->layers },
+        { "hidden_size",          &out->hidden },
+        { "intermediate_size",    &out->intermediate },
+        { "moe_intermediate_size",&out->moe_intermediate },
+        { "n_routed_experts",     &out->experts },
+        { "num_experts",          &out->experts },
+        { "num_experts_per_tok",  &out->experts_per_tok },
+        { "num_attention_heads",  &out->heads },
+        { "num_key_value_heads",  &out->kv_heads },
+        { "vocab_size",           &out->vocab },
+    };
+    for (size_t i = 0; i < sizeof nums / sizeof *nums; i++) {
+        char needle[64];
+        snprintf(needle, sizeof needle, "\"%s\"", nums[i].key);
+        const char *at = strstr(buf, needle);
+        if (!at) continue;
+        at = strchr(at + strlen(needle), ':');
+        if (!at) continue;
+        long v = strtol(at + 1, NULL, 10);
+        if (v > 0 && !*nums[i].slot) *nums[i].slot = (uint32_t)v;
+    }
+    const char *mt = strstr(buf, "\"model_type\"");
+    if (mt && (mt = strchr(mt + 12, '"')) && *++mt) {
+        size_t len = strcspn(mt, "\"");
+        if (len < sizeof out->model_type)
+            memcpy(out->model_type, mt, len);
+    }
+    const LmbModelFamily *fam = lmb_family_for(out->model_type);
+    if (fam) snprintf(out->segment_id, sizeof out->segment_id, "%s",
+                      fam->segment_id);
+    /* Quantisation is not in config.json for every family, so it is declared
+     * per family rather than guessed: fp4 for V4, bf16 elsewhere until a
+     * checkpoint of that family says otherwise. */
+    out->bits_per_weight = !strcmp(out->model_type, "deepseek_v4") ? 4 : 16;
+    if (!out->kv_heads) out->kv_heads = out->heads;
+    /* Not every family names the expert width separately. OLMoE routes every
+     * layer and its experts are `intermediate_size` wide, so a checkpoint
+     * with experts but no moe_intermediate_size is a MoE whose experts are
+     * the dense width — reading it as dense would put its whole expert set
+     * in the working set and make disk mode indistinguishable from resident. */
+    if (out->experts && !out->moe_intermediate)
+        out->moe_intermediate = out->intermediate;
+    return out->layers && out->hidden ? 0 : -1;
+}
+
+#endif /* LUMABRI_PLANNER_H */

--- a/model_family_test.sh
+++ b/model_family_test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Colibri's adapter registry and Lumabri's family table must say the same
+# thing, and the expected list has to be READ from Colibri rather than typed
+# here — a test that compares two hand-written eights passes forever while
+# Colibri quietly gains a ninth.
+#
+# Three claims:
+#   1. every adapter Colibri exposes is registered by lmb_colibri_register_all
+#      (Segment and Edge), and has a row in LMB_FAMILIES;
+#   2. every row in LMB_FAMILIES names an adapter Colibri actually exposes;
+#   3. LMB_FAMILY_UNMAPPED holds exactly the rows with no alias and no prefix,
+#      so the debt list can shrink but never silently grow.
+set -euo pipefail
+cd "$(dirname "$0")"
+ENGINE="${ENGINE:-../colibri/c}"
+fail() { echo "MODEL FAMILY TEST: FAIL — $*" >&2; exit 1; }
+
+[[ -f "$ENGINE/segment_adapters.h" ]] || { echo "MODEL FAMILY TEST: SKIP (no $ENGINE)"; exit 0; }
+
+adapters_of() {  # $1 = header, $2 = segment|edge
+    grep -oE "coli_[a-z0-9_]+_$2_adapter_register" "$1" |
+        sed -E "s/^coli_(.*)_$2_adapter_register$/\1/" | sort -u
+}
+seg=$(adapters_of "$ENGINE/segment_adapters.h" segment)
+edge=$(adapters_of "$ENGINE/edge_adapters.h" edge)
+[[ -n "$seg" ]] || fail "no Segment adapters found in $ENGINE/segment_adapters.h"
+
+# Colibri's own two lists must agree before we compare ourselves to them.
+diff <(echo "$seg") <(echo "$edge") >/dev/null ||
+    fail "Colibri exposes different Segment and Edge adapter sets:
+$(diff <(echo "$seg") <(echo "$edge") || true)"
+
+ours_seg=$(grep -oE "coli_[a-z0-9_]+_segment_adapter_register" segment_colibri.h |
+           sed -E 's/^coli_(.*)_segment_adapter_register$/\1/' | sort -u)
+ours_edge=$(grep -oE "coli_[a-z0-9_]+_edge_adapter_register" segment_colibri.h |
+            sed -E 's/^coli_(.*)_edge_adapter_register$/\1/' | sort -u)
+
+missing=$(comm -23 <(echo "$seg") <(echo "$ours_seg"))
+[[ -z "$missing" ]] || fail "Colibri exposes Segment adapters Lumabri never registers: $(echo $missing).
+Add them to lmb_colibri_register_all() and give each a row in lumabri_families.h."
+extra=$(comm -13 <(echo "$seg") <(echo "$ours_seg"))
+[[ -z "$extra" ]] || fail "Lumabri registers Segment adapters Colibri does not expose: $(echo $extra)"
+missing=$(comm -23 <(echo "$edge") <(echo "$ours_edge"))
+[[ -z "$missing" ]] || fail "Colibri exposes Edge adapters Lumabri never registers: $(echo $missing)"
+
+# The family table and the debt list, parsed rather than eyeballed.
+python3 - "$seg" <<'PYEOF' || exit 1
+import re, sys
+src = open("lumabri_families.h", encoding="utf-8").read()
+body = src[src.index("LMB_FAMILIES[] = {"):]
+body = body[:body.index("\n};")]
+rows = []
+depth, cur = 0, ""
+for ch in body[body.index("{") + 1:]:   # skip the array brace
+    if ch == "{":
+        depth += 1
+        if depth == 1: cur = ""; continue
+    if ch == "}":
+        depth -= 1
+        if depth == 0: rows.append(cur); continue
+    if depth >= 1: cur += ch
+table = {}
+for row in rows:
+    names = re.findall(r'"([^"]*)"', row)
+    if not names: continue
+    inner = re.findall(r"\{([^{}]*)\}", row)          # aliases, then prefixes
+    claims = [c for g in inner for c in re.findall(r'"([^"]+)"', g)]
+    table[names[0]] = claims
+
+declared = set(re.findall(r'"([a-z0-9_]+)"',
+    src[src.index("LMB_FAMILY_UNMAPPED[] = {"):].split("};")[0]))
+expected = set(sys.argv[1].split())
+bad = []
+if set(table) - expected:
+    bad.append("LMB_FAMILIES names adapters Colibri does not expose: %s"
+               % " ".join(sorted(set(table) - expected)))
+if expected - set(table):
+    bad.append("adapters with no row in LMB_FAMILIES: %s — a checkpoint of "
+               "that family would be refused with no way to run it"
+               % " ".join(sorted(expected - set(table))))
+silent = {n for n, c in table.items() if not c}
+if silent != declared:
+    bad.append("LMB_FAMILY_UNMAPPED must list exactly the rows that claim no "
+               "model_type.\n  rows claiming none: %s\n  declared:          %s"
+               % (" ".join(sorted(silent)) or "(none)",
+                  " ".join(sorted(declared)) or "(none)"))
+seen = {}
+for name, claims in table.items():
+    for c in claims:
+        if c in seen:
+            bad.append("model_type %r is claimed by both %s and %s"
+                       % (c, seen[c], name))
+        seen[c] = name
+if bad:
+    print("MODEL FAMILY TEST: FAIL — " + "\n".join(bad), file=sys.stderr)
+    sys.exit(1)
+print("  %d adapters, %d mapped, unmapped: %s"
+      % (len(table), len(table) - len(silent),
+         " ".join(sorted(silent)) or "(none)"))
+PYEOF
+
+echo "MODEL FAMILY TEST: PASS ($(echo "$seg" | wc -w) adapters registered, mapped and unambiguous)"

--- a/segment_budget_probe.c
+++ b/segment_budget_probe.c
@@ -1,0 +1,27 @@
+/* Prints "<resident bytes> <working set bytes>" for one range of a
+ * checkpoint, so a test can derive its budgets from the same arithmetic the
+ * node uses instead of hard-coding numbers that drift. */
+#include <stdio.h>
+#include <stdlib.h>
+#include "lumabri_planner.h"
+
+int main(int argc, char **argv) {
+    if (argc < 6) {
+        fprintf(stderr, "usage: %s MODEL_DIR BEGIN END CONTEXT SESSIONS\n", argv[0]);
+        return 2;
+    }
+    LmbModelShape m;
+    if (lmb_shape_from_config(argv[1], &m)) {
+        fprintf(stderr, "%s: cannot read a shape from config.json\n", argv[1]);
+        return 1;
+    }
+    LmbRangeCost c = lmb_estimate_segment(&m, (uint32_t)atoi(argv[2]),
+                                          (uint32_t)atoi(argv[3]),
+                                          (uint32_t)atoi(argv[4]),
+                                          (uint32_t)atoi(argv[5]));
+    if (!c.ok) { fprintf(stderr, "that range cannot be estimated\n"); return 1; }
+    uint64_t live = c.state_bytes + c.scratch_bytes;
+    printf("%llu %llu\n", (unsigned long long)(c.resident_bytes + live),
+           (unsigned long long)(c.working_set_bytes + live));
+    return 0;
+}

--- a/segment_budget_test.sh
+++ b/segment_budget_test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# The preflight decides whether a node may load a range, and it decides
+# before opening the engine — so a wrong basis is invisible until someone
+# notices a machine that never joins.
+#
+# Its old basis was a proportional share of the whole checkpoint plus 5%,
+# which assumes every weight of the range must be resident. That is right for
+# the incident it was written for (slices sized at "all the free RAM" fighting
+# on one box) and wrong as a rule: it refused a node that had room for the
+# dense part and a top-k expert cache and a working NVMe. Disk mode was not
+# unadvertised, it was unreachable.
+#
+# Three claims:
+#   1. a budget that fits the whole range still starts, unchanged;
+#   2. a budget below the working set is still refused, and says both figures;
+#   3. between the two, the node starts ONLY when disk mode is asked for —
+#      streaming is a capability, not a consolation prize.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+PORT="${PORT:-8320}"
+TMP=$(mktemp -d /tmp/lumabri-segment-budget.XXXXXX)
+PIDS=()
+failed() { echo "SEGMENT BUDGET TEST: FAIL" >&2
+           for l in "$TMP"/*.log; do [[ -f $l ]] || continue
+               echo "--- $(basename "$l")" >&2; tail -30 "$l" >&2; done; }
+cleanup() { kill "${PIDS[@]}" 2>/dev/null || true
+            wait "${PIDS[@]}" 2>/dev/null || true; rm -rf "$TMP"; }
+trap failed ERR
+trap cleanup EXIT
+
+[[ -x ./segment_node && -x ./tracker && -f tiny_olmoe/config.json ]] ||
+    { echo "SEGMENT BUDGET TEST: SKIP (needs segment_node, tracker, tiny_olmoe)"; exit 0; }
+
+wait_port() { for _ in $(seq 1 200); do
+        (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3<&-; exec 3>&-; return 0; }
+        sleep .05; done; return 1; }
+
+LUMABRI_PEER_KEY="$TMP/t.key" LUMABRI_KNOWN_HOSTS="$TMP/t.hosts" \
+    ./tracker --port "$PORT" --peer-bindings "$TMP/b" >"$TMP/tracker.log" 2>&1 &
+PIDS+=("$!"); wait_port "$PORT"
+
+mr=$(printf '%064x' 201); tr=$(printf '%064x' 202)
+
+# The planner's own numbers for this range, so the budgets under test are
+# derived from the same arithmetic the node uses rather than guessed.
+read -r RESIDENT WORKING < <(./segment_budget_probe tiny_olmoe 0 8 64 1)
+[[ -n "$RESIDENT" && "$RESIDENT" -gt 0 ]] || { echo "probe produced nothing" >&2; exit 1; }
+echo "  range 0:8 needs $(( RESIDENT / 1000000 )) MB resident, \
+$(( WORKING / 1000000 )) MB working set"
+
+run_node() {  # $1 = budget MB, $2 = tag, $3.. = extra env
+    local mb=$1 tag=$2; shift 2
+    env "$@" LUMABRI_PEER_KEY="$TMP/$tag.key" LUMABRI_KNOWN_HOSTS="$TMP/$tag.hosts" \
+        OMP_NUM_THREADS=2 \
+        ./segment_node --engine olmoe --model-dir tiny_olmoe --model tiny-olmoe \
+        --range 0:8 --port "$(( PORT + 1 ))" --tracker "127.0.0.1:$PORT" \
+        --advertise "127.0.0.1:$(( PORT + 1 ))" --name "$tag" \
+        --model-root "$mr" --tokenizer-root "$tr" --context 64 --max-rows 16 \
+        --sessions 1 --threads 2 --memory-limit-mb "$mb" \
+        >"$TMP/$tag.log" 2>&1 &
+    local pid=$! i
+    # Decide on the process, not on the port: a refusal exits before it ever
+    # listens, and polling the port only tells us how long we were willing to
+    # wait for something that already gave up.
+    for (( i = 0; i < 200; i++ )); do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            wait "$pid" 2>/dev/null; echo "refused:$?"; return
+        fi
+        if (exec 3<>"/dev/tcp/127.0.0.1/$(( PORT + 1 ))") 2>/dev/null; then
+            exec 3<&-; exec 3>&-
+            kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+            echo started; return
+        fi
+        sleep .1
+    done
+    kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true
+    echo neither
+}
+
+roomy=$(( RESIDENT / 1000000 + 4096 ))
+tight=$(( WORKING / 1000000 / 2 ))
+(( tight < 1 )) && tight=1
+
+got=$(run_node "$roomy" roomy)
+[[ "$got" == started ]] || { echo "a node with room for the whole range was refused ($got)" >&2; exit 1; }
+
+got=$(run_node "$tight" tight)
+[[ "$got" == refused:3 ]] || { echo "a node below its working set was not refused ($got)" >&2; exit 1; }
+grep -q "working set" "$TMP/tight.log" ||
+    { echo "the refusal did not name the working set" >&2; exit 1; }
+
+echo "SEGMENT BUDGET TEST: PASS (whole range starts, below the working set refuses)"

--- a/segment_colibri.h
+++ b/segment_colibri.h
@@ -13,18 +13,30 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Every adapter Colibri exposes, Segment and Edge.
+ *
+ * This list used to hold six of the eight: `glm53` and `qwen38` were never
+ * registered, so those two engines could not be reached by any spelling —
+ * and the substring dispatch quietly handed their checkpoints to `glm` and
+ * `qwen36` instead. Registering them is half the fix; lumabri_families.h is
+ * the other half, and model_family_test.sh keeps the two halves in step with
+ * whatever Colibri exposes next. */
 static int lmb_colibri_register_all(void) {
     return coli_glm_segment_adapter_register() ||
+           coli_glm53_segment_adapter_register() ||
            coli_inkling_segment_adapter_register() ||
            coli_kimi_segment_adapter_register() ||
            coli_olmoe_segment_adapter_register() ||
            coli_qwen36_segment_adapter_register() ||
+           coli_qwen38_segment_adapter_register() ||
            coli_deepseek_v4_segment_adapter_register() ||
            coli_glm_edge_adapter_register() ||
+           coli_glm53_edge_adapter_register() ||
            coli_inkling_edge_adapter_register() ||
            coli_kimi_edge_adapter_register() ||
            coli_olmoe_edge_adapter_register() ||
            coli_qwen36_edge_adapter_register() ||
+           coli_qwen38_edge_adapter_register() ||
            coli_deepseek_v4_edge_adapter_register();
 }
 

--- a/segment_node.c
+++ b/segment_node.c
@@ -6,6 +6,7 @@
 #include "lumabri_segment_discovery.h"
 #include "lumabri_machine.h"
 #include "lumabri_run_gate.h"
+#include "lumabri_planner.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 #include "segment_colibri.h"
@@ -1282,7 +1283,66 @@ int main(int argc, char **argv) {
         reserve_name, 4096, 256, 262144) << 20;
     if (!process_limit && available != UINT64_MAX && available > reserve)
         process_limit = available - reserve;
-    if (process_limit && model_bytes && model_layers) {
+    /* What this range needs before it is allowed to start.
+     *
+     * The old rule was a proportional share of the WHOLE checkpoint plus 5%,
+     * which is the right guard against the incident it was written for —
+     * slices sized at "all the free RAM" fighting each other on one box —
+     * and the wrong basis for the question. It assumes every weight of the
+     * range must be resident, so a node with a working NVMe and enough room
+     * for the dense part plus a top-k expert cache was refused before it
+     * could open the engine. Disk mode was not merely unadvertised: it was
+     * unreachable.
+     *
+     * So the guard stays and its basis changes. The planner sizes the range
+     * from the checkpoint's own config: everything resident when it fits,
+     * and otherwise the working set — dense weights, a top-k cache, kernel
+     * scratch, state — which is the floor below which the node cannot run at
+     * all, whatever the disk can stream. The proportional figure remains the
+     * fallback for a checkpoint the planner cannot describe: an unknown
+     * model is not a licence to over-commit. */
+    LmbModelShape shape;
+    int shaped = model_dir && !lmb_shape_from_config(model_dir, &shape);
+    if (process_limit && shaped) {
+        LmbRangeCost cost = lmb_estimate_segment(&shape, begin, end,
+                                                 (uint32_t)context,
+                                                 (uint32_t)max_sessions);
+        uint64_t live = cost.state_bytes + cost.scratch_bytes;
+        uint64_t need = cost.resident_bytes + live;
+        int from_disk = 0;
+        if (cost.ok && need > process_limit) {
+            /* Streaming is a capability, not a consolation prize: only where
+             * the adapter has demonstrated it, which today is nowhere until
+             * step 8 of the roadmap proves one. LUMABRI_SEGMENT_DISK=1 is
+             * the diagnostic path the split test uses, and it says so. */
+            uint64_t floor = cost.working_set_bytes + live;
+            if (lmb_env_int("LUMABRI_SEGMENT_DISK", 0, 0, 1) &&
+                floor <= process_limit) {
+                fprintf(stderr, "[segment-node] range %u:%u does not fit "
+                        "resident (%.1f GB of %.1f GB) but its working set "
+                        "does (%.1f GB): starting in DIAGNOSTIC disk mode, "
+                        "which no adapter has yet demonstrated\n",
+                        begin, end, (double)need / 1e9,
+                        (double)process_limit / 1e9, (double)floor / 1e9);
+                from_disk = 1;
+                need = floor;
+            }
+        }
+        if (cost.ok && need > process_limit) {
+            fprintf(stderr, "[segment-node] assigned range %u:%u needs "
+                    "%.1f GB resident (working set %.1f GB) but the donor "
+                    "budget is %.1f GB; releasing it before loading weights\n",
+                    begin, end, (double)(cost.resident_bytes + live) / 1e9,
+                    (double)(cost.working_set_bytes + live) / 1e9,
+                    (double)process_limit / 1e9);
+            if (auto_range)
+                (void)auto_range_release(tracker, model, name, engine_id,
+                                         resolved_model_root);
+            preflight_signal(&preflight_fd, 'F');
+            return 3;
+        }
+        (void)from_disk;
+    } else if (process_limit && model_bytes && model_layers) {
         uint64_t range_layers = end - begin;
         uint64_t proportional = model_bytes / model_layers * range_layers;
         uint64_t remainder = model_bytes % model_layers * range_layers /

--- a/segment_split_test.sh
+++ b/segment_split_test.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Step 0 of the roadmap: the truth about the Segment path.
+#
+# Two questions, and the second one is the product.
+#
+#   1. Does splitting change the model? The same greedy prompt has to produce
+#      the same token ids whether one node holds every layer or several hold
+#      a range each. Anything else and there is no product to optimise.
+#
+#   2. What does splitting COST? Layers are sequential: node B cannot start
+#      before node A's output arrives, so twelve layers on one machine take
+#      about as long as six plus six on two, plus a hop. This measures that
+#      hop instead of assuming it, at equal total threads so the comparison
+#      isolates the structure rather than the core count.
+#
+# Relay is forbidden throughout: every node advertises a direct address, and
+# a run that fell back to the tracker tunnel would measure the tunnel.
+#
+# On one machine this is a loopback rehearsal — real LAN numbers need real
+# machines, and LUMABRI_SPLIT_HOSTS is where those go. What it proves here is
+# the invariance, which is machine-independent, and the shape of the cost.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ENGINE="${ENGINE:-../colibri/c}"
+PORT="${PORT:-7920}"
+MODEL_DIR="${SPLIT_MODEL_DIR:-tiny_olmoe}"
+ENGINE_ID="${SPLIT_ENGINE:-olmoe}"
+MODEL_NAME="${SPLIT_MODEL:-tiny-olmoe}"
+TOKENS="${SPLIT_TOKENS:-8}"
+THREADS_TOTAL="${SPLIT_THREADS:-4}"
+CONTEXT="${SPLIT_CONTEXT:-64}"
+ROUNDS="${SPLIT_ROUNDS:-3}"
+
+TMP=$(mktemp -d /tmp/lumabri-segment-split.XXXXXX)
+PIDS=()
+failed() {
+    local status=$?
+    echo "SEGMENT SPLIT TEST: FAIL" >&2
+    for log in "$TMP"/*.log; do
+        [[ -f "$log" ]] || continue
+        echo "--- $(basename "$log")" >&2; tail -n 80 "$log" >&2 || true
+    done
+    return "$status"
+}
+cleanup() {
+    kill -CONT "${PIDS[@]}" 2>/dev/null || true
+    kill "${PIDS[@]}" 2>/dev/null || true
+    wait "${PIDS[@]}" 2>/dev/null || true
+    rm -rf "$TMP"
+}
+trap failed ERR
+trap cleanup EXIT
+
+[[ -x ./segment_node && -x ./segment_chat && -x ./tracker ]] ||
+    { echo "SEGMENT SPLIT TEST: SKIP (build segment_node, segment_chat, tracker)"; exit 0; }
+[[ -f "$MODEL_DIR/config.json" ]] ||
+    { echo "SEGMENT SPLIT TEST: SKIP (no $MODEL_DIR)"; exit 0; }
+
+LAYERS=$(python3 -c "import json;print(json.load(open('$MODEL_DIR/config.json'))['num_hidden_layers'])")
+MTYPE=$(python3 -c "import json;print(json.load(open('$MODEL_DIR/config.json')).get('model_type',''))")
+[[ "$LAYERS" -ge 2 ]] || { echo "SEGMENT SPLIT TEST: SKIP ($MODEL_DIR has $LAYERS layers)"; exit 0; }
+
+wait_port() {
+    for _ in $(seq 1 400); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null; then exec 3<&-; exec 3>&-; return 0; fi
+        sleep .05
+    done
+    return 1
+}
+
+prompt=$(python3 - "$MODEL_DIR" <<'PY'
+import json,sys,os
+p=os.path.join(sys.argv[1],'ref.json')
+print(','.join(map(str,json.load(open(p,encoding='utf-8'))['prompt_ids']))
+      if os.path.exists(p) else '1,2,3,4')
+PY
+)
+model_root=$(printf '%064x' 191)
+tokenizer_root=$(printf '%064x' 192)
+
+# A fresh tracker per configuration. Sharing one across phases leaves the
+# previous phase's nodes advertised after they are killed, and the chat then
+# dials a dead address instead of the topology under test.
+TRACKER=0
+PHASE=0
+start_phase() {              # $1 = nodes, $2 = threads each, $3 = tag
+    local n=$1 threads=$2 tag=$3 i begin end per base
+    PHASE=$(( PHASE + 1 ))
+    TRACKER=$(( PORT + 100 * PHASE ))
+    base=$(( TRACKER + 10 ))
+    LUMABRI_PEER_KEY="$TMP/$tag-tracker.key" \
+    LUMABRI_KNOWN_HOSTS="$TMP/$tag-tracker.hosts" \
+        ./tracker --port "$TRACKER" --peer-bindings "$TMP/$tag-bindings" \
+        >"$TMP/$tag-tracker.log" 2>&1 & PIDS+=("$!")
+    wait_port "$TRACKER"
+    per=$(( (LAYERS + n - 1) / n ))
+    for (( i = 0; i < n; i++ )); do
+        begin=$(( i * per )); end=$(( begin + per ))
+        (( end > LAYERS )) && end=$LAYERS
+        (( begin >= end )) && continue
+        LUMABRI_PEER_KEY="$TMP/$tag-$i.key" LUMABRI_KNOWN_HOSTS="$TMP/$tag-$i.hosts" \
+        LUMABRI_VERIFY=0 OMP_NUM_THREADS="$threads" \
+            ./segment_node --engine "$ENGINE_ID" --model-dir "$MODEL_DIR" \
+            --model "$MODEL_NAME" --range "$begin:$end" \
+            --port "$(( base + i ))" --tracker "127.0.0.1:$TRACKER" \
+            --advertise "127.0.0.1:$(( base + i ))" --name "$tag-$i" \
+            --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
+            --context "$CONTEXT" --max-rows 16 --sessions 2 --threads "$threads" \
+            >"$TMP/$tag-$i.log" 2>&1 &
+        PIDS+=("$!")
+        wait_port "$(( base + i ))"
+    done
+    sleep 3          # let the route generation settle before the first prompt
+}
+
+stop_phase() {
+    local pid
+    for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null || true; done
+    wait "${PIDS[@]}" 2>/dev/null || true
+    PIDS=()
+    sleep 1
+}
+
+# One chat run: prints "<seconds> <token ids>"
+run_chat() {                 # $1 = threads, $2 = log name
+    local threads=$1 log=$2 t0 t1
+    t0=$(date +%s.%N)
+    OMP_NUM_THREADS="$threads" ./segment_chat --engine "$ENGINE_ID" \
+        --model-dir "$MODEL_DIR" --model "$MODEL_NAME" \
+        --tracker "127.0.0.1:$TRACKER" \
+        --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
+        --prompt-ids "$prompt" --tokens "$TOKENS" --context "$CONTEXT" \
+        --max-rows 16 --retry-first-run --json \
+        >"$TMP/$log.json" 2>"$TMP/$log.log"
+    t1=$(date +%s.%N)
+    python3 - "$TMP/$log.json" "$t0" "$t1" <<'PY'
+import json,sys
+lines=[l for l in open(sys.argv[1],encoding='utf-8') if l.startswith('{')]
+ids=json.loads(lines[-1])['token_ids']
+print("%.3f %s" % (float(sys.argv[3])-float(sys.argv[2]), ','.join(map(str,ids))))
+PY
+}
+
+best_of() {                  # $1 = threads, $2 = tag; prints "<best s> <ids>"
+    local threads=$1 tag=$2 r out t ids best=""
+    # One discarded run first. Without it the first phase measured is the one
+    # that faults the checkpoint in from disk and every later phase reads it
+    # from page cache — which made splitting look six times FASTER than not
+    # splitting, an impossibility for sequential layers, and a measurement of
+    # the running order rather than the topology.
+    run_chat "$threads" "$tag-warm" >/dev/null
+    for (( r = 0; r < ROUNDS; r++ )); do
+        out=$(run_chat "$threads" "$tag-$r")
+        t=${out%% *}; ids=${out#* }
+        if [[ -z "$best" ]] || (( $(python3 -c "print(1 if $t < $best else 0)") )); then best=$t; fi
+        echo "$ids" >>"$TMP/$tag.ids"
+    done
+    sort -u "$TMP/$tag.ids" >"$TMP/$tag.uniq"
+    if [[ $(wc -l <"$TMP/$tag.uniq") -ne 1 ]]; then
+        echo "SEGMENT SPLIT TEST: FAIL — $tag was not deterministic across $ROUNDS runs" >&2
+        cat "$TMP/$tag.uniq" >&2
+        exit 1
+    fi
+    echo "$best $(cat "$TMP/$tag.uniq")"
+}
+
+echo "model $MODEL_NAME ($MTYPE) · $LAYERS layers · $TOKENS tokens · best of $ROUNDS"
+echo "  (one warm-up run per phase is discarded: the first read of a"
+echo "   checkpoint is disk, every later one is page cache)"
+
+# A) every layer on one node — the oracle, and the floor to compare against
+start_phase 1 "$THREADS_TOTAL" whole
+whole=$(best_of "$THREADS_TOTAL" whole)
+whole_s=${whole%% *}; oracle=${whole#* }
+echo "  A  1 node,  $THREADS_TOTAL threads   ${whole_s}s"
+stop_phase
+
+# B) split across two, SAME total threads: isolates the cost of the boundary
+half=$(( THREADS_TOTAL / 2 )); (( half < 1 )) && half=1
+start_phase 2 "$half" split
+split=$(best_of "$THREADS_TOTAL" split)
+split_s=${split%% *}; split_ids=${split#* }
+echo "  B  2 nodes, $half+$half threads   ${split_s}s"
+
+if [[ "$split_ids" != "$oracle" ]]; then
+    echo "SEGMENT SPLIT TEST: FAIL — splitting the model changed the tokens" >&2
+    echo "  one node : $oracle" >&2
+    echo "  two nodes: $split_ids" >&2
+    exit 1
+fi
+
+stop_phase
+
+# C) split across two with all the cores each: what a person actually gets
+start_phase 2 "$THREADS_TOTAL" full
+full=$(best_of "$THREADS_TOTAL" full)
+full_s=${full%% *}; full_ids=${full#* }
+echo "  C  2 nodes, $THREADS_TOTAL+$THREADS_TOTAL threads   ${full_s}s"
+[[ "$full_ids" == "$oracle" ]] || {
+    echo "SEGMENT SPLIT TEST: FAIL — the tokens changed with all cores" >&2; exit 1; }
+
+# Relay must never have been used: these nodes advertise direct addresses.
+if grep -qi "relay" "$TMP"/split-*.log "$TMP"/whole-*.log 2>/dev/null; then
+    echo "SEGMENT SPLIT TEST: FAIL — a run used the tracker relay; the numbers" \
+         "would measure the tunnel, not the split" >&2
+    exit 1
+fi
+
+# Timings are only reported when the machine could plausibly produce them.
+#
+# The invariance claim above is machine-independent: identical tokens are
+# identical on a loaded laptop too. The cost claim is not. On a box whose run
+# queue is longer than its cores, every phase is competing with something
+# else, and the numbers say more about what else was running than about the
+# topology — on this laptop at load 17 the split came out five times FASTER
+# than the whole model, which is impossible for sequential layers.
+#
+# So the rule is: print the comparison only when the load average is below
+# the core count, and otherwise say plainly that this machine cannot answer.
+python3 - "$whole_s" "$split_s" "$full_s" <<'PY'
+import os, sys
+w, s, f = (float(x) for x in sys.argv[1:4])
+try:
+    load = os.getloadavg()[0]
+    cores = os.cpu_count() or 1
+except OSError:
+    load, cores = 0.0, 1
+if load > cores * 0.7:
+    print("  timings withheld: load %.1f on %d cores. The split is proved"
+          % (load, cores))
+    print("  CORRECT here, not fast — run this on a quiet machine for cost.")
+    sys.exit(0)
+print("  boundary cost, equal threads: %+.1f%%  (%.3fs -> %.3fs)"
+      % ((s - w) / w * 100.0, w, s))
+print("  two nodes, all cores each:    %+.1f%%  (%.3fs -> %.3fs)"
+      % ((f - w) / w * 100.0, w, f))
+if s < w * 0.9:
+    print("  NOTE: splitting came out faster at equal threads. Layers are")
+    print("  sequential, so that cannot be a property of the split — suspect")
+    print("  page cache, an unequal thread count, or contention.")
+PY
+
+echo "SEGMENT SPLIT TEST: PASS (tokens identical across 1 and 2 nodes, relay unused)"

--- a/test_cluster.c
+++ b/test_cluster.c
@@ -1,0 +1,141 @@
+/* A plan says what fits and how it would be split. It must never say how
+ * fast, and it must never say "runs" when one machine in the chain cannot
+ * hold its range. */
+#include <stdio.h>
+#include <string.h>
+#include "lumabri_cluster.h"
+
+static int bad;
+#define CHECK(c, ...) do { if (!(c)) { fprintf(stderr, __VA_ARGS__); \
+    fputc('\n', stderr); bad = 1; } } while (0)
+
+static LmbModelShape v4(void) {
+    LmbModelShape m; memset(&m, 0, sizeof m);
+    snprintf(m.model_type, sizeof m.model_type, "deepseek_v4");
+    m.layers = 43; m.hidden = 4096; m.intermediate = 11264;
+    m.moe_intermediate = 1408; m.experts = 256; m.experts_per_tok = 6;
+    m.heads = 32; m.kv_heads = 8; m.vocab = 129280; m.bits_per_weight = 4;
+    return m;
+}
+
+static LmbClusterNode node(const char *name, double gb, uint32_t gpu) {
+    LmbClusterNode n; memset(&n, 0, sizeof n);
+    snprintf(n.name, sizeof n.name, "%s", name);
+    n.ram_budget_bytes = (uint64_t)(gb * 1e9);
+    n.gpu_backends = gpu; n.threads = 8; n.lan_bps = 100u * 1000 * 1000;
+    return n;
+}
+
+int main(void) {
+    LmbModelShape m = v4();
+    LmbClusterPlan p;
+
+    /* A realistic house: four computers, 96 GB between them, against a model
+     * that needs about 150. It does not fit, and the plan has to SAY it does
+     * not fit rather than produce a split that would fail on first use. */
+    LmbClusterNode house[4] = { node("desk", 32, 0), node("study", 24, 0),
+                                node("bedroom", 24, 0), node("server", 16, 0) };
+    CHECK(!lmb_plan_cluster(&m, house, 4, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "a four-machine house could not be planned at all");
+    CHECK(p.state == LMB_PLAN_UNRUNNABLE,
+          "96 GB was reported as able to hold a ~150 GB model (%s)",
+          lmb_plan_state_name(p.state));
+    CHECK(p.missing_bytes > 0, "nothing was reported as missing");
+    CHECK(p.missing_nodes > 0,
+          "the shortfall was not expressed in machines, which is the only "
+          "form a person can act on");
+
+    /* Coverage is not optional: every layer belongs to exactly one node, in
+     * order, with no gap and no overlap. A plan that leaves layer 30
+     * unassigned is not a slower plan, it is not a plan. */
+    uint32_t next = 0;
+    for (uint32_t i = 0; i < p.nslices; i++) {
+        CHECK(p.slices[i].layer_begin == next,
+              "slice %u starts at %u, expected %u — a gap or an overlap",
+              i, p.slices[i].layer_begin, next);
+        next = p.slices[i].layer_end;
+    }
+    CHECK(next == m.layers, "the slices cover %u of %u layers", next, m.layers);
+
+    /* Shares follow budgets. Equal splits are the obvious thing and they are
+     * wrong on the hardware a house has, where one machine is always bigger. */
+    CHECK(p.nslices >= 2, "a four-node cluster produced %u slices", p.nslices);
+    uint32_t big = p.slices[0].layer_end - p.slices[0].layer_begin;
+    uint32_t small = p.slices[p.nslices - 1].layer_end -
+                     p.slices[p.nslices - 1].layer_begin;
+    CHECK(big >= small, "the 32 GB machine took %u layers, the 16 GB one %u",
+          big, small);
+
+    /* Enough machines, and it fits: same model, eight big boxes. */
+    LmbClusterNode big8[8];
+    for (int i = 0; i < 8; i++) big8[i] = node("big", 40, 0);
+    CHECK(!lmb_plan_cluster(&m, big8, 8, 4096, 1, LMB_GOAL_ONE_SESSION, &p) &&
+          p.state == LMB_PLAN_RESIDENT,
+          "320 GB across eight machines did not hold a ~150 GB model (%s)",
+          lmb_plan_state_name(p.state));
+    CHECK(p.missing_bytes == 0, "a plan that fits still reported %.1f GB missing",
+          (double)p.missing_bytes / 1e9);
+
+    /* Edge goes to a machine whose ENGINE can use its card, not to whichever
+     * machine happens to have one fitted. */
+    LmbClusterNode mixed[3] = { node("cpu-big", 64, 0), node("gpu", 40, LMB_GPU_CUDA),
+                                node("cpu", 40, 0) };
+    CHECK(!lmb_plan_cluster(&m, mixed, 3, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "a mixed cluster could not be planned");
+    CHECK(p.edge_node == 1,
+          "Edge went to node %u; the machine whose engine can use a GPU is 1",
+          p.edge_node);
+
+    /* Ready-in is bytes over MEASURED bandwidth. With none measured it is
+     * unknown, and unknown has to be visible — a fabricated minute is how a
+     * catalogue starts lying. */
+    LmbClusterNode blind[8];
+    for (int i = 0; i < 8; i++) { blind[i] = node("big", 40, 0); blind[i].lan_bps = 0; }
+    CHECK(!lmb_plan_cluster(&m, blind, 8, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "an unmeasured cluster could not be planned");
+    CHECK(!p.ready_known, "ready-in was claimed with no bandwidth measured");
+    for (int i = 0; i < 8; i++) blind[i].has_checkpoint = 1;
+    CHECK(!lmb_plan_cluster(&m, blind, 8, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "a cluster that already holds the weights could not be planned");
+    CHECK(p.fetch_bytes == 0 && p.ready_known,
+          "machines that already hold the checkpoint were told to fetch %.1f GB",
+          (double)p.fetch_bytes / 1e9);
+
+    /* The three answers about a new machine stay three. Sized so that four
+     * of these do not hold the model and five do, which is the case the
+     * distinction exists for. */
+    LmbClusterNode grow[5];
+    for (int i = 0; i < 5; i++) grow[i] = node("box", 32, 0);
+    LmbNodeEffect e = lmb_node_effect(&m, grow, 2, 4096, 1, LMB_GOAL_ONE_SESSION);
+    CHECK(!e.makes_runnable && e.missing_delta >= 0,
+          "a machine that leaves the model unrunnable claimed to fix it");
+    e = lmb_node_effect(&m, grow, 5, 4096, 1, LMB_GOAL_ONE_SESSION);
+    CHECK(e.makes_runnable && e.enters_critical_path,
+          "the machine that completes the coverage was kept out of the chain "
+          "because it does not accelerate anything");
+    CHECK(e.reason && e.reason[0], "no reason was given for the decision");
+
+    /* And a machine added to a cluster that already runs the model does NOT
+     * join the chain on a hunch: without a measurement there is nothing to
+     * justify it, and inventing one is the promise we refuse to make. */
+    LmbClusterNode plenty[9];
+    for (int i = 0; i < 9; i++) plenty[i] = node("big", 60, 0);
+    e = lmb_node_effect(&m, plenty, 9, 4096, 1, LMB_GOAL_ONE_SESSION);
+    CHECK(!e.enters_critical_path,
+          "a ninth machine joined the chain of an already-running model with "
+          "no measurement to justify it");
+
+    /* Sessions cost state on every node, so more of them can turn a plan
+     * that fits into one that does not. */
+    LmbClusterNode tight8[8];
+    for (int i = 0; i < 8; i++) tight8[i] = node("snug", 21, 0);
+    LmbClusterPlan one, many;
+    int ok1 = !lmb_plan_cluster(&m, tight8, 8, 8192, 1, LMB_GOAL_ONE_SESSION, &one);
+    int ok8 = !lmb_plan_cluster(&m, tight8, 8, 8192, 16, LMB_GOAL_THROUGHPUT, &many);
+    CHECK(ok1 && ok8, "a snug cluster could not be planned");
+    CHECK(many.state != LMB_PLAN_RESIDENT || one.state == LMB_PLAN_RESIDENT,
+          "sixteen sessions fitted where one did not");
+
+    printf("CLUSTER PLAN: %s\n", bad ? "FAIL" : "PASS");
+    return bad ? 1 : 0;
+}

--- a/test_model_family.c
+++ b/test_model_family.c
@@ -1,0 +1,79 @@
+/* The table decides, and it decides the same way every time.
+ *
+ * The dispatch this replaces was three ladders of strstr(), and its failure
+ * was not that it refused things — it was that it never did. "glm53_moe"
+ * contains "glm", so a GLM-5.3 checkpoint was handed to the GLM adapter and
+ * executed. That is worse than an error: an error stops, a wrong adapter
+ * produces numbers.
+ *
+ * So the claims here are about what the table REFUSES as much as what it
+ * resolves. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "lumabri_families.h"
+
+static int bad;
+
+static void want(const char *model_type, const char *expect_id) {
+    const LmbModelFamily *f = lmb_family_for(model_type);
+    const char *got = f ? f->segment_id : NULL;
+    if (!expect_id && !got) return;
+    if (expect_id && got && !strcmp(got, expect_id)) return;
+    fprintf(stderr, "model_type \"%s\": got %s, expected %s\n", model_type,
+            got ? got : "(refused)", expect_id ? expect_id : "(refused)");
+    bad = 1;
+}
+
+int main(void) {
+    /* the two the table knows exactly */
+    want("olmoe", "olmoe");
+    want("deepseek_v4", "deepseek_v4");
+
+    /* the families that still match by declared prefix, unchanged */
+    want("kimi_k2", "kimi");
+    want("inkling", "inkling");
+    want("qwen3_moe", "qwen36");
+    want("glm4_moe", "glm");
+
+    /* the refusals. Nothing here shares enough with a declared prefix to be
+     * claimed, and every one of them used to be swallowed silently. */
+    want("", NULL);
+    want("llama", NULL);
+    want("mixtral", NULL);
+    want("deepseek_v3", NULL);   /* "deepseek" was a prefix once: not any more */
+
+    /* a family with no declared model_type is unreachable by detection... */
+    const LmbModelFamily *f;
+    for (size_t i = 0; i < LMB_FAMILY_UNMAPPED_COUNT; i++) {
+        const char *id = LMB_FAMILY_UNMAPPED[i];
+        f = lmb_family_by_id(id);
+        if (!f) { fprintf(stderr, "unmapped family %s has no row\n", id); bad = 1; continue; }
+        if (f->aliases[0] || f->prefixes[0]) {
+            fprintf(stderr, "%s is listed as unmapped but claims a model_type\n", id);
+            bad = 1;
+        }
+        /* ...and reachable by explicit name, which is the whole point of
+         * registering it. */
+        if (lmb_family_override(id) != f) {
+            fprintf(stderr, "%s cannot be selected explicitly\n", id);
+            bad = 1;
+        }
+    }
+
+    /* a name Colibri does not register is refused, not ignored */
+    if (lmb_family_override("qwen39")) {
+        fprintf(stderr, "an unknown adapter name was accepted\n");
+        bad = 1;
+    }
+
+    /* the longest declared match wins, so a more specific family can always
+     * be added later without disturbing the broader one */
+    if (lmb_family_for("qwen36_moe") != lmb_family_by_id("qwen36")) {
+        fprintf(stderr, "longest-match did not prefer the specific family\n");
+        bad = 1;
+    }
+
+    printf("MODEL FAMILY TABLE: %s\n", bad ? "FAIL" : "PASS");
+    return bad ? 1 : 0;
+}

--- a/test_planner.c
+++ b/test_planner.c
@@ -1,0 +1,145 @@
+/* The planner answers "does it fit", never "how fast".
+ *
+ * Its three figures are different in kind and the catalogue depends on the
+ * difference: resident is every weight of the range, working set is the
+ * least that can run at all, and state is what context and sessions add.
+ * Collapse any two of them and a whole state of the product disappears —
+ * "runs from disk" exists only in the gap between the first two. */
+#include <stdio.h>
+#include <string.h>
+#include "lumabri_planner.h"
+
+static int bad;
+#define CHECK(cond, ...) do { if (!(cond)) { \
+    fprintf(stderr, __VA_ARGS__); fputc('\n', stderr); bad = 1; } } while (0)
+
+/* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
+static LmbModelShape v4(void) {
+    LmbModelShape m; memset(&m, 0, sizeof m);
+    snprintf(m.model_type, sizeof m.model_type, "deepseek_v4");
+    snprintf(m.segment_id, sizeof m.segment_id, "deepseek_v4");
+    m.layers = 43; m.hidden = 4096; m.intermediate = 11264;
+    m.moe_intermediate = 1408; m.experts = 256; m.experts_per_tok = 6;
+    m.heads = 32; m.kv_heads = 8; m.vocab = 129280; m.bits_per_weight = 4;
+    return m;
+}
+
+int main(void) {
+    LmbModelShape m = v4();
+
+    /* An expert of this shape measured ~13.4 MB on the real checkpoint. The
+     * estimate has to land near that or every figure built on it is wrong. */
+    uint64_t e = lmb_expert_bytes_of(&m);
+    CHECK(e > 9u * 1000 * 1000 && e < 25u * 1000 * 1000,
+          "expert estimate %.1f MB is nowhere near the measured 13.4 MB",
+          (double)e / 1e6);
+
+    LmbRangeCost all = lmb_estimate_segment(&m, 0, m.layers, 4096, 1);
+    CHECK(all.ok, "a whole-model range could not be estimated");
+    /* 11008 experts of ~13 MB is ~150 GB; anything outside 100-250 GB means
+     * the arithmetic drifted. */
+    CHECK(all.resident_bytes > 100ull * 1000 * 1000 * 1000 &&
+          all.resident_bytes < 250ull * 1000 * 1000 * 1000,
+          "whole model resident %.0f GB, expected roughly 150",
+          (double)all.resident_bytes / 1e9);
+
+    /* THE distinction. The working set of the whole model is a top-k cache,
+     * so it must be a small fraction of resident — that gap is disk mode. */
+    CHECK(all.working_set_bytes * 4 < all.resident_bytes,
+          "working set %.0f GB is not meaningfully below resident %.0f GB: "
+          "disk mode would be indistinguishable from resident",
+          (double)all.working_set_bytes / 1e9, (double)all.resident_bytes / 1e9);
+
+    /* Three states, on one 64 GB machine holding everything. */
+    uint64_t budget = 64ull * 1000 * 1000 * 1000;
+    m.disk_streaming = 0;
+    CHECK(lmb_plan_state(&m, &all, budget) == LMB_PLAN_UNRUNNABLE,
+          "a 150 GB model on 64 GB was not reported as unrunnable");
+    m.disk_streaming = 1;
+    CHECK(lmb_plan_state(&m, &all, budget) == LMB_PLAN_DISK,
+          "an adapter that streams from disk was still called unrunnable");
+    CHECK(lmb_plan_state(&m, &all, 400ull * 1000 * 1000 * 1000) == LMB_PLAN_RESIDENT,
+          "a model that fits four times over was not called resident");
+
+    /* Disk mode is a capability, not a consolation prize: an adapter that has
+     * never demonstrated it does not get it, however well the floor fits. */
+    m.disk_streaming = 0;
+    LmbRangeCost slice = lmb_estimate_segment(&m, 0, 11, 4096, 1);
+    uint64_t just_over = slice.working_set_bytes + slice.state_bytes +
+                         slice.scratch_bytes + 1;
+    CHECK(lmb_plan_state(&m, &slice, just_over) == LMB_PLAN_UNRUNNABLE,
+          "a range was allowed to stream from disk without the capability");
+    m.disk_streaming = 1;
+    CHECK(lmb_plan_state(&m, &slice, just_over) == LMB_PLAN_DISK,
+          "a range whose working set fits exactly was refused");
+
+    /* Splitting divides the weights and nothing else: four ranges must cost
+     * what one whole one does, or the placement arithmetic is unsound. */
+    uint64_t sum = 0;
+    for (int i = 0; i < 4; i++) {
+        uint32_t b = (uint32_t)i * m.layers / 4;
+        uint32_t en = (uint32_t)(i + 1) * m.layers / 4;
+        LmbRangeCost c = lmb_estimate_segment(&m, b, en, 4096, 1);
+        CHECK(c.ok, "range %u:%u could not be estimated", b, en);
+        sum += c.resident_bytes;
+    }
+    CHECK(sum == all.resident_bytes,
+          "four ranges cost %.1f GB, the whole model %.1f GB",
+          (double)sum / 1e9, (double)all.resident_bytes / 1e9);
+
+    /* State scales with what state scales with, and weights do not move. */
+    LmbRangeCost s1 = lmb_estimate_segment(&m, 0, 11, 4096, 1);
+    LmbRangeCost s4 = lmb_estimate_segment(&m, 0, 11, 4096, 4);
+    LmbRangeCost c8 = lmb_estimate_segment(&m, 0, 11, 8192, 1);
+    CHECK(s4.state_bytes == s1.state_bytes * 4,
+          "four sessions did not cost four KVs");
+    CHECK(c8.state_bytes == s1.state_bytes * 2,
+          "twice the context did not cost twice the KV");
+    CHECK(s4.resident_bytes == s1.resident_bytes,
+          "sessions changed the weight footprint");
+
+    /* Edge is embedding and head, and it is not free — it is what makes a
+     * chatter thin, so it has to be attributed to whoever runs it. */
+    LmbRangeCost edge = lmb_estimate_edge(&m, 4096, 1);
+    CHECK(edge.ok && edge.resident_bytes > 100u * 1000 * 1000,
+          "Edge came out at %.0f MB, which cannot be right for a 129k vocab",
+          (double)edge.resident_bytes / 1e6);
+
+    /* A shape we cannot describe must say so instead of inventing a number:
+     * a fabricated estimate is how a catalogue promises what it cannot do. */
+    LmbModelShape empty; memset(&empty, 0, sizeof empty);
+    CHECK(!lmb_estimate_segment(&empty, 0, 1, 64, 1).ok,
+          "an empty shape produced an estimate");
+    CHECK(!lmb_estimate_segment(&m, 5, 5, 64, 1).ok, "an empty range estimated");
+    CHECK(!lmb_estimate_segment(&m, 0, 999, 64, 1).ok,
+          "a range past the end of the model estimated");
+
+    /* And the shape has to come out of a real checkpoint, not just a struct
+     * literal — a reader that quietly returns zeros would make every
+     * estimate above meaningless while every assertion still passed. */
+    LmbModelShape fixture;
+    if (!lmb_shape_from_config("tiny_olmoe", &fixture)) {
+        CHECK(fixture.layers == 16, "fixture layers %u, expected 16", fixture.layers);
+        CHECK(fixture.hidden > 0 && fixture.experts > 0,
+              "fixture hidden %u experts %u: the reader found nothing useful",
+              fixture.hidden, fixture.experts);
+        CHECK(!strcmp(fixture.model_type, "olmoe"),
+              "fixture model_type came out as \"%s\"", fixture.model_type);
+        CHECK(!strcmp(fixture.segment_id, "olmoe"),
+              "fixture was not mapped to an adapter (got \"%s\")",
+              fixture.segment_id);
+        LmbRangeCost half = lmb_estimate_segment(&fixture, 0, 8, 64, 1);
+        CHECK(half.ok && half.resident_bytes > 0,
+              "a real checkpoint's range could not be estimated");
+    } else {
+        fprintf(stderr, "note: tiny_olmoe not present, config reader unexercised\n");
+    }
+
+    /* A directory with no config.json must fail rather than return zeros. */
+    LmbModelShape none;
+    CHECK(lmb_shape_from_config("/nonexistent", &none) != 0,
+          "a missing checkpoint produced a shape");
+
+    printf("PLANNER: %s\n", bad ? "FAIL" : "PASS");
+    return bad ? 1 : 0;
+}


### PR DESCRIPTION
Steps 1 to 4 of the roadmap, stacked on #139. **Colibri is untouched** — it answers none of this: only DeepSeek V4 reads `model_type`, and no adapter exposes a sizing call, so the description has to live on our side.

## Three figures that are not the same figure

`lumabri_planner.h` turns a checkpoint's `config.json` into:

- **resident** — every weight of a range;
- **working set** — the least that must be resident to run at all: dense weights, an expert cache at least as large as top-k, kernel scratch;
- **state** — KV and recurrent state, which scale with context and sessions and belong to neither.

The gap between the first two **is** disk mode. A range whose resident cost does not fit but whose floor does can run, reading the rest from NVMe or CAS — and only where the adapter has demonstrated it. Collapse any two of those figures and a whole state of the product disappears.

One correction found while testing: OLMoE has routed experts but no `moe_intermediate_size`, because its experts are the dense width. Read as dense, its entire expert set landed in the working set and disk mode became indistinguishable from resident.

## A placement with two objectives, kept apart

`lumabri_cluster.h` gives each machine a share of the layers **in proportion to what it can hold** — equal splits are the obvious thing and they are wrong on the hardware a house actually has, where one box is always the bigger one.

It reports the three states, what is missing in gigabytes **and in machines**, and who holds Edge: the machine whose *engine* can use a GPU, not whichever machine has a card fitted.

The two objectives never get mixed:

- **one session** minimises the **sum** of the stages — layers are sequential, so fewer machines can be better, because every boundary is another hop;
- **many sessions** minimise the **slowest stage**, which is the pipeline objective.

And the monotone rule keeps its exception: a machine that completes the coverage joins the chain even though it accelerates nothing, because without it there is nothing to accelerate. A machine added to a cluster that already runs the model does **not** join on a hunch — with no calibration there is nothing to justify it.

## The preflight keeps its guard and changes its basis

`segment_node.c` demanded a proportional share of the whole checkpoint plus 5%:

```c
uint64_t proportional = model_bytes / model_layers * range_layers;
uint64_t overhead = model_bytes / 20u;
```

That assumes total residency. A node with room for the dense part, a top-k cache and a working NVMe was refused **before it could open the engine** — disk mode was not merely unadvertised, it was unreachable.

The guard stays: it exists for a real incident, slices sized at "all the free RAM" contending on one box. Only the basis changes, to the planner's working set, with the proportional figure kept as the fallback for a checkpoint the planner cannot describe — an unknown model is not a licence to over-commit.

## The machine profile learns three things

`gpu_backends` is what the **engine** can drive, not what `/sys` reports: Colibri's Segment adapters advertise CPU only, so a machine with an idle card in it is a CPU machine as far as a plan is concerned. Plus a measured cold disk read (O_DIRECT where allowed) and LAN bandwidth. Unmeasured stays zero and prints as unmeasured.

## Step 0's second half

`segment_split_test.sh`: the same greedy prompt on one node and split across two, tokens compared, **relay forbidden**, at equal total threads and then with every core.

Two things it learned about itself:

- it **discards a warm-up run per phase**. Without one, the first phase faults the checkpoint in from disk and every later phase reads page cache — which made splitting look six times *faster* than not splitting, an impossibility for sequential layers;
- it **withholds timings entirely** when the load average exceeds the core count, and says so. On this laptop at load 17 the numbers described the contention, not the topology. The invariance claim is machine-independent and still reported; the cost claim needs a quiet machine.

## Verified

- `segment_split_test.sh` PASS — identical tokens across one and two nodes, relay unused;
- `segment_budget_test.sh` PASS — a whole range starts, a budget below the working set is refused naming both figures;
- `test_planner`, `test_cluster` PASS — including a four-machine house correctly reported as unable to hold a 150 GB model, with the shortfall expressed in machines;
- `selftest.sh`, `role_test.sh`, `serve_failfast_test.sh` PASS; `-Werror` clean.
