### PR TITLE
Fix Mac TUI colours and persistent household LAN networking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ permissions:
   contents: read
 
 jobs:
+  windows-network-helper:
+    # Validate the permission helper without changing runner firewall rules.
+    # This does not certify a native Windows model runtime.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse and dry-run private-LAN permission changes
+        shell: powershell
+        run: |
+          & ./tools/setup-household-firewall.ps1 -Subnet 192.168.1.0/24 -WhatIf
+          & ./tools/setup-household-firewall.ps1 -Subnet 192.168.1.0/24 -Remove -WhatIf
+          $rejected = $false
+          try { & ./tools/setup-household-firewall.ps1 -Subnet 0.0.0.0/0 -WhatIf }
+          catch { $rejected = $true }
+          if (-not $rejected) { throw 'An unrestricted network was accepted' }
   macos-workspace:
     # Native frontend gate, not certification of Segment, GPU or a real LAN.
     runs-on: macos-latest
@@ -24,6 +39,8 @@ jobs:
         run: make test-ready-pipe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
       - name: Native cryptographic known-answer tests
         run: bash tests/integration/crypto_test.sh
+      - name: Household ports, discovery parser and terminal palettes
+        run: make test-home-network CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
       - name: Native workspace navigation and terminal restoration
         run: python3 tests/integration/workspace_navigation_test.py
   linux:
@@ -83,3 +100,9 @@ jobs:
           OLMOE_EDGE_MODEL=../colibri/c/olmoe_tiny_merged \
           SEGMENT_NODE_BIN=./segment_node SEGMENT_CHAT_BIN=./segment_chat \
             bash ./tests/integration/segment_priority_test.sh
+      - name: Household TUI — approvals through real Segment generation
+        working-directory: lumabri
+        run: |
+          mkdir -p build/home-flow-models
+          cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,11 @@ check-warnings:
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
+HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h
 MACHINE_SRC = lumabri_machine.c
 MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
-lumabri: lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_proto.h lumabri_sign.h \
+lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_proto.h lumabri_sign.h \
 		lumabri_inventory.h lumabri_home.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h \
 		lumabri_families.h lumabri_planner.h lumabri_cluster.h \
 		lumabri_calibration.h $(SECURE_DEPS) $(MACHINE_DEPS)
@@ -365,14 +366,14 @@ test-engines: test-phase2 test-phase2-glm test-phase2-inkling test-phase2-kimi
 	    echo "   it has no synthetic fixture — MODEL=<dir> make test-engines"; \
 	fi
 
-tracker: tracker.c lumabri_segment_discovery.c lumabri_segment_discovery.h \
+tracker: $(HOME_NET_DEPS) tracker.c lumabri_segment_discovery.c lumabri_segment_discovery.h \
 		 lumabri_inventory.h lumabri_machine.h \
 		 lumabri_segment.c lumabri_segment.h lumabri_proto.h lumabri_sha.h \
 		 lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tracker.c lumabri_segment_discovery.c \
 		lumabri_segment.c -o $@
 
-maintainer: maintainer.c lumabri_content.h lumabri_proto.h lumabri_sha.h \
+maintainer: maintainer.c $(HOME_NET_DEPS) lumabri_content.h lumabri_proto.h lumabri_sha.h \
 		lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread maintainer.c -o $@
 
@@ -426,7 +427,7 @@ test_inventory: tests/c/test_inventory.c lumabri_inventory.h lumabri_machine.h l
 test_home: tests/c/test_home.c lumabri_home.h lumabri_inventory.h lumabri_families.h lumabri_proto.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_home.c -o $@
 
-test_chat_ui: tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h
+test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_chat_ui.c src/ui/lumabri_tui.c lumabri_machine.c -o $@
 
 test-ready-pipe: tests/c/test_ready_pipe.c lumabri_ready.h
@@ -437,6 +438,13 @@ test-ready-pipe: tests/c/test_ready_pipe.c lumabri_ready.h
 	./build/tests/ready-pipe-portable
 
 .PHONY: test-ready-pipe
+
+test-home-network: tests/c/test_home_network.c $(HOME_NET_DEPS) src/ui/lumabri_visual.h
+	mkdir -p build/tests
+	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_home_network.c -o build/tests/home-network
+	./build/tests/home-network
+
+.PHONY: test-home-network
 
 test-chat-ui: lumabri test_chat_ui test-ready-pipe
 	python3 tests/integration/chat_ui_test.py
@@ -569,7 +577,7 @@ $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_brid
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 
-segment_node: segment_node.c lumabri_planner.h lumabri_families.h lumabri_ready.h \
+segment_node: segment_node.c $(HOME_NET_DEPS) lumabri_planner.h lumabri_families.h lumabri_ready.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS) \
 		lumabri_run_gate.c lumabri_run_gate.h
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
@@ -699,10 +707,12 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_inventory
 	./test_home
 	$(MAKE) test-ready-pipe
+	$(MAKE) test-home-network
 	python3 ./tests/integration/chat_ui_test.py
 	python3 tests/ui_text_test.py
 	python3 tests/integration/workspace_navigation_test.py
 	python3 ./tests/integration/lan_inventory_test.py
+	python3 tests/integration/household_network_test.py
 	bash ./tests/integration/hosted_chat_test.sh
 	bash ./tests/integration/tui_test.sh
 	./test_planner
@@ -738,6 +748,7 @@ install: all
 	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/lib/lumabri
 	install -m 755 lumabri tracker maintainer swarm_probe $(DESTDIR)$(PREFIX)/bin/
 	install -m 644 liblumabri.so $(DESTDIR)$(PREFIX)/lib/lumabri/
+	install -m 644 tools/setup-household-firewall.ps1 $(DESTDIR)$(PREFIX)/lib/lumabri/
 	@for b in expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	         expert_node_deepseek expert_node_qwen36 \
 	         olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p qwen36_p2p \

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ After launch, use **arrow keys and Enter**. Press **/** for workspace actions
 and **Esc** to go back. Use a terminal at least 60 columns by 28 rows.
 
 1. On one computer, open **/ → /create**. Keep Lumabri running.
-2. On your other computers, open **/ → /join** and enter the displayed
-   LAN address and household key. Only share that key with your household.
+2. On your other computers, open **/ → /join**. Select the household found
+   on your LAN, compare its identity with **/create** on the owner computer,
+   then enter the household key. Manual address entry remains available.
+   Only share that key with your household.
 3. Open **/settings** to set the maximum RAM you offer. Choose
    **Share resources** on each computer that may participate.
 4. On the requesting computer, set **/settings** to the folder containing
@@ -34,10 +36,26 @@ and **Esc** to go back. Use a terminal at least 60 columns by 28 rows.
    participating donors. Chat starts only after all approve and the complete
    chain is ready.
 
-The computers must be able to reach each other directly. This is explicit
-household membership, not automatic Wi-Fi discovery. If the displayed address
-belongs to a VPN or a WSL-only interface, do not assume another computer can
-reach it. Physical-LAN setup still needs validation.
+The creating computer saves its key and restarts its household when Lumabri
+reopens. The tracker uses **TCP 47300**, household services use **TCP
+47301–47315**, and LAN discovery uses **UDP 47300**. Restarting does not require
+opening another random port. If the fixed range is occupied, Lumabri reports
+the conflict instead of silently choosing ports outside it.
+
+The computers still need direct LAN connectivity. On Windows with mirrored
+WSL networking, open **/network** on the Windows computer: after your explicit
+approval and the Windows administrator prompt, it allows only those ports
+from the detected private subnet. The firewall stays enabled. The same action
+can remove Lumabri's rules. Keep the `tools` folder beside the built binary.
+Other systems use their normal firewall permissions. Guest Wi-Fi isolation,
+VPN routing and WSL NAT mode can still prevent direct discovery or connections;
+the helper does not reconfigure those networks. If your LAN address changes,
+use **/join** to rediscover the household rather than guessing an address.
+
+Apple Terminal uses a compatible 256-colour palette with a contrasting
+selection background. Other terminals use detected colour support. For
+diagnostics, `LUMABRI_COLOR=16`, `256`, `truecolor` or `none` overrides detection;
+`NO_COLOR=1` disables the canvas colours. Normal use needs no colour command.
 
 ## A plan before a download
 

--- a/lumabri.c
+++ b/lumabri.c
@@ -26,6 +26,7 @@
  */
 #define _GNU_SOURCE
 #include "lumabri_ready.h"
+#include "lumabri_home_net.h"
 #include <arpa/inet.h>
 #include <dirent.h>
 #include <fcntl.h>
