### PR TITLE
fix: macOS workspace build and native frontend gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ permissions:
   contents: read
 
 jobs:
+  macos-workspace:
+    # Native frontend gate, not certification of Segment, GPU or a real LAN.
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build the C workspace with Apple Clang
+        run: make lumabri test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+      - name: Readiness descriptors and portable fallback
+        run: make test-ready-pipe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+      - name: Native workspace navigation and terminal restoration
+        run: python3 tests/integration/workspace_navigation_test.py
   linux:
     runs-on: ubuntu-24.04
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: make lumabri test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
       - name: Readiness descriptors and portable fallback
         run: make test-ready-pipe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+      - name: Native cryptographic known-answer tests
+        run: bash tests/integration/crypto_test.sh
       - name: Native workspace navigation and terminal restoration
         run: python3 tests/integration/workspace_navigation_test.py
   linux:

--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,16 @@ test_home: tests/c/test_home.c lumabri_home.h lumabri_inventory.h lumabri_famili
 test_chat_ui: tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_chat_ui.c src/ui/lumabri_tui.c lumabri_machine.c -o $@
 
-test-chat-ui: lumabri test_chat_ui
+test-ready-pipe: tests/c/test_ready_pipe.c lumabri_ready.h
+	mkdir -p build/tests
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_ready_pipe.c -o build/tests/ready-pipe
+	./build/tests/ready-pipe
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DLMB_READY_PORTABLE_PIPE tests/c/test_ready_pipe.c -o build/tests/ready-pipe-portable
+	./build/tests/ready-pipe-portable
+
+.PHONY: test-ready-pipe
+
+test-chat-ui: lumabri test_chat_ui test-ready-pipe
 	python3 tests/integration/chat_ui_test.py
 	python3 tests/ui_text_test.py
 	python3 tests/integration/workspace_navigation_test.py
@@ -689,6 +698,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	bash ./tests/integration/catalog_test.sh
 	./test_inventory
 	./test_home
+	$(MAKE) test-ready-pipe
 	python3 ./tests/integration/chat_ui_test.py
 	python3 tests/ui_text_test.py
 	python3 tests/integration/workspace_navigation_test.py

