### PR TITLE
fix: make the roadmap stack fail closed and evidence based

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,9 @@ SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
 MACHINE_SRC = lumabri_machine.c
 MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
-lumabri: lumabri.c lumabri_tui.c lumabri_tui.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS) $(MACHINE_DEPS)
+lumabri: lumabri.c lumabri_tui.c lumabri_tui.h lumabri_proto.h lumabri_sign.h \
+		lumabri_families.h lumabri_planner.h lumabri_cluster.h \
+		lumabri_calibration.h $(SECURE_DEPS) $(MACHINE_DEPS)
 	$(CC) $(CFLAGS) -pthread lumabri.c lumabri_tui.c $(MACHINE_SRC) -o $@
 
 # ---- phase 2: peers execute experts ------------------------------------
@@ -539,7 +541,8 @@ $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_brid
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 
-segment_node: segment_node.c $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS) \
+segment_node: segment_node.c lumabri_planner.h lumabri_families.h \
+		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS) \
 		lumabri_run_gate.c lumabri_run_gate.h
 	$(CC) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
 		lumabri_segment_discovery.c $(MACHINE_SRC) lumabri_run_gate.c \

--- a/README.md
+++ b/README.md
@@ -472,16 +472,16 @@ have their own scripts (`assign_test.sh`, `concurrency_test.sh`,
 `make test-cas test-key-rotation test-hedge test-relay-exec` and
 `make test-segment-v2 test-segment-discovery test-segment-direct-real`.
 Segment discovery checks leases, route generations, replicas, draining,
-compatibility and the asynchronous snapshot. The direct gate runs all six tiny
-families through real TCP executors, matches independent Colibri token oracles,
+compatibility and the asynchronous snapshot. The direct gate runs six
+fixture-backed families through real TCP executors, matches independent Colibri token oracles,
 drives sampled persistent TUI turns, overlaps sessions, and proves rarest-first
 automatic range replacement. The same target also forces Segment through a
 relay-only NAT topology, kills a selected executor to require checkpoint
 restore/replay, and launches the ordinary `serve` + `chat` UX without a public
 data address. Relay EXEC needs
 an OLMoE engine source under `ENGINE`; its script reports `SKIP` explicitly
-when that external checkout is absent. Every claim in this README has a script
-behind it.
+when that external checkout is absent. GLM-5.3 and Qwen3.8 remain experimental
+until they pass the same real-checkpoint conformance matrix.
 
 ## How it compares
 

--- a/README_HOME.md
+++ b/README_HOME.md
@@ -3,8 +3,19 @@
 Turn the computers you already have into one machine that runs a model none
 of them could hold alone.
 
+## Current implementation boundary
+
+The home-cluster roadmap is not complete yet. The current code has the exact
+eight-adapter registry, a loopback Segment proof, a conservative memory
+preflight, a local catalogue/TUI, and one-session Hosted chat by explicit
+address. The catalogue does not yet collect a distributed LAN inventory or
+apply its proposed plan. Adapter-specific memory sizing is currently verified
+only for OLMoE and DeepSeek V4; the other registered adapters are shown as
+experimental/unsized until their C planner and real-checkpoint conformance run
+land. A real two-physical-machine LAN gate is still required.
+
 ```
-lumabri models          # what these computers can run, and what is missing
+lumabri models          # current local planning preview
 lumabri host --model M  # this machine owns the model and serves sessions
 lumabri chat --host H   # this machine holds nothing and just types
 ```
@@ -81,7 +92,7 @@ calls it experimental, and CI fails while the two registries disagree.
 ## Verifying it yourself
 
 ```
-bash ./segment_split_test.sh    # same tokens on one node and split across two
+bash ./segment_split_test.sh    # loopback: same tokens on one node and two
 bash ./segment_budget_test.sh   # a range that does not fit is refused, and says why
 bash ./multi_session_test.sh    # contention may make a session wait, never change it
 bash ./hosted_chat_test.sh      # zero checkpoint bytes on the client
@@ -89,7 +100,9 @@ bash ./catalog_test.sh          # no invented speeds, shortfall in machines
 bash ./adapter_conformance_test.sh
 ```
 
-`segment_split_test.sh` withholds its timings when the machine's load average
+`segment_split_test.sh` is a loopback rehearsal, not a LAN benchmark. It
+withholds its timings when the machine's load average
 exceeds its core count, because on a busy box the numbers describe the
 contention rather than the topology. The token comparison still runs: that
-one is machine-independent.
+one is machine-independent. The two-physical-machine LAN gate remains a
+separate roadmap item.

--- a/SEGMENT_DIRECT.md
+++ b/SEGMENT_DIRECT.md
@@ -7,10 +7,13 @@ chain of layer-aligned peers:
 prompt -> local Edge -> peer A [0:k] -> peer B [k:n] -> local Edge -> token
 ```
 
-The implementation is model-neutral. The release gate runs the same direct
-TCP path for GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4. Every
-family is split over two peers and three generated token IDs are compared with
-its independent Colibri tiny-model oracle. The gate also overlaps two OLMoE
+The registry is model-neutral and mirrors all eight adapters currently exposed
+by Colibri: GLM, GLM-5.3, Inkling, Kimi, OLMoE, Qwen3.6, Qwen3.8 and DeepSeek
+V4. Registration is not the same as conformance: the legacy real-checkpoint
+release gate covers GLM, Inkling, Kimi K3, OLMoE, Qwen3.6 and DeepSeek V4;
+GLM-5.3 and Qwen3.8 remain experimental until their fixture runs pass the same
+gate. Each gated family is split over two peers and its generated token IDs
+are compared with an independent Colibri oracle. The gate also overlaps two OLMoE
 chats against the same executors to exercise real session isolation, and
 retransmits a committed run to prove the cached duplicate response is exact.
 
@@ -43,8 +46,9 @@ make ENGINE=/path/to/colibri/c
 
 When the two additive ABI headers exist, ordinary `make` includes
 `segment_node` and `segment_chat`; older Colibri release trees keep the legacy
-build. `segment-edge-library` contains both public runtimes and all six
-adapters, and is not linked into ordinary Colibri executables.
+build. `segment-edge-library` contains both public runtimes and every adapter
+exposed by the selected Colibri checkout, and is not linked into ordinary
+Colibri executables.
 
 ## Normal use
 
@@ -136,7 +140,7 @@ relay with the same idempotent request ID.
 
 ## Sampling and recovery
 
-Colibri Edge ABI v2 exposes the full logits for all six adapters. The ordinary
+Colibri Edge ABI v2 exposes the full logits for the conforming adapters. The ordinary
 TUI's temperature and top-p are therefore honored on the Segment path. A zero
 temperature calls Colibri's original greedy selector unchanged; a positive
 temperature uses deterministic-seedable nucleus sampling (`--seed` or
@@ -203,6 +207,6 @@ the oracle again.
 - One chatter process hosts one active Edge model. This also respects Qwen's
   currently process-global tokenizer state.
 
-These are roadmap items, not hidden fallbacks. The completed milestone proves
-one RTT per segment, sampled multi-session generation, NAT reachability and
-checkpoint/replay over the network for every current model family.
+These are roadmap items, not hidden fallbacks. Existing gates prove the common
+Segment path and the explicitly exercised adapters; they do not yet prove a
+real two-machine LAN, disk mode, or conformance of every current family.

--- a/SEGMENT_V2.md
+++ b/SEGMENT_V2.md
@@ -176,9 +176,10 @@ execution, fence, restore, stale owners, snapshot checks, close and TTL reap.
 The real-tracker discovery gate additionally covers signed registration,
 compatibility filtering, replicas, complete chains, telemetry stability,
 draining, lease rotation and asynchronous snapshots. These are protocol and
-control-plane fixtures. `segment_direct_test.sh` adds the real data plane: two
-peers per family, real prefill/decode, persistent sampled sessions and three
-greedy oracle tokens for all six models, plus overlapping real sessions. The
+control-plane fixtures. `segment_direct_test.sh` adds the real data plane for
+the six fixture-backed families: two peers per family, real prefill/decode,
+persistent sampled sessions and three greedy oracle tokens per model, plus
+overlapping real sessions. The
 relay gate forces every stateful operation through tracker tunnels; the
 failover gate kills a selected peer between turns and requires checkpoint
 restore plus replay before generation can continue.

--- a/adapter_conformance_test.sh
+++ b/adapter_conformance_test.sh
@@ -10,7 +10,9 @@
 # A family with no fixture checkpoint on this machine is SKIPPED, and skipped
 # is not passed: the summary says so, and the exit status stays zero only
 # because a laptop cannot be expected to hold a 167 GB checkpoint. The real
-# matrix runs where the checkpoints live.
+# matrix runs where the checkpoints live. Set LUMABRI_REQUIRE_ALL_ADAPTERS=1
+# there: then a missing fixture is a failure, so green really means that every
+# registered adapter was exercised rather than merely enumerated.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -60,5 +62,11 @@ echo "ADAPTER CONFORMANCE: $pass supported, $skip experimental, $fail failed"
 if (( fail > 0 )); then exit 1; fi
 if (( pass == 0 )); then
     echo "  nothing was actually exercised: this run proves nothing" >&2
+fi
+if [[ "${LUMABRI_REQUIRE_ALL_ADAPTERS:-0}" == 1 ]] && (( skip > 0 )); then
+    printf '  strict run requires all adapters; missing:' >&2
+    printf ' %s' "${untested[@]}" >&2
+    printf '\n' >&2
+    exit 1
 fi
 exit 0

--- a/catalog_test.sh
+++ b/catalog_test.sh
@@ -26,9 +26,15 @@ cat >"$T/models/tiny/config.json" <<'EOF'
  "intermediate_size":128,"num_experts":8,"num_experts_per_tok":2,
  "num_attention_heads":4,"num_key_value_heads":4,"vocab_size":256}
 EOF
+# A config is metadata, not a checkpoint. These files stand in for actual
+# model containers; a separate case below proves config-only is refused.
+truncate -s 4096 "$T/models/huge/model.bin"
+truncate -s 4096 "$T/models/tiny/model.bin"
 
 out=$(./lumabri models --models-dir "$T/models" 2>&1) || fail "the catalogue exited non-zero"
 echo "$out" | sed 's/^/    /'
+echo "$out" | grep -qi "local planning preview" ||
+    fail "the one-node catalogue pretended to be a distributed cluster inventory"
 
 huge=$(echo "$out" | grep -E '^\s*[x+!]\s+huge' || true)
 tiny=$(echo "$out" | grep -E '^\s*[x+!]\s+tiny' || true)
@@ -48,12 +54,28 @@ echo "$huge" | grep -qE "more machine" ||
 echo "$tiny" | grep -q "resident" ||
     fail "a four-layer toy model was not reported as resident: $tiny"
 
+mkdir -p "$T/models/config-only"
+cp "$T/models/tiny/config.json" "$T/models/config-only/config.json"
+config_only=$(./lumabri models --models-dir "$T/models" 2>&1 |
+              grep -E '^\s*[x+!]\s+config-only' || true)
+echo "$config_only" | grep -q "checkpoint weights missing" ||
+    fail "config.json alone was presented as a resident checkpoint: $config_only"
+
 # No speed, anywhere, ever, until something is measured.
 echo "$out" | grep -q "not calibrated" ||
     fail "the speed column did not say the plan is uncalibrated"
 if echo "$out" | grep -qE "[0-9]+([.,][0-9]+)? *tok/s"; then
     fail "a tok/s figure appeared for a plan nobody has measured"
 fi
+
+json=$(./lumabri models --models-dir "$T/models" --json)
+python3 - "$json" <<'PY' || fail "the versioned JSON snapshot is invalid"
+import json, sys
+doc = json.loads(sys.argv[1])
+assert doc["schema"] == "lumabri.models.v1"
+assert {m["name"] for m in doc["models"]} >= {"huge", "tiny", "config-only"}
+assert next(m for m in doc["models"] if m["name"] == "config-only")["weights_present"] is False
+PY
 
 # A directory with no checkpoints says so instead of printing an empty table.
 mkdir -p "$T/empty"

--- a/chat_proto_test.sh
+++ b/chat_proto_test.sh
@@ -18,7 +18,7 @@ make -s lumabri
 T=$(mktemp -d /tmp/lumabri-proto.XXXXXX)
 trap 'rm -rf "$T"' EXIT
 mkdir -p "$T/model"
-printf '{"model_type":"fake"}' > "$T/model/config.json"
+printf '{"model_type":"glm"}' > "$T/model/config.json"
 
 # --- a fake engine that speaks the framed SERVE protocol ------------------
 cat > "$T/framed" <<'EOF'
@@ -51,6 +51,7 @@ echo "$OUT" | grep -q "disco locale" || { echo "   --local not honoured"; echo "
 echo "   ✓ two turns and a reset, streamed, with the engine's own numbers"
 
 echo "· 2) line dialect (olmoe) still works"
+printf '{"model_type":"olmoe"}' > "$T/model/config.json"
 cat > "$T/liner" <<'EOF'
 #!/usr/bin/env bash
 [ -n "${CHAT:-}" ] || { echo "CHAT not set" >&2; exit 3; }
@@ -64,6 +65,7 @@ echo "$OUT" | grep -q "echo: salve" || { echo "   line protocol broke"; echo "$O
 echo "   ✓ olmoe's prompt dialect untouched"
 
 echo "· 3) an engine that dies must say why"
+printf '{"model_type":"glm"}' > "$T/model/config.json"
 cat > "$T/dead" <<'EOF'
 #!/usr/bin/env bash
 echo "config.json: unsupported quantization iq3_xxs" >&2

--- a/hosted_chat_test.sh
+++ b/hosted_chat_test.sh
@@ -35,6 +35,7 @@ cat > "$T/fakehost.c" <<'EOF'
 int main(int argc, char **argv) {
     int port = argc > 1 ? atoi(argv[1]) : 8441;
     int busy_after = argc > 2 ? atoi(argv[2]) : 1;
+    if (lmb_secure_init()) return 1;
     int lfd = lmb_listen(port);
     if (lfd < 0) return 1;
     fprintf(stderr, "fakehost listening\n");
@@ -57,23 +58,27 @@ int main(int argc, char **argv) {
         free(b.p);
         if (served >= busy_after) { close(fd); continue; }
         served++;
-        /* the serve codec, minimally: ACCEPT, one DATA, DONE */
-        char buf[8192];
+        /* the serve codec remains inside HOST_STREAM frames. */
         for (;;) {
-            ssize_t n = read(fd, buf, sizeof buf);
-            if (n <= 0) break;
-            if (!memchr(buf, '\n', (size_t)n)) continue;
+            LmbMsg stream = {0};
+            if (lmb_recv(fd, &stream) || stream.op != LMB_HOST_STREAM ||
+                !stream.pay_len) { lmb_msg_free(&stream); break; }
+            lmb_msg_free(&stream);
             const char *reply = "ACCEPT 0\nDATA 0 5\nhello\nDONE 0\n";
-            if (write(fd, reply, strlen(reply)) < 0) break;
+            if (lmb_send(fd, LMB_HOST_STREAM, NULL, 0,
+                         reply, (uint32_t)strlen(reply))) break;
         }
-        close(fd);
+        lmb_close(fd);
     }
 }
 EOF
 cc -O2 -I. -pthread -o "$T/fakehost" "$T/fakehost.c" 2>"$T/build.log" ||
     { echo "HOSTED CHAT TEST: SKIP (stand-in host did not build)"; cat "$T/build.log"; exit 0; }
 
-"$T/fakehost" "$PORT" 1 >"$T/host.log" 2>&1 & PIDS+=("$!")
+HOME="$T/fake-host-home" LUMABRI_ENCRYPT=1 \
+LUMABRI_PEER_KEY="$T/fake-host.key" \
+LUMABRI_KNOWN_HOSTS="$T/fake-host.hosts" \
+    "$T/fakehost" "$PORT" 1 >"$T/host.log" 2>&1 & PIDS+=("$!")
 for _ in $(seq 1 100); do
     (exec 3<>"/dev/tcp/127.0.0.1/$PORT") 2>/dev/null && { exec 3<&-; exec 3>&-; break; }
     sleep .05
@@ -82,9 +87,12 @@ done
 # THE measurement: a client home directory that starts empty must stay empty.
 export HOME="$T/home"
 mkdir -p "$HOME"
+export LUMABRI_ENCRYPT=1
+export LUMABRI_PEER_KEY="$T/client.key"
+export LUMABRI_KNOWN_HOSTS="$T/client.hosts"
 before=$(du -sb "$HOME" 2>/dev/null | cut -f1)
 
-printf '/quit\n' | timeout 60 ./lumabri chat --host "127.0.0.1:$PORT" --plain \
+printf 'hi\n/quit\n' | timeout 60 ./lumabri chat --host "127.0.0.1:$PORT" --plain \
     >"$T/client.log" 2>&1 || true
 
 after=$(du -sb "$HOME" 2>/dev/null | cut -f1)
@@ -94,6 +102,8 @@ grep -qi "receives the text" "$T/client.log" ||
     fail "the client did not say the host sees the conversation"
 grep -qi "not yet measured" "$T/client.log" ||
     fail "an unmeasured host did not say its speed is unknown"
+grep -q "hello" "$T/client.log" ||
+    fail "the encrypted HOST_STREAM did not carry a generated reply"
 
 # Not one byte of model, mirror or CAS.
 (( after - before < 65536 )) ||
@@ -108,4 +118,59 @@ printf '/quit\n' | timeout 30 ./lumabri chat --host "127.0.0.1:$PORT" --plain \
 grep -qE "0 sessions free" "$T/second.log" ||
     fail "a busy host did not tell the second client it was full"
 
-echo "HOSTED CHAT TEST: PASS (zero checkpoint bytes, host disclosed, busy is an answer)"
+# The real host loop, with a tiny stand-in engine. This exercises admission in
+# Lumabri itself; the fake host above exercises the thin client in isolation.
+# It has a distinct identity, so use a distinct TOFU database too; accepting a
+# second key for the same address in the first database would weaken the test.
+export LUMABRI_KNOWN_HOSTS="$T/real-client.hosts"
+mkdir -p "$T/model"
+printf '%s\n' '{"model_type":"qwen3_5_moe","text_config":{"model_type":"qwen3_5_moe"}}' >"$T/model/config.json"
+cat >"$T/qwen36.c" <<'EOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+int main(void) {
+    setvbuf(stdout, NULL, _IONBF, 0);
+    fputs("\1\1READY\1\1\nSTAT 0 0 0 0\n", stdout);
+    char line[512];
+    while (fgets(line, sizeof line, stdin)) {
+        char id[64]; unsigned slot, max_new; size_t bytes; float t, p;
+        if (sscanf(line, "SUBMIT %63s %u %zu %u %f %f",
+                   id, &slot, &bytes, &max_new, &t, &p) != 6) continue;
+        char *payload = malloc(bytes + 2);
+        if (!payload || fread(payload, 1, bytes + 1, stdin) != bytes + 1)
+            return 1;
+        payload[bytes] = 0;
+        if (!strstr(payload, "<|im_start|>assistant\n<think>\n")) return 2;
+        free(payload);
+        printf("ACCEPT %s\nDATA %s 5\nhello\nDONE %s\n", id, id, id);
+    }
+    return 0;
+}
+EOF
+cc -O2 -o "$T/qwen36" "$T/qwen36.c"
+REAL_PORT=$(( PORT + 1 ))
+mkdir -p "$T/real-home"
+HOME="$T/real-home" LUMABRI_PEER_KEY="$T/real-host.key" \
+LUMABRI_KNOWN_HOSTS="$T/real-host.hosts" \
+    ./lumabri host --local "$T/model" --engine "$T/qwen36" \
+    --port "$REAL_PORT" --max-new 8 >"$T/real-host.log" 2>&1 & PIDS+=("$!")
+for _ in $(seq 1 200); do
+    grep -q "host ready" "$T/real-host.log" 2>/dev/null && break
+    sleep .05
+done
+grep -q "host ready" "$T/real-host.log" || fail "the real host did not start"
+
+( sleep 3; printf '/quit\n' ) | timeout 20 ./lumabri chat \
+    --host "127.0.0.1:$REAL_PORT" --plain >"$T/held.log" 2>&1 & held=$!
+sleep .5
+started=$(date +%s)
+printf '/quit\n' | timeout 10 ./lumabri chat --host "127.0.0.1:$REAL_PORT" \
+    --plain >"$T/real-busy.log" 2>&1 || true
+elapsed=$(( $(date +%s) - started ))
+grep -qi "busy (0 sessions free)" "$T/real-busy.log" ||
+    fail "the real host did not refuse its second client with BUSY"
+(( elapsed < 3 )) || fail "BUSY was queued for $elapsed seconds instead of immediate"
+wait "$held" || true
+
+echo "HOSTED CHAT TEST: PASS (zero checkpoint bytes, authenticated encrypted stream, real BUSY)"

--- a/lumabri.c
+++ b/lumabri.c
@@ -365,18 +365,19 @@ static void install_chat_signal_handlers(void) {
 
 /* One table decides the family; the three lookups below only read it.
  *
- * LUMABRI_ENGINE_ID names an adapter directly, for a checkpoint whose
- * model_type nobody has declared yet — the two rows of LMB_FAMILY_UNMAPPED
- * are reachable only this way, and a name Colibri does not register is
- * refused instead of ignored. */
+ * LUMABRI_ENGINE_ID names an adapter directly. A name Colibri does not
+ * register is refused instead of being ignored and falling through to an
+ * automatic choice. */
 static const LmbModelFamily *lumi_family(const char *model_type) {
     const char *forced = getenv("LUMABRI_ENGINE_ID");
     if (forced && forced[0]) {
         const LmbModelFamily *f = lmb_family_override(forced);
-        if (!f)
+        if (!f) {
             fprintf(stderr, "[lumabri] LUMABRI_ENGINE_ID=%s is not an adapter "
-                            "Colibri registers; ignoring it\n", forced);
-        else
+                            "Colibri registers; refusing to choose an engine\n",
+                    forced);
+            return NULL;
+        } else
             return f;
     }
     const LmbModelFamily *f = lmb_family_for(model_type ? model_type : "");
@@ -427,15 +428,7 @@ static void local_model_type(const char *model_dir, char *out, size_t cap) {
     size_t n = fread(buf, 1, sizeof buf - 1, f);
     fclose(f);
     buf[n] = 0;
-    char *mt = strstr(buf, "\"model_type\"");
-    if (!mt) return;
-    mt = strchr(mt + 12, '"');
-    if (!mt) return;
-    char *end = strchr(mt + 1, '"');
-    if (end && (size_t)(end - mt - 1) < cap) {
-        memcpy(out, mt + 1, (size_t)(end - mt - 1));
-        out[end - mt - 1] = 0;
-    }
+    (void)lmb_json_string(buf, "model_type", out, cap);
 }
 
 /* All current Colibri families publish num_hidden_layers in config.json.
@@ -490,7 +483,8 @@ static uint64_t expert_executor_ram_estimate(const char *model_dir,
                                              const char *model_type,
                                              int cache_slots) {
     uint32_t inter = 0, hidden = 0, layers = 0, topk = 0;
-    if (!model_type || !strstr(model_type, "deepseek")) return 0;
+    const LmbModelFamily *family = lmb_family_for(model_type);
+    if (!family || strcmp(family->segment_id, "deepseek_v4")) return 0;
     if (local_model_u32(model_dir, "moe_intermediate_size", &inter) ||
         local_model_u32(model_dir, "hidden_size", &hidden) ||
         local_model_layers(model_dir, &layers))
@@ -1151,16 +1145,8 @@ static int swarm_inspect(const char *tracker, const char *model, Swarm *s) {
     if (cfg) {
         memcpy(cfg, r.pay, r.pay_len);
         cfg[r.pay_len] = 0;
-        char *mt = strstr(cfg, "\"model_type\"");
-        if (mt) {
-            mt = strchr(mt + 12, '"');
-            if (mt) {
-                char *end = strchr(mt + 1, '"');
-                if (end && end - mt - 1 < (long)sizeof s->model_type)
-                    { memcpy(s->model_type, mt + 1, (size_t)(end - mt - 1));
-                      s->model_type[end - mt - 1] = 0; }
-            }
-        }
+        (void)lmb_json_string(cfg, "model_type", s->model_type,
+                              sizeof s->model_type);
         free(cfg);
     }
     lmb_msg_free(&r);
@@ -2287,10 +2273,13 @@ typedef enum { PROTO_UNKNOWN = 0, PROTO_LINE, PROTO_FRAMED, PROTO_SERVE2 } Proto
  * gateway, must apply each engine's own chat template. GLM (EK_GLM) templates
  * inside its serve and speaks the older framed dialect, so it needs neither. */
 typedef enum {
+    EK_INVALID = -1,
     EK_GLM = 0,        /* colibri monolith: framed, templates internally */
+    EK_GLM53,          /* glm53:         GLM-5.3 template, serve codec        */
     EK_DEEPSEEK,       /* deepseek_v4:  <｜User｜>…<｜Assistant｜></think>       */
     EK_OLMOE,          /* olmoe:        |||IP_ADDRESS|||<|user|>…<|assistant|> */
     EK_QWEN36,         /* qwen36:       ChatML <|im_start|>…                   */
+    EK_QWEN38,         /* qwen38:       system reasoning prompt + ChatML     */
     EK_INKLING,        /* inkling:      <|message_user|><|content_text|>…      */
     EK_KIMI            /* kimi_k3:      K3CHAT1 byte-counted wire              */
 } EngKind;
@@ -2317,20 +2306,43 @@ typedef struct {
     EngineTransport transport;
 } Engine;
 
-/* Map the resolved engine binary name to its kind. Unknown ⇒ EK_GLM, the safe
- * default: the framed dialect with no client-side templating, which is exactly
- * how lumabri behaved before per-engine templates existed. */
+static int artifact_is(const char *value, const char *name) {
+    if (!value || !name) return 0;
+    const char *base = strrchr(value, '/');
+    base = base ? base + 1 : value;
+    if (!strcmp(base, name)) return 1;
+    size_t n = strlen(name);
+    return !strncmp(base, name, n) && !strcmp(base + n, "_p2p");
+}
+
+/* Protocol and prompt-template dispatch is exact for the same reason model
+ * family dispatch is exact. Unknown is not GLM: it is an error. */
 static EngKind engine_kind_of(const char *engine) {
-    if (strstr(engine, "deepseek")) return EK_DEEPSEEK;
-    if (strstr(engine, "olmoe"))    return EK_OLMOE;
-    if (strstr(engine, "qwen"))     return EK_QWEN36;
-    if (strstr(engine, "inkling"))  return EK_INKLING;
-    if (strstr(engine, "kimi"))     return EK_KIMI;
-    return EK_GLM;
+    if (artifact_is(engine, "colibri") || !strcmp(engine ? engine : "", "glm") ||
+        !strcmp(engine ? engine : "", "glm_moe_dsa") ||
+        !strcmp(engine ? engine : "", "glm5_moe")) return EK_GLM;
+    if (artifact_is(engine, "glm53") ||
+        !strcmp(engine ? engine : "", "glm5_next") ||
+        !strcmp(engine ? engine : "", "glm5_next_text")) return EK_GLM53;
+    if (artifact_is(engine, "deepseek_v4") || artifact_is(engine, "deepseek"))
+        return EK_DEEPSEEK;
+    if (artifact_is(engine, "olmoe")) return EK_OLMOE;
+    if (artifact_is(engine, "qwen36") ||
+        !strcmp(engine ? engine : "", "qwen3_5_moe") ||
+        !strcmp(engine ? engine : "", "qwen3_5_moe_text")) return EK_QWEN36;
+    if (artifact_is(engine, "qwen38") ||
+        !strcmp(engine ? engine : "", "qwen4_exp") ||
+        !strcmp(engine ? engine : "", "qwen4_exp_text")) return EK_QWEN38;
+    if (artifact_is(engine, "inkling") ||
+        !strcmp(engine ? engine : "", "inkling_mm_model")) return EK_INKLING;
+    if (artifact_is(engine, "kimi_k3") ||
+        !strcmp(engine ? engine : "", "kimi") ||
+        !strcmp(engine ? engine : "", "kimi_linear")) return EK_KIMI;
+    return EK_INVALID;
 }
 /* The serve-codec engines: framed READY at boot, but SUBMIT/DATA/DONE turns and
  * a raw (un-templated) payload. Everything but GLM. */
-static int kind_is_serve2(EngKind k) { return k != EK_GLM; }
+static int kind_is_serve2(EngKind k) { return k != EK_INVALID && k != EK_GLM; }
 
 static char *read_until_prompt(int fd) {
     size_t cap = 8192, len = 0;
@@ -2637,10 +2649,15 @@ static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured
 #define GLM_BOS  "[gMASK]<sop>"
 #define GLM_U    "<|user|>"
 #define GLM_ASST "<|assistant|><think></think>"
+#define GLM53_ASST "<|assistant|><think>"
 /* qwen36 (qwen36.c: ChatML, no BOS). */
 #define QW_U    "<|im_start|>user\n"
-#define QW_ASST "<|im_end|>\n<|im_start|>assistant\n"
+#define QW_ASST "<|im_end|>\n<|im_start|>assistant\n<think>\n"
 #define QW_AEND "<|im_end|>\n"
+#define QW38_SYS "<|im_start|>system\nReasoning effort is set to xhigh. Please " \
+    "think carefully through the task, validate key assumptions, consider " \
+    "plausible alternatives, and prioritize correctness, consistency, and " \
+    "clarity in the final answer.<|im_end|>\n"
 /* inkling (inkling.c chat template, thinking-effort system line dropped). */
 #define INK_U    "<|message_user|><|content_text|>"
 #define INK_ASST "<|end_message|><|message_model|>"
@@ -2657,6 +2674,9 @@ static int serve2_turn(Cap *c, EngKind k, int first, const char *u, const char *
     case EK_GLM:
         if (cap_str(c, GLM_U) || cap_str(c, u) || cap_str(c, GLM_ASST)) return -1;
         return reply ? cap_str(c, reply) : 0;
+    case EK_GLM53:
+        if (cap_str(c, GLM_U) || cap_str(c, u) || cap_str(c, GLM53_ASST)) return -1;
+        return reply ? cap_str(c, reply) : 0;
     case EK_DEEPSEEK:
         if (cap_str(c, DS_USER) || cap_str(c, u) || cap_str(c, DS_ASST)) return -1;
         return reply ? cap_str(c, reply) : 0;
@@ -2665,6 +2685,9 @@ static int serve2_turn(Cap *c, EngKind k, int first, const char *u, const char *
             cap_str(c, OLMO_ASST)) return -1;
         return reply ? cap_str(c, reply) : 0;
     case EK_QWEN36:
+        if (cap_str(c, QW_U) || cap_str(c, u) || cap_str(c, QW_ASST)) return -1;
+        return reply ? (cap_str(c, reply) || cap_str(c, QW_AEND)) : 0;
+    case EK_QWEN38:
         if (cap_str(c, QW_U) || cap_str(c, u) || cap_str(c, QW_ASST)) return -1;
         return reply ? (cap_str(c, reply) || cap_str(c, QW_AEND)) : 0;
     case EK_INKLING:
@@ -2686,7 +2709,9 @@ static int serve2_turn(Cap *c, EngKind k, int first, const char *u, const char *
 /* The once-at-front SUBMIT prefix (kept out of the stored history). */
 static int serve2_prefix(Cap *c, EngKind k) {
     if (k == EK_GLM)      return cap_str(c, GLM_BOS);
+    if (k == EK_GLM53)    return cap_str(c, GLM_BOS);
     if (k == EK_DEEPSEEK) return cap_str(c, DS_BOS);
+    if (k == EK_QWEN38)   return cap_str(c, QW38_SYS);
     if (k == EK_KIMI)     return cap_str(c, "K3CHAT1\n");
     return 0;
 }
@@ -2700,9 +2725,10 @@ static int submit_serve2(Engine *e, const char *history, const char *prompt, int
     char hdr[128];
     int hn = snprintf(hdr, sizeof hdr, "SUBMIT %u 0 %zu %d 0.7 0.95\n",
                       ++id, c.len, max_new < 1 ? 1 : max_new);
-    int ok = hn >= 0 && write(e->to, hdr, (size_t)hn) >= 0 &&
-             write(e->to, c.p, c.len) >= 0 &&
-             write(e->to, "\n", 1) >= 0;                  /* payload terminator */
+    int ok = hn >= 0 && (size_t)hn < sizeof hdr &&
+             !lmb_write_full(e->to, hdr, (size_t)hn) &&
+             !lmb_write_full(e->to, c.p, c.len) &&
+             !lmb_write_full(e->to, "\n", 1);             /* payload terminator */
     free(c.p);
     return ok ? 0 : -1;
 }
@@ -2720,15 +2746,16 @@ static char *serve2_history_append(Engine *e, char *history, const char *user,
     return c.p ? c.p : calloc(1, 1);
 }
 
-/* The monolithic engine binary for the same family. "colibri" stays the
- * last resort here — unlike the Segment id, an unknown model_type used to
- * land on the monolith and sometimes worked, and refusing to launch anything
- * would be a regression for a checkpoint that runs today. The refusal that
- * matters is the Segment one, where the wrong adapter is silent corruption
- * rather than a failed open. */
+/* The monolithic engine binary for the same family. Unknown model types are
+ * refused: a generic fallback can tokenize or execute with the wrong ABI. */
 static const char *engine_for(const char *model_type) {
     const LmbModelFamily *f = lumi_family(model_type);
-    return f ? f->engine : "colibri";
+    return f ? f->engine : NULL;
+}
+
+static const char *p2p_engine_for(const char *model_type) {
+    const LmbModelFamily *f = lumi_family(model_type);
+    return f ? f->p2p_engine : NULL;
 }
 
 /* `local_dir` non-NULL: the model is already on this disk, so no shim, no
@@ -2736,7 +2763,8 @@ static const char *engine_for(const char *model_type) {
  * the model — otherwise chatting there downloads it from itself. */
 static int engine_spawn(const char *engine, const char *shim, const char *tracker,
                         const char *model, const char *local_dir,
-                        int ctx, int max_new, int cap_experts, Engine *e) {
+                        int ctx, int max_new, int cap_experts, EngKind kind,
+                        Engine *e) {
     const char *home = getenv("HOME") ? getenv("HOME") : ".";
     char vroot[1024], cache[1024], cas[1024];
     const char *vroot_env = getenv("LUMABRI_VROOT");
@@ -2751,7 +2779,7 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
     /* olmoe takes <cap> <bits>; the SERVE-mode engines take <cap> alone and
      * read the quantization out of the file — passing bits there would
      * override what the model actually is */
-    int line_proto = strstr(engine, "olmoe") != NULL;
+    int line_proto = kind == EK_OLMOE;
     char cap_s[32];
     snprintf(cap_s, sizeof cap_s, "%d", cap_experts);
 
@@ -2806,7 +2834,7 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
          * one-by-one path). The batched MoE rows travel as one multi-row
          * call per expert, which the client already speaks. An explicit
          * V4_DRAFT (0 to turn it off) still wins. */
-        if (!local_dir && strstr(engine, "deepseek")) setenv("V4_DRAFT", "8", 0);
+        if (!local_dir && kind == EK_DEEPSEEK) setenv("V4_DRAFT", "8", 0);
         /* Same split for the expert cache. A swarm chatter caches almost nothing
          * (experts run on peers), so its cap stays at the small default. But a
          * --local run holds its own experts, and there the cap IS the resident
@@ -2833,7 +2861,14 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
     e->pid = pid; e->to = in_pipe[1]; e->from = out_pipe[0];
     g_signal_engine_pid = (sig_atomic_t)pid;
     e->proto = PROTO_UNKNOWN;
-    e->kind = engine_kind_of(engine);
+    e->kind = kind;
+    if (e->kind == EK_INVALID) {
+        fprintf(stderr, "[lumabri] cannot determine protocol for engine %s\n",
+                engine);
+        close(e->to); close(e->from); kill(pid, SIGTERM); waitpid(pid, NULL, 0);
+        e->pid = 0; e->to = e->from = -1;
+        return -1;
+    }
     e->segment = 0;
     pthread_t t;
     pthread_create(&t, NULL, stderr_thread, (void *)(intptr_t)err_pipe[0]);
@@ -2898,6 +2933,11 @@ static int segment_engine_spawn(const char *engine, const char *shim,
     g_signal_engine_pid = (sig_atomic_t)pid;
     e->proto = PROTO_UNKNOWN;
     e->kind = engine_kind_of(model_type);
+    if (e->kind == EK_INVALID) {
+        close(e->to); close(e->from); kill(pid, SIGTERM); waitpid(pid, NULL, 0);
+        e->pid = 0; e->to = e->from = -1;
+        return -1;
+    }
     e->segment = 1;
     pthread_t thread;
     pthread_create(&thread, NULL, stderr_thread,
@@ -2909,7 +2949,18 @@ static int segment_engine_spawn(const char *engine, const char *shim,
 /* Why the child is gone, in the words of the kernel and of the child. */
 static void engine_diag(Engine *e, int booting) {
     int st = 0;
-    if (e->pid > 0 && waitpid(e->pid, &st, WNOHANG) == e->pid) {
+    pid_t waited = e->pid > 0 ? waitpid(e->pid, &st, WNOHANG) : -1;
+    /* EOF on the child's stdout can win the tiny race before exit status is
+     * published. Give a boot failure a bounded moment to become waitable so
+     * diagnostics do not randomly lose the engine's actual exit code. */
+    if (booting && e->pid > 0 && waited == 0) {
+        for (int i = 0; i < 20 && waited == 0; i++) {
+            struct timespec pause = {0, 10 * 1000 * 1000};
+            while (nanosleep(&pause, &pause) && errno == EINTR) { }
+            waited = waitpid(e->pid, &st, WNOHANG);
+        }
+    }
+    if (e->pid > 0 && waited == e->pid) {
         if (g_signal_engine_pid == (sig_atomic_t)e->pid)
             g_signal_engine_pid = 0;
         e->pid = 0;
@@ -2973,6 +3024,7 @@ static void engine_stop(Engine *e) {
         }
         e->to = e->from = -1;
         e->pid = 0;
+        g_signal_engine_fd = -1;
         return;
     }
     if (e->pid <= 0) return;
@@ -3030,6 +3082,8 @@ typedef struct {
     const char *engine_kind;
     uint32_t speed_milli;      /* 0 until this host has been measured */
     uint32_t max_frame;
+    uint32_t max_new;
+    uint32_t idle_seconds;
 } HostState;
 
 static int host_greet(int fd, const HostState *h, int busy) {
@@ -3039,47 +3093,142 @@ static int host_greet(int fd, const HostState *h, int busy) {
     lmb_buf_str(&b, "cpu");    /* no Segment adapter advertises a GPU yet */
     lmb_buf_u32(&b, busy ? 0u : 1u);
     lmb_buf_u32(&b, h->speed_milli);
+    lmb_buf_u32(&b, h->max_new);
+    lmb_buf_u32(&b, h->max_frame);
     int rc = lmb_send(fd, LMB_HOST_HELLO_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
 }
 
-/* Copy between the client socket and the engine until one of them ends.
- *
- * Both directions have to be watched at once. Reading the client to
- * completion first would deadlock the moment a reply is larger than a pipe
- * buffer — the engine blocks writing, the host blocks reading, and the chat
- * hangs with no error anywhere. */
-static void host_bridge(int fd, Engine *e, uint32_t max_frame) {
+typedef struct {
+    char header[512];
+    size_t header_len;
+    uint64_t payload_left;
+    int need_terminator;
+} HostInput;
+
+static int host_header(HostInput *in, Engine *e, const HostState *h) {
+    in->header[in->header_len] = 0;
+    char id[64], extra;
+    unsigned slot = 0, max_new = 0;
+    unsigned long long bytes = 0;
+    float temp = 0, top_p = 0;
+    int fields = sscanf(in->header, "SUBMIT %63s %u %llu %u %f %f %c",
+                        id, &slot, &bytes, &max_new, &temp, &top_p, &extra);
+    if (fields == 6) {
+        if (slot != 0 || bytes > h->max_frame || max_new < 1 ||
+            max_new > h->max_new || !isfinite(temp) || !isfinite(top_p) ||
+            temp < 0 || top_p <= 0 || top_p > 1) return -1;
+        if (lmb_write_full(e->to, in->header, in->header_len)) return -1;
+        in->payload_left = bytes;
+        in->need_terminator = bytes == 0;
+        in->header_len = 0;
+        return 0;
+    }
+    fields = sscanf(in->header, "CANCEL %63s %c", id, &extra);
+    if (fields == 1) {
+        int rc = lmb_write_full(e->to, in->header, in->header_len);
+        in->header_len = 0;
+        return rc;
+    }
+    fields = sscanf(in->header, "STOP %63s %c", id, &extra);
+    if (fields == 1) {
+        int rc = lmb_write_full(e->to, in->header, in->header_len);
+        in->header_len = 0;
+        return rc;
+    }
+    return -1;
+}
+
+static int host_input(HostInput *in, Engine *e, const HostState *h,
+                      const uint8_t *data, size_t bytes) {
+    size_t at = 0;
+    while (at < bytes) {
+        if (in->payload_left) {
+            size_t take = bytes - at;
+            if ((uint64_t)take > in->payload_left)
+                take = (size_t)in->payload_left;
+            if (lmb_write_full(e->to, data + at, take)) return -1;
+            at += take;
+            in->payload_left -= take;
+            if (!in->payload_left) in->need_terminator = 1;
+            continue;
+        }
+        if (in->need_terminator) {
+            if (data[at++] != '\n' || lmb_write_full(e->to, "\n", 1))
+                return -1;
+            in->need_terminator = 0;
+            continue;
+        }
+        const uint8_t *nl = memchr(data + at, '\n', bytes - at);
+        size_t take = nl ? (size_t)(nl - (data + at)) + 1 : bytes - at;
+        if (take > sizeof in->header - 1 - in->header_len) return -1;
+        memcpy(in->header + in->header_len, data + at, take);
+        in->header_len += take;
+        at += take;
+        if (nl && host_header(in, e, h)) return -1;
+    }
+    return 0;
+}
+
+/* Both directions remain inside LMB_HOST_STREAM frames (authenticated and
+ * encrypted whenever the transport's strict mode is enabled). */
+static void host_bridge(int fd, Engine *e, const HostState *h) {
     char buf[16384];
-    uint64_t from_client = 0;
+    HostInput input = {0};
+    double last_input = nowd();
     for (;;) {
         struct pollfd p[2] = { { fd, POLLIN, 0 }, { e->from, POLLIN, 0 } };
         int n = poll(p, 2, 1000);
         if (g_stopping) return;
         if (n < 0) { if (errno == EINTR) continue; return; }
+        if (!n && h->idle_seconds && nowd() - last_input > h->idle_seconds) {
+            fprintf(stderr, "[host] idle session expired\n");
+            return;
+        }
         if (p[0].revents & POLLIN) {
-            ssize_t got = read(fd, buf, sizeof buf);
-            if (got <= 0) return;                 /* client left: session over */
-            /* A prompt is text, and text has a size. Without a cap a client
-             * can make the host allocate its context on demand, which is a
-             * denial of service dressed as a long question. */
-            from_client += (uint64_t)got;
-            if (max_frame && from_client > max_frame) {
-                fprintf(stderr, "[host] client sent more than %u bytes in one "
-                        "turn; closing\n", max_frame);
+            LmbMsg m = {0};
+            if (lmb_recv(fd, &m) || m.op != LMB_HOST_STREAM || m.body_len ||
+                !m.pay_len || host_input(&input, e, h, m.pay, m.pay_len)) {
+                lmb_msg_free(&m);
+                fprintf(stderr, "[host] invalid or oversized client frame\n");
                 return;
             }
-            if (write(e->to, buf, (size_t)got) != got) return;
-            if (memchr(buf, '\n', (size_t)got)) from_client = 0;
+            last_input = nowd();
+            lmb_msg_free(&m);
         }
         if (p[1].revents & POLLIN) {
             ssize_t got = read(e->from, buf, sizeof buf);
             if (got <= 0) return;                 /* engine died: so does this */
-            if (write(fd, buf, (size_t)got) != got) return;
+            if (lmb_send(fd, LMB_HOST_STREAM, NULL, 0, buf, (uint32_t)got))
+                return;
         }
         if ((p[0].revents | p[1].revents) & (POLLERR | POLLHUP)) return;
     }
+}
+
+typedef struct {
+    int lfd;
+    const HostState *host;
+    _Atomic int stop;
+} BusyAcceptor;
+
+static void *host_busy_acceptor(void *arg) {
+    BusyAcceptor *a = (BusyAcceptor *)arg;
+    while (!atomic_load(&a->stop) && !g_stopping) {
+        struct pollfd p = { a->lfd, POLLIN, 0 };
+        int n = poll(&p, 1, 100);
+        if (n <= 0) continue;
+        int fd = accept(a->lfd, NULL, NULL);
+        if (fd < 0) continue;
+        LmbMsg m = {0};
+        if (!lmb_secure_server(fd) && !lmb_recv(fd, &m) &&
+            m.op == LMB_HOST_HELLO)
+            (void)host_greet(fd, a->host, 1);
+        lmb_msg_free(&m);
+        lmb_close(fd);
+    }
+    return NULL;
 }
 
 static int cmd_host(int argc, char **argv) {
@@ -3087,6 +3236,7 @@ static int cmd_host(int argc, char **argv) {
     const char *engines_dir = NULL, *engine_path = NULL;
     int port = 7350, ctx = 2048, max_new = 256, cap_experts = 64;
     uint32_t max_frame = 1u << 20;
+    uint32_t idle_seconds = 300;
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "--port") && i + 1 < argc) port = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--tracker") && i + 1 < argc) tracker = argv[++i];
@@ -3098,16 +3248,23 @@ static int cmd_host(int argc, char **argv) {
         else if (!strcmp(argv[i], "--max-new") && i + 1 < argc) max_new = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--max-frame") && i + 1 < argc)
             max_frame = (uint32_t)atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--idle-seconds") && i + 1 < argc)
+            idle_seconds = (uint32_t)atoi(argv[++i]);
         else {
             fprintf(stderr, "usage: lumabri host --model NAME [--port N] "
                             "[--tracker H:P] [--local DIR]\n"
                             "                   [--ctx N] [--max-new N] "
-                            "[--max-frame BYTES]\n");
+                            "[--max-frame BYTES] [--idle-seconds N]\n");
             return 2;
         }
     }
     if (!want_model && !local_dir) {
         fprintf(stderr, "lumabri host needs --model NAME or --local DIR\n");
+        return 2;
+    }
+    if (max_new < 1 || max_new > (1 << 20) || max_frame < 1 ||
+        max_frame > LMB_MAX_PAY || idle_seconds < 1) {
+        fprintf(stderr, "invalid host limit\n");
         return 2;
     }
     char dir[1024], shim[1200];
@@ -3127,7 +3284,10 @@ static int cmd_host(int argc, char **argv) {
     char mtype[64] = "";
     if (local_dir) local_model_type(local_dir, mtype, sizeof mtype);
     else snprintf(mtype, sizeof mtype, "%s", sw.model_type);
-    HostState h = { &eng, mtype, engine_for(mtype), 0, max_frame };
+    const char *host_engine = engine_for(mtype);
+    if (!host_engine) { engine_stop(&eng); return 1; }
+    HostState h = { &eng, mtype, host_engine, 0, max_frame,
+                    (uint32_t)max_new, idle_seconds };
 
     int lfd = lmb_listen(port);
     if (lfd < 0) {
@@ -3139,8 +3299,8 @@ static int cmd_host(int argc, char **argv) {
            C_DIM, port, mtype[0] ? mtype : "?", C_R);
     printf("  %sclients need no checkpoint; this machine holds the model and "
            "sees the text of every conversation%s\n", C_DIM, C_R);
+    fflush(stdout);
 
-    int serving = 0;
     while (!g_stopping) {
         struct pollfd lp = { lfd, POLLIN, 0 };
         int r = poll(&lp, 1, 500);
@@ -3150,20 +3310,18 @@ static int cmd_host(int argc, char **argv) {
         LmbMsg m = {0};
         if (lmb_secure_server(fd) || lmb_recv(fd, &m) ||
             m.op != LMB_HOST_HELLO) {
-            lmb_msg_free(&m); close(fd); continue;
+            lmb_msg_free(&m); lmb_close(fd); continue;
         }
         lmb_msg_free(&m);
-        if (serving) {
-            /* Busy is an answer, not a wait. */
-            (void)host_greet(fd, &h, 1);
-            close(fd);
-            continue;
-        }
-        if (host_greet(fd, &h, 0)) { close(fd); continue; }
-        serving = 1;
-        host_bridge(fd, &eng, max_frame);
-        close(fd);
-        serving = 0;
+        if (host_greet(fd, &h, 0)) { lmb_close(fd); continue; }
+        BusyAcceptor busy = { lfd, &h, 0 };
+        pthread_t busy_thread;
+        int watching = pthread_create(&busy_thread, NULL,
+                                      host_busy_acceptor, &busy) == 0;
+        host_bridge(fd, &eng, &h);
+        atomic_store(&busy.stop, 1);
+        if (watching) pthread_join(busy_thread, NULL);
+        lmb_close(fd);
         /* Between two clients the engine keeps the previous conversation in
          * its KV, so the next client would continue somebody else's chat.
          * Restart it: with one session there is nothing cheaper that is also
@@ -3197,7 +3355,44 @@ static int cmd_host(int argc, char **argv) {
  * SUBMIT payload themselves, so a hosted chatter needs zero bytes of the
  * checkpoint. That is the promise, and it is only kept by not calling
  * model_boot at all. */
-static int host_connect(const char *addr, const char *model_type, Engine *e) {
+typedef struct { int local_fd, network_fd; } HostPump;
+
+static void *host_client_pump(void *arg) {
+    HostPump *pump = (HostPump *)arg;
+    char bytes[16384];
+    for (;;) {
+        struct pollfd p[2] = {
+            { pump->local_fd, POLLIN, 0 }, { pump->network_fd, POLLIN, 0 }
+        };
+        int n = poll(p, 2, 1000);
+        if (n < 0) { if (errno == EINTR) continue; break; }
+        if (!n) continue;
+        if (p[0].revents & POLLIN) {
+            ssize_t got = read(pump->local_fd, bytes, sizeof bytes);
+            if (got <= 0 || lmb_send(pump->network_fd, LMB_HOST_STREAM,
+                                     NULL, 0, bytes, (uint32_t)got)) break;
+        }
+        if (p[1].revents & POLLIN) {
+            LmbMsg m = {0};
+            if (lmb_recv(pump->network_fd, &m) ||
+                m.op != LMB_HOST_STREAM || m.body_len || !m.pay_len ||
+                lmb_write_full(pump->local_fd, m.pay, m.pay_len)) {
+                lmb_msg_free(&m);
+                break;
+            }
+            lmb_msg_free(&m);
+        }
+        if ((p[0].revents | p[1].revents) & (POLLERR | POLLHUP)) break;
+    }
+    shutdown(pump->local_fd, SHUT_RDWR);
+    close(pump->local_fd);
+    lmb_close(pump->network_fd);
+    free(pump);
+    return NULL;
+}
+
+static int host_connect(const char *addr, const char *model_type, Engine *e,
+                        int *requested_max_new) {
     memset(e, 0, sizeof *e);
     e->to = e->from = -1;
     e->pid = 0;
@@ -3216,30 +3411,64 @@ static int host_connect(const char *addr, const char *model_type, Engine *e) {
         fprintf(stderr, "[lumabri] %s did not answer as an inference host\n",
                 addr);
         lmb_msg_free(&m);
-        close(fd);
+        lmb_close(fd);
         return -1;
     }
     LmbCur c = { m.body, m.body_len, 0 };
     char kind[64] = "", mtype[64] = "", backend[32] = "";
     uint32_t sessions_free = 0, speed_milli = 0;
+    uint32_t host_max_new = 0, host_max_frame = 0;
     if (lmb_cur_str(&c, mtype, sizeof mtype) ||
         lmb_cur_str(&c, kind, sizeof kind) ||
         lmb_cur_str(&c, backend, sizeof backend) ||
         lmb_cur_u32(&c, &sessions_free) || lmb_cur_u32(&c, &speed_milli)) {
         fprintf(stderr, "[lumabri] %s sent a greeting this build cannot read\n",
                 addr);
-        lmb_msg_free(&m); close(fd); return -1;
+        lmb_msg_free(&m); lmb_close(fd); return -1;
+    }
+    if (c.off < c.len &&
+        (lmb_cur_u32(&c, &host_max_new) || lmb_cur_u32(&c, &host_max_frame))) {
+        fprintf(stderr, "[lumabri] %s sent invalid host limits\n", addr);
+        lmb_msg_free(&m); lmb_close(fd); return -1;
     }
     lmb_msg_free(&m);
     if (model_type && model_type[0] && strcmp(model_type, mtype)) {
         fprintf(stderr, "[lumabri] %s serves %s, not %s\n", addr, mtype,
                 model_type);
-        close(fd); return -1;
+        lmb_close(fd); return -1;
     }
-    e->to = e->from = fd;
-    e->kind = engine_kind_of(kind);
+    if (!sessions_free) {
+        fprintf(stderr, "[lumabri] host %s is busy (0 sessions free)\n", addr);
+        lmb_close(fd); return -1;
+    }
+    if (host_max_new && requested_max_new && *requested_max_new > (int)host_max_new) {
+        printf("  %shost limit: max-new reduced from %d to %u%s\n", C_DIM,
+               *requested_max_new, host_max_new, C_R);
+        *requested_max_new = (int)host_max_new;
+    }
+    (void)host_max_frame;
+    EngKind kind_id = engine_kind_of(kind);
+    if (kind_id == EK_INVALID) {
+        fprintf(stderr, "[lumabri] host %s announced unknown engine %s\n",
+                addr, kind);
+        lmb_close(fd); return -1;
+    }
+    int pair[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair)) {
+        lmb_close(fd); return -1;
+    }
+    HostPump *pump = calloc(1, sizeof *pump);
+    if (!pump) { close(pair[0]); close(pair[1]); lmb_close(fd); return -1; }
+    pump->local_fd = pair[1]; pump->network_fd = fd;
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, host_client_pump, pump)) {
+        free(pump); close(pair[0]); close(pair[1]); lmb_close(fd); return -1;
+    }
+    pthread_detach(thread);
+    e->to = e->from = pair[0];
+    e->kind = kind_id;
     e->proto = kind_is_serve2(e->kind) ? PROTO_SERVE2 : PROTO_FRAMED;
-    g_signal_engine_fd = (sig_atomic_t)fd;
+    g_signal_engine_fd = (sig_atomic_t)pair[0];
 
     printf("  %shost %s · %s · %s%s\n", C_DIM, addr, mtype,
            backend[0] ? backend : "cpu", C_R);
@@ -3267,17 +3496,23 @@ static int resolve_engine(const char *engines_dir, const char *engine_path,
         if (checked_printf(out, cap, "%s", engine_path)) return -1;
         return access(out, X_OK);
     }
-    const char *eng = engine_for(model_type);
+    const LmbModelFamily *family = lumi_family(model_type);
+    const char *eng = family ? family->engine : NULL;
+    if (!eng) { if (cap) out[0] = 0; return -1; }
     const char *dir = engines_dir ? engines_dir : "../moe-stream/c";
     /* prefer the P2P build when one exists: it is the same engine (identical
      * without expert peers) plus the ability to run the routed experts on
      * the swarm when the tracker offers executors */
     char me[1200];
     exe_dir(me, sizeof me);
-    if (checked_printf(out, cap, "%s/%s_p2p", dir, eng)) return -1;
-    if (access(out, X_OK) == 0) return 0;
-    if (checked_printf(out, cap, "%s/%s_p2p", me, eng)) return -1;
-    if (access(out, X_OK) == 0) return 0;
+    if (family->p2p_engine) {
+        if (checked_printf(out, cap, "%s/%s_p2p", dir,
+                           family->p2p_engine)) return -1;
+        if (access(out, X_OK) == 0) return 0;
+        if (checked_printf(out, cap, "%s/%s_p2p", me,
+                           family->p2p_engine)) return -1;
+        if (access(out, X_OK) == 0) return 0;
+    }
     if (checked_printf(out, cap, "%s/%s", dir, eng)) return -1;
     return access(out, X_OK);
 }
@@ -4320,7 +4555,8 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
         local_model_type(local_dir, mtype, sizeof mtype);
         printf("  %smodello locale %s%s%s%s · niente rete, niente mirror%s\n",
                C_DIM, C_R, C_BOLD, local_dir, C_DIM, C_R);
-        if (strstr(mtype, "kimi"))
+        const LmbModelFamily *family = lmb_family_for(mtype);
+        if (family && !strcmp(family->segment_id, "kimi"))
             kimi_tokenizer_selfheal(local_dir, engines_dir);
     } else {
         printf("  %schiedo allo sciame chi ha %s…%s\n", C_DIM, model, C_R);
@@ -4397,6 +4633,13 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
         }
     }
 
+    const char *expected_engine = engine_for(mtype);
+    EngKind expected_kind = engine_kind_of(expected_engine);
+    if (!expected_engine || expected_kind == EK_INVALID) {
+        printf("  %sunsupported model_type: %s%s\n", C_RED,
+               mtype[0] ? mtype : "(missing)", C_R);
+        return -1;
+    }
     char engine[1200];
     if (resolve_engine(engines_dir, engine_path, mtype, engine, sizeof engine)) {
         printf("  %sengine not found: %s%s\n"
@@ -4427,14 +4670,15 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
                    "scarichera' invece di farli eseguire%s\n"
                    "  %sci sono %d peer pronti a eseguirli. Serve %s_p2p, che "
                    "si costruisce con:  make chatters ENGINE=/path/to/colibri/c%s\n\n",
-                   C_RED, C_R, C_DIM, nexec, engine_for(mtype), C_R);
+                   C_RED, C_R, C_DIM, nexec,
+                   p2p_engine_for(mtype) ? p2p_engine_for(mtype) : "(none)", C_R);
     }
     if (!local_dir)
         printf("  %sora scarico la parte densa una volta sola — gli esperti "
                "restano sullo sciame%s\n", C_DIM, C_R);
 
     if (engine_spawn(engine, shim, tracker, model, local_dir,
-                     ctx, max_new, cap_experts, e)) return -1;
+                     ctx, max_new, cap_experts, expected_kind, e)) return -1;
 
     g_eng.booting = 1;
     g_eng.last_out = nowd();
@@ -4596,7 +4840,7 @@ static int cmd_chat(int argc, char **argv) {
     snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
     if (access(shim, R_OK))       /* installed layout: bin/../lib/lumabri/ */
         snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
-    if (!local_dir && access(shim, R_OK)) {
+    if (!host_addr && !local_dir && access(shim, R_OK)) {
         fprintf(stderr, "liblumabri.so missing; run make (or make install)\n");
         return 1;
     }
@@ -4672,7 +4916,7 @@ static int cmd_chat(int argc, char **argv) {
      * and the only way to actually mean it. */
     if (host_addr) {
         memset(&sw, 0, sizeof sw);
-        if (host_connect(host_addr, NULL, &eng)) return 1;
+        if (host_connect(host_addr, NULL, &eng, &max_new)) return 1;
     } else if (model_boot(tracker, model, shim, engines_dir, engine_path,
                           local_dir, ctx, max_new, cap_experts, &eng, &sw))
         return 1;
@@ -4758,11 +5002,11 @@ static int cmd_chat(int argc, char **argv) {
             /* framed dialect: reset is a control byte, everything else is the
              * prompt line as-is */
             const char *send = is_reset ? "\x02RESET" : line;
-            if (write(eng.to, send, strlen(send)) < 0) break;
-            if (write(eng.to, "\n", 1) < 0) break;
+            if (lmb_write_full(eng.to, send, strlen(send))) break;
+            if (lmb_write_full(eng.to, "\n", 1)) break;
         } else {
             line[L] = '\n';
-            if (write(eng.to, line, L + 1) < 0) break;
+            if (lmb_write_full(eng.to, line, L + 1)) break;
             line[L] = 0;
             if (is_reset) {
                 printf("  %s\xe2\x9c\xa6 nuova conversazione%s\n", C_DIM, C_R);
@@ -5003,7 +5247,38 @@ typedef struct {
     char dir[512];
     char name[64];
     LmbModelShape shape;
+    int has_weights;
 } CatalogEntry;
+
+static int catalog_has_weights(const char *root, unsigned depth) {
+    if (depth > 3) return 0;
+    DIR *d = opendir(root);
+    if (!d) return 0;
+    int found = 0;
+    struct dirent *e;
+    while (!found && (e = readdir(d))) {
+        if (e->d_name[0] == '.') continue;
+        char path[1024];
+        int n = snprintf(path, sizeof path, "%s/%s", root, e->d_name);
+        if (n < 0 || (size_t)n >= sizeof path) continue;
+        struct stat st;
+        if (stat(path, &st)) continue;
+        if (S_ISDIR(st.st_mode)) {
+            found = catalog_has_weights(path, depth + 1);
+            continue;
+        }
+        /* A config-side metadata stub is not a weight container. Four KiB is
+         * still only a presence check—the adapter validates the real format
+         * before READY—but it rejects empty and token-sized placeholders. */
+        if (!S_ISREG(st.st_mode) || st.st_size < 4096) continue;
+        const char *dot = strrchr(e->d_name, '.');
+        if (dot && (!strcmp(dot, ".safetensors") || !strcmp(dot, ".bin") ||
+                    !strcmp(dot, ".gguf") || !strcmp(dot, ".coli")))
+            found = 1;
+    }
+    closedir(d);
+    return found;
+}
 
 static int catalog_scan(const char *root, CatalogEntry *out, int cap) {
     DIR *d = opendir(root);
@@ -5020,6 +5295,7 @@ static int catalog_scan(const char *root, CatalogEntry *out, int cap) {
         if (lmb_shape_from_config(path, &out[n].shape)) continue;
         snprintf(out[n].dir, sizeof out[n].dir, "%.511s", path);
         snprintf(out[n].name, sizeof out[n].name, "%.63s", e->d_name);
+        out[n].has_weights = catalog_has_weights(path, 0);
         n++;
     }
     closedir(d);
@@ -5041,20 +5317,55 @@ static void catalog_self(LmbClusterNode *n, const char *disk) {
     n->disk_read_bps = p.disk_read_bps;
     n->gpu_backends = p.gpu_backends;
     n->threads = p.logical_cpus;
-    n->has_checkpoint = 1;
+    n->has_checkpoint = 0;      /* set per catalogue entry, never globally */
+}
+
+static int catalog_state_refresh(LmbTuiState *st, void *unused) {
+    (void)unused;
+    CatalogEntry found[LMB_TUI_MAX_MODELS];
+    int n = catalog_scan(st->root, found, LMB_TUI_MAX_MODELS);
+    st->nmodels = 0;
+    catalog_self(&st->nodes[0], st->disk[0] ? st->disk : ".");
+    st->nnodes = 1;
+    for (int i = 0; i < n; i++) {
+        LmbTuiModel *m = &st->models[st->nmodels];
+        memset(m, 0, sizeof *m);
+        snprintf(m->name, sizeof m->name, "%.63s", found[i].name);
+        snprintf(m->dir, sizeof m->dir, "%.511s", found[i].dir);
+        m->shape = found[i].shape;
+        st->nodes[0].has_checkpoint = found[i].has_weights;
+        m->planned = !lmb_plan_cluster(&m->shape, st->nodes, st->nnodes,
+                                       st->context, st->sessions,
+                                       LMB_GOAL_ONE_SESSION, &m->plan);
+        /* A calibration store is not implemented yet. Never manufacture a
+         * partial key in the renderer: no record means no speed. */
+        m->calibration = NULL;
+        st->nmodels++;
+    }
+    return 0;
 }
 
 static void catalog_row(const CatalogEntry *m, const LmbClusterNode *nodes,
                         uint32_t nn, uint32_t context, uint32_t sessions) {
+    LmbClusterNode actual[LMB_CLUSTER_MAX_NODES];
+    if (nn > LMB_CLUSTER_MAX_NODES) nn = LMB_CLUSTER_MAX_NODES;
+    memcpy(actual, nodes, (size_t)nn * sizeof *actual);
+    /* The current local catalogue has one complete-checkpoint source. The
+     * distributed CAS inventory will replace this boolean at step 2. */
+    if (nn) actual[0].has_checkpoint = m->has_weights;
     LmbClusterPlan plan;
-    int ok = !lmb_plan_cluster(&m->shape, nodes, nn, context, sessions,
+    int ok = !lmb_plan_cluster(&m->shape, actual, nn, context, sessions,
                                LMB_GOAL_ONE_SESSION, &plan);
-    const char *state = !ok ? "not runnable"
+    const char *state = !ok ? "cannot plan"
                             : lmb_plan_state_name(plan.state);
     const char *mark = !ok || plan.state == LMB_PLAN_UNRUNNABLE ? "x"
                      : plan.state == LMB_PLAN_DISK ? "!" : "+";
     char detail[96] = "";
-    if (ok && plan.state == LMB_PLAN_UNRUNNABLE && plan.missing_bytes)
+    if (!m->shape.sizing_verified)
+        snprintf(detail, sizeof detail, "adapter sizing unavailable");
+    else if (!m->has_weights)
+        snprintf(detail, sizeof detail, "checkpoint weights missing");
+    else if (ok && plan.state == LMB_PLAN_UNRUNNABLE && plan.missing_bytes)
         snprintf(detail, sizeof detail, "%.0f GB short (~%u more machine%s)",
                  (double)plan.missing_bytes / 1e9, plan.missing_nodes,
                  plan.missing_nodes == 1 ? "" : "s");
@@ -5072,6 +5383,53 @@ static void catalog_row(const CatalogEntry *m, const LmbClusterNode *nodes,
            mark, C_R, m->name, state, detail, "not calibrated");
 }
 
+static void json_string(FILE *out, const char *s) {
+    fputc('"', out);
+    for (const unsigned char *p = (const unsigned char *)(s ? s : ""); *p; p++) {
+        if (*p == '"' || *p == '\\') fprintf(out, "\\%c", *p);
+        else if (*p == '\n') fputs("\\n", out);
+        else if (*p == '\r') fputs("\\r", out);
+        else if (*p == '\t') fputs("\\t", out);
+        else if (*p < 0x20) fprintf(out, "\\u%04x", *p);
+        else fputc(*p, out);
+    }
+    fputc('"', out);
+}
+
+static void catalog_json(const CatalogEntry *models, int n,
+                         const LmbClusterNode *self, uint32_t context,
+                         uint32_t sessions) {
+    fputs("{\"schema\":\"lumabri.models.v1\",\"nodes\":[{\"name\":", stdout);
+    json_string(stdout, self->name);
+    printf(",\"ram_budget_bytes\":%llu,\"vram_inventory_bytes\":%llu,"
+           "\"threads\":%u}],\"models\":[",
+           (unsigned long long)self->ram_budget_bytes,
+           (unsigned long long)self->vram_budget_bytes, self->threads);
+    for (int i = 0; i < n; i++) {
+        LmbClusterNode node = *self;
+        node.has_checkpoint = models[i].has_weights;
+        LmbClusterPlan plan;
+        int planned = !lmb_plan_cluster(&models[i].shape, &node, 1, context,
+                                        sessions, LMB_GOAL_ONE_SESSION, &plan);
+        if (i) fputc(',', stdout);
+        fputs("{\"name\":", stdout); json_string(stdout, models[i].name);
+        fputs(",\"model_type\":", stdout);
+        json_string(stdout, models[i].shape.model_type);
+        fputs(",\"adapter\":", stdout);
+        json_string(stdout, models[i].shape.segment_id);
+        printf(",\"sizing_verified\":%s,\"weights_present\":%s,"
+               "\"planned\":%s,\"state\":",
+               models[i].shape.sizing_verified ? "true" : "false",
+               models[i].has_weights ? "true" : "false",
+               planned ? "true" : "false");
+        json_string(stdout, planned ? lmb_plan_state_name(plan.state) :
+                                     "cannot plan");
+        printf(",\"missing_bytes\":%llu,\"calibration\":null}",
+               (unsigned long long)(planned ? plan.missing_bytes : 0));
+    }
+    fputs("]}\n", stdout);
+}
+
 static int models_screen(const char *root, const char *disk, uint32_t context,
                          uint32_t sessions, int snapshot, const char *keys);
 
@@ -5081,7 +5439,7 @@ static int cmd_models(int argc, char **argv) {
     /* The screen is the default and the listing is the fallback, not the
      * other way round: a plain list is what you want in a pipe or a log, and
      * a pipe is exactly where a full-screen interface is useless. */
-    int plain = !isatty(STDOUT_FILENO), snapshot = 0;
+    int plain = !isatty(STDOUT_FILENO), snapshot = 0, json = 0;
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "--models-dir") && i + 1 < argc) root = argv[++i];
         else if (!strcmp(argv[i], "--disk") && i + 1 < argc) disk = argv[++i];
@@ -5090,12 +5448,13 @@ static int cmd_models(int argc, char **argv) {
         else if (!strcmp(argv[i], "--sessions") && i + 1 < argc)
             sessions = (uint32_t)atoi(argv[++i]);
         else if (!strcmp(argv[i], "--plain")) plain = 1;
+        else if (!strcmp(argv[i], "--json")) { json = 1; plain = 1; }
         else if (!strcmp(argv[i], "--snapshot")) { snapshot = 1; plain = 0; }
         else if (!strcmp(argv[i], "--keys") && i + 1 < argc) keys = argv[++i];
         else {
             fprintf(stderr, "usage: lumabri models [--models-dir DIR] "
                             "[--disk PATH] [--context N] [--sessions N]\n"
-                            "                      [--plain] [--snapshot] "
+                            "                      [--plain|--json] [--snapshot] "
                             "[--keys SEQUENCE]\n");
             return 2;
         }
@@ -5113,7 +5472,9 @@ static int cmd_models(int argc, char **argv) {
     LmbClusterNode self;
     catalog_self(&self, disk);
 
-    printf("%s%sLUMABRI · what these computers can run%s\n\n", C_BOLD, C_CORAL, C_R);
+    if (json) { catalog_json(models, n, &self, context, sessions); return 0; }
+
+    printf("%s%sLUMABRI · local planning preview%s\n\n", C_BOLD, C_CORAL, C_R);
     printf("  %s1 computer · %.0f GB usable RAM · engine %s%s\n", C_DIM,
            (double)self.ram_budget_bytes / 1e9,
            self.gpu_backends ? "can use a GPU" : "CPU only", C_R);
@@ -5146,23 +5507,9 @@ static int models_screen(const char *root, const char *disk, uint32_t context,
     st.context = context;
     st.sessions = sessions;
     snprintf(st.root, sizeof st.root, "%.511s", root);
-
-    catalog_self(&st.nodes[0], disk);
-    st.nnodes = 1;
-
-    CatalogEntry found[LMB_TUI_MAX_MODELS];
-    int n = catalog_scan(root, found, LMB_TUI_MAX_MODELS);
-    for (int i = 0; i < n; i++) {
-        LmbTuiModel *m = &st.models[st.nmodels];
-        snprintf(m->name, sizeof m->name, "%.63s", found[i].name);
-        snprintf(m->dir, sizeof m->dir, "%.511s", found[i].dir);
-        m->shape = found[i].shape;
-        m->planned = !lmb_plan_cluster(&m->shape, st.nodes, st.nnodes,
-                                       context, sessions,
-                                       LMB_GOAL_ONE_SESSION, &m->plan);
-        m->calibration = NULL;        /* nothing measured yet, and it shows */
-        st.nmodels++;
-    }
+    snprintf(st.disk, sizeof st.disk, "%.511s", disk);
+    st.refresh = catalog_state_refresh;
+    catalog_state_refresh(&st, NULL);
     if (!st.nmodels) {
         printf("no checkpoints under %s\n", root);
         printf("put a model directory there, or pass --models-dir\n");
@@ -5446,11 +5793,8 @@ int main(int argc, char **argv) {
     if (argc >= 2 && !strcmp(argv[1], "key")) return cmd_key(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "peer-key"))
         return cmd_peer_key(argc - 2, argv + 2);
-    if (argc >= 2 && !strcmp(argv[1], "host")) return cmd_host(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "models"))
         return cmd_models(argc - 2, argv + 2);
-    if (argc >= 2 && (!strcmp(argv[1], "machine") || !strcmp(argv[1], "status")))
-        return cmd_machine(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "limits"))
         return cmd_limits(argc - 2, argv + 2);
     if (argc >= 2 && !strcmp(argv[1], "pause"))
@@ -5458,6 +5802,10 @@ int main(int argc, char **argv) {
     if (argc >= 2 && !strcmp(argv[1], "resume"))
         return cmd_governor_manual(argc - 2, argv + 2, 0);
     if (lmb_secure_init()) return 1; /* children inherit the same strict mode */
+    if (argc >= 2 && !strcmp(argv[1], "host"))
+        return cmd_host(argc - 2, argv + 2);
+    if (argc >= 2 && (!strcmp(argv[1], "machine") || !strcmp(argv[1], "status")))
+        return cmd_machine(argc - 2, argv + 2);
     const char *tok = getenv("LUMABRI_TOKEN");
     if (tok && strlen(tok) > LMB_TOKEN_MAX) {
         fprintf(stderr, "LUMABRI_TOKEN must be at most %u bytes\n",

--- a/lumabri_calibration.h
+++ b/lumabri_calibration.h
@@ -33,9 +33,13 @@ typedef struct {
     char commit_lumabri[41];
     char commit_colibri[41];
     char build_id[65];          /* compiler, flags, engine configuration */
-    char backend[16];           /* the one actually in use, not the one fitted */
+    char plan_kind[16];         /* segment or expert */
+    uint32_t goal;              /* LmbPlanGoal without including cluster.h */
     uint32_t nodes;
     char node_id[LMB_CAL_NODES_MAX][64];
+    char node_hardware_id[LMB_CAL_NODES_MAX][65];
+    char node_build_id[LMB_CAL_NODES_MAX][65];
+    char node_backend[LMB_CAL_NODES_MAX][16];
     uint32_t layer_begin[LMB_CAL_NODES_MAX];
     uint32_t layer_end[LMB_CAL_NODES_MAX];
     uint32_t threads[LMB_CAL_NODES_MAX];
@@ -64,12 +68,21 @@ static LMB_UNUSED const char *lmb_cal_mismatch(const LmbCalKey *a,
     if (strcmp(a->commit_lumabri, b->commit_lumabri)) return "the Lumabri build";
     if (strcmp(a->commit_colibri, b->commit_colibri)) return "the Colibri build";
     if (strcmp(a->build_id, b->build_id))           return "the compiler flags";
-    if (strcmp(a->backend, b->backend))             return "the backend";
+    if (strcmp(a->plan_kind, b->plan_kind))         return "the execution plan";
+    if (a->goal != b->goal)                         return "the planning goal";
     if (a->context != b->context)                   return "the context length";
     if (a->sessions != b->sessions)                 return "the session count";
     if (a->nodes != b->nodes)                       return "the number of machines";
-    for (uint32_t i = 0; i < a->nodes && i < LMB_CAL_NODES_MAX; i++) {
+    if (a->nodes > LMB_CAL_NODES_MAX || b->nodes > LMB_CAL_NODES_MAX)
+        return "an invalid machine count";
+    for (uint32_t i = 0; i < a->nodes; i++) {
         if (strcmp(a->node_id[i], b->node_id[i]))   return "which machines";
+        if (strcmp(a->node_hardware_id[i], b->node_hardware_id[i]))
+            return "the machine hardware";
+        if (strcmp(a->node_build_id[i], b->node_build_id[i]))
+            return "a node build";
+        if (strcmp(a->node_backend[i], b->node_backend[i]))
+            return "a node backend";
         if (a->layer_begin[i] != b->layer_begin[i] ||
             a->layer_end[i] != b->layer_end[i])     return "the assigned ranges";
         if (a->threads[i] != b->threads[i])         return "the thread counts";
@@ -110,11 +123,15 @@ static LMB_UNUSED void lmb_cal_build_id(char *out, size_t cap,
      * to differ when a profile does. */
     uint64_t h = 1469598103934665603ull;
     const char *parts[2] = { cc ? cc : "", cflags ? cflags : "" };
-    for (int p = 0; p < 2; p++)
+    for (int p = 0; p < 2; p++) {
         for (const char *c = parts[p]; *c; c++) {
             h ^= (unsigned char)*c;
             h *= 1099511628211ull;
         }
+        /* Separate ("ab", "c") from ("a", "bc"). */
+        h ^= 0xffu;
+        h *= 1099511628211ull;
+    }
     snprintf(out, cap, "%016llx", (unsigned long long)h);
 }
 

--- a/lumabri_cluster.h
+++ b/lumabri_cluster.h
@@ -11,13 +11,12 @@
  * knows what fits; only a calibration knows what it does, and the two must
  * never be printed in the same voice.
  *
- * The placement has two objectives and they pull apart, so the caller says
- * which one it wants. One session is a chain: the layers are sequential, so
- * what matters is the SUM of the stages plus the hops between them, and
- * fewer machines can be better because every boundary is another hop. Many
- * sessions are a pipeline: different chats occupy different stages at once,
- * so what matters is the SLOWEST stage. Optimising one while reporting the
- * other is how a plan looks good and feels wrong. */
+ * The final placement has two objectives and they pull apart: one serial
+ * session minimises the SUM of stages and hops, while concurrent sessions
+ * minimise the SLOWEST pipeline stage. This preliminary planner records the
+ * requested goal but has no calibrated stage times yet; it therefore makes a
+ * memory-feasible proportional split and never claims that split is a speed
+ * optimum. Calibration is the prerequisite for performance placement. */
 #ifndef LUMABRI_CLUSTER_H
 #define LUMABRI_CLUSTER_H
 
@@ -30,11 +29,11 @@ typedef struct {
     char name[64];
     char addr[64];
     uint64_t ram_budget_bytes;   /* what this machine offers, reserve removed */
-    uint64_t vram_budget_bytes;
+    uint64_t vram_budget_bytes;  /* inventory only; never fungible with RAM */
     uint64_t disk_read_bps;      /* 0 = unmeasured: disk mode cannot be judged */
     uint64_t lan_bps;            /* to the node running Edge; 0 = unmeasured */
     double rtt_ms;               /* to the node running Edge */
-    uint32_t gpu_backends;       /* what the ENGINE can use, not what is fitted */
+    uint32_t gpu_backends;       /* inventory; adapter-specific use comes later */
     uint32_t threads;
     int has_checkpoint;          /* the weights are already on this machine */
 } LmbClusterNode;
@@ -64,6 +63,7 @@ typedef struct {
     double ready_seconds;        /* download and distribution, NOT speed */
     int ready_known;             /* 0 when no bandwidth was measured */
     uint32_t sessions;
+    int data_available;          /* at least one node owns the checkpoint */
 } LmbClusterPlan;
 
 /* Give each node a share of the layers proportional to what it can hold, so
@@ -81,25 +81,32 @@ static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
     out->state = LMB_PLAN_UNRUNNABLE;
     if (!m->layers || !n || n > LMB_CLUSTER_MAX_NODES) return -1;
 
-    /* Edge goes where it fits and the engine is fastest: a machine whose
-     * engine can use its GPU beats one that merely has a card in it. */
+    /* Until an adapter declares a working GPU backend, RAM and VRAM are not
+     * interchangeable. Counting both can accept a plan no engine can load. */
     LmbRangeCost edge = lmb_estimate_edge(m, context, sessions);
+    if (!edge.ok) return -1;
+    uint64_t edge_need = edge.resident_bytes + edge.state_bytes +
+                         edge.scratch_bytes;
     uint32_t best_edge = UINT32_MAX;
     uint64_t best_edge_room = 0;
     for (uint32_t i = 0; i < n; i++) {
-        uint64_t room = nodes[i].ram_budget_bytes + nodes[i].vram_budget_bytes;
-        if (edge.ok && room < edge.resident_bytes + edge.state_bytes) continue;
-        uint64_t score = room + (nodes[i].gpu_backends ? room : 0);
-        if (best_edge == UINT32_MAX || score > best_edge_room) {
-            best_edge = i; best_edge_room = score;
+        uint64_t room = nodes[i].ram_budget_bytes;
+        if (room < edge_need) continue;
+        if (best_edge == UINT32_MAX || room > best_edge_room) {
+            best_edge = i; best_edge_room = room;
         }
     }
     if (best_edge == UINT32_MAX) return -1;      /* nobody can hold Edge */
     out->edge_node = best_edge;
 
+    uint64_t effective[LMB_CLUSTER_MAX_NODES];
     uint64_t total_budget = 0;
-    for (uint32_t i = 0; i < n; i++)
-        total_budget += nodes[i].ram_budget_bytes + nodes[i].vram_budget_bytes;
+    for (uint32_t i = 0; i < n; i++) {
+        effective[i] = nodes[i].ram_budget_bytes;
+        if (i == best_edge) effective[i] -= edge_need;
+        total_budget += effective[i];
+        if (nodes[i].has_checkpoint) out->data_available = 1;
+    }
     if (!total_budget) return -1;
 
     /* Hand out layers in proportion to budget, in one pass, never leaving a
@@ -107,7 +114,7 @@ static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
     uint32_t assigned = 0;
     uint64_t whole_resident = 0;
     for (uint32_t i = 0; i < n && assigned < m->layers; i++) {
-        uint64_t budget = nodes[i].ram_budget_bytes + nodes[i].vram_budget_bytes;
+        uint64_t budget = effective[i];
         uint32_t take = (uint32_t)((uint64_t)m->layers * budget / total_budget);
         if (i + 1 == n) take = m->layers - assigned;
         if (!take) continue;
@@ -124,7 +131,9 @@ static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
         s->bytes_resident = s->state == LMB_PLAN_DISK
                           ? c.working_set_bytes + live
                           : c.resident_bytes + live;
-        s->bytes_to_fetch = nodes[i].has_checkpoint ? 0 : c.resident_bytes;
+        uint64_t needed_weights = s->state == LMB_PLAN_DISK
+                                ? c.working_set_bytes : c.resident_bytes;
+        s->bytes_to_fetch = nodes[i].has_checkpoint ? 0 : needed_weights;
         whole_resident += c.resident_bytes + live;
         if (s->state == LMB_PLAN_UNRUNNABLE) {
             /* Missing is measured against what this node would ACTUALLY have
@@ -155,6 +164,10 @@ static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
         if (out->slices[i].state == LMB_PLAN_DISK)
             out->state = LMB_PLAN_DISK;
     }
+    if (!out->data_available) {
+        out->state = LMB_PLAN_UNRUNNABLE;
+        out->missing_bytes = whole_resident + edge.resident_bytes;
+    }
 
     if (out->state == LMB_PLAN_UNRUNNABLE && out->missing_bytes) {
         uint64_t median = total_budget / n;
@@ -164,18 +177,16 @@ static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
 
     /* How long before it can answer, which is bytes over measured bandwidth
      * and nothing else. Unmeasured bandwidth means unknown, not a guess. */
-    uint64_t slowest = 0;
     int all_measured = 1;
     for (uint32_t i = 0; i < out->nslices; i++) {
         const LmbClusterNode *nd = &nodes[out->slices[i].node];
         if (!out->slices[i].bytes_to_fetch) continue;
         if (!nd->lan_bps) { all_measured = 0; continue; }
-        uint64_t secs = out->slices[i].bytes_to_fetch / nd->lan_bps;
-        if (secs > slowest) slowest = secs;
+        double secs = (double)out->slices[i].bytes_to_fetch /
+                      (double)nd->lan_bps;
+        if (secs > out->ready_seconds) out->ready_seconds = secs;
     }
     out->ready_known = all_measured;
-    out->ready_seconds = (double)slowest;
-    (void)whole_resident;
     return 0;
 }
 

--- a/lumabri_families.h
+++ b/lumabri_families.h
@@ -1,9 +1,9 @@
 /* lumabri_families.h — which Colibri adapter runs which checkpoint.
  *
- * Colibri does not answer this question. Only DeepSeek V4 checks
- * `model_type` at all (`require_string(root, "model_type", "deepseek_v4")`);
- * the other seven adapters never read it, so there is no table in the engine
- * to consult and the mapping has to be declared here.
+ * Lumabri mirrors Colibri's authoritative family registry here because the
+ * runtime ABI exposes adapter registrations, not checkpoint model_type
+ * aliases. model_family_test.sh compares the two registries directly, so an
+ * alias or adapter added upstream cannot remain silently unmapped here.
  *
  * It used to be declared as three separate ladders of strstr(), and that is
  * not a mapping, it is a guess that always succeeds:
@@ -17,17 +17,12 @@
  * `qwen38` was ever registered, those two adapters could not be reached at
  * all, by any spelling.
  *
- * So: one table, exact aliases and declared prefixes, longest match wins,
- * and NO fallback. A checkpoint whose model_type nobody has declared is an
+ * So: one table, exact model_type aliases and NO prefix matching or fallback.
+ * A checkpoint whose model_type nobody has declared is an
  * explicit error naming the string, not a silent hand-off to whichever row
  * happened to share three letters with it.
  *
- * The `aliases` of a family may legitimately be empty. That means the
- * adapter is registered and usable, but we do not yet know what its
- * checkpoints write in config.json — it is reachable only through an
- * explicit override. Those families are named in LMB_FAMILY_UNMAPPED, which
- * the parity test keeps shrink-only: it may never grow without someone
- * looking at a real checkpoint. */
+ * The aliases below come from Colibri's authoritative family registry. */
 #ifndef LUMABRI_FAMILIES_H
 #define LUMABRI_FAMILIES_H
 
@@ -44,42 +39,33 @@
 typedef struct {
     const char *segment_id;   /* Colibri Segment and Edge adapter id */
     const char *engine;       /* monolithic engine binary basename */
+    const char *p2p_engine;   /* Lumabri chatter basename, NULL when absent */
     const char *expert_node;  /* phase-2 executor basename, NULL when none */
-    /* exact config.json model_type values, then declared prefixes. Longest
-     * match wins, so a more specific family always beats a broader one. */
-    const char *aliases[6];
-    const char *prefixes[4];
+    const char *config_section; /* "root" or "text_config" */
+    const char *aliases[6];     /* exact config.json model_type values */
 } LmbModelFamily;
 
 /* Every adapter Colibri registers has a row here. The parity test fails when
  * Colibri gains one that does not. */
 static const LmbModelFamily LMB_FAMILIES[] = {
-    { "olmoe",       "olmoe",    "expert_node",
-      { "olmoe", NULL }, { NULL } },
-    { "deepseek_v4", "deepseek", "expert_node_deepseek",
-      { "deepseek_v4", NULL }, { NULL } },
-    { "kimi",        "kimi_k3",  "expert_node_kimi",
-      { NULL }, { "kimi", NULL } },
-    { "inkling",     "inkling",  "expert_node_inkling",
-      { NULL }, { "inkling", NULL } },
-    { "qwen36",      "qwen36",   "expert_node_qwen36",
-      { NULL }, { "qwen3_", "qwen36", NULL } },
-    { "glm",         "colibri",  "expert_node_glm",
-      { NULL }, { "glm", NULL } },
-    /* Registered and usable, but no checkpoint of theirs has been read yet,
-     * so nothing is claimed about their model_type. Reachable through the
-     * explicit override until someone looks at one. */
-    { "glm53",       "colibri",  "expert_node_glm",   { NULL }, { NULL } },
-    { "qwen38",      "qwen36",   "expert_node_qwen36", { NULL }, { NULL } },
+    { "olmoe",       "olmoe",    "olmoe", "expert_node", "root",
+      { "olmoe", NULL } },
+    { "deepseek_v4", "deepseek_v4", "deepseek", "expert_node_deepseek", "root",
+      { "deepseek_v4", NULL } },
+    { "kimi",        "kimi_k3",  "kimi_k3", "expert_node_kimi", "text_config",
+      { "kimi_k3", "kimi_linear", NULL } },
+    { "inkling",     "inkling",  "inkling", "expert_node_inkling", "text_config",
+      { "inkling_mm_model", "inkling", NULL } },
+    { "qwen36",      "qwen36",   "qwen36", "expert_node_qwen36", "text_config",
+      { "qwen3_5_moe", "qwen3_5_moe_text", NULL } },
+    { "glm",         "colibri",  "colibri", "expert_node_glm", "root",
+      { "glm_moe_dsa", "glm5_moe", "glm", NULL } },
+    { "glm53",       "glm53",    NULL, NULL, "text_config",
+      { "glm5_next", "glm5_next_text", NULL } },
+    { "qwen38",      "qwen38",   NULL, NULL, "text_config",
+      { "qwen4_exp", "qwen4_exp_text", NULL } },
 };
 #define LMB_FAMILY_COUNT (sizeof LMB_FAMILIES / sizeof *LMB_FAMILIES)
-
-/* Shrink-only. A row belongs here exactly while its aliases and prefixes are
- * both empty; the parity test enforces both directions, so this list cannot
- * quietly grow when a new adapter arrives. */
-static const char *const LMB_FAMILY_UNMAPPED[] = { "glm53", "qwen38" };
-#define LMB_FAMILY_UNMAPPED_COUNT \
-    (sizeof LMB_FAMILY_UNMAPPED / sizeof *LMB_FAMILY_UNMAPPED)
 
 static LMB_UNUSED const LmbModelFamily *lmb_family_by_id(const char *segment_id) {
     if (!segment_id || !segment_id[0]) return NULL;
@@ -89,24 +75,15 @@ static LMB_UNUSED const LmbModelFamily *lmb_family_by_id(const char *segment_id)
     return NULL;
 }
 
-/* The checkpoint's model_type decides, and the longest declared match wins.
- * NULL means "no family claims this string" — the caller must say so out
- * loud rather than pick one. */
+/* NULL means "no family claims this exact string". */
 static LMB_UNUSED const LmbModelFamily *lmb_family_for(const char *model_type) {
     if (!model_type || !model_type[0]) return NULL;
-    const LmbModelFamily *best = NULL;
-    size_t best_len = 0;
     for (size_t i = 0; i < LMB_FAMILY_COUNT; i++) {
         const LmbModelFamily *f = &LMB_FAMILIES[i];
         for (int a = 0; a < 6 && f->aliases[a]; a++)
-            if (!strcmp(model_type, f->aliases[a])) return f;   /* exact wins */
-        for (int p = 0; p < 4 && f->prefixes[p]; p++) {
-            size_t n = strlen(f->prefixes[p]);
-            if (strncmp(model_type, f->prefixes[p], n)) continue;
-            if (n > best_len) { best = f; best_len = n; }
-        }
+            if (!strcmp(model_type, f->aliases[a])) return f;
     }
-    return best;
+    return NULL;
 }
 
 /* An operator with a checkpoint we have not mapped names the adapter

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -278,12 +278,14 @@ static uint64_t disk_read_speed(const char *path) {
     if (fsync(fd)) { close(fd); unlink(probe); free(buf); return 0; }
     close(fd);
 
-    int flags = O_RDONLY;
 #ifdef O_DIRECT
-    flags |= O_DIRECT;
+    fd = open(probe, O_RDONLY | O_DIRECT);
+#else
+    fd = -1;
 #endif
-    fd = open(probe, flags);
-    if (fd < 0) fd = open(probe, O_RDONLY);   /* O_DIRECT refused: still useful */
+    /* A buffered read immediately after creating the probe measures page
+     * cache, not disk. If direct I/O is unavailable, report unmeasured rather
+     * than publish a fast but fictitious "cold read" number. */
     if (fd < 0) { unlink(probe); free(buf); return 0; }
     struct timespec t0, t1;
     clock_gettime(CLOCK_MONOTONIC, &t0);

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -3,9 +3,9 @@
  *
  * The catalogue has to say "this cluster can run that model, split this way,
  * ready in about this long" without opening an engine, so somebody has to
- * turn a checkpoint into memory figures. Colibri will not: only DeepSeek V4
- * reads model_type at all, and no adapter exposes a sizing call. So the
- * description lives here, on our side, and Colibri stays untouched.
+ * turn a checkpoint into memory figures. The Colibri runtime ABI exposes no
+ * C sizing call (its Python control plane is not linked here), so the
+ * description lives in Lumabri's adapter layer and Colibri stays untouched.
  *
  * Three numbers matter and they are not the same number:
  *
@@ -57,6 +57,7 @@ typedef struct {
     uint32_t vocab;
     uint32_t bits_per_weight;   /* 16 bf16, 8, 4 for fp4 checkpoints */
     int disk_streaming;         /* the adapter has DEMONSTRATED disk mode */
+    int sizing_verified;        /* adapter-specific arithmetic was verified */
 } LmbModelShape;
 
 typedef struct {
@@ -120,7 +121,8 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_segment(const LmbModelShape *m,
                                          uint32_t context, uint32_t sessions) {
     LmbRangeCost c;
     memset(&c, 0, sizeof c);
-    if (!m->layers || begin >= end || end > m->layers || !m->hidden) return c;
+    if (!m->sizing_verified || !m->layers || begin >= end ||
+        end > m->layers || !m->hidden) return c;
     uint32_t n = end - begin;
 
     uint64_t dense = lmb_dense_layer_bytes(m) * n;
@@ -150,7 +152,7 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_edge(const LmbModelShape *m,
                                       uint32_t context, uint32_t sessions) {
     LmbRangeCost c;
     memset(&c, 0, sizeof c);
-    if (!m->vocab || !m->hidden) return c;
+    if (!m->sizing_verified || !m->vocab || !m->hidden) return c;
     c.resident_bytes = c.working_set_bytes = lmb_edge_bytes(m);
     c.state_bytes = (uint64_t)(context ? context : 4096) * m->hidden * 4u *
                     (sessions ? sessions : 1);
@@ -193,6 +195,70 @@ static LMB_UNUSED const char *lmb_plan_state_name(LmbPlanState s) {
  * alternative — defaults — is how a catalogue ends up promising a model it
  * cannot size. Returns 0 when at least the layer count and hidden size were
  * found, which is the minimum any estimate needs. */
+/* Small, scope-aware JSON member lookup. It intentionally handles only the
+ * primitive/object forms config.json needs, but unlike strstr it never picks
+ * a same-named field from a nested vision config. */
+static const char *LMB_UNUSED lmb_json_member(const char *object,
+                                              const char *key) {
+    if (!object || *object != '{') return NULL;
+    int depth = 1, in_string = 0, escape = 0;
+    for (const char *p = object + 1; *p && depth; p++) {
+        if (in_string) {
+            if (escape) { escape = 0; continue; }
+            if (*p == '\\') { escape = 1; continue; }
+            if (*p == '"') in_string = 0;
+            continue;
+        }
+        if (*p == '{' || *p == '[') { depth++; continue; }
+        if (*p == '}' || *p == ']') { depth--; continue; }
+        if (*p != '"') continue;
+        const char *start = p + 1, *q = start;
+        int esc = 0;
+        for (; *q; q++) {
+            if (esc) { esc = 0; continue; }
+            if (*q == '\\') { esc = 1; continue; }
+            if (*q == '"') break;
+        }
+        if (!*q) return NULL;
+        if (depth == 1 && (size_t)(q - start) == strlen(key) &&
+            !memcmp(start, key, (size_t)(q - start))) {
+            const char *v = q + 1;
+            while (*v == ' ' || *v == '\t' || *v == '\r' || *v == '\n') v++;
+            if (*v != ':') return NULL;
+            do { v++; } while (*v == ' ' || *v == '\t' || *v == '\r' || *v == '\n');
+            return v;
+        }
+        p = q;
+    }
+    return NULL;
+}
+
+static int LMB_UNUSED lmb_json_u32(const char *object, const char *key,
+                                   uint32_t *out) {
+    const char *v = lmb_json_member(object, key);
+    if (!v || *v < '0' || *v > '9') return -1;
+    char *end = NULL;
+    unsigned long n = strtoul(v, &end, 10);
+    if (end == v || n == 0 || n > UINT32_MAX) return -1;
+    *out = (uint32_t)n;
+    return 0;
+}
+
+static int LMB_UNUSED lmb_json_string(const char *object, const char *key,
+                                      char *out, size_t cap) {
+    const char *v = lmb_json_member(object, key);
+    if (!v || *v != '"' || cap == 0) return -1;
+    const char *end = v + 1;
+    while (*end && *end != '"') {
+        if (*end == '\\') return -1; /* model_type never needs escapes */
+        end++;
+    }
+    size_t n = (size_t)(end - (v + 1));
+    if (*end != '"' || n >= cap) return -1;
+    memcpy(out, v + 1, n); out[n] = 0;
+    return 0;
+}
+
 static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                                             LmbModelShape *out) {
     memset(out, 0, sizeof *out);
@@ -206,6 +272,19 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
     fclose(f);
     buf[n] = 0;
 
+    if (lmb_json_string(buf, "model_type", out->model_type,
+                        sizeof out->model_type)) return -1;
+    const LmbModelFamily *fam = lmb_family_for(out->model_type);
+    if (!fam) return -1;
+    snprintf(out->segment_id, sizeof out->segment_id, "%s", fam->segment_id);
+
+    const char *cfg = buf;
+    if (!strcmp(fam->config_section, "text_config")) {
+        const char *nested = lmb_json_member(buf, "text_config");
+        /* Text-only exports put their text fields at the root. Vision wrappers
+         * must provide a real text_config object. */
+        if (nested && *nested == '{') cfg = nested;
+    }
     struct { const char *key; uint32_t *slot; } nums[] = {
         { "num_hidden_layers",    &out->layers },
         { "hidden_size",          &out->hidden },
@@ -219,28 +298,14 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
         { "vocab_size",           &out->vocab },
     };
     for (size_t i = 0; i < sizeof nums / sizeof *nums; i++) {
-        char needle[64];
-        snprintf(needle, sizeof needle, "\"%s\"", nums[i].key);
-        const char *at = strstr(buf, needle);
-        if (!at) continue;
-        at = strchr(at + strlen(needle), ':');
-        if (!at) continue;
-        long v = strtol(at + 1, NULL, 10);
-        if (v > 0 && !*nums[i].slot) *nums[i].slot = (uint32_t)v;
+        uint32_t v = 0;
+        if (!lmb_json_u32(cfg, nums[i].key, &v) && !*nums[i].slot)
+            *nums[i].slot = v;
     }
-    const char *mt = strstr(buf, "\"model_type\"");
-    if (mt && (mt = strchr(mt + 12, '"')) && *++mt) {
-        size_t len = strcspn(mt, "\"");
-        if (len < sizeof out->model_type)
-            memcpy(out->model_type, mt, len);
-    }
-    const LmbModelFamily *fam = lmb_family_for(out->model_type);
-    if (fam) snprintf(out->segment_id, sizeof out->segment_id, "%s",
-                      fam->segment_id);
     /* Quantisation is not in config.json for every family, so it is declared
      * per family rather than guessed: fp4 for V4, bf16 elsewhere until a
      * checkpoint of that family says otherwise. */
-    out->bits_per_weight = !strcmp(out->model_type, "deepseek_v4") ? 4 : 16;
+    out->bits_per_weight = !strcmp(fam->segment_id, "deepseek_v4") ? 4 : 16;
     if (!out->kv_heads) out->kv_heads = out->heads;
     /* Not every family names the expert width separately. OLMoE routes every
      * layer and its experts are `intermediate_size` wide, so a checkpoint
@@ -249,6 +314,12 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
      * in the working set and make disk mode indistinguishable from resident. */
     if (out->experts && !out->moe_intermediate)
         out->moe_intermediate = out->intermediate;
+    /* The current formula is verified only for the two fixtures against which
+     * it was written. Other adapters remain visible through the family table,
+     * but cannot produce a fit decision until their adapter-specific sizing
+     * callback lands. This is preferable to a confident under-allocation. */
+    out->sizing_verified = !strcmp(fam->segment_id, "olmoe") ||
+                           !strcmp(fam->segment_id, "deepseek_v4");
     return out->layers && out->hidden ? 0 : -1;
 }
 

--- a/lumabri_proto.h
+++ b/lumabri_proto.h
@@ -305,12 +305,12 @@ enum {
      * thousandths — zero meaning nobody has measured this host yet, which
      * is a state the screen shows rather than a number it invents.
      *
-     * After the greeting the socket carries the SUBMIT/DATA/DONE codec the
-     * terminal already speaks, unchanged: that is what makes a thin client a
-     * connection rather than a rewrite. The client boots no engine, opens no
-     * mirror and holds no checkpoint — the serve-codec engines tokenize the
-     * payload themselves, so it needs no tokenizer either. */
+     * HOST_STREAM payloads carry chunks of the SUBMIT/DATA/DONE codec. When
+     * transport encryption is enabled they remain authenticated and encrypted;
+     * a local socketpair unwraps them so the terminal-facing Engine API still
+     * sees an ordinary byte stream. */
     LMB_HOST_HELLO = 74, LMB_HOST_HELLO_R = 75,
+    LMB_HOST_STREAM = 76,
 };
 #define LMB_CAP_EXEC2 (1u << 0)
 #define LMB_ENC_F32  0u
@@ -433,6 +433,7 @@ static void lmb_frame_caps(uint32_t op, uint32_t *body_cap, uint32_t *pay_cap) {
     case LMB_SEG_RUN_R:
     case LMB_SEG_SNAPSHOT_R:
     case LMB_SEG_RESTORE:
+    case LMB_HOST_STREAM:
     case LMB_RSEG:
     case LMB_RSEG_FWD:
     case LMB_RSEG_R:

--- a/lumabri_tui.c
+++ b/lumabri_tui.c
@@ -60,8 +60,8 @@ static Size term_size(void) {
     struct winsize ws;
     Size s = { 100, 30 };
     if (ioctl(1, TIOCGWINSZ, &ws) == 0) {
-        if (ws.ws_col > 40) s.w = ws.ws_col;
-        if (ws.ws_row > 10) s.h = ws.ws_row;
+        if (ws.ws_col > 0) s.w = ws.ws_col;
+        if (ws.ws_row > 0) s.h = ws.ws_row;
     }
     /* A terminal narrower than this cannot show the table without wrapping
      * into nonsense, so the compact view takes over rather than the layout
@@ -134,14 +134,11 @@ static const char *state_word(const LmbTuiModel *m) {
  * calibration exists for this exact plan. */
 static void speed_text(const LmbTuiModel *m, char *out, size_t cap) {
     if (!m->calibration) { snprintf(out, cap, "not calibrated"); return; }
-    LmbCalKey want;
-    memset(&want, 0, sizeof want);
-    /* Only the fields this screen knows; the rest come from the record and
-     * therefore always match, which is why a real calibration is written by
-     * the run that measured it and not assembled here. */
-    snprintf(want.adapter, sizeof want.adapter, "%s", m->shape.segment_id);
-    want.context = m->plan.sessions ? 4096 : 4096;
-    lmb_cal_speed_text(m->calibration, &want, out, cap);
+    if (!m->calibration_key_valid) {
+        snprintf(out, cap, "stale (plan key unavailable)");
+        return;
+    }
+    lmb_cal_speed_text(m->calibration, &m->calibration_key, out, cap);
 }
 
 static void human_bytes(uint64_t b, char *out, size_t cap) {
@@ -255,7 +252,7 @@ static void draw_nodes(const LmbTuiState *st, Size sz) {
                                        n->disk_read_bps / 1e6);
         else snprintf(disk, sizeof disk, "unmeasured");
         at(5 + (int)i, 1);
-        fputs("\x1b[K", stdout);
+        if (!g_snapshot) fputs("\x1b[K", stdout);
         printf("  %-20.20s %-12s %-12s %-12s %s", n->name, ram,
                n->vram_budget_bytes ? vram : "—", disk,
                /* A card the engine cannot drive is not a GPU machine, and
@@ -271,6 +268,30 @@ static void draw_nodes(const LmbTuiState *st, Size sz) {
     fflush(stdout);
 }
 
+static void draw_compact(const LmbTuiState *st, Size sz, int tab, int sel) {
+    clear_screen();
+    at(1, 1); printf("%s%sLUMABRI%s  %u computer%s", c(BOLD), c(AMBER),
+                     c(OFF), st->nnodes, st->nnodes == 1 ? "" : "s");
+    at(2, 1); printf("%s%s%s", c(INV), tab ? "COMPUTERS" : "MODELS", c(OFF));
+    int room = sz.w > 8 ? sz.w - 8 : 8;
+    if (tab) {
+        for (uint32_t i = 0; i < st->nnodes && (int)i + 4 < sz.h; i++) {
+            at(4 + (int)i, 1);
+            printf("%c %-*.*s", (int)i == sel ? '>' : ' ', room, room,
+                   st->nodes[i].name);
+        }
+    } else {
+        for (int i = 0; i < st->nmodels && i + 4 < sz.h; i++) {
+            at(4 + i, 1);
+            printf("%c %-*.*s %s", i == sel ? '>' : ' ', room / 2, room / 2,
+                   st->models[i].name, state_word(&st->models[i]));
+        }
+    }
+    at(sz.h > 1 ? sz.h : 1, 1);
+    printf("%s↑↓  tab  r  q%s", c(DIM), c(OFF));
+    fflush(stdout);
+}
+
 /* ---- the detail --------------------------------------------------------- */
 
 static void draw_detail(const LmbTuiState *st, Size sz, int sel) {
@@ -280,7 +301,7 @@ static void draw_detail(const LmbTuiState *st, Size sz, int sel) {
     LmbRangeCost edge = lmb_estimate_edge(&m->shape, st->context, st->sessions);
     uint64_t budget = 0;
     for (uint32_t i = 0; i < st->nnodes; i++)
-        budget += st->nodes[i].ram_budget_bytes + st->nodes[i].vram_budget_bytes;
+        budget += st->nodes[i].ram_budget_bytes;
 
     clear_screen();
     at(1, 1);
@@ -292,6 +313,14 @@ static void draw_detail(const LmbTuiState *st, Size sz, int sel) {
     int row = 4;
     at(row++, 1);
     printf("  %sWHAT IT NEEDS%s", c(DIM), c(OFF));
+    if (!whole.ok || !edge.ok) {
+        at(row++, 1);
+        printf("    adapter-specific sizing is unavailable; no fit decision");
+        at(sz.h, 1);
+        printf("%s ↵ back   q quit%s", c(DIM), c(OFF));
+        fflush(stdout);
+        return;
+    }
     char t[32];
     human_bytes(whole.resident_bytes, t, sizeof t);
     at(row++, 1); printf("    every weight resident      %10s", t);
@@ -413,14 +442,24 @@ int lmb_tui_run(LmbTuiState *st, int snapshot, const char *keys) {
             case 'j': if (sel + 1 < st->nmodels) sel++; break;
             case 'k': if (sel > 0) sel--; break;
             case '\t': tab = !tab; break;
-            case '\r': case '\n': if (st->nmodels) detail = 1; break;
+            case 'r':
+                if (st->refresh) {
+                    (void)st->refresh(st, st->refresh_context);
+                    if (!st->nmodels) sel = top = 0;
+                    else if (sel >= st->nmodels) sel = st->nmodels - 1;
+                }
+                break;
+            case '\r': case '\n':
+                if (st->nmodels && sz.w >= 60 && sz.h >= 12) detail = 1;
+                break;
             default: break;
             }
         }
         int rows = sz.h - 7; if (rows < 1) rows = 1;
         if (sel < top) top = sel;
         if (sel >= top + rows) top = sel - rows + 1;
-        if (detail) draw_detail(st, sz, sel);
+        if (sz.w < 60 || sz.h < 12) draw_compact(st, sz, tab, sel);
+        else if (detail) draw_detail(st, sz, sel);
         else {
             draw_header(st, sz, tab);
             if (tab == 0) draw_models(st, sz, sel, top);
@@ -442,7 +481,8 @@ int lmb_tui_run(LmbTuiState *st, int snapshot, const char *keys) {
     for (;;) {
         if (g_quit) break;
         if (g_resized) { g_resized = 0; sz = term_size(); clear_screen(); }
-        if (detail) draw_detail(st, sz, sel);
+        if (sz.w < 60 || sz.h < 12) draw_compact(st, sz, tab, sel);
+        else if (detail) draw_detail(st, sz, sel);
         else {
             clear_screen();
             draw_header(st, sz, tab);
@@ -459,7 +499,17 @@ int lmb_tui_run(LmbTuiState *st, int snapshot, const char *keys) {
         case 'j': if (sel + 1 < st->nmodels) sel++; break;
         case 'k': if (sel > 0) sel--; break;
         case '\t': tab = !tab; break;
-        case '\r': case '\n': if (st->nmodels) detail = 1; break;
+        case 'r':
+            if (st->refresh) {
+                int selected = sel;
+                (void)st->refresh(st, st->refresh_context);
+                if (!st->nmodels) sel = top = 0;
+                else if (selected >= st->nmodels) sel = st->nmodels - 1;
+            }
+            break;
+        case '\r': case '\n':
+            if (st->nmodels && sz.w >= 60 && sz.h >= 12) detail = 1;
+            break;
         default: break;
         }
         int rows = sz.h - 7; if (rows < 1) rows = 1;

--- a/lumabri_tui.h
+++ b/lumabri_tui.h
@@ -25,15 +25,20 @@ typedef struct {
     LmbClusterPlan plan;
     int planned;                    /* 0 when the cluster cannot be planned */
     const LmbCalibration *calibration;   /* NULL until something is measured */
+    LmbCalKey calibration_key;      /* exact current conditions */
+    int calibration_key_valid;
 } LmbTuiModel;
 
-typedef struct {
+typedef struct LmbTuiState {
     LmbTuiModel models[LMB_TUI_MAX_MODELS];
     int nmodels;
     LmbClusterNode nodes[LMB_CLUSTER_MAX_NODES];
     uint32_t nnodes;
     uint32_t context, sessions;
     char root[512];                 /* where the checkpoints were found */
+    char disk[512];
+    int (*refresh)(struct LmbTuiState *state, void *context);
+    void *refresh_context;
 } LmbTuiState;
 
 /* Run the interface. `snapshot` renders one frame to stdout and returns

--- a/model_family_test.sh
+++ b/model_family_test.sh
@@ -8,14 +8,14 @@
 #   1. every adapter Colibri exposes is registered by lmb_colibri_register_all
 #      (Segment and Edge), and has a row in LMB_FAMILIES;
 #   2. every row in LMB_FAMILIES names an adapter Colibri actually exposes;
-#   3. LMB_FAMILY_UNMAPPED holds exactly the rows with no alias and no prefix,
-#      so the debt list can shrink but never silently grow.
+#   3. every row has at least one exact model_type; no prefix debt is accepted.
 set -euo pipefail
 cd "$(dirname "$0")"
 ENGINE="${ENGINE:-../colibri/c}"
 fail() { echo "MODEL FAMILY TEST: FAIL — $*" >&2; exit 1; }
 
 [[ -f "$ENGINE/segment_adapters.h" ]] || { echo "MODEL FAMILY TEST: SKIP (no $ENGINE)"; exit 0; }
+[[ -f "$ENGINE/family_registry.py" ]] || fail "Colibri has no authoritative family_registry.py"
 
 adapters_of() {  # $1 = header, $2 = segment|edge
     grep -oE "coli_[a-z0-9_]+_$2_adapter_register" "$1" |
@@ -44,8 +44,8 @@ missing=$(comm -23 <(echo "$edge") <(echo "$ours_edge"))
 [[ -z "$missing" ]] || fail "Colibri exposes Edge adapters Lumabri never registers: $(echo $missing)"
 
 # The family table and the debt list, parsed rather than eyeballed.
-python3 - "$seg" <<'PYEOF' || exit 1
-import re, sys
+python3 - "$seg" "$ENGINE/family_registry.py" <<'PYEOF' || exit 1
+import re, runpy, sys
 src = open("lumabri_families.h", encoding="utf-8").read()
 body = src[src.index("LMB_FAMILIES[] = {"):]
 body = body[:body.index("\n};")]
@@ -63,13 +63,13 @@ table = {}
 for row in rows:
     names = re.findall(r'"([^"]*)"', row)
     if not names: continue
-    inner = re.findall(r"\{([^{}]*)\}", row)          # aliases, then prefixes
+    inner = re.findall(r"\{([^{}]*)\}", row)
     claims = [c for g in inner for c in re.findall(r'"([^"]+)"', g)]
     table[names[0]] = claims
 
-declared = set(re.findall(r'"([a-z0-9_]+)"',
-    src[src.index("LMB_FAMILY_UNMAPPED[] = {"):].split("};")[0]))
 expected = set(sys.argv[1].split())
+registry = runpy.run_path(sys.argv[2])
+official = {f.id: set(f.model_types) for f in registry["FAMILIES"]}
 bad = []
 if set(table) - expected:
     bad.append("LMB_FAMILIES names adapters Colibri does not expose: %s"
@@ -78,12 +78,16 @@ if expected - set(table):
     bad.append("adapters with no row in LMB_FAMILIES: %s — a checkpoint of "
                "that family would be refused with no way to run it"
                % " ".join(sorted(expected - set(table))))
+for name in sorted(expected & set(table)):
+    if set(table[name]) != official.get(name, set()):
+        bad.append("%s exact model_type aliases differ from Colibri:\n"
+                   "  Lumabri: %s\n  Colibri: %s" %
+                   (name, " ".join(sorted(table[name])) or "(none)",
+                    " ".join(sorted(official.get(name, set()))) or "(none)"))
 silent = {n for n, c in table.items() if not c}
-if silent != declared:
-    bad.append("LMB_FAMILY_UNMAPPED must list exactly the rows that claim no "
-               "model_type.\n  rows claiming none: %s\n  declared:          %s"
-               % (" ".join(sorted(silent)) or "(none)",
-                  " ".join(sorted(declared)) or "(none)"))
+if silent:
+    bad.append("adapters without an exact model_type mapping: %s"
+               % " ".join(sorted(silent)))
 seen = {}
 for name, claims in table.items():
     for c in claims:
@@ -94,9 +98,7 @@ for name, claims in table.items():
 if bad:
     print("MODEL FAMILY TEST: FAIL — " + "\n".join(bad), file=sys.stderr)
     sys.exit(1)
-print("  %d adapters, %d mapped, unmapped: %s"
-      % (len(table), len(table) - len(silent),
-         " ".join(sorted(silent)) or "(none)"))
+print("  %d adapters, all exactly mapped" % len(table))
 PYEOF
 
 echo "MODEL FAMILY TEST: PASS ($(echo "$seg" | wc -w) adapters registered, mapped and unambiguous)"

--- a/multi_session_test.sh
+++ b/multi_session_test.sh
@@ -45,7 +45,7 @@ LUMABRI_VERIFY=0 OMP_NUM_THREADS=2 \
     --range 0:16 --port "$(( PORT + 1 ))" --tracker "127.0.0.1:$PORT" \
     --advertise "127.0.0.1:$(( PORT + 1 ))" --name solo \
     --model-root "$mr" --tokenizer-root "$tk" --context 64 --max-rows 16 \
-    --sessions 1 --threads 2 --run-queue 1 --run-wait-ms 1500 \
+    --sessions 1 --threads 2 --run-queue 0 --run-wait-ms 1500 \
     >"$TMP/node.log" 2>&1 &
 PIDS+=("$!"); wait_port "$(( PORT + 1 ))"
 sleep 3
@@ -88,7 +88,9 @@ for got in "$a" "$b"; do
   under contention: $got
   contention may make a session wait or be refused; it may never change it."
 done
-(( served >= 1 )) || fail "neither of two concurrent sessions completed"
+(( served == 1 )) || fail "capacity one served $served of two concurrent sessions; expected exactly one"
+grep -qiE "busy|refused|admission" "$TMP/par-a.log" "$TMP/par-b.log" ||
+    fail "the rejected session did not receive an explicit capacity refusal"
 
 # Capacity is stated, not implied: the node has to have said how many it takes.
 grep -qE "[0-9]+ session" "$TMP/node.log" ||

--- a/segment_budget_test.sh
+++ b/segment_budget_test.sh
@@ -3,18 +3,17 @@
 # before opening the engine — so a wrong basis is invisible until someone
 # notices a machine that never joins.
 #
-# Its old basis was a proportional share of the whole checkpoint plus 5%,
-# which assumes every weight of the range must be resident. That is right for
-# the incident it was written for (slices sized at "all the free RAM" fighting
-# on one box) and wrong as a rule: it refused a node that had room for the
-# dense part and a top-k expert cache and a working NVMe. Disk mode was not
-# unadvertised, it was unreachable.
+# The adapter ABI currently exposes no verified minimum working set and no
+# switch that makes a resident Segment engine stream weights. Therefore the
+# production guard must remain conservative: proportional checkpoint bytes
+# plus overhead. A catalogue estimate must never authorize a smaller runtime
+# allocation.
 #
 # Three claims:
 #   1. a budget that fits the whole range still starts, unchanged;
-#   2. a budget below the working set is still refused, and says both figures;
-#   3. between the two, the node starts ONLY when disk mode is asked for —
-#      streaming is a capability, not a consolation prize.
+#   2. a budget below the conservative share is refused;
+#   3. LUMABRI_SEGMENT_DISK cannot bypass it: that variable never changed the
+#      Colibri engine's allocation policy.
 set -euo pipefail
 cd "$(dirname "$0")"
 
@@ -87,7 +86,13 @@ got=$(run_node "$roomy" roomy)
 
 got=$(run_node "$tight" tight)
 [[ "$got" == refused:3 ]] || { echo "a node below its working set was not refused ($got)" >&2; exit 1; }
-grep -q "working set" "$TMP/tight.log" ||
-    { echo "the refusal did not name the working set" >&2; exit 1; }
+grep -q "needs about" "$TMP/tight.log" ||
+    { echo "the refusal did not state its conservative estimate" >&2; exit 1; }
 
-echo "SEGMENT BUDGET TEST: PASS (whole range starts, below the working set refuses)"
+got=$(run_node "$tight" fake-disk LUMABRI_SEGMENT_DISK=1)
+[[ "$got" == refused:3 ]] || {
+    echo "an unimplemented disk-mode flag bypassed the memory guard ($got)" >&2
+    exit 1
+}
+
+echo "SEGMENT BUDGET TEST: PASS (resident share starts, undersized range refuses)"

--- a/segment_coverage_test.sh
+++ b/segment_coverage_test.sh
@@ -87,7 +87,8 @@ print(','.join(map(str,json.loads(lines[-1])['token_ids'])) if lines else '')
 PY
 )
 [[ -n "$ids" ]] || fail "a complete chain produced no tokens"
-grep -qE "cov-0.*cov-2.*cov-1|Segment route" "$TMP/whole.log" ||
-    echo "  (note: the route line was not in the expected form; tokens were produced)"
+grep -qE "cov-0\[0:6\].*cov-2\[6:10\].*cov-1\[10:16\]" \
+    "$TMP/whole.json" "$TMP/whole.log" ||
+    fail "the complete-chain run produced tokens without proving that the exact 0:16 Segment route served them"
 
 echo "SEGMENT COVERAGE TEST: PASS (a gap in the chain never silently answers)"

--- a/segment_direct_test.sh
+++ b/segment_direct_test.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Real network gate: every current Colibri family is split across two direct
+# Real network gate for the six fixture-backed Colibri families. GLM-5.3 and
+# Qwen3.8 are registered separately but are not covered by this legacy matrix
+# until real fixtures are supplied to adapter_conformance_test.sh.
 # Segment peers and its first three greedy tokens must match the independent
 # tiny-model oracle. No family is accepted from registration alone.
 set -euo pipefail
@@ -256,4 +258,4 @@ PY
     echo "SEGMENT DIRECT $family: PASS (two peers, oracle + TUI codec)"
 done
 
-echo "SEGMENT DIRECT: PASS (all six Colibri families)"
+echo "SEGMENT DIRECT: PASS (six fixture-backed Colibri families)"

--- a/segment_node.c
+++ b/segment_node.c
@@ -12,11 +12,13 @@
 #include "segment_colibri.h"
 
 #include <pthread.h>
+#include <dirent.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -24,6 +26,29 @@
 #define NODE_SESSIONS_MAX 256u
 #define NODE_CONNECTIONS_MAX 256u
 #define NODE_SNAPSHOT_CHUNK (1u << 20)
+
+static uint64_t directory_bytes(const char *path, unsigned depth) {
+    if (!path || depth > 8) return 0;
+    DIR *dir = opendir(path);
+    if (!dir) return 0;
+    uint64_t total = 0;
+    struct dirent *entry;
+    while ((entry = readdir(dir))) {
+        if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, ".."))
+            continue;
+        char child[4096];
+        int n = snprintf(child, sizeof child, "%s/%s", path, entry->d_name);
+        if (n < 0 || (size_t)n >= sizeof child) { total = UINT64_MAX; break; }
+        struct stat st;
+        if (lstat(child, &st)) continue;
+        uint64_t add = S_ISREG(st.st_mode) ? (uint64_t)st.st_size :
+                       S_ISDIR(st.st_mode) ? directory_bytes(child, depth + 1) : 0;
+        if (UINT64_MAX - total < add) { total = UINT64_MAX; break; }
+        total += add;
+    }
+    closedir(dir);
+    return total;
+}
 
 typedef struct {
     int used;
@@ -1283,66 +1308,17 @@ int main(int argc, char **argv) {
         reserve_name, 4096, 256, 262144) << 20;
     if (!process_limit && available != UINT64_MAX && available > reserve)
         process_limit = available - reserve;
-    /* What this range needs before it is allowed to start.
-     *
-     * The old rule was a proportional share of the WHOLE checkpoint plus 5%,
-     * which is the right guard against the incident it was written for —
-     * slices sized at "all the free RAM" fighting each other on one box —
-     * and the wrong basis for the question. It assumes every weight of the
-     * range must be resident, so a node with a working NVMe and enough room
-     * for the dense part plus a top-k expert cache was refused before it
-     * could open the engine. Disk mode was not merely unadvertised: it was
-     * unreachable.
-     *
-     * So the guard stays and its basis changes. The planner sizes the range
-     * from the checkpoint's own config: everything resident when it fits,
-     * and otherwise the working set — dense weights, a top-k cache, kernel
-     * scratch, state — which is the floor below which the node cannot run at
-     * all, whatever the disk can stream. The proportional figure remains the
-     * fallback for a checkpoint the planner cannot describe: an unknown
-     * model is not a licence to over-commit. */
+    /* The runtime preflight must be conservative. The generic catalogue
+     * arithmetic is not an adapter contract and cannot authorize a smaller
+     * allocation; in particular setting a "disk" environment flag did not
+     * make any Colibri adapter stream its weights. Until an adapter exposes a
+     * verified minimum-working-set callback, retain the proven guard: its
+     * proportional share of the actual checkpoint plus overhead. */
     LmbModelShape shape;
     int shaped = model_dir && !lmb_shape_from_config(model_dir, &shape);
-    if (process_limit && shaped) {
-        LmbRangeCost cost = lmb_estimate_segment(&shape, begin, end,
-                                                 (uint32_t)context,
-                                                 (uint32_t)max_sessions);
-        uint64_t live = cost.state_bytes + cost.scratch_bytes;
-        uint64_t need = cost.resident_bytes + live;
-        int from_disk = 0;
-        if (cost.ok && need > process_limit) {
-            /* Streaming is a capability, not a consolation prize: only where
-             * the adapter has demonstrated it, which today is nowhere until
-             * step 8 of the roadmap proves one. LUMABRI_SEGMENT_DISK=1 is
-             * the diagnostic path the split test uses, and it says so. */
-            uint64_t floor = cost.working_set_bytes + live;
-            if (lmb_env_int("LUMABRI_SEGMENT_DISK", 0, 0, 1) &&
-                floor <= process_limit) {
-                fprintf(stderr, "[segment-node] range %u:%u does not fit "
-                        "resident (%.1f GB of %.1f GB) but its working set "
-                        "does (%.1f GB): starting in DIAGNOSTIC disk mode, "
-                        "which no adapter has yet demonstrated\n",
-                        begin, end, (double)need / 1e9,
-                        (double)process_limit / 1e9, (double)floor / 1e9);
-                from_disk = 1;
-                need = floor;
-            }
-        }
-        if (cost.ok && need > process_limit) {
-            fprintf(stderr, "[segment-node] assigned range %u:%u needs "
-                    "%.1f GB resident (working set %.1f GB) but the donor "
-                    "budget is %.1f GB; releasing it before loading weights\n",
-                    begin, end, (double)(cost.resident_bytes + live) / 1e9,
-                    (double)(cost.working_set_bytes + live) / 1e9,
-                    (double)process_limit / 1e9);
-            if (auto_range)
-                (void)auto_range_release(tracker, model, name, engine_id,
-                                         resolved_model_root);
-            preflight_signal(&preflight_fd, 'F');
-            return 3;
-        }
-        (void)from_disk;
-    } else if (process_limit && model_bytes && model_layers) {
+    if (!model_layers && shaped) model_layers = shape.layers;
+    if (!model_bytes && model_dir) model_bytes = directory_bytes(model_dir, 0);
+    if (process_limit && model_bytes && model_layers) {
         uint64_t range_layers = end - begin;
         uint64_t proportional = model_bytes / model_layers * range_layers;
         uint64_t remainder = model_bytes % model_layers * range_layers /
@@ -1354,7 +1330,8 @@ int main(int argc, char **argv) {
         if (estimated > process_limit) {
             fprintf(stderr, "[segment-node] assigned range %u:%u needs about "
                     "%.1f GB but the donor budget is %.1f GB; releasing it "
-                    "before loading weights\n", begin, end,
+                    "before loading weights (disk mode is not verified for "
+                    "this adapter)\n", begin, end,
                     (double)estimated / 1e9, (double)process_limit / 1e9);
             if (auto_range)
                 (void)auto_range_release(tracker, model, name, engine_id,

--- a/segment_split_test.sh
+++ b/segment_split_test.sh
@@ -16,9 +16,10 @@
 # Relay is forbidden throughout: every node advertises a direct address, and
 # a run that fell back to the tracker tunnel would measure the tunnel.
 #
-# On one machine this is a loopback rehearsal — real LAN numbers need real
-# machines, and LUMABRI_SPLIT_HOSTS is where those go. What it proves here is
-# the invariance, which is machine-independent, and the shape of the cost.
+# This script is deliberately a loopback rehearsal. It proves protocol/token
+# invariance and exercises the one-node/two-node topology, but it does not
+# measure a LAN and accepts no remote-host option. Real LAN numbers require a
+# separate two-machine harness and must never be inferred from this output.
 set -euo pipefail
 cd "$(dirname "$0")"
 

--- a/test_calibration.c
+++ b/test_calibration.c
@@ -21,10 +21,14 @@ static LmbCalKey base(void) {
     snprintf(k.commit_lumabri, sizeof k.commit_lumabri, "deadbeef");
     snprintf(k.commit_colibri, sizeof k.commit_colibri, "cafebabe");
     snprintf(k.build_id, sizeof k.build_id, "0123456789abcdef");
-    snprintf(k.backend, sizeof k.backend, "cpu");
+    snprintf(k.plan_kind, sizeof k.plan_kind, "segment");
+    k.goal = 0;
     k.nodes = 2; k.context = 4096; k.sessions = 1;
     for (int i = 0; i < 2; i++) {
         snprintf(k.node_id[i], sizeof k.node_id[i], "node%d", i);
+        snprintf(k.node_hardware_id[i], sizeof k.node_hardware_id[i], "hw%d", i);
+        snprintf(k.node_build_id[i], sizeof k.node_build_id[i], "build%d", i);
+        snprintf(k.node_backend[i], sizeof k.node_backend[i], "cpu");
         k.layer_begin[i] = (uint32_t)i * 22;
         k.layer_end[i] = (uint32_t)(i + 1) * 22;
         k.threads[i] = 8;
@@ -39,7 +43,7 @@ int main(void) {
 
     /* Every field, one at a time. A key that lets any of these through will
      * eventually show somebody the wrong number with full confidence. */
-    struct { const char *what; LmbCalKey k; } cases[16];
+    struct { const char *what; LmbCalKey k; } cases[24];
     int n = 0;
 #define VARY(label, mutation) do { LmbCalKey v = base(); mutation; \
     cases[n].what = label; cases[n].k = v; n++; } while (0)
@@ -50,11 +54,15 @@ int main(void) {
     VARY("lumabri commit",  snprintf(v.commit_lumabri, sizeof v.commit_lumabri, "0000"));
     VARY("colibri commit",  snprintf(v.commit_colibri, sizeof v.commit_colibri, "1111"));
     VARY("build id",        snprintf(v.build_id, sizeof v.build_id, "ffff"));
-    VARY("backend",         snprintf(v.backend, sizeof v.backend, "cuda"));
+    VARY("plan",            snprintf(v.plan_kind, sizeof v.plan_kind, "expert"));
+    VARY("goal",            v.goal = 1);
     VARY("context",         v.context = 8192);
     VARY("sessions",        v.sessions = 4);
     VARY("machine count",   v.nodes = 1);
     VARY("which machine",   snprintf(v.node_id[1], sizeof v.node_id[1], "elsewhere"));
+    VARY("node hardware",   snprintf(v.node_hardware_id[1], sizeof v.node_hardware_id[1], "other"));
+    VARY("node build",      snprintf(v.node_build_id[1], sizeof v.node_build_id[1], "other"));
+    VARY("node backend",    snprintf(v.node_backend[1], sizeof v.node_backend[1], "cuda"));
     VARY("ranges",          v.layer_begin[1] = 20; v.layer_end[0] = 20);
     VARY("threads",         v.threads[0] = 4);
     VARY("resident/disk",   v.from_disk[1] = 1);
@@ -86,7 +94,7 @@ int main(void) {
           "a matching calibration did not print its number: \"%s\"", text);
 
     LmbCalKey gpu = base();
-    snprintf(gpu.backend, sizeof gpu.backend, "cuda");
+    snprintf(gpu.node_backend[0], sizeof gpu.node_backend[0], "cuda");
     lmb_cal_speed_text(&have, &gpu, text, sizeof text);
     CHECK(strstr(text, "stale") != NULL,
           "a CPU measurement was shown for a CUDA plan: \"%s\"", text);
@@ -103,6 +111,13 @@ int main(void) {
     lmb_cal_build_id(id3, sizeof id3, "cc", "-O2 -fopenmp");
     CHECK(strcmp(id1, id2), "two different flag sets produced the same build id");
     CHECK(!strcmp(id1, id3), "the same flags produced different build ids");
+    lmb_cal_build_id(id2, sizeof id2, "ab", "c");
+    lmb_cal_build_id(id3, sizeof id3, "a", "bc");
+    CHECK(strcmp(id2, id3), "build-id fields were concatenated ambiguously");
+
+    LmbCalKey invalid = base(); invalid.nodes = LMB_CAL_NODES_MAX + 1;
+    CHECK(!lmb_cal_matches(&invalid, &invalid),
+          "an out-of-bounds machine count was accepted as a calibration key");
 
     printf("CALIBRATION KEY: %s\n", bad ? "FAIL" : "PASS");
     return bad ? 1 : 0;

--- a/test_cluster.c
+++ b/test_cluster.c
@@ -15,6 +15,7 @@ static LmbModelShape v4(void) {
     m.layers = 43; m.hidden = 4096; m.intermediate = 11264;
     m.moe_intermediate = 1408; m.experts = 256; m.experts_per_tok = 6;
     m.heads = 32; m.kv_heads = 8; m.vocab = 129280; m.bits_per_weight = 4;
+    m.sizing_verified = 1;
     return m;
 }
 
@@ -23,6 +24,7 @@ static LmbClusterNode node(const char *name, double gb, uint32_t gpu) {
     snprintf(n.name, sizeof n.name, "%s", name);
     n.ram_budget_bytes = (uint64_t)(gb * 1e9);
     n.gpu_backends = gpu; n.threads = 8; n.lan_bps = 100u * 1000 * 1000;
+    n.has_checkpoint = 1;
     return n;
 }
 
@@ -44,6 +46,17 @@ int main(void) {
     CHECK(p.missing_nodes > 0,
           "the shortfall was not expressed in machines, which is the only "
           "form a person can act on");
+
+    /* VRAM is not spare RAM. Until this adapter exposes a real Segment GPU
+     * backend, a large card cannot make an undersized host runnable. */
+    LmbClusterNode fake_gpu = node("gpu", 1, LMB_GPU_CUDA);
+    fake_gpu.vram_budget_bytes = 200ull * 1000 * 1000 * 1000;
+    CHECK(lmb_plan_cluster(&m, &fake_gpu, 1, 4096, 1,
+                           LMB_GOAL_ONE_SESSION, &p) != 0 ||
+          p.state == LMB_PLAN_UNRUNNABLE,
+          "VRAM was silently added to RAM for a CPU Segment adapter");
+    (void)lmb_plan_cluster(&m, house, 4, 4096, 1,
+                           LMB_GOAL_ONE_SESSION, &p);
 
     /* Coverage is not optional: every layer belongs to exactly one node, in
      * order, with no gap and no overlap. A plan that leaves layer 30
@@ -76,21 +89,25 @@ int main(void) {
     CHECK(p.missing_bytes == 0, "a plan that fits still reported %.1f GB missing",
           (double)p.missing_bytes / 1e9);
 
-    /* Edge goes to a machine whose ENGINE can use its card, not to whichever
-     * machine happens to have one fitted. */
+    /* A generic GPU inventory is not proof that this adapter can use it.
+     * Until that capability exists, Edge goes where verified RAM fits. */
     LmbClusterNode mixed[3] = { node("cpu-big", 64, 0), node("gpu", 40, LMB_GPU_CUDA),
                                 node("cpu", 40, 0) };
     CHECK(!lmb_plan_cluster(&m, mixed, 3, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
           "a mixed cluster could not be planned");
-    CHECK(p.edge_node == 1,
-          "Edge went to node %u; the machine whose engine can use a GPU is 1",
+    CHECK(p.edge_node == 0,
+          "Edge went to node %u; unverified VRAM influenced placement",
           p.edge_node);
 
     /* Ready-in is bytes over MEASURED bandwidth. With none measured it is
      * unknown, and unknown has to be visible — a fabricated minute is how a
      * catalogue starts lying. */
     LmbClusterNode blind[8];
-    for (int i = 0; i < 8; i++) { blind[i] = node("big", 40, 0); blind[i].lan_bps = 0; }
+    for (int i = 0; i < 8; i++) {
+        blind[i] = node("big", 40, 0);
+        blind[i].lan_bps = 0;
+        blind[i].has_checkpoint = i == 0;
+    }
     CHECK(!lmb_plan_cluster(&m, blind, 8, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
           "an unmeasured cluster could not be planned");
     CHECK(!p.ready_known, "ready-in was claimed with no bandwidth measured");

--- a/test_model_family.c
+++ b/test_model_family.c
@@ -26,15 +26,21 @@ static void want(const char *model_type, const char *expect_id) {
 }
 
 int main(void) {
-    /* the two the table knows exactly */
     want("olmoe", "olmoe");
     want("deepseek_v4", "deepseek_v4");
-
-    /* the families that still match by declared prefix, unchanged */
-    want("kimi_k2", "kimi");
+    want("kimi_k3", "kimi");
+    want("kimi_linear", "kimi");
+    want("inkling_mm_model", "inkling");
     want("inkling", "inkling");
-    want("qwen3_moe", "qwen36");
-    want("glm4_moe", "glm");
+    want("qwen3_5_moe", "qwen36");
+    want("qwen3_5_moe_text", "qwen36");
+    want("qwen4_exp", "qwen38");
+    want("qwen4_exp_text", "qwen38");
+    want("glm_moe_dsa", "glm");
+    want("glm5_moe", "glm");
+    want("glm", "glm");
+    want("glm5_next", "glm53");
+    want("glm5_next_text", "glm53");
 
     /* the refusals. Nothing here shares enough with a declared prefix to be
      * claimed, and every one of them used to be swallowed silently. */
@@ -42,35 +48,28 @@ int main(void) {
     want("llama", NULL);
     want("mixtral", NULL);
     want("deepseek_v3", NULL);   /* "deepseek" was a prefix once: not any more */
+    want("kimi_future", NULL);
+    want("glm53_moe", NULL);
+    want("qwen3_moe", NULL);
+    want("qwen36_moe", NULL);
 
-    /* a family with no declared model_type is unreachable by detection... */
-    const LmbModelFamily *f;
-    for (size_t i = 0; i < LMB_FAMILY_UNMAPPED_COUNT; i++) {
-        const char *id = LMB_FAMILY_UNMAPPED[i];
-        f = lmb_family_by_id(id);
-        if (!f) { fprintf(stderr, "unmapped family %s has no row\n", id); bad = 1; continue; }
-        if (f->aliases[0] || f->prefixes[0]) {
-            fprintf(stderr, "%s is listed as unmapped but claims a model_type\n", id);
-            bad = 1;
-        }
-        /* ...and reachable by explicit name, which is the whole point of
-         * registering it. */
-        if (lmb_family_override(id) != f) {
-            fprintf(stderr, "%s cannot be selected explicitly\n", id);
-            bad = 1;
-        }
+    const LmbModelFamily *deepseek = lmb_family_by_id("deepseek_v4");
+    if (!deepseek || strcmp(deepseek->engine, "deepseek_v4") ||
+        !deepseek->p2p_engine || strcmp(deepseek->p2p_engine, "deepseek")) {
+        fprintf(stderr, "DeepSeek artifact/P2P names drifted apart\n");
+        bad = 1;
+    }
+    const LmbModelFamily *glm53 = lmb_family_by_id("glm53");
+    const LmbModelFamily *qwen38 = lmb_family_by_id("qwen38");
+    if (!glm53 || glm53->p2p_engine || glm53->expert_node ||
+        !qwen38 || qwen38->p2p_engine || qwen38->expert_node) {
+        fprintf(stderr, "an adapter without an Expert path advertised one\n");
+        bad = 1;
     }
 
     /* a name Colibri does not register is refused, not ignored */
     if (lmb_family_override("qwen39")) {
         fprintf(stderr, "an unknown adapter name was accepted\n");
-        bad = 1;
-    }
-
-    /* the longest declared match wins, so a more specific family can always
-     * be added later without disturbing the broader one */
-    if (lmb_family_for("qwen36_moe") != lmb_family_by_id("qwen36")) {
-        fprintf(stderr, "longest-match did not prefer the specific family\n");
         bad = 1;
     }
 

--- a/test_planner.c
+++ b/test_planner.c
@@ -7,6 +7,7 @@
  * "runs from disk" exists only in the gap between the first two. */
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "lumabri_planner.h"
 
 static int bad;
@@ -21,6 +22,7 @@ static LmbModelShape v4(void) {
     m.layers = 43; m.hidden = 4096; m.intermediate = 11264;
     m.moe_intermediate = 1408; m.experts = 256; m.experts_per_tok = 6;
     m.heads = 32; m.kv_heads = 8; m.vocab = 129280; m.bits_per_weight = 4;
+    m.sizing_verified = 1;
     return m;
 }
 
@@ -139,6 +141,24 @@ int main(void) {
     LmbModelShape none;
     CHECK(lmb_shape_from_config("/nonexistent", &none) != 0,
           "a missing checkpoint produced a shape");
+
+    /* A structurally plausible config for a family we do not support must not
+     * become a plan merely because it contains familiar transformer keys. */
+    char tmp[] = "/tmp/lmb-plan-XXXXXX";
+    char *td = mkdtemp(tmp);
+    if (td) {
+        char path[256]; snprintf(path, sizeof path, "%s/config.json", td);
+        FILE *fp = fopen(path, "w");
+        if (fp) {
+            fputs("{\"model_type\":\"not_a_colibri_adapter\","
+                  "\"num_hidden_layers\":4,\"hidden_size\":64}", fp);
+            fclose(fp);
+            CHECK(lmb_shape_from_config(td, &none) != 0,
+                  "an unsupported model_type produced a shape");
+            unlink(path);
+        }
+        rmdir(td);
+    }
 
     printf("PLANNER: %s\n", bad ? "FAIL" : "PASS");
     return bad ? 1 : 0;

--- a/tui_test.sh
+++ b/tui_test.sh
@@ -26,6 +26,8 @@ cat >"$T/models/small/config.json" <<'EOF'
  "intermediate_size":128,"num_experts":8,"num_experts_per_tok":2,
  "num_attention_heads":4,"num_key_value_heads":4,"vocab_size":256}
 EOF
+truncate -s 4096 "$T/models/huge/model.bin"
+truncate -s 4096 "$T/models/small/model.bin"
 
 snap() { ./lumabri models --models-dir "$T/models" --snapshot "$@" 2>&1; }
 
@@ -97,4 +99,3 @@ if python3 ./tui_pty_check.py "$T/models"; then :
 else fail "the terminal was left in raw mode after quitting"; fi
 
 echo "TUI TEST: PASS (nothing truncated, nothing claimed, terminal restored)"
-


### PR DESCRIPTION
## Perché

Audit e correzione dello stack #139–#143. Le PR introducevano il primo percorso verso il cluster domestico, ma contenevano alcuni errori fail-open, affermazioni più forti delle prove disponibili e un problema critico nel trasporto Hosted.

Questa PR non dichiara conclusa la roadmap: rende la base corrente sicura, verificabile e onesta prima delle successive milestone.

## Correzioni principali

- dispatch esatto e fail-closed per tutti gli 8 adapter Colibri correnti; aggiunti `glm53` e `qwen38`, rimossi substring e fallback generici;
- test di parità automatico contro il registro autorevole di Colibri, inclusi tutti gli alias `model_type`;
- separati artifact monolitico e chatter P2P (in particolare `deepseek_v4` vs `deepseek`);
- protocol kind ricavato dal `model_type`, così rinominare un binario non cambia silenziosamente codec/template;
- planner scope-aware su `config.json`, senza leggere per errore campi vision annidati;
- sizing dichiarato verificato solo per OLMoE e DeepSeek V4; gli altri adapter restano visibili ma non ottengono una decisione di fit inventata;
- RAM e VRAM non sono più sommate come memoria fungibile; Edge viene sottratto dal budget RAM del nodo;
- nessun piano eseguibile senza una sorgente reale dei pesi;
- preflight Segment riportato alla guardia conservativa basata sul checkpoint reale: il vecchio flag disco non può autorizzare una modalità che l'adapter non implementa;
- catalogo ricorsivo dei pesi, JSON versionato come secondo consumer dello snapshot C, refresh TUI reale e calibrazioni stale/fresh basate sulla chiave completa;
- Hosted Chat interamente dentro frame autenticati/cifrati `HOST_STREAM` (prima, dopo l'handshake, i byte del codec viaggiavano raw);
- validazione server-side di `SUBMIT`, limiti, timeout, BUSY immediato e lifecycle corretto dei socket remoti;
- scritture complete dei prompt: una short write non può più troncare silenziosamente una richiesta Hosted;
- test di conformità e documentazione non presentano loopback come LAN reale, fixture assenti come adapter supportati o stime non calibrate come prestazioni.

## Verifiche

- `make test ENGINE=/tmp/colibri-current-lean` — PASS completo;
- `make check-warnings ENGINE=/tmp/colibri-current-lean` — PASS con `-Werror` per Lumabri (rimane un warning upstream nell'inizializzatore Qwen38 di Colibri);
- `hosted_chat_test.sh` — zero byte checkpoint al chatter, stream cifrato/autenticato, BUSY reale;
- `segment_budget_test.sh` — budget residente accettato, range sottodimensionato rifiutato;
- `multi_session_test.sh` — capacità 1 serve esattamente 1 di 2 e rifiuta esplicitamente l'altro;
- `segment_coverage_test.sh` — gap rifiutato e route esatta `0:6 -> 6:10 -> 10:16` verificata;
- `segment_split_test.sh` — token identici tra uno e due nodi e relay non usato. I tempi sono stati invalidati automaticamente per carico host alto: è una prova loopback di correttezza, non una misura LAN;
- conformità adapter: `1 supported, 7 experimental, 0 failed` con le fixture presenti; modalità strict disponibile per il laboratorio.

## Confine attuale, esplicito

Restano da implementare prima di poter dire “roadmap conclusa”: sizing adapter-specific per le altre sei famiglie, inventario distribuito, placement calibrato (ora è solo memory-feasible), applicazione automatica del piano, prova LAN reale, persistenza/runner delle calibrazioni, modalità disco verificata per adapter, Hosted discovery/autoselezione, failover e concorrenza su scala, GPU Segment e acceleratori Hybrid.

Target intenzionale: `feat/tui`, perché questa è una correzione cumulativa dello stack #139–#143.