@@ -3386,28 +3387,24 @@ static int cmd_host(int argc, char **argv) {
     snprintf(model, sizeof model, "%s", want_model ? want_model : "local");
     Engine eng = {0};
     Swarm sw;
+    int lfd = lmb_home_take_listener(port);
+    if (lfd < 0) { fprintf(stderr, "[host] cannot listen on %d\n", port); return 1; }
     if (model_boot(tracker ? tracker : "", model, shim, engines_dir,
                    engine_path, local_dir, ctx, max_new, cap_experts, &eng, &sw))
-        return 1;
+        { close(lfd); return 1; }
     if (!eng.segment && !kind_is_serve2(eng.kind)) {
         fprintf(stderr, "Hosted chat requires a SUBMIT/DATA/DONE engine; use Segment for this adapter.\n");
-        engine_stop(&eng); return 1;
+        close(lfd); engine_stop(&eng); return 1;
     }
 
     char mtype[64] = "";
     if (local_dir) local_model_type(local_dir, mtype, sizeof mtype);
     else snprintf(mtype, sizeof mtype, "%s", sw.model_type);
     const char *host_engine = engine_for(mtype);
-    if (!host_engine) { engine_stop(&eng); return 1; }
+    if (!host_engine) { close(lfd); engine_stop(&eng); return 1; }
     HostState h = { &eng, mtype, host_engine, 0, max_frame,
                     (uint32_t)max_new, idle_seconds, client_key ? allowed_client : NULL };
 
-    int lfd = lmb_listen(port);
-    if (lfd < 0) {
-        fprintf(stderr, "[host] cannot listen on %d\n", port);
-        engine_stop(&eng);
-        return 1;
-    }
     printf("  %shost ready on port %d · %s · one session at a time%s\n",
            C_DIM, port, mtype[0] ? mtype : "?", C_R);
     printf("  %sclients need no checkpoint; this machine holds the model and "

--- a/lumabri_home_discovery.h
+++ b/lumabri_home_discovery.h
@@ -1,0 +1,119 @@
+/* LAN-only discovery hints. No key/token/model data is broadcast. A result
+ * is NOT trusted: the user compares its identity with the host, and the
+ * encrypted connection must prove that identity before AUTH is sent. */
+#ifndef LUMABRI_HOME_DISCOVERY_H
+#define LUMABRI_HOME_DISCOVERY_H
+#include "lumabri_home_net.h"
+#include <pthread.h>
+
+#define LMB_HOME_DISC_QUERY 24
+#define LMB_HOME_DISC_REPLY 122
+#define LMB_HOME_DISC_MAX 8
+typedef struct { char address[64], name[64]; uint8_t identity[32]; } LmbHomeFound;
+
+static inline uint64_t lmb_home_disc_ms(void) {
+    struct timespec t; clock_gettime(CLOCK_MONOTONIC, &t);
+    return (uint64_t)t.tv_sec * 1000 + (uint64_t)t.tv_nsec / 1000000;
+}
+
+static inline int lmb_home_on_link(struct in_addr peer) {
+    if ((ntohl(peer.s_addr) >> 24) == 127) return 1;
+    struct ifaddrs *all = NULL; int found = 0;
+    if (getifaddrs(&all)) return 0;
+    for (struct ifaddrs *p = all; p; p = p->ifa_next) {
+        if (!p->ifa_addr || !p->ifa_netmask || p->ifa_addr->sa_family != AF_INET ||
+            !(p->ifa_flags & IFF_UP) || (p->ifa_flags & (IFF_LOOPBACK | IFF_POINTOPOINT))) continue;
+        struct in_addr local = ((struct sockaddr_in *)p->ifa_addr)->sin_addr;
+        uint32_t mask = ((struct sockaddr_in *)p->ifa_netmask)->sin_addr.s_addr;
+        if (mask && (peer.s_addr & mask) == (local.s_addr & mask)) found = 1;
+    }
+    freeifaddrs(all); return found;
+}
+
+static inline int lmb_home_disc_parse(const uint8_t *p, size_t len,
+    const uint8_t nonce[16], const struct sockaddr_in *from, LmbHomeFound *out) {
+    if (len != LMB_HOME_DISC_REPLY || memcmp(p, "LMBHOME1", 8) ||
+        memcmp(p + 8, nonce, 16) || !memchr(p + 58, 0, 64)) return -1;
+    unsigned port = p[56] | ((unsigned)p[57] << 8), any = 0;
+    if (port < 1024 || !p[58]) return -1;
+    for (int i = 0; i < 32; i++) any |= p[24 + i];
+    if (!any) return -1;
+    for (int i = 58; i < 122 && p[i]; i++) if (p[i] < 32 || p[i] > 126) return -1;
+    char ip[INET_ADDRSTRLEN];
+    if (!inet_ntop(AF_INET, &from->sin_addr, ip, sizeof ip)) return -1;
+    memset(out, 0, sizeof *out);
+    snprintf(out->address, sizeof out->address, "%s:%u", ip, port);
+    memcpy(out->identity, p + 24, 32);
+    memcpy(out->name, p + 58, 64); /* bounded and NUL-checked above */
+    return 0;
+}
+
+typedef struct { int fd, port; uint8_t identity[32]; } LmbHomeBeacon;
+static inline void *lmb_home_beacon_loop(void *arg) {
+    LmbHomeBeacon b = *(LmbHomeBeacon *)arg; free(arg);
+    char hostname[64] = "household";
+    (void)gethostname(hostname, sizeof hostname - 1); hostname[63] = 0;
+    for (char *p = hostname; *p; p++) if ((unsigned char)*p < 32 || (unsigned char)*p > 126) *p = '_';
+    uint64_t previous = 0;
+    for (;;) {
+        uint8_t query[LMB_HOME_DISC_QUERY + 1]; struct sockaddr_in peer;
+        socklen_t size = sizeof peer;
+        ssize_t n = recvfrom(b.fd, query, sizeof query, 0, (struct sockaddr *)&peer, &size);
+        if (n < 0) { if (errno == EINTR) continue; break; }
+        uint64_t now = lmb_home_disc_ms();
+        if (n != LMB_HOME_DISC_QUERY || memcmp(query, "LMBFIND1", 8) ||
+            peer.sin_family != AF_INET || now - previous < 100 || !lmb_home_on_link(peer.sin_addr)) continue;
+        previous = now;
+        uint8_t reply[LMB_HOME_DISC_REPLY] = {0};
+        memcpy(reply, "LMBHOME1", 8); memcpy(reply + 8, query + 8, 16);
+        memcpy(reply + 24, b.identity, 32);
+        reply[56] = (uint8_t)b.port; reply[57] = (uint8_t)(b.port >> 8);
+        memcpy(reply + 58, hostname, strlen(hostname));
+        (void)sendto(b.fd, reply, sizeof reply, 0, (struct sockaddr *)&peer, size);
+    }
+    close(b.fd); return NULL;
+}
+
+static inline int lmb_home_beacon_start(int port, const uint8_t identity[32]) {
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) return -1;
+    struct sockaddr_in addr = {0}; addr.sin_family = AF_INET;
+    addr.sin_port = htons((uint16_t)port); addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) || bind(fd, (struct sockaddr *)&addr, sizeof addr)) { close(fd); return -1; }
+    LmbHomeBeacon *b = malloc(sizeof *b);
+    if (!b) { close(fd); return -1; }
+    b->fd = fd; b->port = port; memcpy(b->identity, identity, 32);
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, lmb_home_beacon_loop, b)) { free(b); close(fd); return -1; }
+    pthread_detach(thread); return 0;
+}
+
+static inline int lmb_home_find(LmbHomeFound found[LMB_HOME_DISC_MAX], const uint8_t nonce[16]) {
+    int base = lmb_home_port_base(), count = 0;
+    if (base < 0) return 0;
+    int fd = socket(AF_INET, SOCK_DGRAM, 0), one = 1;
+    if (fd < 0) return 0;
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) || setsockopt(fd, SOL_SOCKET, SO_BROADCAST, &one, sizeof one)) { close(fd); return 0; }
+    uint8_t query[LMB_HOME_DISC_QUERY]; memcpy(query, "LMBFIND1", 8); memcpy(query + 8, nonce, 16);
+    struct sockaddr_in dst = {0}; dst.sin_family = AF_INET; dst.sin_port = htons((uint16_t)base);
+    dst.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+    (void)sendto(fd, query, sizeof query, 0, (struct sockaddr *)&dst, sizeof dst);
+    /* Same-machine test/development households are also discoverable. */
+    dst.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    (void)sendto(fd, query, sizeof query, 0, (struct sockaddr *)&dst, sizeof dst);
+    uint64_t deadline = lmb_home_disc_ms() + 1200;
+    while (count < LMB_HOME_DISC_MAX && lmb_home_disc_ms() < deadline) {
+        struct pollfd pollfd = {fd, POLLIN, 0};
+        if (poll(&pollfd, 1, 100) <= 0) continue;
+        uint8_t reply[LMB_HOME_DISC_REPLY + 1]; struct sockaddr_in peer; socklen_t len = sizeof peer;
+        ssize_t n = recvfrom(fd, reply, sizeof reply, 0, (struct sockaddr *)&peer, &len);
+        LmbHomeFound entry;
+        if (n < 0 || !lmb_home_on_link(peer.sin_addr) ||
+            lmb_home_disc_parse(reply, (size_t)n, query + 8, &peer, &entry)) continue;
+        int duplicate = 0;
+        for (int i = 0; i < count; i++) if (!memcmp(found[i].identity, entry.identity, 32)) duplicate = 1;
+        if (!duplicate) found[count++] = entry;
+    }
+    close(fd); return count;
+}
+#endif

--- a/lumabri_home_net.h
+++ b/lumabri_home_net.h
@@ -1,0 +1,112 @@
+/* Fixed household service range. No random port may escape the firewall
+ * allowance. The override is for isolated tests/advanced deployments. */
+#ifndef LUMABRI_HOME_NET_H
+#define LUMABRI_HOME_NET_H
+#include "lumabri_proto.h"
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <limits.h>
+
+#define LMB_HOME_PORT_BASE 47300
+#define LMB_HOME_PORT_COUNT 16
+
+/* Consume a socket reserved by our launcher. Holding it across exec avoids
+ * two concurrently approved donors choosing the same apparently free port.
+ * Restore CLOEXEC before any engine descendants are launched. */
+static inline int lmb_home_take_listener(int port) {
+    const char *value = getenv("LUMABRI_HOME_LISTEN_FD");
+    if (!value) {
+        int fd = lmb_listen(port);
+        if (fd >= 0 && fcntl(fd, F_SETFD, FD_CLOEXEC)) {
+            int saved = errno; close(fd); errno = saved; return -1;
+        }
+        return fd;
+    }
+    char *end; errno = 0;
+    long n = strtol(value, &end, 10);
+    int bad = errno || !*value || *end || n < 3 || n > INT_MAX;
+    unsetenv("LUMABRI_HOME_LISTEN_FD");
+    if (bad) { errno = EINVAL; return -1; }
+    int fd = (int)n, listening = 0;
+    struct sockaddr_in addr = {0}; socklen_t size = sizeof addr, opt = sizeof listening;
+    if (getsockname(fd, (struct sockaddr *)&addr, &size) || size != sizeof addr ||
+        addr.sin_family != AF_INET || ntohs(addr.sin_port) != port ||
+        getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &listening, &opt) || !listening ||
+        fcntl(fd, F_SETFD, FD_CLOEXEC)) { close(fd); errno = EINVAL; return -1; }
+    return fd;
+}
+
+static inline int lmb_home_port_base(void) {
+    const char *s = getenv("LUMABRI_HOME_PORT_BASE");
+    if (!s || !*s) return LMB_HOME_PORT_BASE;
+    char *end; errno = 0;
+    long n = strtol(s, &end, 10);
+    if (errno || *end || n < 1024 || n > 65536 - LMB_HOME_PORT_COUNT) {
+        errno = EINVAL; return -1;
+    }
+    return (int)n;
+}
+
+static inline int lmb_home_listen_service(int *port) {
+    int base = lmb_home_port_base();
+    if (base < 0) return -1;
+    for (int n = base + 1; n < base + LMB_HOME_PORT_COUNT; n++) {
+        int fd = lmb_listen(n);
+        if (fd < 0) {
+            if (errno == EADDRINUSE) continue;
+            return -1;
+        }
+        if (fcntl(fd, F_SETFD, FD_CLOEXEC) < 0) {
+            int saved = errno; close(fd); errno = saved; return -1;
+        }
+        *port = n; return fd;
+    }
+    errno = EADDRINUSE; return -1;
+}
+
+static inline int lmb_home_ip_score(unsigned flags, uint32_t host) {
+    if (!(flags & IFF_UP) || (flags & IFF_LOOPBACK) || !host ||
+        (host >> 24) == 127 || (host >> 24) == 0 ||
+        (host >> 16) == 0xa9fe || (host >> 28) >= 14) return 0;
+    int private_ip = (host >> 24) == 10 || (host >> 20) == 0xac1 ||
+                     (host >> 16) == 0xc0a8;
+    return 1 + private_ip * 2 + !(flags & IFF_POINTOPOINT);
+}
+
+static inline int lmb_home_interface_ip(char *out, size_t cap) {
+    struct ifaddrs *all = NULL;
+    if (getifaddrs(&all)) return -1;
+    int best = 0;
+    for (struct ifaddrs *p = all; p; p = p->ifa_next) {
+        if (!p->ifa_addr || p->ifa_addr->sa_family != AF_INET) continue;
+        struct sockaddr_in *a = (struct sockaddr_in *)p->ifa_addr;
+        int score = lmb_home_ip_score(p->ifa_flags, ntohl(a->sin_addr.s_addr));
+        if (score > best && inet_ntop(AF_INET, &a->sin_addr, out, cap)) best = score;
+    }
+    freeifaddrs(all);
+    return best ? 0 : -1;
+}
+
+static inline int lmb_home_subnet(const char *ip, char *out, size_t cap) {
+    struct in_addr wanted;
+    if (inet_pton(AF_INET, ip, &wanted) != 1) return -1;
+    struct ifaddrs *all = NULL; int rc = -1;
+    if (getifaddrs(&all)) return -1;
+    for (struct ifaddrs *p = all; p; p = p->ifa_next) {
+        if (!p->ifa_addr || !p->ifa_netmask || p->ifa_addr->sa_family != AF_INET ||
+            ((struct sockaddr_in *)p->ifa_addr)->sin_addr.s_addr != wanted.s_addr) continue;
+        uint32_t mask = ntohl(((struct sockaddr_in *)p->ifa_netmask)->sin_addr.s_addr);
+        unsigned prefix = 0; uint32_t bits = mask;
+        while (bits & 0x80000000u) { prefix++; bits <<= 1; }
+        if (bits || prefix < 8 || prefix > 30) continue;
+        struct in_addr network = {htonl(ntohl(wanted.s_addr) & mask)};
+        char text[INET_ADDRSTRLEN];
+        if (inet_ntop(AF_INET, &network, text, sizeof text)) {
+            int n = snprintf(out, cap, "%s/%u", text, prefix);
+            rc = n >= 0 && (size_t)n < cap ? 0 : -1;
+        }
+    }
+    freeifaddrs(all); return rc;
+}
+#endif