--- a/lumabri.c
+++ b/lumabri.c
@@ -3971,7 +3971,7 @@ static int role_start_segment(const Role *r, const char *tracker,
     donor_base_name(r, base, sizeof base);
     snprintf(name, sizeof name, "%s-segment-%d", base, port);
     int ready_pipe[2];
-    if (pipe2(ready_pipe, O_CLOEXEC)) return 0;
+    if (lmb_ready_pipe(ready_pipe)) return 0;
     int fd_flags = fcntl(ready_pipe[1], F_GETFD);
     if (fd_flags < 0 || fcntl(ready_pipe[1], F_SETFD,
                               fd_flags & ~FD_CLOEXEC)) {

--- a/lumabri_crypto.h
+++ b/lumabri_crypto.h
@@ -37,7 +37,9 @@ static void lc_st32(uint8_t *p, uint32_t v) {
 
 static void lc_chacha_block(const uint8_t key[32], uint32_t counter,
                             const uint8_t nonce[12], uint8_t out[64]) {
-    static const char sigma[16] = "expand 32-byte k";
+    /* Keep the C string terminator; the four loads below consume only the
+     * 16 protocol bytes, not the terminator. */
+    static const char sigma[] = "expand 32-byte k";
     uint32_t s[16], x[16];
     s[0] = lc_ld32((const uint8_t *)sigma);
     s[1] = lc_ld32((const uint8_t *)sigma + 4);

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -592,8 +592,11 @@ static int home_request_chat(LmbTuiState *st, int selected) {
             ui_printf(7, 5, UI_TEXT, "Indexing %s", m->name);
             ui_text(10, 5, UI_MUTED, "Verifying checkpoint identity before requesting allocations.");
             ui_footer("No donor starts without approval.", "Esc cancels"); ui_present();
-        } else printf("LUMABRI / PREPARE CHAT\n\nIndexing %s and verifying its checkpoint identity.\n"
-               "No donor engine is running yet.\n\n[q] Cancel\n", m->name); fflush(stdout);
+        } else {
+            printf("LUMABRI / PREPARE CHAT\n\nIndexing %s and verifying its checkpoint identity.\n"
+                   "No donor engine is running yet.\n\n[q] Cancel\n", m->name);
+        }
+        fflush(stdout);
         if (!lmb_model_identity_get(st->tracker, model, &identity) &&
             !swarm_inspect(st->tracker, model, &swarm) && swarm.total_bytes) { found = 1; break; }
         if (waitpid(s.source, NULL, WNOHANG) == s.source) break;

--- a/lumabri_ready.h
+++ b/lumabri_ready.h
@@ -4,6 +4,29 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <limits.h>
+#include <errno.h>
+#include <fcntl.h>
+
+/* Linux can create CLOEXEC descriptors atomically. macOS has no pipe2;
+ * configure both ends before exposing them to the launch code. The portable
+ * fallback, like pipe()+fcntl() generally, requires no concurrent fork/exec
+ * between these calls. Keep the atomic path on Linux. */
+static inline int lmb_ready_pipe(int fd[2]) {
+#if defined(__linux__) && defined(_GNU_SOURCE) && !defined(LMB_READY_PORTABLE_PIPE)
+    return pipe2(fd, O_CLOEXEC);
+#else
+    if (pipe(fd)) return -1;
+    if (fcntl(fd[0], F_SETFD, FD_CLOEXEC) < 0 ||
+        fcntl(fd[1], F_SETFD, FD_CLOEXEC) < 0) {
+        int saved = errno;
+        close(fd[0]); close(fd[1]); fd[0] = fd[1] = -1;
+        errno = saved;
+        return -1;
+    }
+    return 0;
+#endif
+}
+
 static int lmb_ready_notify(void) {
     const char *s = getenv("LUMABRI_READY_FD");
     if (!s || !*s) return 0;

--- a/lumabri_secure.h
+++ b/lumabri_secure.h
@@ -29,6 +29,16 @@
 #include <ctype.h>
 #include <sys/file.h>
 
+/* Linux has a key-specific errno; Darwin uses EAUTH. Authentication still
+ * fails closed on systems that only expose the POSIX permission error. */
+#if defined(EKEYREJECTED)
+#define LMB_AUTH_REJECTED EKEYREJECTED
+#elif defined(EAUTH)
+#define LMB_AUTH_REJECTED EAUTH
+#else
+#define LMB_AUTH_REJECTED EACCES
+#endif
+
 typedef struct {
     int active;
     uint8_t tx_key[32], rx_key[32];
@@ -100,12 +110,12 @@ static int lmb_secure_handshake(int fd, int is_client,
         /* the server sends its identity and signature right after its
          * ephemeral; read and verify them, then send ours */
         if (lmb_read_full(fd, peer_id, 32) || lmb_read_full(fd, peer_sig, 64)) return -1;
-        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) { errno = EKEYREJECTED; return -1; }
+        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) { errno = LMB_AUTH_REJECTED; return -1; }
         if (lmb_write_full(fd, id_pk, 32) || lmb_write_full(fd, my_sig, 64)) return -1;
     } else {
         if (lmb_write_full(fd, id_pk, 32) || lmb_write_full(fd, my_sig, 64)) return -1;
         if (lmb_read_full(fd, peer_id, 32) || lmb_read_full(fd, peer_sig, 64)) return -1;
-        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) { errno = EKEYREJECTED; return -1; }
+        if (lmb_sign_verify(peer_sig, tr, tl, peer_id)) { errno = LMB_AUTH_REJECTED; return -1; }
     }
     memcpy(s->peer_id, peer_id, 32); s->have_peer_id = 1;
 

--- a/src/ui/lumabri_tui.c
+++ b/src/ui/lumabri_tui.c
@@ -7,6 +7,10 @@
  * in advance, and the layout code is straight-line because straight-line is
  * what two views need.
  */
+/* Darwin hides SIGWINCH in strict XSI mode even with <signal.h> included. */
+#if defined(__APPLE__) && !defined(_DARWIN_C_SOURCE)
+#define _DARWIN_C_SOURCE 1
+#endif
 #define _XOPEN_SOURCE 700
 #include "lumabri_tui.h"
 #include "lumabri_visual.h"

--- a/tests/c/test_ready_pipe.c
+++ b/tests/c/test_ready_pipe.c
@@ -1,0 +1,43 @@
+#define _GNU_SOURCE
+#include "lumabri_ready.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+
+int main(int argc, char **argv) {
+    if (argc == 4 && !strcmp(argv[1], "child")) {
+        int read_fd = atoi(argv[2]), write_fd = atoi(argv[3]);
+        errno = 0;
+        assert(fcntl(read_fd, F_GETFD) == -1 && errno == EBADF);
+        assert(fcntl(write_fd, F_GETFD) >= 0);
+        assert(!lmb_ready_notify());
+        return 0;
+    }
+    int fd[2];
+    assert(!lmb_ready_pipe(fd));
+    assert(fcntl(fd[0], F_GETFD) & FD_CLOEXEC);
+    assert(fcntl(fd[1], F_GETFD) & FD_CLOEXEC);
+    /* Only the explicitly designated writer survives the engine exec. */
+    assert(!fcntl(fd[1], F_SETFD, 0));
+    char read_fd[32], write_fd[32];
+    snprintf(read_fd, sizeof read_fd, "%d", fd[0]);
+    snprintf(write_fd, sizeof write_fd, "%d", fd[1]);
+    assert(!setenv("LUMABRI_READY_FD", write_fd, 1));
+    pid_t child = fork();
+    assert(child >= 0);
+    if (!child) {
+        execl(argv[0], argv[0], "child", read_fd, write_fd, (char *)NULL);
+        _exit(127);
+    }
+    close(fd[1]);
+    char byte = 0;
+    assert(read(fd[0], &byte, 1) == 1 && byte == 'R');
+    assert(read(fd[0], &byte, 1) == 0);
+    close(fd[0]);
+    int status;
+    assert(waitpid(child, &status, 0) == child);
+    assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    puts("READY PIPE: PASS (CLOEXEC, explicit writer inheritance, readiness, EOF)");
+    return 0;
+}


### PR DESCRIPTION
## Scope

Fix the three errors reported by a user building the workspace with Apple Clang on macOS 12.6 Intel:

- Map handshake signature rejection to the platform's authentication errno (EKEYREJECTED, EAUTH, or EACCES), without changing rejection behavior.
- Use a CLOEXEC pipe helper with an atomic Linux path and a checked pipe/fcntl fallback on macOS.
- Enable Darwin extensions before includes in the TUI; signal.h was already present, but strict XSI mode hid SIGWINCH.

## Regression coverage

- Add a readiness descriptor test covering both native and forced portable paths, CLOEXEC, explicit writer inheritance through exec, readiness delivery and EOF.
- Add a native macOS workspace build/navigation job. This is NOT certification of the engine, shim, GPU, physical LAN or Monterey.
- Linux Werror workspace/editor and security regression checks are run locally; CI results remain separately visible.

No model math, Colibri sources, household consent or wire protocol changes.