--- a/lumabri_home_net.h
+++ b/lumabri_home_net.h
@@ -28,11 +28,14 @@ static inline int lmb_home_take_listener(int port) {
     int bad = errno || !*value || *end || n < 3 || n > INT_MAX;
     unsetenv("LUMABRI_HOME_LISTEN_FD");
     if (bad) { errno = EINVAL; return -1; }
-    int fd = (int)n, listening = 0;
-    struct sockaddr_in addr = {0}; socklen_t size = sizeof addr, opt = sizeof listening;
+    int fd = (int)n, type = 0;
+    struct sockaddr_in addr = {0}; socklen_t size = sizeof addr, opt = sizeof type;
+    /* Darwin defines SO_ACCEPTCONN but does not expose it via getsockopt.
+     * Validate the type/endpoint, then assert listening with portable listen;
+     * this is idempotent for our listener and rejects connected sockets. */
     if (getsockname(fd, (struct sockaddr *)&addr, &size) || size != sizeof addr ||
         addr.sin_family != AF_INET || ntohs(addr.sin_port) != port ||
-        getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &listening, &opt) || !listening ||
+        getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &opt) || type != SOCK_STREAM || listen(fd, 64) ||
         fcntl(fd, F_SETFD, FD_CLOEXEC)) { close(fd); errno = EINVAL; return -1; }
     return fd;
 }

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -2,6 +2,7 @@
  * Only this translation unit owns the secure transport sessions. */
 #ifndef LUMABRI_HOME_RUNTIME_H
 #define LUMABRI_HOME_RUNTIME_H
+#include "lumabri_home_net.h"
 
 typedef struct {
     struct termios saved;
@@ -66,25 +67,13 @@ static int home_local_ip(const char *tracker, char out[INET_ADDRSTRLEN]) {
 }
 
 static int home_listen(int *port) {
-    int fd = lmb_listen(0);
-    struct sockaddr_in local;
-    socklen_t len = sizeof local;
-    if (fd < 0) return -1;
-    if (getsockname(fd, (struct sockaddr *)&local, &len)) { close(fd); return -1; }
-    *port = ntohs(local.sin_port);
-    (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
-    return fd;
+    return lmb_home_listen_service(port);
 }
 
-static int home_free_port(void) {
-    int port = 0, fd = home_listen(&port);
-    if (fd >= 0) close(fd);
-    return port;
-}
-
-static pid_t home_spawn(char *const argv[], char *const envv[], const char *log, int *ready_fd) {
+/* Consumes listener, including on failure; other child descriptors stay CLOEXEC. */
+static pid_t home_spawn(char *const argv[], char *const envv[], const char *log, int *ready_fd, int listener) {
     int ready[2] = {-1, -1};
-    if (ready_fd && pipe(ready)) return -1;
+    if (ready_fd && pipe(ready)) { if (listener >= 0) close(listener); return -1; }
     if (ready_fd) (void)fcntl(ready[0], F_SETFD, FD_CLOEXEC);
     pid_t parent = getpid(), pid = fork();
     if (!pid) {
@@ -96,6 +85,12 @@ static pid_t home_spawn(char *const argv[], char *const envv[], const char *log,
         if (nullfd > 2) close(nullfd);
         if (logfd > 2) close(logfd);
         for (int i = 0; envv && envv[i]; i++) putenv(envv[i]);
+        if (listener >= 0) {
+            char descriptor[32];
+            if (fcntl(listener, F_SETFD, 0)) _exit(125);
+            snprintf(descriptor, sizeof descriptor, "%d", listener);
+            setenv("LUMABRI_HOME_LISTEN_FD", descriptor, 1);
+        } else unsetenv("LUMABRI_HOME_LISTEN_FD");
         if (ready_fd) {
             char descriptor[32];
             close(ready[0]);
@@ -104,6 +99,7 @@ static pid_t home_spawn(char *const argv[], char *const envv[], const char *log,
         } else unsetenv("LUMABRI_READY_FD");
         execv(argv[0], argv); _exit(127);
     }
+    if (listener >= 0) close(listener);
     if (ready_fd) {
         close(ready[1]);
         if (pid < 0) close(ready[0]);
@@ -212,8 +208,8 @@ static int home_donor_launch(HomeDonor *d, int edge) {
                    e_key, "LUMABRI_SEGMENT_REQUIRED=1", "LUMABRI_VERIFY=0",
                    "LUMABRI_PREFETCH=0", "LUMABRI_NO_EXEC=1", e_log,
                    edge ? e_limit : "LUMABRI_HOME_SEGMENT=1", NULL};
-    int chosen_port = home_free_port();
-    if (!chosen_port) return -1;
+    int chosen_port = 0, listener = home_listen(&chosen_port);
+    if (listener < 0) return -1;
     snprintf(port, sizeof port, "%d", chosen_port);
     snprintf(addr, sizeof addr, "%s:%d", d->ip, chosen_port);
     snprintf(name, sizeof name, "home-%.12s-%u", id, o->begin);
@@ -238,11 +234,11 @@ static int home_donor_launch(HomeDonor *d, int edge) {
         /* The host itself must not be preloaded; model_boot passes the mirror
          * to its Edge child, while its own networking remains ordinary C. */
         envv[0] = "LD_PRELOAD=";
-        d->host = home_spawn(host_argv, envv, d->log, &d->host_ready);
+        d->host = home_spawn(host_argv, envv, d->log, &d->host_ready, listener);
         d->host_port = chosen_port;
         return d->host > 0 ? 0 : -1;
     }
-    d->segment = home_spawn(segment_argv, envv, d->log, &d->segment_ready);
+    d->segment = home_spawn(segment_argv, envv, d->log, &d->segment_ready, listener);
     d->segment_port = chosen_port;
     return d->segment > 0 ? 0 : -1;
 }
@@ -271,8 +267,9 @@ static void home_donor_screen(const HomeDonor *d, const char *name, uint64_t ram
         if (t->phase == LMB_HOME_PENDING) {
             ui_item(y, choice == 0, "Accept this request", "Reserve only the displayed resources for this plan.");
             ui_item(y + 3, choice == 1, "Decline", "No weights or model state will be loaded.");
-        } else ui_item(y, 1, "Stop sharing and return", "Release this plan and its resources.");
-        ui_footer(t->reason[0] ? t->reason : d->log, "↑ ↓ choose   Enter confirm   Esc stop and return");
+        } else ui_item(y, 0, "Keep this window open to share", "Press Esc to stop sharing and release resources.");
+        ui_footer(t->reason[0] ? t->reason : d->log, t->phase == LMB_HOME_PENDING ?
+            "↑ ↓ choose   Enter confirm   Esc stop and return" : "Esc stop sharing and return");
         if (ui_w < 60 || ui_h < 28) {
             ui_begin("share resources"); ui_text(5, 4, UI_SAND, "Resize to at least 60 × 28. Esc stops sharing.");
         }
@@ -402,7 +399,7 @@ static int cmd_donor(int argc, char **argv) {
     char *worker_argv[] = {own_bin, "worker", "--join", (char *)tracker,
         "--name", (char *)name, "--ram-gb", budget, "--disk", d.cache_base,
         "--control-address", addr, NULL};
-    pid_t reporter = home_spawn(worker_argv, NULL, report_log, NULL);
+    pid_t reporter = home_spawn(worker_argv, NULL, report_log, NULL, -1);
     if (reporter <= 0) { close(listener); return 1; }
     g_stopping = 0; install_chat_signal_handlers(); signal(SIGPIPE, SIG_IGN);
     HomeTerminal term; home_terminal_begin(&term);
@@ -433,7 +430,7 @@ static int cmd_donor(int argc, char **argv) {
         if (key == 1001 || key == 1002) { donor_choice = !donor_choice; redraw = 0; }
         if (key == '\r' || key == '\n') {
             if (term.active && (ui_w < 60 || ui_h < 28)) continue;
-            if (d.transaction.phase != LMB_HOME_PENDING) break;
+            if (d.transaction.phase != LMB_HOME_PENDING) continue;
             key = donor_choice ? 'n' : 'y';
         }
         if (key == 'x') home_donor_disconnect(&d, "Stopped by this computer's owner.");
@@ -570,7 +567,8 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     char logdir[1100], logfile[1200];
     exe_dir(dir, sizeof dir); snprintf(maintainer, sizeof maintainer, "%s/maintainer", dir);
     if (access(maintainer, X_OK) || home_local_ip(st->tracker, ip)) return -1;
-    int source_port = home_free_port(); if (!source_port) return -1;
+    int source_port = 0, source_listener = home_listen(&source_port);
+    if (source_listener < 0) return -1;
     snprintf(port, sizeof port, "%d", source_port); snprintf(addr, sizeof addr, "%s:%d", ip, source_port);
     snprintf(name, sizeof name, "home-source-%.16s", idhex);
     snprintf(logdir, sizeof logdir, "%s/.lumabri/logs", getenv("HOME") ? getenv("HOME") : ".");
@@ -580,7 +578,7 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         "--advertise", addr, "--key", kp, NULL};
     HomeTerminal term; home_terminal_begin(&term);
     g_stopping = 0; install_chat_signal_handlers(); signal(SIGPIPE, SIG_IGN);
-    s.source = home_spawn(source_argv, NULL, logfile, NULL);
+    s.source = home_spawn(source_argv, NULL, logfile, NULL, source_listener);
     int result = -1;
     if (s.source <= 0) goto done;
     LmbModelIdentity identity;

--- a/maintainer.c
+++ b/maintainer.c
@@ -27,6 +27,7 @@
 #include "lumabri_sha.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
+#include "lumabri_home_net.h"
 
 #define MAX_FILES          4096
 #define MAX_INCLUDES       64
@@ -1146,7 +1147,7 @@ int main(int argc, char **argv) {
             return 1;
         }
     }
-    int lfd = lmb_listen(port);
+    int lfd = lmb_home_take_listener(port);
     if (lfd < 0) { perror("[maintainer] listen"); return 1; }
     pthread_t t;
     if (g.tracker[0]) { pthread_create(&t, NULL, control_thread, NULL); pthread_detach(t); }

--- a/segment_node.c
+++ b/segment_node.c
@@ -11,6 +11,7 @@
 #include "lumabri_secure.h"
 #include "segment_colibri.h"
 #include "lumabri_ready.h"
+#include "lumabri_home_net.h"
 
 #include <pthread.h>
 #include <dirent.h>
@@ -1465,7 +1466,7 @@ int main(int argc, char **argv) {
                 peer_key_path);
         return 1;
     }
-    g_listen_fd = lmb_listen((int)port);
+    g_listen_fd = lmb_home_take_listener((int)port);
     if (g_listen_fd < 0) { perror("segment listen"); return 1; }
     pthread_t registration_thread, reaper_thread, governor_thread;
     if (pthread_create(&registration_thread, NULL, registration_worker,

--- a/src/ui/lumabri_home_ui.h
+++ b/src/ui/lumabri_home_ui.h
@@ -1,9 +1,11 @@
-/* Household launcher. Connections are configured in the terminal, not flags.
- * No multicast discovery claim: membership uses one explicit LAN endpoint. */
+/* Household launcher. LAN discovery suggests endpoints; joining still
+ * requires a verified host identity and the household key. */
 #ifndef LUMABRI_HOME_UI_H
 #define LUMABRI_HOME_UI_H
+#include "lumabri_home_discovery.h"
 typedef struct {
     char tracker[256], token[LMB_TOKEN_MAX + 1], models[512], ram[32];
+    int owner;
 } HomeSettings;
 
 static int home_settings_path(char *path, size_t cap) {
@@ -30,6 +32,7 @@ static void home_settings_load(HomeSettings *s) {
         else if (!strcmp(line, "token")) (void)checked_printf(s->token, sizeof s->token, "%s", eq);
         else if (!strcmp(line, "models")) (void)checked_printf(s->models, sizeof s->models, "%s", eq);
         else if (!strcmp(line, "ram")) (void)checked_printf(s->ram, sizeof s->ram, "%s", eq);
+        else if (!strcmp(line, "owner")) s->owner = !strcmp(eq, "1");
     }
     fclose(f);
 }
@@ -42,8 +45,8 @@ static int home_settings_save(const HomeSettings *s) {
     if (fd < 0) return -1;
     FILE *f = fdopen(fd, "w");
     if (!f) { close(fd); unlink(temporary); return -1; }
-    int bad = fprintf(f, "tracker=%s\ntoken=%s\nmodels=%s\nram=%s\n",
-                      s->tracker, s->token, s->models, s->ram) < 0;
+    int bad = fprintf(f, "tracker=%s\ntoken=%s\nmodels=%s\nram=%s\nowner=%d\n",
+                      s->tracker, s->token, s->models, s->ram, s->owner) < 0;
     if (fflush(f) || fsync(fd)) bad = 1;
     if (fclose(f)) bad = 1;
     if (!bad && !rename(temporary, path)) return 0;
@@ -67,17 +70,183 @@ static int home_field(const char *label, char *value, size_t cap, int secret) {
 }
 
 static int home_interface_ip(char *out, size_t cap) {
-    struct ifaddrs *all = NULL;
-    if (getifaddrs(&all)) return -1;
-    int found = -1;
-    for (struct ifaddrs *p = all; p; p = p->ifa_next) {
-        if (!p->ifa_addr || p->ifa_addr->sa_family != AF_INET) continue;
-        struct sockaddr_in *a = (struct sockaddr_in *)p->ifa_addr;
-        uint32_t host = ntohl(a->sin_addr.s_addr);
-        if ((host >> 24) == 127 || !host) continue;
-        if (inet_ntop(AF_INET, &a->sin_addr, out, cap)) { found = 0; break; }
+    return lmb_home_interface_ip(out, cap);
+}
+
+static int home_connection_check(const char *address, const uint8_t *expected_identity) {
+    int fd = lmb_connect_ms_io(address, 1200, 1500);
+    if (fd < 0) return -1;
+    int rc = (expected_identity && !lmb_secure_peer_matches(fd, expected_identity)) || lmb_auth(fd);
+    LmbMsg response = {0};
+    if (!rc) rc = lmb_send(fd, LMB_PING, NULL, 0, NULL, 0) ||
+                  lmb_recv(fd, &response) || response.op != LMB_OK;
+    lmb_msg_free(&response); lmb_close(fd);
+    return rc ? -2 : 0;
+}
+
+/* Persist the household key and fixed tracker endpoint. A second local
+ * window may attach to our authenticated tracker; an unrelated listener
+ * must never be adopted or displaced. */
+static int home_tracker_resume(HomeSettings *s, pid_t *child, char *notice, size_t cap) {
+    char ip[INET_ADDRSTRLEN], dir[1024], binary[1200], log[1200], port[20];
+    int chosen = lmb_home_port_base();
+    if (chosen < 0 || home_interface_ip(ip, sizeof ip)) {
+        snprintf(notice, cap, "No usable LAN address or valid household port range."); return -1;
     }
-    freeifaddrs(all); return found;
+    HomeSettings next = *s;
+    if (!next.owner || !next.token[0]) {
+        uint8_t secret[16]; lmb_random(secret, sizeof secret);
+        lmb_hex(next.token, secret, sizeof secret);
+    }
+    next.owner = 1;
+    snprintf(next.tracker, sizeof next.tracker, "%s:%d", ip, chosen);
+    snprintf(port, sizeof port, "%d", chosen);
+    setenv("LUMABRI_TOKEN", next.token, 1);
+    int probe = lmb_listen(chosen);
+    if (probe < 0) {
+        if (errno != EADDRINUSE) {
+            int saved = errno; setenv("LUMABRI_TOKEN", s->token, 1);
+            snprintf(notice, cap, "Cannot open household port %d: %s", chosen, strerror(saved)); return -1;
+        }
+        if (home_connection_check(next.tracker, g_sec_pk)) {
+            setenv("LUMABRI_TOKEN", s->token, 1);
+            snprintf(notice, cap, "Household port %d is occupied. No random fallback; close the conflicting service.", chosen);
+            return -1;
+        }
+    } else {
+        if (fcntl(probe, F_SETFD, FD_CLOEXEC)) { close(probe); return -1; }
+        exe_dir(dir, sizeof dir);
+        snprintf(binary, sizeof binary, "%s/tracker", dir);
+        if (access(binary, X_OK)) {
+            close(probe);
+            setenv("LUMABRI_TOKEN", s->token, 1);
+            snprintf(notice, cap, "Tracker is not installed. Build the household services before creating a network."); return -1;
+        }
+        snprintf(log, sizeof log, "%s/.lumabri/home-tracker.log", getenv("HOME") ? getenv("HOME") : ".");
+        char *args[] = {binary, "--port", port, "--household-discovery", NULL};
+        *child = home_spawn(args, NULL, log, NULL, probe);
+        int ready = 0;
+        for (int attempt = 0; *child > 0 && attempt < 20 && !g_stopping; attempt++) {
+            if (!home_connection_check(next.tracker, g_sec_pk)) { ready = 1; break; }
+            if (waitpid(*child, NULL, WNOHANG) == *child) break;
+            (void)poll(NULL, 0, 100);
+        }
+        if (!ready) {
+            home_stop_child(child); setenv("LUMABRI_TOKEN", s->token, 1);
+            snprintf(notice, cap, "Household tracker did not become ready. Check home-tracker.log."); return -1;
+        }
+    }
+    if (home_settings_save(&next)) {
+        home_stop_child(child); setenv("LUMABRI_TOKEN", s->token, 1);
+        snprintf(notice, cap, "Could not save the household. No new settings were applied."); return -1;
+    }
+    *s = next;
+    snprintf(notice, cap, "Household ready at %.63s. TCP %d-%d stays fixed across restarts.",
+             s->tracker, chosen, chosen + LMB_HOME_PORT_COUNT - 1);
+    return 0;
+}
+
+/* A hint only becomes an endpoint after an explicit visual identity check.
+ * Manual joining stays available when broadcast is filtered by the router. */
+static int home_pick_household(HomeSettings *s, uint8_t expected[32]) {
+    HomeTerminal term; home_terminal_begin(&term);
+    ui_begin("find your household");
+    ui_text(7, 5, UI_TEXT, "Looking for households on this LAN...");
+    ui_footer("No key or conversation is broadcast.", "Discovery takes about one second."); ui_present();
+    uint8_t nonce[16]; lmb_random(nonce, sizeof nonce);
+    LmbHomeFound found[LMB_HOME_DISC_MAX]; int count = lmb_home_find(found, nonce), selected = 0;
+    if (!count) { home_terminal_end(&term); return 0; }
+    for (;;) {
+        ui_begin("join a household");
+        ui_text(5, 5, UI_TEXT, "Choose your computer, then verify its identity.");
+        int rows = (ui_h - 12) / 3; if (rows < 1) rows = 1;
+        int top = selected >= rows ? selected - rows + 1 : 0;
+        for (int i = top; i <= count && i < top + rows; i++) {
+            char label[160], description[160], hex[65];
+            if (i == count) {
+                snprintf(label, sizeof label, "Enter an address manually");
+                snprintf(description, sizeof description, "For networks where discovery is blocked.");
+            } else {
+                lmb_hex(hex, found[i].identity, 32);
+                snprintf(label, sizeof label, "%s", found[i].name);
+                snprintf(description, sizeof description, "%s · identity %.16s · not yet trusted", found[i].address, hex);
+            }
+            ui_item(8 + (i - top) * 3, selected == i, label, description);
+        }
+        ui_footer("Only pair with a computer you own and recognize.", "↑ ↓ move   Enter select   Esc cancel"); ui_present();
+        int key = home_key();
+        if (key == 27 || key == 3 || g_stopping) { home_terminal_end(&term); return -1; }
+        if (key == 1001) selected = (selected + count) % (count + 1);
+        if (key == 1002) selected = (selected + 1) % (count + 1);
+        if (key == '\r' || key == '\n') break;
+        (void)poll(NULL, 0, 80);
+    }
+    home_terminal_end(&term);
+    if (selected == count) return 0;
+    char hex[65], answer[16] = ""; lmb_hex(hex, found[selected].identity, 32);
+    printf("\nOn the host, open /create to view its identity. It must match: %.16s\n", hex);
+    if (home_field("Type yes only if the identity matches your host", answer, sizeof answer, 0) || strcmp(answer, "yes")) return -1;
+    snprintf(s->tracker, sizeof s->tracker, "%s", found[selected].address);
+    memcpy(expected, found[selected].identity, 32);
+    return 1;
+}
+
+static void home_network_setup(char *notice, size_t cap) {
+    char ip[INET_ADDRSTRLEN], subnet[64], answer[16] = "", port[20];
+    int base = lmb_home_port_base();
+    if (base < 0 || home_interface_ip(ip, sizeof ip) || lmb_home_subnet(ip, subnet, sizeof subnet)) {
+        snprintf(notice, cap, "Cannot determine the LAN subnet. No firewall changes made."); return;
+    }
+    printf("\nHousehold network: %s\nStable TCP ports: %d-%d\nDiscovery UDP port: %d\n",
+           subnet, base, base + LMB_HOME_PORT_COUNT - 1, base);
+    if (!getenv("WSL_DISTRO_NAME")) {
+        printf("\nAllow Lumabri in your system firewall on this trusted LAN.\n"
+               "Automatic permission setup here is available for Windows/WSL only.\n");
+        (void)home_field("Press Enter to return", answer, sizeof answer, 0); return;
+    }
+    printf("\nWindows will ask for administrator approval. Only this LAN and these ports\n"
+           "are allowed. The firewall stays enabled. Use only on a trusted home network.\n");
+    if (home_field("Type allow to configure once, remove to undo, or Enter to cancel", answer, sizeof answer, 0) ||
+        (strcmp(answer, "allow") && strcmp(answer, "remove"))) return;
+    char dir[1024], script[1200], windows[1600];
+    exe_dir(dir, sizeof dir);
+    if (checked_printf(script, sizeof script, "%s/tools/setup-household-firewall.ps1", dir) ||
+        (access(script, R_OK) &&
+         (checked_printf(script, sizeof script, "%s/../lib/lumabri/setup-household-firewall.ps1", dir) || access(script, R_OK)))) {
+        snprintf(notice, cap, "Network helper is missing beside Lumabri. No firewall changes made."); return;
+    }
+    int pipefd[2];
+    if (lmb_ready_pipe(pipefd)) return;
+    pid_t converter = fork();
+    if (!converter) {
+        close(pipefd[0]); dup2(pipefd[1], STDOUT_FILENO); close(pipefd[1]);
+        execlp("wslpath", "wslpath", "-w", script, (char *)NULL); _exit(127);
+    }
+    close(pipefd[1]);
+    FILE *output = fdopen(pipefd[0], "r");
+    int got = output && fgets(windows, sizeof windows, output) != NULL;
+    if (output) fclose(output); else close(pipefd[0]);
+    int status = 0;
+    if (converter <= 0 || waitpid(converter, &status, 0) != converter ||
+        !WIFEXITED(status) || WEXITSTATUS(status) || !got) {
+        snprintf(notice, cap, "Cannot locate the Windows network helper. No firewall changes made."); return;
+    }
+    windows[strcspn(windows, "\r\n")] = 0;
+    snprintf(port, sizeof port, "%d", base);
+    pid_t helper = fork();
+    if (!helper) {
+        char *args[] = {"powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass",
+            "-File", windows, "-Subnet", subnet, "-PortBase", port,
+            !strcmp(answer, "remove") ? "-Remove" : NULL, NULL};
+        execvp(args[0], args); _exit(127);
+    }
+    if (helper > 0) {
+        pid_t result;
+        do result = waitpid(helper, &status, 0); while (result < 0 && errno == EINTR);
+        snprintf(notice, cap, "%s", result == helper && WIFEXITED(status) && !WEXITSTATUS(status) ?
+            "Network permission updated. Reopen Join/Your computers to test the connection." :
+            "Network setup was cancelled or failed. Review the Windows error; no firewall was disabled.");
+    }
 }
 
 static int cmd_home(void) {
@@ -87,13 +256,14 @@ static int cmd_home(void) {
     char notice[200] = "";
     int selected = 0, actions = 0;
     g_stopping = 0; install_chat_signal_handlers();
+    if (s.owner) (void)home_tracker_resume(&s, &tracker_child, notice, sizeof notice);
     while (!g_stopping) {
         HomeTerminal term; home_terminal_begin(&term);
         int key = -1;
         while (!g_stopping) {
             ui_begin("your workspace");
             int top = 5;
-            if (ui_h >= 34 && ui_w >= 64) {
+            if (ui_h >= (actions ? 38 : 34) && ui_w >= 64) {
                 for (int r = 0; r < 6; r++) ui_text(top + r, 5, r < 3 ? UI_ACCENT : UI_SAND, WORDMARK[r]);
                 ui_text(top + 7, 5, UI_MUTED, "tiny engine, immense swarm");
                 if (ui_w >= 100) {
@@ -106,11 +276,11 @@ static int cmd_home(void) {
             static const char *titles[] = {"Start a conversation", "Explore models", "Your computers", "Share resources"};
             static const char *help[] = {"Choose a model and ask your selected donors.", "Memory needs, plans and measured speed.",
                 "See resources. Choose who participates.", "Review a request before anything is loaded."};
-            static const char *commands[] = {"/create", "/join", "/settings", "/quit"};
-            static const char *command_help[] = {"Create a household on this computer", "Join with its LAN address and household key",
-                "Model folder and maximum RAM to share", "Close Lumabri"};
+            static const char *commands[] = {"/create", "/join", "/settings", "/quit", "/network"};
+            static const char *command_help[] = {"Create or show this household", "Find your household on the LAN and pair with its key",
+                "Model folder and maximum RAM to share", "Close Lumabri", "Set up trusted LAN access once (Windows/WSL)"};
             ui_text(top, 5, UI_TEXT, actions ? "Workspace actions" : "What would you like to do?");
-            for (int i = 0; i < 4; i++) ui_item(top + 2 + i * 3, selected == i,
+            for (int i = 0; i < (actions ? 5 : 4); i++) ui_item(top + 2 + i * 3, selected == i,
                 actions ? commands[i] : titles[i], actions ? command_help[i] : help[i]);
             ui_footer(notice[0] ? notice : s.tracker[0] ? s.tracker : "Create or join a household with / actions.",
                       "↑ ↓ move   Enter select   / actions   Esc back   Ctrl-C exit");
@@ -124,10 +294,11 @@ static int cmd_home(void) {
             if (key == 3 || (key == 27 && !actions)) break;
             if (key == 27) { actions = 0; selected = 0; }
             if (key == '/') { actions = !actions; selected = 0; }
-            if (key == 1001) selected = (selected + 3) % 4;
-            if (key == 1002) selected = (selected + 1) % 4;
+            int choices = actions ? 5 : 4;
+            if (key == 1001) selected = (selected + choices - 1) % choices;
+            if (key == 1002) selected = (selected + 1) % choices;
             if ((key == '\r' || key == '\n') && ui_h >= 28 && ui_w >= 60) {
-                key = actions ? "njsq"[selected] : "ccpd"[selected];
+                key = actions ? "njsqf"[selected] : "ccpd"[selected];
                 actions = 0; selected = 0; break;
             }
             (void)poll(NULL, 0, 100);
@@ -135,19 +306,34 @@ static int cmd_home(void) {
         home_terminal_end(&term);
         if (key == 'q' || key == 3 || key == 27 || g_stopping) break;
         notice[0] = 0;
-        if (key == 'j') {
+        if (key == 'f') {
+            home_network_setup(notice, sizeof notice);
+        } else if (key == 'j') {
             if (tracker_child > 0) {
                 snprintf(notice, sizeof notice, "Close this household before joining another."); continue;
             }
             HomeSettings next = s;
-            if (home_field("Household LAN address (IP:port)", next.tracker, sizeof next.tracker, 0) ||
+            uint8_t expected[32]; int discovered = home_pick_household(&next, expected);
+            if (discovered < 0) continue;
+            if ((!discovered && home_field("Household LAN address (IP:port)", next.tracker, sizeof next.tracker, 0)) ||
                 home_field("Household key from its owner", next.token, sizeof next.token, 1) ||
                 !next.tracker[0] || !next.token[0]) continue;
             char normalized[256];
             if (tracker_addr_set(normalized, sizeof normalized, next.tracker)) continue;
             snprintf(next.tracker, sizeof next.tracker, "%s", normalized);
+            setenv("LUMABRI_TOKEN", next.token, 1);
+            int connected = home_connection_check(next.tracker, discovered ? expected : NULL);
+            if (connected) {
+                setenv("LUMABRI_TOKEN", s.token, 1);
+                snprintf(notice, sizeof notice, "%s", connected == -1 ?
+                    "Connection or secure handshake failed. Check the LAN address and Windows/WSL firewall." :
+                    "Household authentication failed. Check the household key and tracker.");
+                continue;
+            }
+            next.owner = s.owner && !strcmp(s.tracker, next.tracker);
             s = next;
             if (home_settings_save(&s)) snprintf(notice, sizeof notice, "Could not save household settings.");
+            else snprintf(notice, sizeof notice, "Connected. Open Your computers; helpers must keep Share resources active.");
         } else if (key == 's') {
             HomeSettings next = s;
             if (home_field("Folder containing your model directories", next.models, sizeof next.models, 0) ||
@@ -159,35 +345,10 @@ static int cmd_home(void) {
             s = next;
             if (home_settings_save(&s)) snprintf(notice, sizeof notice, "Could not save settings.");
         } else if (key == 'n') {
-            if (tracker_child > 0) { snprintf(notice, sizeof notice, "This household is already running."); continue; }
-            char ip[INET_ADDRSTRLEN], dir[1024], binary[1200], log[1200], port[20];
-            if (home_interface_ip(ip, sizeof ip)) { snprintf(notice, sizeof notice, "No active IPv4 LAN interface found."); continue; }
-            int chosen = home_free_port(); if (!chosen) continue;
-            uint8_t secret[16]; lmb_random(secret, sizeof secret); lmb_hex(s.token, secret, sizeof secret);
-            snprintf(s.tracker, sizeof s.tracker, "%s:%d", ip, chosen);
-            snprintf(port, sizeof port, "%d", chosen);
-            exe_dir(dir, sizeof dir);
-            snprintf(binary, sizeof binary, "%s/tracker", dir);
-            snprintf(log, sizeof log, "%s/.lumabri/home-tracker.log", getenv("HOME") ? getenv("HOME") : ".");
-            if (setenv("LUMABRI_TOKEN", s.token, 1)) continue;
-            char *args[] = {binary, "--port", port, NULL};
-            tracker_child = home_spawn(args, NULL, log, NULL);
-            if (tracker_child <= 0) { snprintf(notice, sizeof notice, "Could not start the household tracker."); continue; }
-            int ready = 0;
-            for (int attempt = 0; attempt < 20 && !g_stopping; attempt++) {
-                int fd = lmb_connect_ms_io(s.tracker, 250, 500);
-                if (fd >= 0) { ready = !lmb_auth(fd); lmb_close(fd); }
-                if (ready || waitpid(tracker_child, NULL, WNOHANG) == tracker_child) break;
-                (void)poll(NULL, 0, 100);
-            }
-            if (!ready) {
-                home_stop_child(&tracker_child);
-                home_settings_load(&s);
-                snprintf(notice, sizeof notice, "Household tracker did not become ready. Check home-tracker.log."); continue;
-            }
-            (void)home_settings_save(&s);
+            if (tracker_child <= 0 && home_tracker_resume(&s, &tracker_child, notice, sizeof notice)) continue;
+            char identity[65]; lmb_hex(identity, g_sec_pk, 32);
             printf("\nOn your other computers choose Join a household.\n\nAddress: %s\nHousehold key: %s\n\n"
-                   "Keep this Lumabri window open. Only share the key with your household.\nPress Enter to continue.\n", s.tracker, s.token);
+                   "Host identity: %.16s\nKeep this Lumabri window open. Only share the key with your household.\nPress Enter to continue.\n", s.tracker, s.token, identity);
             char line[16]; if (!fgets(line, sizeof line, stdin)) break;
         } else if (key == 'c' || key == 'p' || key == 'd') {
             if (!s.tracker[0] || !s.token[0]) { snprintf(notice, sizeof notice, "Create or join a household first."); continue; }

--- a/src/ui/lumabri_visual.h
+++ b/src/ui/lumabri_visual.h
@@ -5,6 +5,7 @@
 #include <locale.h>
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <wchar.h>
@@ -16,6 +17,41 @@ static const unsigned ui_colors[] = {
 typedef struct { wchar_t ch; unsigned char fg, bg; } UiCell;
 static UiCell ui_canvas[100][200];
 static int ui_w, ui_h;
+
+/* Apple Terminal can report xterm-256color but does not implement RGB SGR.
+ * Sending 48;2;r;g;b there can select unrelated ANSI backgrounds. */
+static inline int ui_color_mode(void) {
+    const char *override = getenv("LUMABRI_COLOR");
+    if (getenv("NO_COLOR") && *getenv("NO_COLOR")) return 0;
+    if (override) {
+        if (!strcmp(override, "none")) return 0;
+        if (!strcmp(override, "16")) return 16;
+        if (!strcmp(override, "256")) return 256;
+        if (!strcmp(override, "truecolor")) return 24;
+    }
+    const char *program = getenv("TERM_PROGRAM"), *color = getenv("COLORTERM");
+    if (program && !strcmp(program, "Apple_Terminal")) return 256;
+    if (color && (!strcmp(color, "truecolor") || !strcmp(color, "24bit"))) return 24;
+    const char *term = getenv("TERM");
+    if (term && strstr(term, "256color")) return 256;
+    return 16;
+}
+
+static inline void ui_sgr(int mode, int fg, int bg) {
+    static const unsigned palette256[] = {234, 255, 248, 209, 239, 238, 108, 223};
+    static const unsigned palette16[] = {30, 37, 90, 33, 90, 30, 32, 93};
+    if (mode == 24) {
+        unsigned f = ui_colors[fg], b = ui_colors[bg];
+        printf("\x1b[38;2;%u;%u;%um\x1b[48;2;%u;%u;%um",
+               f >> 16, (f >> 8) & 255, f & 255, b >> 16, (b >> 8) & 255, b & 255);
+    } else if (mode == 256) {
+        printf("\x1b[38;5;%um\x1b[48;5;%um", palette256[fg], palette256[bg]);
+    } else if (mode == 16) {
+        printf("\x1b[%u;%um", palette16[fg], bg == UI_SELECTED ? 100u : 40u);
+    } else {
+        fputs("\x1b[0m", stdout);
+    }
+}
 
 static inline void ui_text(int y, int x, int fg, const char *s) {
     mbstate_t state = {0};
@@ -70,6 +106,7 @@ static inline void ui_footer(const char *status, const char *keys) {
 
 static inline void ui_present(void) {
     int fg = -1, bg = -1;
+    int mode = ui_color_mode();
     fputs("\x1b[H", stdout);
     for (int y = 0; y < ui_h; y++) {
         printf("\x1b[%d;1H", y + 1);
@@ -79,9 +116,7 @@ static inline void ui_present(void) {
             if (!cell.ch) continue;
             if (fg != cell.fg || bg != cell.bg) {
                 fg = cell.fg; bg = cell.bg;
-                unsigned f = ui_colors[fg], b = ui_colors[bg];
-                printf("\x1b[38;2;%u;%u;%um\x1b[48;2;%u;%u;%um",
-                       f >> 16, (f >> 8) & 255, f & 255, b >> 16, (b >> 8) & 255, b & 255);
+                ui_sgr(mode, fg, bg);
             }
             printf("%lc", (wint_t)cell.ch);
         }

--- a/tests/c/test_home_network.c
+++ b/tests/c/test_home_network.c
@@ -1,0 +1,81 @@
+#define _GNU_SOURCE
+#include "lumabri_home_discovery.h"
+#include "src/ui/lumabri_visual.h"
+#include <assert.h>
+
+int main(void) {
+    unsigned up = IFF_UP;
+    assert(!lmb_home_ip_score(up | IFF_LOOPBACK, 0x0afffffe)); /* WSL DNS alias */
+    assert(!lmb_home_ip_score(0, 0xc0a8010d));
+    assert(!lmb_home_ip_score(up, 0x7f000001));
+    assert(!lmb_home_ip_score(up, 0xa9fe0001));
+    assert(!lmb_home_ip_score(up, 0xe0000001));
+    assert(lmb_home_ip_score(up, 0xc0a8010d) > lmb_home_ip_score(up | IFF_POINTOPOINT, 0x0a000001));
+    unsetenv("LUMABRI_HOME_PORT_BASE"); assert(lmb_home_port_base() == 47300);
+    setenv("LUMABRI_HOME_PORT_BASE", "0", 1); assert(lmb_home_port_base() < 0);
+    setenv("LUMABRI_HOME_PORT_BASE", "65521", 1); assert(lmb_home_port_base() < 0);
+    setenv("LUMABRI_HOME_PORT_BASE", "47300oops", 1); assert(lmb_home_port_base() < 0);
+
+    int fds[16], base = 0;
+    for (int attempt = 0; attempt < 40 && !base; attempt++) {
+        int candidate = 50000 + ((getpid() + attempt) % 800) * 16, count = 0;
+        for (; count < 16; count++) { fds[count] = lmb_listen(candidate + count); if (fds[count] < 0) break; }
+        for (int i = 0; i < count; i++) close(fds[i]);
+        if (count == 16) base = candidate;
+    }
+    assert(base);
+    char setting[20]; snprintf(setting, sizeof setting, "%d", base);
+    setenv("LUMABRI_HOME_PORT_BASE", setting, 1);
+    for (int i = 0; i < 15; i++) {
+        int port = 0; fds[i] = lmb_home_listen_service(&port);
+        assert(fds[i] >= 0 && port == base + i + 1);
+        assert(fcntl(fds[i], F_GETFD) & FD_CLOEXEC);
+    }
+    int port = 0;
+    assert(lmb_home_listen_service(&port) < 0); /* never spill to random ports */
+    for (int i = 0; i < 15; i++) close(fds[i]);
+    int restarted = lmb_home_listen_service(&port);
+    assert(restarted >= 0 && port == base + 1);
+    char descriptor[32]; snprintf(descriptor, sizeof descriptor, "%d", restarted);
+    assert(!fcntl(restarted, F_SETFD, 0));
+    setenv("LUMABRI_HOME_LISTEN_FD", descriptor, 1);
+    assert(lmb_home_take_listener(port) == restarted);
+    assert(!getenv("LUMABRI_HOME_LISTEN_FD"));
+    assert(fcntl(restarted, F_GETFD) & FD_CLOEXEC);
+    setenv("LUMABRI_HOME_LISTEN_FD", descriptor, 1);
+    assert(lmb_home_take_listener(port + 1) < 0); /* wrong port fails closed */
+    assert(fcntl(restarted, F_GETFD) < 0);
+    setenv("LUMABRI_HOME_LISTEN_FD", "1", 1);
+    assert(lmb_home_take_listener(port) < 0);
+    assert(fcntl(1, F_GETFD) >= 0); /* malformed env must not close stdout */
+
+    uint8_t nonce[16] = {3}, reply[LMB_HOME_DISC_REPLY] = {0};
+    memcpy(reply, "LMBHOME1", 8); memcpy(reply + 8, nonce, 16);
+    reply[24] = 9; reply[56] = (uint8_t)base; reply[57] = (uint8_t)(base >> 8);
+    memcpy(reply + 58, "test-house", 10);
+    struct sockaddr_in peer = {0}; peer.sin_family = AF_INET; peer.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    LmbHomeFound found;
+    assert(!lmb_home_disc_parse(reply, sizeof reply, nonce, &peer, &found));
+    for (size_t n = 0; n < sizeof reply; n++) assert(lmb_home_disc_parse(reply, n, nonce, &peer, &found));
+    reply[8] ^= 1; assert(lmb_home_disc_parse(reply, sizeof reply, nonce, &peer, &found)); reply[8] ^= 1;
+    reply[58] = 27; assert(lmb_home_disc_parse(reply, sizeof reply, nonce, &peer, &found)); reply[58] = 't';
+    memset(reply + 58, 'x', 64); assert(lmb_home_disc_parse(reply, sizeof reply, nonce, &peer, &found));
+
+    uint8_t identity[32] = {9};
+    assert(!lmb_home_beacon_start(base, identity));
+    LmbHomeFound results[LMB_HOME_DISC_MAX];
+    int n = lmb_home_find(results, nonce), matched = 0;
+    for (int i = 0; i < n; i++) if (!memcmp(results[i].identity, identity, 32)) matched = 1;
+    assert(matched);
+
+    unsetenv("NO_COLOR"); unsetenv("LUMABRI_COLOR");
+    setenv("TERM_PROGRAM", "Apple_Terminal", 1);
+    setenv("COLORTERM", "truecolor", 1); /* inherited value must not break Apple Terminal */
+    assert(ui_color_mode() == 256);
+    setenv("TERM_PROGRAM", "iTerm.app", 1); assert(ui_color_mode() == 24);
+    unsetenv("COLORTERM"); setenv("TERM", "xterm-256color", 1); assert(ui_color_mode() == 256);
+    setenv("TERM", "vt100", 1); assert(ui_color_mode() == 16);
+    setenv("NO_COLOR", "1", 1); assert(ui_color_mode() == 0);
+    puts("HOME NETWORK: PASS (loopback exclusion, bounded ports, restart, discovery validation, terminal palette)");
+    return 0;
+}

--- a/tests/c/test_home_network.c
+++ b/tests/c/test_home_network.c
@@ -48,6 +48,15 @@ int main(void) {
     setenv("LUMABRI_HOME_LISTEN_FD", "1", 1);
     assert(lmb_home_take_listener(port) < 0);
     assert(fcntl(1, F_GETFD) >= 0); /* malformed env must not close stdout */
+    int udp = socket(AF_INET, SOCK_DGRAM, 0);
+    assert(udp >= 3);
+    struct sockaddr_in invalid = {0}; invalid.sin_family = AF_INET;
+    invalid.sin_port = htons((uint16_t)port); invalid.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(!bind(udp, (struct sockaddr *)&invalid, sizeof invalid));
+    snprintf(descriptor, sizeof descriptor, "%d", udp);
+    setenv("LUMABRI_HOME_LISTEN_FD", descriptor, 1);
+    assert(lmb_home_take_listener(port) < 0); /* matching port is not enough: it must be TCP */
+    assert(fcntl(udp, F_GETFD) < 0);
 
     uint8_t nonce[16] = {3}, reply[LMB_HOME_DISC_REPLY] = {0};
     memcpy(reply, "LMBHOME1", 8); memcpy(reply + 8, nonce, 16);

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -97,7 +97,7 @@ def main():
 
     try:
         with open(tmp / "tracker.log", "wb") as log:
-            tracker = subprocess.Popen(["./tracker", "--port", str(port),
+            tracker = subprocess.Popen(["./tracker", "--port", str(port), "--token", "household-test",
                 "--peer-bindings", str(tmp / "bindings")], cwd=ROOT,
                 env=env("tracker"), stdout=log, stderr=subprocess.STDOUT)
         children.append(tracker)
@@ -114,6 +114,9 @@ def main():
         until(lambda: a.has("your workspace") and b.has("your workspace"))
         a.send("\x1b[B\x1b[B\x1b[B\r"); b.send("\x1b[B\x1b[B\x1b[B\r")
         until(lambda: a.has("Available") and b.has("Available"))
+        a.send("\r"); b.send("\r")  # Enter without a request must not stop sharing.
+        time.sleep(.3)
+        assert a.p.poll() is None and b.p.poll() is None
 
         def inventory_ready():
             p = subprocess.run(base + ["--json"], cwd=ROOT, env=env("observer"),

--- a/tests/integration/household_network_test.py
+++ b/tests/integration/household_network_test.py
@@ -1,0 +1,165 @@
+"""Real tracker + PTYs: fixed endpoint, restart, discovery and authenticated join.
+
+Only temporary identities/settings are used. No firewall changes are made.
+This is loopback/local-interface coverage, not a physical-LAN certification.
+"""
+import fcntl
+import os
+from pathlib import Path
+import pty
+import select
+import socket
+import struct
+import subprocess
+import tempfile
+import termios
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def free_base():
+    for base in range(53000, 62000, 16):
+        probes = []
+        try:
+            for kind in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
+                s = socket.socket(socket.AF_INET, kind)
+                probes.append(s)
+                s.bind(("0.0.0.0", base))
+            return base
+        except OSError:
+            pass
+        finally:
+            for s in probes:
+                s.close()
+    raise AssertionError("no isolated test port")
+
+
+class Terminal:
+    def __init__(self, home, base):
+        self.home, self.data = Path(home), bytearray()
+        self.home.mkdir(exist_ok=True)
+        self.master, self.slave = pty.openpty()
+        fcntl.ioctl(self.slave, termios.TIOCSWINSZ, struct.pack("HHHH", 38, 120, 0, 0))
+        env = {**os.environ, "HOME": str(home), "LUMABRI_HOME_PORT_BASE": str(base),
+               "LUMABRI_PEER_KEY": str(self.home / "peer.key"), "LUMABRI_TOKEN": "",
+               "LUMABRI_KNOWN_HOSTS": str(self.home / "known.hosts"), "LUMABRI_ENCRYPT": "1"}
+        self.p = subprocess.Popen([str(ROOT / "lumabri")], cwd=ROOT, env=env,
+                                  stdin=self.slave, stdout=self.slave, stderr=self.slave)
+
+    def drain(self):
+        while select.select([self.master], [], [], .02)[0]:
+            self.data.extend(os.read(self.master, 65536))
+
+    def expect(self, text, seconds=15):
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            self.drain()
+            if text.encode() in self.data:
+                return
+            if self.p.poll() is not None:
+                break
+        # Do not print the output: /create includes a household key.
+        states = [s for s in ("Connected.", "authentication failed", "secure handshake failed",
+                              "Could not save", "Household key from", "Type yes", "Workspace actions")
+                  if s.encode() in self.data]
+        raise AssertionError(f"missing {text!r}; exit={self.p.poll()}; states={states}")
+
+    def send(self, data):
+        self.data.clear()
+        os.write(self.master, data)
+
+    def action(self, index):
+        self.send(b"/")
+        self.expect("Workspace actions")
+        self.send(b"\x1b[B" * index + b"\r")
+
+    def settings(self):
+        p = self.home / ".lumabri/home.conf"
+        return dict(line.split("=", 1) for line in p.read_text().splitlines())
+
+    def quit(self):
+        self.send(b"\x1b")
+        deadline = time.monotonic() + 8
+        while self.p.poll() is None and time.monotonic() < deadline:
+            self.drain()
+        assert self.p.wait(timeout=2) == 0
+
+    def close(self):
+        if self.p.poll() is None:
+            self.p.terminate()
+        try:
+            self.p.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.p.kill(); self.p.wait()
+        os.close(self.master); os.close(self.slave)
+
+
+def main():
+    terminals = []
+    with tempfile.TemporaryDirectory(prefix="lumabri-household-network-") as tmp:
+        base = free_base()
+
+        def start(name):
+            t = Terminal(Path(tmp) / name, base)
+            terminals.append(t)
+            t.expect("What would you like to do?")
+            return t
+
+        try:
+            owner = start("owner")
+            owner.action(0)
+            owner.expect("Host identity:")
+            saved = owner.settings()
+            assert saved["owner"] == "1" and saved["tracker"].endswith(f":{base}")
+            assert saved["token"] and not saved["tracker"].startswith("10.255.255.254:")
+            owner.send(b"\n"); owner.expect("What would you like to do?")
+
+            second = start("owner")
+            second.expect("Household ready")
+            assert second.settings() == saved
+            second.quit()  # An attached second window must not kill the first tracker.
+
+            wrong = start("wrong")
+            wrong.action(1)
+            wrong.expect("Choose your computer")
+            wrong.send(b"\r"); wrong.expect("Type yes only")
+            wrong.send(b"yes\n"); wrong.expect("Household key from its owner")
+            wrong.send(b"incorrect-test-key\n"); wrong.expect("Household authentication failed")
+            assert not (wrong.home / ".lumabri/home.conf").exists()
+            wrong.quit()
+
+            joiner = start("joiner")
+            joiner.action(1)
+            joiner.expect("Choose your computer")
+            joiner.send(b"\r"); joiner.expect("Type yes only")
+            joiner.send(b"yes\n"); joiner.expect("Household key from its owner")
+            joiner.send(saved["token"].encode() + b"\n")
+            joiner.expect("Connected. Open Your computers")
+            assert joiner.settings()["token"] == saved["token"]
+            assert joiner.settings()["owner"] == "0"
+            joiner.quit()
+            owner.quit()
+
+            resumed = start("owner")
+            resumed.expect("Household ready")
+            assert resumed.settings() == saved
+            resumed.quit()
+
+            with socket.socket() as blocked:
+                blocked.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                blocked.bind(("0.0.0.0", base)); blocked.listen()
+                # The listener cannot authenticate; creation must not fall back to another port.
+                occupied = start("occupied")
+                occupied.action(0)
+                occupied.expect("is occupied", seconds=20)
+                assert not (occupied.home / ".lumabri/home.conf").exists()
+                occupied.quit()
+            print("HOUSEHOLD NETWORK: PASS (fixed port/key, restart, second window, discovery, auth rejection, join, occupied port)")
+        finally:
+            for t in reversed(terminals):
+                t.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/workspace_navigation_test.py
+++ b/tests/integration/workspace_navigation_test.py
@@ -13,13 +13,17 @@ import time
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def check(args, compact):
+def check(args, compact, apple=False):
     with tempfile.TemporaryDirectory(prefix="lumabri-workspace-") as home:
         master, slave = pty.openpty()
         before = termios.tcgetattr(slave)
         fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 12 if compact else 38, 50 if compact else 104, 0, 0))
         env = {**os.environ, "HOME": home, "LUMABRI_ENCRYPT": "1",
                "LUMABRI_PEER_KEY": home + "/peer.key"}
+        if apple:
+            env.update(TERM_PROGRAM="Apple_Terminal", TERM="xterm-256color", COLORTERM="truecolor")
+            env.pop("LUMABRI_COLOR", None)
+            env.pop("NO_COLOR", None)
         p = subprocess.Popen([str(ROOT / "lumabri"), *args], env=env, cwd=ROOT,
                              stdin=slave, stdout=slave, stderr=slave)
         output = bytearray()
@@ -37,6 +41,10 @@ def check(args, compact):
 
         try:
             until(lambda: (b"Resize the terminal" if compact else b"What would you like to do?") in output)
+            if apple:
+                assert b"\x1b[38;2;" not in output and b"\x1b[48;2;" not in output
+                assert b"\x1b[48;5;234m" in output
+                assert b"\x1b[48;5;238m" in output, "selection must have a contrasting background"
             if not compact:
                 os.write(master, b"\r")
                 until(lambda: b"Create or join a household first" in output)
@@ -61,4 +69,5 @@ def check(args, compact):
 for args in ([], ["chat"]):
     for compact in (False, True):
         check(args, compact)
-print("WORKSPACE NAVIGATION: PASS (app/chat, actions, no implicit sharing, compact view, terminal restore)")
+check([], False, apple=True)
+print("WORKSPACE NAVIGATION: PASS (app/chat, actions, Apple palette/selection, no implicit sharing, compact view, terminal restore)")

--- a/tools/setup-household-firewall.ps1
+++ b/tools/setup-household-firewall.ps1
@@ -1,0 +1,61 @@
+# Invoked only by an explicit /network approval. Never disables a firewall.
+[CmdletBinding(SupportsShouldProcess=$true, ConfirmImpact='Medium')]
+param(
+    [Parameter(Mandatory=$true)][string]$Subnet,
+    [ValidateRange(1024,65520)][int]$PortBase = 47300,
+    [switch]$Remove
+)
+$ErrorActionPreference = 'Stop'
+if ($Subnet -notmatch '^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]{1,2})$') { throw 'Invalid LAN subnet' }
+$parts = $Subnet.Split('/')
+$address = [System.Net.IPAddress]::Parse($parts[0])
+$octets = $address.GetAddressBytes()
+$prefix = [int]$parts[1]
+$private = $octets.Length -eq 4 -and ($octets[0] -eq 10 -or
+    ($octets[0] -eq 172 -and $octets[1] -ge 16 -and $octets[1] -le 31) -or
+    ($octets[0] -eq 192 -and $octets[1] -eq 168))
+$minimumPrefix = if ($octets[0] -eq 10) { 8 } elseif ($octets[0] -eq 172) { 12 } else { 16 }
+if (-not $private -or $prefix -lt $minimumPrefix -or $prefix -gt 30) { throw 'Only a private LAN subnet is allowed' }
+if (-not $PSCmdlet.ShouldProcess($Subnet, $(if ($Remove) { 'Remove Lumabri household firewall rules' } else { "Allow household TCP $PortBase-$($PortBase + 15) and UDP $PortBase" }))) { return }
+$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    $arguments = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', ('"{0}"' -f $PSCommandPath),
+                   '-Subnet', $Subnet, '-PortBase', $PortBase)
+    if ($Remove) { $arguments += '-Remove' }
+    $elevated = Start-Process powershell.exe -Verb RunAs -ArgumentList $arguments -Wait -PassThru
+    exit $elevated.ExitCode
+}
+$creator = '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}'
+if (-not (Get-Command New-NetFirewallHyperVRule -ErrorAction SilentlyContinue)) {
+    throw 'The WSL Hyper-V firewall commands are unavailable. No firewall rules were changed.'
+}
+foreach ($protocol in @('TCP', 'UDP')) {
+    $name = 'Lumabri-Household-' + $protocol
+    $hyperName = $name + '-WSL'
+    $windows = Get-NetFirewallRule -Name $name -ErrorAction SilentlyContinue
+    $hyper = Get-NetFirewallHyperVRule -Name $hyperName -ErrorAction SilentlyContinue
+    if ($Remove) {
+        if ($windows) { Remove-NetFirewallRule -Name $name }
+        if ($hyper) { Remove-NetFirewallHyperVRule -Name $hyperName }
+        continue
+    }
+    $ports = if ($protocol -eq 'TCP') { '{0}-{1}' -f $PortBase, ($PortBase + 15) } else { "$PortBase" }
+    if ($windows) {
+        Set-NetFirewallRule -Name $name -Enabled True -Direction Inbound -Action Allow `
+            -Protocol $protocol -LocalPort $ports -RemoteAddress $Subnet -Profile Any | Out-Null
+    } else {
+        New-NetFirewallRule -Name $name -DisplayName $name -Group 'Lumabri household' `
+            -Direction Inbound -Action Allow -Protocol $protocol -LocalPort $ports `
+            -RemoteAddress $Subnet -Profile Any | Out-Null
+    }
+    if ($hyper) {
+        Set-NetFirewallHyperVRule -Name $hyperName -Enabled True -Direction Inbound -Action Allow `
+            -Protocol $protocol -LocalPorts $ports -RemoteAddresses $Subnet | Out-Null
+    } else {
+        New-NetFirewallHyperVRule -Name $hyperName -VMCreatorId $creator `
+            -Direction Inbound -Action Allow -Protocol $protocol -LocalPorts $ports `
+            -RemoteAddresses $Subnet | Out-Null
+    }
+}
+if ($Remove) { Write-Host 'Lumabri household rules removed.' }
+else { Write-Host "Lumabri allowed from $Subnet only: TCP $PortBase-$($PortBase + 15), UDP $PortBase." }

--- a/tracker.c
+++ b/tracker.c
@@ -28,6 +28,7 @@
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 #include "lumabri_inventory.h"
+#include "lumabri_home_discovery.h"
 
 #define MAX_PEERS  64
 #define MAX_FILES  4096
@@ -2962,9 +2963,10 @@ static void *conn_thread(void *arg) {
 }
 
 int main(int argc, char **argv) {
-    int port = 7300;
+    int port = 7300, household_discovery = 0;
     for (int i = 1; i < argc; i++)
         if (!strcmp(argv[i], "--port") && i + 1 < argc) port = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--household-discovery")) household_discovery = 1;
         else if (!strcmp(argv[i], "--token") && i + 1 < argc) {
             const char *tok = argv[++i];
             if (strlen(tok) > LMB_TOKEN_MAX) {
@@ -2991,8 +2993,15 @@ int main(int argc, char **argv) {
             }
         }
         else { fprintf(stderr, "usage: %s [--port N] [--token S] [--pubkey FILE] "
-                               "[--peer-bindings FILE]\n",
+                               "[--peer-bindings FILE] [--household-discovery]\n",
                        argv[0]); return 2; }
+    if (household_discovery && !g_token[0]) {
+        const char *token = getenv("LUMABRI_TOKEN");
+        if (!token || !*token || strlen(token) > LMB_TOKEN_MAX) {
+            fprintf(stderr, "[tracker] household mode requires a nonempty household key\n"); return 2;
+        }
+        snprintf(g_token, sizeof g_token, "%s", token);
+    }
     signal(SIGPIPE, SIG_IGN);   /* a vanished peer must not kill the tracker */
     g_stale_s = (double)lmb_env_int("LUMABRI_STALE_MS", (int)(STALE_S * 1000),
                                     100, 3600000) / 1000.0;
@@ -3014,9 +3023,12 @@ int main(int argc, char **argv) {
                 g_bindings_path);
     else g_segment_generation_ready = 1;
     lmb_conn_gate_init(&g_conn_gate);
-    if (lmb_secure_init()) return 1;
-    int lfd = lmb_listen(port);
+    if (lmb_secure_init() || (household_discovery && !lmb_secure_enabled())) return 1;
+    int lfd = lmb_home_take_listener(port);
     if (lfd < 0) { perror("[tracker] listen"); return 1; }
+    if (household_discovery && (!lmb_secure_enabled() || lmb_home_beacon_start(port, g_sec_pk))) {
+        fprintf(stderr, "[tracker] household discovery unavailable; manual LAN joining remains available\n");
+    }
     printf("[tracker] listening on :%d\n", port);
     if (g_have_pubkey)
         printf("[tracker] signed swarm: truth accepted from %zu trusted "


### PR DESCRIPTION
## Summary

- Detect terminal colour capability: Apple Terminal uses 256-colour SGR instead of unsupported RGB; keep a contrasting selection background and arrow marker. Preserve existing keyboard navigation. Add NO_COLOR and an explicit diagnostic override.
- Keep household TCP ports inside 47300–47315 and discovery on UDP 47300. Exclude loopback/WSL DNS aliases from advertised LAN addresses. Save the creator role/key and resume the household on launch; another local window may attach only to its authenticated tracker.
- Discover LAN household hints, explicitly compare the host identity, then authenticate with the household key before saving a join. No secrets are broadcast. Manual joining stays available.
- Reserve sockets across child startup so concurrent donor approvals cannot select the same free port. Validate inherited listeners and restore CLOEXEC before engine descendants. Do not infer model readiness merely from an open port.
- Add `/network` for explicit, one-time Windows/WSL firewall permission: private-subnet scoped TCP/UDP rules, administrator approval, and removal. No firewall is disabled. Ship the helper with `make install` too.
- Keep resource sharing active when Enter is pressed without a pending request; show Esc as the exit action.

## Verification

- Warning-clean Linux C build (`-Wall -Wextra -Werror`), including Segment node linked against the existing compatible Colibri archive.
- `make test-chat-ui`: chat transcript, slash completion, navigation, terminal restoration, Apple Terminal palette and visible selection escape sequences.
- `make test-home-network`: loopback exclusion, bounded/exhausted port range, inherited socket validation/CLOEXEC, discovery parser and local query, palettes.
- `python3 tests/integration/household_network_test.py`: real encrypted tracker, fixed port/key across restart, second window, discovery, wrong-key rejection without saving, successful pairing, occupied-port refusal.
- `python3 tests/integration/home_flow_test.py --models-dir /tmp/lumabri-home-model.jtpqSn/models`: actual tiny OLMoE Segment engines, two donor TUIs, approval/rejection, generation and cleanup. This test exposed the concurrent port reservation race and passes with socket handoff.
- `bash tests/integration/hosted_chat_test.sh`: encrypted stream, zero checkpoint bytes, real BUSY response.
- Windows PowerShell `-WhatIf` dry-run and read-only cmdlet parameter validation. **No actual firewall rules were changed.**
- CI adds native macOS network/palette coverage, Windows helper dry-runs, and the Linux household lifecycle test.

## Deliberate limits

The user still needs to confirm rendering in their Intel macOS 12.6 terminal and test their physical PC↔Mac LAN after explicit firewall permission. WSL NAT, guest-Wi-Fi isolation and VPN routing are not automatically reconfigured. This PR does not certify native macOS/Windows donor engines, GPU execution, all model families or the remaining performance roadmap. The creator window must remain open; if its IP changes, Join can rediscover it.
