### PR TITLE
Fix native macOS household donors, resource detection and visible errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,9 @@ jobs:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
         run: |
-          make lumabri tracker maintainer liblumabri.dylib test_machine test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
+          python3 tests/integration/native_shim_test.py
           python3 tests/integration/household_network_test.py
       - name: Readiness descriptors and portable fallback
         run: make test-ready-pipe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
@@ -121,6 +122,7 @@ jobs:
           mkdir -p build/home-flow-models
           cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -153,4 +155,14 @@ jobs:
           path: lumabri/build/home-flow-models/olmoe-tiny
       - name: Request, accept, fetch weights and chat on native macOS
         working-directory: lumabri
-        run: python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: |
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: household-logs-${{ matrix.runner }}
+          path: ${{ runner.temp }}/lumabri-home-flow-*/**/*.log
+          retention-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,16 @@ jobs:
           try { & ./tools/setup-household-firewall.ps1 -Subnet 0.0.0.0/0 -WhatIf }
           catch { $rejected = $true }
           if (-not $rejected) { throw 'An unrestricted network was accepted' }
+      - name: Execute create, update and remove against strict command doubles
+        shell: powershell
+        run: ./tests/integration/firewall_helper_test.ps1
   macos-workspace:
     # Native frontend gate, not certification of Segment, GPU or a real LAN.
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-15-intel, macos-15]
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +41,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
-        run: make lumabri test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+        run: |
+          make lumabri tracker maintainer liblumabri.dylib test_machine test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          ./test_machine
+          python3 tests/integration/household_network_test.py
       - name: Readiness descriptors and portable fallback
         run: make test-ready-pipe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
       - name: Native cryptographic known-answer tests
@@ -90,6 +100,11 @@ jobs:
           python3 tools/make_olmoe_tiny.py --output olmoe_tiny_src --force
           python3 tools/make_edge_tiny_tokenizer.py olmoe_tiny_src --vocab-size 128
           python3 tools/convert_olmoe_merged.py --model olmoe_tiny_src --out olmoe_tiny_merged --min-free-gb 0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-olmoe-checkpoint
+          path: colibri/c/olmoe_tiny_merged/*
+          retention-days: 3
       - name: Segment failover gate — run
         working-directory: lumabri
         run: |
@@ -106,3 +121,36 @@ jobs:
           mkdir -p build/home-flow-models
           cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
+  macos-household:
+    # Real native CPU engines + signed CAS + approvals + streaming. Loopback
+    # coverage does not replace the macOS 12.6 / physical household LAN test.
+    needs: linux
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [macos-15-intel, macos-15]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: lumabri
+      - uses: actions/checkout@v4
+        with:
+          repository: JustVugg/colibri
+          ref: dev
+          path: colibri
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: brew install libomp
+      - name: Build the native household runtime
+        working-directory: lumabri
+        run: make household ENGINE=../colibri/c CC=clang -j3
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-olmoe-checkpoint
+          path: lumabri/build/home-flow-models/olmoe-tiny
+      - name: Request, accept, fetch weights and chat on native macOS
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ maintainer
 lumabri
 lumibri
 liblumabri.so
+liblumabri.dylib
 liblumibri.so
 .lumabri_hashes/
 test_shim

--- a/Makefile
+++ b/Makefile
@@ -572,7 +572,7 @@ HYBRID_PATCH_INPUTS = engine_patches/make_patches.py \
 	lumabri_proto.h lumabri_sign.h lumabri_secure.h lumabri_crypto.h \
 	lumabri_sha.h
 
-$(HYBRID_ENGINE_DIR)/.prepared: $(HYBRID_PATCH_INPUTS) \
+$(HYBRID_ENGINE_DIR)/.prepared: Makefile $(HYBRID_PATCH_INPUTS) \
 		$(ENGINE)/colibri.c $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c \
 		$(ENGINE)/olmoe.c $(ENGINE)/qwen36.c $(ENGINE)/deepseek_v4.c
 	rm -rf $(HYBRID_ENGINE_DIR)
@@ -594,7 +594,7 @@ build/segment_hybrid_bridge.o: lumi_v4_bridge.c $(HYBRID_PATCH_INPUTS)
 $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_bridge.o
 	env -u MAKEFLAGS $(MAKE) -C $(HYBRID_ENGINE_DIR) MAKEOVERRIDES= \
 		COLI_V4_SUPPORTED=1 CC='$(CC)' \
-		CFLAGS='-O2 $(OMP_FLAGS) -pthread -I$(HYBRID_ROOT) -include $(HYBRID_ROOT)/lumi_v4_ext.h -DLUMABRI_P2P -DLUMIBRI_P2P' \
+		CFLAGS='-O2 $(CPPFLAGS) $(OMP_FLAGS) -pthread -I$(HYBRID_ROOT) -include $(HYBRID_ROOT)/lumi_v4_ext.h -DLUMABRI_P2P -DLUMIBRI_P2P' \
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,27 @@ CFLAGS  ?= -O2 -Wall -Wextra
 ENGINE  ?= ../colibri/c
 # Shared headers remain in the repository root during the staged layout cleanup.
 override CPPFLAGS += -I.
+PLATFORM := $(shell uname -s)
+SHIM_LIB = liblumabri.so
+SHIM_FLAGS = -shared -fPIC -ldl
+OMP_FLAGS = -fopenmp
+OMP_LIBS =
+ifeq ($(PLATFORM),Darwin)
+SHIM_LIB = liblumabri.dylib
+SHIM_FLAGS = -dynamiclib -fPIC
+OMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
+ifneq ($(wildcard $(OMP_PREFIX)/include/omp.h),)
+OMP_FLAGS = -Xclang -fopenmp -I$(OMP_PREFIX)/include
+OMP_LIBS = -L$(OMP_PREFIX)/lib -Wl,-rpath,$(OMP_PREFIX)/lib -lomp
+else
+OMP_FLAGS =
+endif
+endif
 
-all: tracker maintainer liblumabri.so test_shim swarm_probe lumabri
+all: tracker maintainer $(SHIM_LIB) test_shim swarm_probe lumabri
+
+# Native household runtime (Colibri sources are a build-time dependency).
+household: tracker maintainer $(SHIM_LIB) lumabri segment_node segment_chat
 
 
 # A checkout with Colibri's additive ABI gets the transparent Segment path
@@ -29,7 +48,7 @@ check-warnings:
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
-HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h
+HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h lumabri_platform.h lumabri_wakeup.h
 MACHINE_SRC = lumabri_machine.c
 MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
@@ -379,8 +398,8 @@ maintainer: maintainer.c $(HOME_NET_DEPS) lumabri_content.h lumabri_proto.h luma
 
 # The shim interposes libc symbols, so it must not itself be interposable
 # state: -fPIC shared object, resolved via RTLD_NEXT at load time.
-liblumabri.so: lumashim.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
-	$(CC) $(CPPFLAGS) $(CFLAGS) -shared -fPIC -pthread lumashim.c -o $@ -ldl
+$(SHIM_LIB): lumashim.c lumabri_proto.h lumabri_sha.h lumabri_sign.h $(SECURE_DEPS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread lumashim.c -o $@ $(SHIM_FLAGS)
 
 test_shim: tests/c/test_shim.c lumabri_content.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_shim.c -o $@
@@ -541,7 +560,7 @@ production-gate:
 HYBRID_ENGINE_DIR = build/segment-hybrid-colibri
 COLIBRI_SEGMENT_LIB = $(HYBRID_ENGINE_DIR)/build/segment/libcolibri_segment_edge.a
 HYBRID_ROOT = $(abspath .)
-SEGMENT_CFLAGS = $(CFLAGS) -I. -I$(ENGINE) -fopenmp
+SEGMENT_CFLAGS = $(CFLAGS) -I. -I$(ENGINE) $(OMP_FLAGS)
 SEGMENT_COMMON = segment_colibri.h lumabri_segment.c lumabri_segment.h \
 		lumabri_segment_discovery.c lumabri_segment_discovery.h \
 		lumabri_proto.h lumabri_sign.h lumabri_sha.h $(SECURE_DEPS)
@@ -569,11 +588,12 @@ $(HYBRID_ENGINE_DIR)/.prepared: $(HYBRID_PATCH_INPUTS) \
 
 build/segment_hybrid_bridge.o: lumi_v4_bridge.c $(HYBRID_PATCH_INPUTS)
 	mkdir -p build
-	$(CC) $(CPPFLAGS) $(CFLAGS) -fopenmp -pthread -I. -I$(ENGINE) -c lumi_v4_bridge.c -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(OMP_FLAGS) -pthread -I. -I$(ENGINE) -c lumi_v4_bridge.c -o $@
 
 $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_bridge.o
 	env -u MAKEFLAGS $(MAKE) -C $(HYBRID_ENGINE_DIR) MAKEOVERRIDES= \
-		CFLAGS='-O2 -fopenmp -pthread -I$(HYBRID_ROOT) -include $(HYBRID_ROOT)/lumi_v4_ext.h -DLUMABRI_P2P -DLUMIBRI_P2P' \
+		COLI_V4_SUPPORTED=1 CC='$(CC)' \
+		CFLAGS='-O2 $(OMP_FLAGS) -pthread -I$(HYBRID_ROOT) -include $(HYBRID_ROOT)/lumi_v4_ext.h -DLUMABRI_P2P -DLUMIBRI_P2P' \
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 
@@ -582,13 +602,13 @@ segment_node: segment_node.c $(HOME_NET_DEPS) lumabri_planner.h lumabri_families
 		lumabri_run_gate.c lumabri_run_gate.h
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
 		lumabri_segment_discovery.c $(MACHINE_SRC) lumabri_run_gate.c \
-		$(COLIBRI_SEGMENT_LIB) -o $@ -lm
+		$(COLIBRI_SEGMENT_LIB) -o $@ -lm $(OMP_LIBS)
 
 segment_chat: segment_chat.c lumabri_sampling.c lumabri_sampling.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread segment_chat.c lumabri_segment.c \
 		lumabri_segment_discovery.c lumabri_sampling.c \
-		$(COLIBRI_SEGMENT_LIB) -o $@ -lm
+		$(COLIBRI_SEGMENT_LIB) -o $@ -lm $(OMP_LIBS)
 
 test_sampling: tests/c/test_sampling.c lumabri_sampling.c lumabri_sampling.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_sampling.c lumabri_sampling.c -o $@ -lm
@@ -747,7 +767,7 @@ PREFIX ?= /usr/local
 install: all
 	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/lib/lumabri
 	install -m 755 lumabri tracker maintainer swarm_probe $(DESTDIR)$(PREFIX)/bin/
-	install -m 644 liblumabri.so $(DESTDIR)$(PREFIX)/lib/lumabri/
+	install -m 644 $(SHIM_LIB) $(DESTDIR)$(PREFIX)/lib/lumabri/
 	install -m 644 tools/setup-household-firewall.ps1 $(DESTDIR)$(PREFIX)/lib/lumabri/
 	@for b in expert_node expert_node_glm expert_node_inkling expert_node_kimi \
 	         expert_node_deepseek expert_node_qwen36 \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SHIM_FLAGS = -shared -fPIC -ldl
 OMP_FLAGS = -fopenmp
 OMP_LIBS =
 ifeq ($(PLATFORM),Darwin)
+override CPPFLAGS += -D_DARWIN_C_SOURCE
 SHIM_LIB = liblumabri.dylib
 SHIM_FLAGS = -dynamiclib -fPIC
 OMP_PREFIX := $(shell brew --prefix libomp 2>/dev/null)
@@ -777,7 +778,7 @@ install: all
 	@echo "installed under $(DESTDIR)$(PREFIX)"
 
 clean:
-	rm -f tracker maintainer liblumabri.so test_shim swarm_probe lumabri \
+	rm -f tracker maintainer liblumabri.so liblumabri.dylib test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
 	      test_model_family test_planner test_cluster test_calibration test_inventory test_home test_chat_ui segment_budget_probe \

--- a/lumabri.c
+++ b/lumabri.c
@@ -26,6 +26,10 @@
  */
 #define _GNU_SOURCE
 #include "lumabri_ready.h"
+#include "lumabri_platform.h"
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 #include "lumabri_home_net.h"
 #include <arpa/inet.h>
 #include <dirent.h>
@@ -134,9 +138,21 @@ static int chat_command_matches(const char *prefix, int *indices) {
 }
 
 static void exe_dir(char *dst, size_t cap) {
+#ifdef __APPLE__
+    char executable[PATH_MAX];
+    uint32_t size = sizeof executable;
+    if (_NSGetExecutablePath(executable, &size)) {
+        snprintf(dst, cap, "."); return;
+    }
+    char *resolved = realpath(executable, NULL);
+    if (!resolved) { snprintf(dst, cap, "."); return; }
+    snprintf(dst, cap, "%s", resolved);
+    free(resolved);
+#else
     ssize_t n = readlink("/proc/self/exe", dst, cap - 1);
     if (n <= 0) { snprintf(dst, cap, "."); return; }
     dst[n] = 0;
+#endif
     char *slash = strrchr(dst, '/');
     if (slash) *slash = 0;
 }
@@ -2869,7 +2885,7 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
         if (local_dir) {
             setenv("SNAP", local_dir, 1);
         } else {
-            setenv("LD_PRELOAD", shim, 1);
+            setenv(LMB_PRELOAD_ENV, shim, 1);
             setenv("LUMABRI_VROOT", vroot, 1);
             setenv("LUMABRI_CACHE", cache, 1);
             setenv("LUMABRI_CAS", cas, 0);       /* shared across model mirrors */
@@ -2977,7 +2993,7 @@ static int segment_engine_spawn(const char *engine, const char *shim,
     if (pid == 0) {
         dup2(in_pipe[0], 0); dup2(out_pipe[1], 1); dup2(err_pipe[1], 2);
         close(in_pipe[1]); close(out_pipe[0]); close(err_pipe[0]);
-        setenv("LD_PRELOAD", shim, 1);
+        setenv(LMB_PRELOAD_ENV, shim, 1);
         setenv("LUMABRI_VROOT", vroot, 1);
         setenv("LUMABRI_CACHE", cache, 1);
         setenv("LUMABRI_CAS", cas, 0);
@@ -3379,9 +3395,9 @@ static int cmd_host(int argc, char **argv) {
     }
     char dir[1024], shim[1200];
     exe_dir(dir, sizeof dir);
-    snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
+    snprintf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, dir);
     if (access(shim, R_OK))
-        snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
+        snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, dir);
 
     char model[128];
     snprintf(model, sizeof model, "%s", want_model ? want_model : "local");
@@ -3873,9 +3889,9 @@ static int role_start_segment(const Role *r, const char *tracker,
     exe_dir(dir, sizeof dir);
     snprintf(bin, sizeof bin, "%s/segment_node", dir);
     if (access(bin, X_OK)) return 0;
-    snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
+    snprintf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, dir);
     if (access(shim, R_OK))
-        snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
+        snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, dir);
 
     char host[INET_ADDRSTRLEN] = "";
     int relay_only = 0;
@@ -3931,7 +3947,7 @@ static int role_start_segment(const Role *r, const char *tracker,
         else snprintf(cachedir, sizeof cachedir, "%s/.lumabri/%s/cache", home, model);
         snprintf(casdir, sizeof casdir, "%s/.lumabri/cas", home);
         mkdir_p(cachedir);
-        snprintf(e_pre, sizeof e_pre, "LD_PRELOAD=%s", shim);
+        snprintf(e_pre, sizeof e_pre, LMB_PRELOAD_ENV "=%s", shim);
         snprintf(e_vr, sizeof e_vr, "LUMABRI_VROOT=%s", vroot);
         snprintf(e_ca, sizeof e_ca, "LUMABRI_CACHE=%s", cachedir);
         snprintf(e_cs, sizeof e_cs, "LUMABRI_CAS=%s", casdir);
@@ -4123,9 +4139,9 @@ static void role_start(const Role *r, const char *tracker, const char *model,
         char probe[1100], shim[1200];
         snprintf(probe, sizeof probe, "%s/config.json", r->model_dir);
         int local = r->model_dir[0] && access(probe, R_OK) == 0;
-        snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
+        snprintf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, dir);
         if (access(shim, R_OK))
-            snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
+            snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, dir);
         if (!node || !port || access(bin, X_OK)) {
             printf("  %sno expert node for %s (make engines): compute sharing "
                    "skipped%s\n", C_DIM, model_type ? model_type : "?", C_R);
@@ -4152,7 +4168,7 @@ static void role_start(const Role *r, const char *tracker, const char *model,
                               home, model);
                 snprintf(casdir, sizeof casdir, "%s/.lumabri/cas", home);
                 mkdir_p(cachedir);              /* the vroot stays virtual */
-                snprintf(e_pre, sizeof e_pre, "LD_PRELOAD=%s", shim);
+                snprintf(e_pre, sizeof e_pre, LMB_PRELOAD_ENV "=%s", shim);
                 snprintf(e_vr, sizeof e_vr, "LUMABRI_VROOT=%s", vroot);
                 snprintf(e_ca, sizeof e_ca, "LUMABRI_CACHE=%s", cachedir);
                 snprintf(e_cs, sizeof e_cs, "LUMABRI_CAS=%s", casdir);
@@ -4500,9 +4516,9 @@ static int cmd_chat(int argc, char **argv) {
 
     char dir[1024], shim[1200];
     exe_dir(dir, sizeof dir);
-    snprintf(shim, sizeof shim, "%s/liblumabri.so", dir);
+    snprintf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, dir);
     if (access(shim, R_OK))       /* installed layout: bin/../lib/lumabri/ */
-        snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", dir);
+        snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, dir);
     if (!host_addr && !local_dir && access(shim, R_OK)) {
         fprintf(stderr, "liblumabri.so missing; run make (or make install)\n");
         return 1;
@@ -5496,9 +5512,9 @@ static int cmd_doctor(int argc, char **argv) {
                                             "run make all or reinstall Lumabri");
     }
     char shim[1200];
-    snprintf(shim, sizeof shim, "%s/liblumabri.so", directory);
+    snprintf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, directory);
     if (access(shim, R_OK))
-        snprintf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", directory);
+        snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, directory);
     doctor_add(checks, &count, "library-liblumabri", access(shim, R_OK) == 0, 1,
                access(shim, R_OK) == 0 ? "CAS interposer found" :
                                         "liblumabri.so is missing");

--- a/lumabri.c
+++ b/lumabri.c
@@ -4520,7 +4520,7 @@ static int cmd_chat(int argc, char **argv) {
     if (access(shim, R_OK))       /* installed layout: bin/../lib/lumabri/ */
         snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, dir);
     if (!host_addr && !local_dir && access(shim, R_OK)) {
-        fprintf(stderr, "liblumabri.so missing; run make (or make install)\n");
+        fprintf(stderr, "%s missing; run make (or make install)\n", LMB_SHIM_NAME);
         return 1;
     }
 
@@ -5517,7 +5517,7 @@ static int cmd_doctor(int argc, char **argv) {
         snprintf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, directory);
     doctor_add(checks, &count, "library-liblumabri", access(shim, R_OK) == 0, 1,
                access(shim, R_OK) == 0 ? "CAS interposer found" :
-                                        "liblumabri.so is missing");
+                                        LMB_SHIM_NAME " is missing");
     const char *segment_bins[] = {"segment_node", "segment_chat"};
     for (size_t i = 0; i < sizeof segment_bins / sizeof segment_bins[0]; i++) {
         char path[1200], name[64];

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -4,6 +4,15 @@
 #define LUMABRI_HOME_RUNTIME_H
 #include "lumabri_home_net.h"
 
+static char home_error[512];
+static int home_fail(const char *fmt, ...) {
+    va_list args; va_start(args, fmt);
+    vsnprintf(home_error, sizeof home_error, fmt, args);
+    va_end(args);
+    fprintf(stderr, "%s\n", home_error);
+    return 1;
+}
+
 typedef struct {
     struct termios saved;
     int active;
@@ -78,6 +87,28 @@ static pid_t home_spawn(char *const argv[], char *const envv[], const char *log,
     pid_t parent = getpid(), pid = fork();
     if (!pid) {
         if (setpgid(0, 0) || child_follow_parent(parent)) _exit(125);
+#ifdef __APPLE__
+        /* Darwin has no PR_SET_PDEATHSIG. An owning supervisor keeps the
+         * dedicated group alive only while both the TUI and service live.
+         * No watcher thread is lost at exec, and no orphan retains a RAM
+         * lease when the terminal is killed. The engine still owns READY. */
+        pid_t service = fork();
+        if (service < 0) _exit(125);
+        if (service > 0) {
+            int limit = getdtablesize();
+            for (int fd = 3; fd < limit; fd++) close(fd);
+            for (;;) {
+                int status;
+                pid_t result = waitpid(service, &status, WNOHANG);
+                if (getppid() != parent || result == service ||
+                    (result < 0 && errno != EINTR)) {
+                    (void)kill(-getpgrp(), SIGKILL);
+                    _exit(125);
+                }
+                (void)poll(NULL, 0, 100);
+            }
+        }
+#endif
         int nullfd = open("/dev/null", O_RDONLY);
         int logfd = open(log, O_WRONLY | O_CREAT | O_APPEND, 0600);
         if (nullfd < 0 || logfd < 0) _exit(125);
@@ -184,17 +215,17 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     char e_tracker[300], e_model[100], e_root[100], e_key[100], e_limit[100], e_log[1232];
     char range[40], port[20], addr[64], name[64], context[20], threads[20], ram[32];
     char bytes[32], layers[20], max_new[20];
-    if (checked_printf(shim, sizeof shim, "%s/liblumabri.so", d->bin_dir) ||
+    if (checked_printf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, d->bin_dir) ||
         checked_printf(binary, sizeof binary, "%s/%s", d->bin_dir, edge ? "lumabri" : "segment_node") ||
         checked_printf(vroot, sizeof vroot, "%s/%.16s/vroot", d->cache_base, id) ||
         checked_printf(cache, sizeof cache, "%s/%.16s/cache", d->cache_base, id) ||
         checked_printf(cas, sizeof cas, "%s/%.16s/cas", d->cache_base, id) ||
         access(binary, X_OK)) return -1;
     if (access(shim, R_OK) &&
-        (checked_printf(shim, sizeof shim, "%s/../lib/lumabri/liblumabri.so", d->bin_dir) ||
+        (checked_printf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, d->bin_dir) ||
          access(shim, R_OK))) return -1;
     mkdir_p(cache); mkdir_p(cas);
-    snprintf(e_shim, sizeof e_shim, "LD_PRELOAD=%s", shim);
+    snprintf(e_shim, sizeof e_shim, LMB_PRELOAD_ENV "=%s", shim);
     snprintf(e_vroot, sizeof e_vroot, "LUMABRI_VROOT=%s", vroot);
     snprintf(e_cache, sizeof e_cache, "LUMABRI_CACHE=%s", cache);
     snprintf(e_cas, sizeof e_cas, "LUMABRI_CAS=%s", cas);
@@ -233,7 +264,7 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     if (edge) {
         /* The host itself must not be preloaded; model_boot passes the mirror
          * to its Edge child, while its own networking remains ordinary C. */
-        envv[0] = "LD_PRELOAD=";
+        envv[0] = LMB_PRELOAD_ENV "=";
         d->host = home_spawn(host_argv, envv, d->log, &d->host_ready, listener);
         d->host_port = chosen_port;
         return d->host > 0 ? 0 : -1;
@@ -360,6 +391,7 @@ static int home_donor_message(HomeDonor *d) {
 }
 
 static int cmd_donor(int argc, char **argv) {
+    home_error[0] = 0;
     const char *tracker = NULL, *name = NULL, *disk = NULL;
     uint64_t limit = UINT64_MAX;
     for (int i = 0; i < argc; i++) {
@@ -379,18 +411,25 @@ static int cmd_donor(int argc, char **argv) {
     exe_dir(d.bin_dir, sizeof d.bin_dir);
     if (checked_printf(d.cache_base, sizeof d.cache_base, "%s/%s", disk ? disk :
                        (getenv("HOME") ? getenv("HOME") : "."), disk ? "lumabri-home" : ".lumabri/home") ||
-        home_local_ip(tracker, d.ip)) return 1;
+        home_local_ip(tracker, d.ip))
+        return home_fail("Cannot reach the household. Check its address and LAN access; no resources were shared.");
+    int auth = lmb_connect_ms_io(tracker, 1200, 1500);
+    if (auth < 0) return home_fail("Cannot connect to the household tracker. No resources were shared.");
+    int rejected = lmb_auth(auth);
+    lmb_close(auth);
+    if (rejected) return home_fail("Household authentication failed. Use /join to check the household key. No resources were shared.");
     mkdir_p(d.cache_base);
     if (checked_printf(d.log, sizeof d.log, "%s/engines.log", d.cache_base)) return 1;
     LmbMachineProfile profile;
-    if (lmb_machine_probe(&profile, d.cache_base, NULL)) return 1;
+    if (lmb_machine_probe(&profile, d.cache_base, NULL) || !profile.ram_total_bytes)
+        return home_fail("Cannot read this computer's memory. Sharing is disabled until hardware detection succeeds.");
     uint64_t reserve = (uint64_t)lmb_env_int("LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
     uint64_t ram = profile.ram_available_bytes > reserve ? profile.ram_available_bytes - reserve : 0;
     if (limit < ram) ram = limit;
-    if (ram < (32u << 20)) { fprintf(stderr, "Not enough RAM beyond the system reserve.\n"); return 1; }
+    if (ram < (32u << 20)) return home_fail("Not enough available RAM to share safely: %.2f GB available, %.2f GB system reserve. Close other applications and retry.", profile.ram_available_bytes / 1e9, reserve / 1e9);
     if (!name) name = profile.hostname;
     int port, listener = home_listen(&port);
-    if (listener < 0) return 1;
+    if (listener < 0) return home_fail("Cannot open a donor port in the household range: %s. Close another sharing window and retry.", strerror(errno));
     char own_bin[1200], addr[64], budget[32], report_log[1200];
     snprintf(own_bin, sizeof own_bin, "%s/lumabri", d.bin_dir);
     snprintf(addr, sizeof addr, "%s:%d", d.ip, port);
@@ -400,12 +439,16 @@ static int cmd_donor(int argc, char **argv) {
         "--name", (char *)name, "--ram-gb", budget, "--disk", d.cache_base,
         "--control-address", addr, NULL};
     pid_t reporter = home_spawn(worker_argv, NULL, report_log, NULL, -1);
-    if (reporter <= 0) { close(listener); return 1; }
+    if (reporter <= 0) { close(listener); return home_fail("Cannot start the inventory reporter: %s.", strerror(errno)); }
     g_stopping = 0; install_chat_signal_handlers(); signal(SIGPIPE, SIG_IGN);
     HomeTerminal term; home_terminal_begin(&term);
     double redraw = 0;
     int donor_choice = 1; /* Enter alone must never accept a new allocation. */
     while (!g_stopping) {
+        if (waitpid(reporter, NULL, WNOHANG) == reporter) {
+            (void)home_fail("The inventory reporter stopped. See %s. No new requests can be accepted.", report_log);
+            break;
+        }
         double now = nowd();
         if (now - redraw >= .25) { home_donor_screen(&d, name, ram, term.active, donor_choice); redraw = now; }
         struct pollfd ready[2] = {{listener, POLLIN, 0}, {d.client, POLLIN, 0}};

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -409,6 +409,18 @@ static int cmd_donor(int argc, char **argv) {
         return 2;
     HomeDonor d = {0}; d.client = d.lease = d.segment_ready = d.host_ready = -1;
     exe_dir(d.bin_dir, sizeof d.bin_dir);
+    const char *services[] = {"segment_node", "segment_chat"};
+    char service_path[1200];
+    for (size_t i = 0; i < sizeof services / sizeof *services; i++) {
+        if (checked_printf(service_path, sizeof service_path, "%s/%s", d.bin_dir, services[i]) ||
+            access(service_path, X_OK))
+            return home_fail("Household runtime is not installed: %s is missing. Install or build the household services, not only the TUI.", services[i]);
+    }
+    if (checked_printf(service_path, sizeof service_path, "%s/" LMB_SHIM_NAME, d.bin_dir) ||
+        (access(service_path, R_OK) &&
+         (checked_printf(service_path, sizeof service_path, "%s/../lib/lumabri/" LMB_SHIM_NAME, d.bin_dir) ||
+          access(service_path, R_OK))))
+        return home_fail("The household weight loader (%s) is missing. Install or build the complete household runtime.", LMB_SHIM_NAME);
     if (checked_printf(d.cache_base, sizeof d.cache_base, "%s/%s", disk ? disk :
                        (getenv("HOME") ? getenv("HOME") : "."), disk ? "lumabri-home" : ".lumabri/home") ||
         home_local_ip(tracker, d.ip))
@@ -506,7 +518,7 @@ static int cmd_donor(int argc, char **argv) {
     home_terminal_end(&term);
     home_donor_disconnect(&d, "Donor closed.");
     home_stop_child(&reporter); close(listener);
-    return 0;
+    return home_error[0] ? 1 : 0;
 }
 typedef struct {
     int fd[LMB_CLUSTER_MAX_NODES];

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -18,6 +18,10 @@
 #include <sys/utsname.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef __APPLE__
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#endif
 
 static int read_u64_file(const char *path, uint64_t *value) {
     FILE *file = fopen(path, "r");
@@ -80,6 +84,31 @@ int lmb_machine_read_meminfo(FILE *file, uint64_t *total,
 
 static void meminfo(uint64_t *total, uint64_t *available,
                     uint64_t *swap_total, uint64_t *swap_free) {
+#ifdef __APPLE__
+    uint64_t mt = 0, ma = 0;
+    size_t size = sizeof mt;
+    if (sysctlbyname("hw.memsize", &mt, &size, NULL, 0)) mt = 0;
+    mach_port_t host = mach_host_self();
+    vm_size_t page_size = 0;
+    vm_statistics64_data_t vm = {0};
+    mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
+    if (host_page_size(host, &page_size) == KERN_SUCCESS &&
+        host_statistics64(host, HOST_VM_INFO64, (host_info64_t)&vm, &count) == KERN_SUCCESS) {
+        /* free_count includes speculative pages. Purgeable pages can overlap
+         * inactive pages: do not count either twice, or count compressed/wired
+         * memory as immediately available. The governor retains its reserve. */
+        ma = ((uint64_t)vm.free_count + vm.inactive_count) * page_size;
+        if (ma > mt) ma = mt;
+    }
+    mach_port_deallocate(mach_task_self(), host);
+    struct xsw_usage swap = {0};
+    size = sizeof swap;
+    if (sysctlbyname("vm.swapusage", &swap, &size, NULL, 0)) memset(&swap, 0, sizeof swap);
+    if (total) *total = mt;
+    if (available) *available = ma;
+    if (swap_total) *swap_total = swap.xsu_total;
+    if (swap_free) *swap_free = swap.xsu_avail;
+#else
     FILE *file = fopen("/proc/meminfo", "r");
     if (!file || lmb_machine_read_meminfo(file, total, available,
                                           swap_total, swap_free)) {
@@ -89,6 +118,7 @@ static void meminfo(uint64_t *total, uint64_t *available,
         if (swap_free) *swap_free = 0;
     }
     if (file) fclose(file);
+#endif
 }
 
 uint64_t lmb_machine_available_ram(void) {
@@ -159,6 +189,30 @@ int lmb_machine_compute_lease_acquire(const char *model, const char *tracker,
 }
 
 static void cpu_profile(LmbMachineProfile *profile) {
+#ifdef __APPLE__
+    unsigned logical = 0, physical = 0;
+    size_t size = sizeof logical;
+    (void)sysctlbyname("hw.logicalcpu", &logical, &size, NULL, 0);
+    size = sizeof physical;
+    (void)sysctlbyname("hw.physicalcpu", &physical, &size, NULL, 0);
+    long online = sysconf(_SC_NPROCESSORS_ONLN);
+    profile->logical_cpus = logical ? logical : online > 0 ? (uint32_t)online : 1;
+    profile->physical_cores = physical ? physical : profile->logical_cpus;
+    size = sizeof profile->cpu_model;
+    if (sysctlbyname("machdep.cpu.brand_string", profile->cpu_model, &size, NULL, 0)) {
+        size = sizeof profile->cpu_model;
+        (void)sysctlbyname("hw.model", profile->cpu_model, &size, NULL, 0);
+    }
+    profile->cpu_model[sizeof profile->cpu_model - 1] = 0;
+    int supported = 0;
+    size = sizeof supported;
+    (void)sysctlbyname("hw.optional.avx2_0", &supported, &size, NULL, 0);
+#if defined(__aarch64__) || defined(__arm64__)
+    snprintf(profile->isa, sizeof profile->isa, "asimd");
+#else
+    snprintf(profile->isa, sizeof profile->isa, "%s", supported ? "avx2" : "generic");
+#endif
+#else
     FILE *file = fopen("/proc/cpuinfo", "r");
     char line[1024], flags[4096] = "";
     unsigned processors = 0;
@@ -212,6 +266,7 @@ static void cpu_profile(LmbMachineProfile *profile) {
     else if (strstr(flags, " avx2 ")) isa = "avx2";
     else if (strstr(flags, " asimd ")) isa = "asimd";
     snprintf(profile->isa, sizeof profile->isa, "%s", isa);
+#endif
 }
 
 static void numa_profile(LmbMachineProfile *profile) {

--- a/lumabri_platform.h
+++ b/lumabri_platform.h
@@ -1,0 +1,11 @@
+/* Platform differences at the process/libc boundary, never model arithmetic. */
+#ifndef LUMABRI_PLATFORM_H
+#define LUMABRI_PLATFORM_H
+#ifdef __APPLE__
+#define LMB_SHIM_NAME "liblumabri.dylib"
+#define LMB_PRELOAD_ENV "DYLD_INSERT_LIBRARIES"
+#else
+#define LMB_SHIM_NAME "liblumabri.so"
+#define LMB_PRELOAD_ENV "LD_PRELOAD"
+#endif
+#endif

--- a/lumabri_wakeup.h
+++ b/lumabri_wakeup.h
@@ -1,0 +1,23 @@
+/* Nonblocking wakeups for the tracker control loop. A full pipe already
+ * contains a wakeup; request state itself lives behind the peer mutex. */
+#ifndef LUMABRI_WAKEUP_H
+#define LUMABRI_WAKEUP_H
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+static inline int lmb_wakeup_open(int *writer) {
+    int pair[2];
+    *writer = -1;
+    if (pipe(pair)) return -1;
+    for (int i = 0; i < 2; i++) {
+        int flags = fcntl(pair[i], F_GETFL);
+        if (flags < 0 || fcntl(pair[i], F_SETFL, flags | O_NONBLOCK) ||
+            fcntl(pair[i], F_SETFD, FD_CLOEXEC)) {
+            int saved = errno;
+            close(pair[0]); close(pair[1]); errno = saved; return -1;
+        }
+    }
+    *writer = pair[1];
+    return pair[0];
+}
+#endif

--- a/lumashim.c
+++ b/lumashim.c
@@ -91,6 +91,20 @@ static void  *(*real_mmap64)(void *, size_t, int, int, int, off_t);
 
 static void shim_resolve(void) {
     if (real_open) return;
+#ifdef __APPLE__
+    /* References from the interposing image keep their original libc
+     * bindings. Resolve them directly: querying dyld while its initializer
+     * is running can itself need the I/O functions being interposed. This
+     * also preserves the SDK's ABI aliases (notably opendir$INODE64). */
+    real_openat = openat; real_openat64 = openat;
+    real_fopen = fopen; real_fopen64 = fopen;
+    real_opendir = opendir;
+    real_pread = pread; real_pread64 = pread;
+    real_read = read; real_close = close;
+    real_mmap = mmap; real_mmap64 = mmap;
+    real_open64 = open;
+    real_open = open;
+#else
     real_open64   = (int (*)(const char *, int, ...))dlsym(RTLD_NEXT, "open64");
     real_openat   = (int (*)(int, const char *, int, ...))dlsym(RTLD_NEXT, "openat");
     real_openat64 = (int (*)(int, const char *, int, ...))dlsym(RTLD_NEXT, "openat64");
@@ -105,6 +119,7 @@ static void shim_resolve(void) {
     real_pread    = (ssize_t (*)(int, void *, size_t, off_t))dlsym(RTLD_NEXT, "pread");
     /* last, and last assigned: real_open doubles as the "resolved" flag */
     real_open     = (int (*)(const char *, int, ...))dlsym(RTLD_NEXT, "open");
+#endif
 }
 
 /* forward: g is defined below; the ctor only resolves symbols and learns the

--- a/lumashim.c
+++ b/lumashim.c
@@ -47,6 +47,14 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <time.h>
+#ifdef __APPLE__
+#include <mach-o/dyld-interposing.h>
+#define O_TMPFILE 0
+#define O_LARGEFILE 0
+/* Darwin has no Linux data-only durability primitive. Never weaken the
+ * write-before-publication guarantee of the signed block cache. */
+#define fdatasync fsync
+#endif
 
 #define LMB_SECURE_NO_CLOSE_REDIRECT 1
 #include "lumabri_proto.h"
@@ -1936,6 +1944,18 @@ static int open_common(const char *path, int flags, mode_t mode) {
     return fd;
 }
 
+#ifdef __APPLE__
+/* Mach-O does not use ELF symbol preemption. Keep replacements distinct
+ * from their libc targets; dyld excludes this image from its interposition. */
+#define open lmb_darwin_open
+#define openat lmb_darwin_openat
+#define fopen lmb_darwin_fopen
+#define opendir lmb_darwin_opendir
+#define pread lmb_darwin_pread
+#define read lmb_darwin_read
+#define mmap lmb_darwin_mmap
+#define close lmb_darwin_close
+#endif
 int open(const char *path, int flags, ...) {
     mode_t mode = 0;
     if (flags & (O_CREAT | O_TMPFILE)) {
@@ -2087,3 +2107,21 @@ int close(int fd) {
     lmb_sec_forget_hook(fd);
     return real_close(fd);
 }
+#ifdef __APPLE__
+#undef open
+#undef openat
+#undef fopen
+#undef opendir
+#undef pread
+#undef read
+#undef mmap
+#undef close
+DYLD_INTERPOSE(lmb_darwin_open, open)
+DYLD_INTERPOSE(lmb_darwin_openat, openat)
+DYLD_INTERPOSE(lmb_darwin_fopen, fopen)
+DYLD_INTERPOSE(lmb_darwin_opendir, opendir)
+DYLD_INTERPOSE(lmb_darwin_pread, pread)
+DYLD_INTERPOSE(lmb_darwin_read, read)
+DYLD_INTERPOSE(lmb_darwin_mmap, mmap)
+DYLD_INTERPOSE(lmb_darwin_close, close)
+#endif

--- a/lumashim.c
+++ b/lumashim.c
@@ -48,7 +48,10 @@
 #include <sys/stat.h>
 #include <time.h>
 #ifdef __APPLE__
-#include <mach-o/dyld-interposing.h>
+/* The dyld interpose ABI is a retained Mach-O section of pointer pairs:
+ * replacement first, original symbol second. Xcode's public SDK does not
+ * ship dyld-interposing.h, so emit that ABI directly, without a private SDK
+ * dependency. The array is used even though C code never references it. */
 #define O_TMPFILE 0
 #define O_LARGEFILE 0
 /* Darwin has no Linux data-only durability primitive. Never weaken the
@@ -2116,12 +2119,15 @@ int close(int fd) {
 #undef read
 #undef mmap
 #undef close
-DYLD_INTERPOSE(lmb_darwin_open, open)
-DYLD_INTERPOSE(lmb_darwin_openat, openat)
-DYLD_INTERPOSE(lmb_darwin_fopen, fopen)
-DYLD_INTERPOSE(lmb_darwin_opendir, opendir)
-DYLD_INTERPOSE(lmb_darwin_pread, pread)
-DYLD_INTERPOSE(lmb_darwin_read, read)
-DYLD_INTERPOSE(lmb_darwin_mmap, mmap)
-DYLD_INTERPOSE(lmb_darwin_close, close)
+__attribute__((used, section("__DATA,__interpose")))
+static const struct { const void *replacement, *original; } lmb_interpose[] = {
+    {(const void *)lmb_darwin_open, (const void *)open},
+    {(const void *)lmb_darwin_openat, (const void *)openat},
+    {(const void *)lmb_darwin_fopen, (const void *)fopen},
+    {(const void *)lmb_darwin_opendir, (const void *)opendir},
+    {(const void *)lmb_darwin_pread, (const void *)pread},
+    {(const void *)lmb_darwin_read, (const void *)read},
+    {(const void *)lmb_darwin_mmap, (const void *)mmap},
+    {(const void *)lmb_darwin_close, (const void *)close}
+};
 #endif

--- a/maintainer.c
+++ b/maintainer.c
@@ -21,6 +21,11 @@
 #include <stdarg.h>
 #include <stdatomic.h>
 #include <sys/stat.h>
+#ifdef __APPLE__
+/* Darwin retains nanosecond timestamps under the BSD member names. */
+#define st_mtim st_mtimespec
+#define st_ctim st_ctimespec
+#endif
 
 #include "lumabri_proto.h"
 #include "lumabri_content.h"

--- a/segment_node.c
+++ b/segment_node.c
@@ -21,6 +21,9 @@
 #include <string.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
 #ifdef _OPENMP
 #include <omp.h>
 #endif
@@ -118,11 +121,18 @@ static uint64_t now_ms(void) {
 }
 
 static uint64_t available_memory_bytes(void) {
-    uint64_t available = lmb_machine_available_ram();
-    return available ? available : UINT64_MAX;
+    /* Unknown or exhausted memory is never unlimited admission capacity. */
+    return lmb_machine_available_ram();
 }
 
 static uint64_t resident_memory_bytes(void) {
+#ifdef __APPLE__
+    struct mach_task_basic_info info;
+    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+    if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                  (task_info_t)&info, &count) != KERN_SUCCESS) return 0;
+    return info.resident_size;
+#else
     FILE *file = fopen("/proc/self/statm", "r");
     unsigned long long pages = 0, resident = 0;
     if (!file) return 0;
@@ -131,6 +141,7 @@ static uint64_t resident_memory_bytes(void) {
     long page = sysconf(_SC_PAGESIZE);
     if (!ok || page <= 0 || resident > UINT64_MAX / (uint64_t)page) return 0;
     return resident * (uint64_t)page;
+#endif
 }
 
 static int process_budget_exhausted(Node *node) {

--- a/src/ui/lumabri_home_ui.h
+++ b/src/ui/lumabri_home_ui.h
@@ -84,6 +84,38 @@ static int home_connection_check(const char *address, const uint8_t *expected_id
     return rc ? -2 : 0;
 }
 
+/* Failure is an acknowledged screen, not a footer erased by the next frame.
+ * Never include household secrets or captured engine output here. */
+static void home_error_dialog(const char *title, const char *message) {
+    HomeTerminal term; home_terminal_begin(&term);
+    while (!g_stopping) {
+        ui_begin("action could not complete");
+        ui_text(5, 4, UI_SAND, title);
+        const char *p = message;
+        int width = ui_w > 12 ? ui_w - 8 : 10;
+        if (width > 120) width = 120;
+        for (int row = 8; *p && row < ui_h - 4; row++) {
+            char line[121];
+            size_t n = strlen(p);
+            if (n > (size_t)width) {
+                n = (size_t)width;
+                while (n > 0 && p[n] != ' ') n--;
+                if (!n) n = (size_t)width;
+            }
+            memcpy(line, p, n); line[n] = 0;
+            ui_text(row, 4, UI_TEXT, line);
+            p += n; while (*p == ' ') p++;
+        }
+        ui_footer("Your previous household settings are unchanged.", "Enter or Esc back   Ctrl-C exit");
+        ui_present();
+        int key = home_key();
+        if (key == 3) { g_stopping = 1; break; }
+        if (key == '\r' || key == '\n' || key == 27) break;
+        (void)poll(NULL, 0, 50);
+    }
+    home_terminal_end(&term);
+}
+
 /* Persist the household key and fixed tracker endpoint. A second local
  * window may attach to our authenticated tracker; an unrelated listener
  * must never be adopted or displaced. */
@@ -328,12 +360,17 @@ static int cmd_home(void) {
                 snprintf(notice, sizeof notice, "%s", connected == -1 ?
                     "Connection or secure handshake failed. Check the LAN address and Windows/WSL firewall." :
                     "Household authentication failed. Check the household key and tracker.");
+                home_error_dialog("Could not join the household", notice);
                 continue;
             }
             next.owner = s.owner && !strcmp(s.tracker, next.tracker);
-            s = next;
-            if (home_settings_save(&s)) snprintf(notice, sizeof notice, "Could not save household settings.");
-            else snprintf(notice, sizeof notice, "Connected. Open Your computers; helpers must keep Share resources active.");
+            if (home_settings_save(&next)) {
+                setenv("LUMABRI_TOKEN", s.token, 1);
+                home_error_dialog("Could not save household settings", "Check that your home directory is writable, then retry.");
+            } else {
+                s = next;
+                snprintf(notice, sizeof notice, "Connected. Open Your computers; helpers must keep Share resources active.");
+            }
         } else if (key == 's') {
             HomeSettings next = s;
             if (home_field("Folder containing your model directories", next.models, sizeof next.models, 0) ||
@@ -342,8 +379,8 @@ static int cmd_home(void) {
             if (*end || !isfinite(ram) || ram <= 0 || ram > 1048576) {
                 snprintf(notice, sizeof notice, "RAM limit must be a positive number of GB."); continue;
             }
-            s = next;
-            if (home_settings_save(&s)) snprintf(notice, sizeof notice, "Could not save settings.");
+            if (home_settings_save(&next)) home_error_dialog("Could not save settings", "Check that your home directory is writable, then retry.");
+            else s = next;
         } else if (key == 'n') {
             if (tracker_child <= 0 && home_tracker_resume(&s, &tracker_child, notice, sizeof notice)) continue;
             char identity[65]; lmb_hex(identity, g_sec_pk, 32);
@@ -353,6 +390,7 @@ static int cmd_home(void) {
         } else if (key == 'c' || key == 'p' || key == 'd') {
             if (!s.tracker[0] || !s.token[0]) { snprintf(notice, sizeof notice, "Create or join a household first."); continue; }
             setenv("LUMABRI_TOKEN", s.token, 1);
+            home_error[0] = 0;
             int rc;
             if (key == 'd') {
                 char *args[] = {"--join", s.tracker, "--ram-gb", s.ram};
@@ -362,7 +400,8 @@ static int cmd_home(void) {
                 rc = cmd_models(key == 'p' ? 5 : 4, args);
             }
             g_stopping = 0; install_chat_signal_handlers();
-            if (rc) snprintf(notice, sizeof notice, "The operation did not finish. No plan is running; check diagnostics before retrying.");
+            if (rc || home_error[0]) home_error_dialog("Could not complete the operation", home_error[0] ? home_error :
+                "The operation did not finish. No plan is running. Check diagnostics before retrying.");
         }
     }
     home_stop_child(&tracker_child);

--- a/tests/c/test_home_network.c
+++ b/tests/c/test_home_network.c
@@ -1,9 +1,26 @@
 #define _GNU_SOURCE
 #include "lumabri_home_discovery.h"
+#include "lumabri_wakeup.h"
 #include "src/ui/lumabri_visual.h"
 #include <assert.h>
 
 int main(void) {
+    int writer = -1, reader = lmb_wakeup_open(&writer);
+    assert(reader >= 0 && writer >= 0 && reader != writer);
+    assert(fcntl(reader, F_GETFL) & O_NONBLOCK);
+    assert(fcntl(writer, F_GETFL) & O_NONBLOCK);
+    assert(fcntl(reader, F_GETFD) & FD_CLOEXEC);
+    assert(fcntl(writer, F_GETFD) & FD_CLOEXEC);
+    uint64_t one = 1, got = 0;
+    assert(write(writer, &one, sizeof one) == sizeof one);
+    assert(read(reader, &got, sizeof got) == sizeof got && got == one);
+    while (write(writer, &one, sizeof one) == sizeof one) { }
+    assert(errno == EAGAIN || errno == EWOULDBLOCK);
+    while (read(reader, &got, sizeof got) == sizeof got) { }
+    assert(errno == EAGAIN || errno == EWOULDBLOCK);
+    close(writer);
+    assert(read(reader, &got, sizeof got) == 0);
+    close(reader);
     unsigned up = IFF_UP;
     assert(!lmb_home_ip_score(up | IFF_LOOPBACK, 0x0afffffe)); /* WSL DNS alias */
     assert(!lmb_home_ip_score(0, 0xc0a8010d));

--- a/tests/c/test_machine.c
+++ b/tests/c/test_machine.c
@@ -12,6 +12,11 @@ int main(void) {
     assert(profile.physical_cores > 0);
     assert(profile.ram_total_bytes > 0);
     assert(profile.ram_available_bytes > 0);
+    assert(profile.ram_available_bytes <= profile.ram_total_bytes);
+    assert(profile.physical_cores <= profile.logical_cpus);
+#ifdef __APPLE__
+    assert(profile.cpu_model[0]);
+#endif
 
     /* Never alter the real user's persistent pause state while testing. */
     char home[] = "/tmp/lumabri-machine.XXXXXX";

--- a/tests/integration/firewall_helper_test.ps1
+++ b/tests/integration/firewall_helper_test.ps1
@@ -1,0 +1,59 @@
+# Execute the helper, not just its outer -WhatIf. No real firewall cmdlet is
+# invoked. Mandatory parameters match the production command contracts.
+$ErrorActionPreference = 'Stop'
+$script:rules = @{}
+$script:created = 0
+$script:updated = 0
+$script:removed = 0
+function Get-NetFirewallRule { [CmdletBinding()] param($Name) $script:rules[$Name] }
+function Get-NetFirewallHyperVRule { [CmdletBinding()] param($Name) $script:rules[$Name] }
+function New-NetFirewallRule {
+    [CmdletBinding()] param([Parameter(Mandatory)]$Name, [Parameter(Mandatory)]$DisplayName,
+        $Group, $Direction, $Action, $Protocol, $LocalPort, $RemoteAddress, $Profile)
+    if ($RemoteAddress -ne '192.168.1.0/24' -or $Action -ne 'Allow' -or $Direction -ne 'Inbound') { throw 'Unsafe Windows rule' }
+    $script:rules[$Name] = $true; $script:created++
+}
+function New-NetFirewallHyperVRule {
+    [CmdletBinding()] param([Parameter(Mandatory)]$Name, [Parameter(Mandatory)]$DisplayName,
+        [Parameter(Mandatory)]$VMCreatorId, $Direction, $Action, $Protocol, $LocalPorts, $RemoteAddresses)
+    if ($VMCreatorId -ne '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -or
+        $RemoteAddresses -ne '192.168.1.0/24' -or $Action -ne 'Allow') { throw 'Unsafe Hyper-V rule' }
+    $expected = if ($Protocol -eq 'TCP') { '47300-47315' } else { '47300' }
+    if ($LocalPorts -ne $expected) { throw 'Incorrect ports' }
+    $script:rules[$Name] = $true; $script:created++
+}
+function Set-NetFirewallRule {
+    [CmdletBinding()] param($Name, $Enabled, $Direction, $Action, $Protocol, $LocalPort, $RemoteAddress, $Profile)
+    if (-not $script:rules[$Name]) { throw 'Updating an absent rule' }; $script:updated++
+}
+function Set-NetFirewallHyperVRule {
+    [CmdletBinding()] param($Name, $Enabled, $Direction, $Action, $Protocol, $LocalPorts, $RemoteAddresses)
+    if (-not $script:rules[$Name]) { throw 'Updating an absent Hyper-V rule' }; $script:updated++
+}
+function Remove-NetFirewallRule { [CmdletBinding()] param($Name) $script:rules.Remove($Name); $script:removed++ }
+function Remove-NetFirewallHyperVRule { [CmdletBinding()] param($Name) $script:rules.Remove($Name); $script:removed++ }
+
+$helper = Join-Path $PSScriptRoot '../../tools/setup-household-firewall.ps1'
+# Refuse to run an incomplete invocation rather than waiting for a mandatory
+# parameter prompt on the CI runner (the original user-visible failure).
+$tokens = $null; $errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path $helper), [ref]$tokens, [ref]$errors)
+if ($errors.Count) { throw 'Helper parse errors' }
+$commands = $ast.FindAll({ param($node)
+    $node -is [System.Management.Automation.Language.CommandAst] -and
+    $node.GetCommandName() -eq 'New-NetFirewallHyperVRule'
+}, $true)
+foreach ($command in $commands) {
+    $parameters = $command.CommandElements | Where-Object { $_ -is [System.Management.Automation.Language.CommandParameterAst] }
+    if ('DisplayName' -notin $parameters.ParameterName) { throw 'Missing mandatory DisplayName' }
+}
+# Hosted Windows runners are administrators. Refuse elevation in this test.
+$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Run this test on the Windows CI runner; no elevation is performed' }
+& $helper -Subnet 192.168.1.0/24 -Confirm:$false
+if ($script:created -ne 4 -or $script:rules.Count -ne 4) { throw 'Creation did not exercise all four commands' }
+& $helper -Subnet 192.168.1.0/24 -Confirm:$false
+if ($script:created -ne 4 -or $script:updated -ne 4) { throw 'Update is not idempotent' }
+& $helper -Subnet 192.168.1.0/24 -Remove -Confirm:$false
+if ($script:removed -ne 4 -or $script:rules.Count) { throw 'Removal failed' }
+Write-Host 'FIREWALL HELPER: PASS (mandatory display names, scoped create, update, remove)'

--- a/tests/integration/firewall_helper_test.ps1
+++ b/tests/integration/firewall_helper_test.ps1
@@ -1,17 +1,17 @@
 # Execute the helper, not just its outer -WhatIf. No real firewall cmdlet is
 # invoked. Mandatory parameters match the production command contracts.
 $ErrorActionPreference = 'Stop'
-$script:rules = @{}
-$script:created = 0
-$script:updated = 0
-$script:removed = 0
-function Get-NetFirewallRule { [CmdletBinding()] param($Name) $script:rules[$Name] }
-function Get-NetFirewallHyperVRule { [CmdletBinding()] param($Name) $script:rules[$Name] }
+$global:LmbFirewallTestRules = @{}
+$global:LmbFirewallTestCreated = 0
+$global:LmbFirewallTestUpdated = 0
+$global:LmbFirewallTestRemoved = 0
+function Get-NetFirewallRule { [CmdletBinding()] param($Name) $global:LmbFirewallTestRules[$Name] }
+function Get-NetFirewallHyperVRule { [CmdletBinding()] param($Name) $global:LmbFirewallTestRules[$Name] }
 function New-NetFirewallRule {
     [CmdletBinding()] param([Parameter(Mandatory)]$Name, [Parameter(Mandatory)]$DisplayName,
         $Group, $Direction, $Action, $Protocol, $LocalPort, $RemoteAddress, $Profile)
     if ($RemoteAddress -ne '192.168.1.0/24' -or $Action -ne 'Allow' -or $Direction -ne 'Inbound') { throw 'Unsafe Windows rule' }
-    $script:rules[$Name] = $true; $script:created++
+    $global:LmbFirewallTestRules[$Name] = $true; $global:LmbFirewallTestCreated++
 }
 function New-NetFirewallHyperVRule {
     [CmdletBinding()] param([Parameter(Mandatory)]$Name, [Parameter(Mandatory)]$DisplayName,
@@ -20,18 +20,18 @@ function New-NetFirewallHyperVRule {
         $RemoteAddresses -ne '192.168.1.0/24' -or $Action -ne 'Allow') { throw 'Unsafe Hyper-V rule' }
     $expected = if ($Protocol -eq 'TCP') { '47300-47315' } else { '47300' }
     if ($LocalPorts -ne $expected) { throw 'Incorrect ports' }
-    $script:rules[$Name] = $true; $script:created++
+    $global:LmbFirewallTestRules[$Name] = $true; $global:LmbFirewallTestCreated++
 }
 function Set-NetFirewallRule {
     [CmdletBinding()] param($Name, $Enabled, $Direction, $Action, $Protocol, $LocalPort, $RemoteAddress, $Profile)
-    if (-not $script:rules[$Name]) { throw 'Updating an absent rule' }; $script:updated++
+    if (-not $global:LmbFirewallTestRules[$Name]) { throw 'Updating an absent rule' }; $global:LmbFirewallTestUpdated++
 }
 function Set-NetFirewallHyperVRule {
     [CmdletBinding()] param($Name, $Enabled, $Direction, $Action, $Protocol, $LocalPorts, $RemoteAddresses)
-    if (-not $script:rules[$Name]) { throw 'Updating an absent Hyper-V rule' }; $script:updated++
+    if (-not $global:LmbFirewallTestRules[$Name]) { throw 'Updating an absent Hyper-V rule' }; $global:LmbFirewallTestUpdated++
 }
-function Remove-NetFirewallRule { [CmdletBinding()] param($Name) $script:rules.Remove($Name); $script:removed++ }
-function Remove-NetFirewallHyperVRule { [CmdletBinding()] param($Name) $script:rules.Remove($Name); $script:removed++ }
+function Remove-NetFirewallRule { [CmdletBinding()] param($Name) $global:LmbFirewallTestRules.Remove($Name); $global:LmbFirewallTestRemoved++ }
+function Remove-NetFirewallHyperVRule { [CmdletBinding()] param($Name) $global:LmbFirewallTestRules.Remove($Name); $global:LmbFirewallTestRemoved++ }
 
 $helper = Join-Path $PSScriptRoot '../../tools/setup-household-firewall.ps1'
 # Refuse to run an incomplete invocation rather than waiting for a mandatory
@@ -51,9 +51,9 @@ foreach ($command in $commands) {
 $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
 if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) { throw 'Run this test on the Windows CI runner; no elevation is performed' }
 & $helper -Subnet 192.168.1.0/24 -Confirm:$false
-if ($script:created -ne 4 -or $script:rules.Count -ne 4) { throw 'Creation did not exercise all four commands' }
+if ($global:LmbFirewallTestCreated -ne 4 -or $global:LmbFirewallTestRules.Count -ne 4) { throw 'Creation did not exercise all four commands' }
 & $helper -Subnet 192.168.1.0/24 -Confirm:$false
-if ($script:created -ne 4 -or $script:updated -ne 4) { throw 'Update is not idempotent' }
+if ($global:LmbFirewallTestCreated -ne 4 -or $global:LmbFirewallTestUpdated -ne 4) { throw 'Update is not idempotent' }
 & $helper -Subnet 192.168.1.0/24 -Remove -Confirm:$false
-if ($script:removed -ne 4 -or $script:rules.Count) { throw 'Removal failed' }
+if ($global:LmbFirewallTestRemoved -ne 4 -or $global:LmbFirewallTestRules.Count) { throw 'Removal failed' }
 Write-Host 'FIREWALL HELPER: PASS (mandatory display names, scoped create, update, remove)'

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -14,6 +14,7 @@ import signal
 import socket
 import struct
 import subprocess
+import sys
 import tempfile
 import termios
 import time
@@ -24,6 +25,8 @@ ROOT = Path(__file__).resolve().parents[2]
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--models-dir", required=True)
+    parser.add_argument("--kill-donor", action="store_true",
+                        help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
     tmp = Path(tempfile.mkdtemp(prefix="lumabri-home-flow-"))
     children, terminals = [], []
@@ -163,10 +166,28 @@ def main():
               message="real model did not finish a response")
         assert chat.has("tok/s"), "engine failed during generation"
         assert "hosted stream · no local checkpoint" in chat.text
-        chat.send("/quit\n")
-        until(lambda: chat.p.poll() is not None, message="quit left hosted chat blocked")
-        assert chat.p.returncode == 0
-        until(lambda: a.has("Released") and b.has("Released"), message="donor leases were not released")
+        owned_groups = set()
+        if args.kill_donor:
+            rows = subprocess.check_output(["ps", "-axo", "pid=,ppid=,pgid="], text=True)
+            processes = [tuple(map(int, row.split())) for row in rows.splitlines()]
+            owned = {a.p.pid}
+            while True:
+                descendants = owned | {pid for pid, parent, group in processes if parent in owned}
+                if descendants == owned:
+                    break
+                owned = descendants
+            owned_groups = {group for pid, parent, group in processes
+                            if pid in owned and group != os.getpgrp() and group == pid}
+            assert owned_groups, "test did not find the owned runtime groups"
+            a.p.kill(); a.p.wait(timeout=5)
+            until(lambda: chat.p.poll() is not None, seconds=45,
+                  message="lost donor left hosted chat blocked")
+            until(lambda: b.has("Released"), message="surviving donor was not released")
+        else:
+            chat.send("/quit\n")
+            until(lambda: chat.p.poll() is not None, message="quit left hosted chat blocked")
+            assert chat.p.returncode == 0
+            until(lambda: a.has("Released") and b.has("Released"), message="donor leases were not released")
         def leases_released():
             for name in ("donor-a", "donor-b"):
                 with open(tmp / name / ".lumabri" / "compute-donor.lock", "r") as lease:
@@ -176,15 +197,27 @@ def main():
                         return False
             return True
         until(leases_released, message="a child retained a donor resource lease after closing chat")
+        def no_owned_processes():
+            rows = subprocess.check_output(["ps", "-axo", "pgid=,stat="], text=True)
+            return not any(int(row.split()[0]) in owned_groups and not row.split()[1].startswith("Z")
+                           for row in rows.splitlines())
+        if args.kill_donor:
+            until(no_owned_processes, message="a donor engine survived its terminated TUI")
         for name in ("chatter", "reject"):
             assert not list((tmp / name).rglob("*.safetensors")), "thin client downloaded weights"
             assert not list((tmp / name).rglob("vroot")), "thin client mounted a checkpoint"
-        a.text = b.text = ""
-        a.send("\x1b"); b.send("\x1b")
-        until(lambda: a.has("your workspace") and b.has("your workspace"))
-        a.send("\x1b"); b.send("\x1b")
+        for donor in ([b] if args.kill_donor else [a, b]):
+            donor.text = ""
+            donor.send("\x1b")
+            until(lambda: donor.has("your workspace"))
+            donor.send("\x1b")
         until(lambda: a.p.poll() is not None and b.p.poll() is not None)
-        print("HOME FLOW: PASS (all-party consent, rejection, real Segment load, hosted generation, cleanup)", flush=True)
+        print(f"HOME FLOW: PASS (consent, real Segment generation, {'killed donor recovery' if args.kill_donor else 'normal cleanup'})", flush=True)
+    except Exception:
+        # Only test-owned engine logs: no shell environment or real keys.
+        for log in tmp.rglob("engines.log"):
+            print(f"\n{log.relative_to(tmp)}:\n{log.read_text(errors='replace')[-12000:]}", file=sys.stderr)
+        raise
     finally:
         for p in reversed(children):
             if p.poll() is None:

--- a/tests/integration/household_network_test.py
+++ b/tests/integration/household_network_test.py
@@ -127,6 +127,10 @@ def main():
             wrong.send(b"yes\n"); wrong.expect("Household key from its owner")
             wrong.send(b"incorrect-test-key\n"); wrong.expect("Household authentication failed")
             assert not (wrong.home / ".lumabri/home.conf").exists()
+            wrong.data.clear()
+            time.sleep(.3)
+            wrong.expect("Could not join the household")  # persists until acknowledged
+            wrong.send(b"\r"); wrong.expect("What would you like to do?")
             wrong.quit()
 
             joiner = start("joiner")

--- a/tests/integration/household_network_test.py
+++ b/tests/integration/household_network_test.py
@@ -44,7 +44,7 @@ class Terminal:
         env = {**os.environ, "HOME": str(home), "LUMABRI_HOME_PORT_BASE": str(base),
                "LUMABRI_PEER_KEY": str(self.home / "peer.key"), "LUMABRI_TOKEN": "",
                "LUMABRI_KNOWN_HOSTS": str(self.home / "known.hosts"), "LUMABRI_ENCRYPT": "1"}
-        self.p = subprocess.Popen([str(ROOT / "lumabri")], cwd=ROOT, env=env,
+        self.p = subprocess.Popen([str(ROOT / "lumabri")], cwd=home, env=env,
                                   stdin=self.slave, stdout=self.slave, stderr=self.slave)
 
     def drain(self):

--- a/tests/integration/native_shim_test.py
+++ b/tests/integration/native_shim_test.py
@@ -71,10 +71,21 @@ def main():
                        "LUMABRI_CAS": str(tmp / "cas"), "LUMABRI_BLOCK_MIB": "1",
                        "LUMABRI_CACHE": str(tmp / f"cache-{name}"),
                        "LUMABRI_VROOT": str(tmp / f"vroot-{name}")}
-                result = subprocess.run([str(ROOT / "test_shim"), env["LUMABRI_VROOT"], str(source)],
-                                        cwd=ROOT, env=env, capture_output=True, text=True, timeout=60)
-                if result.returncode:
-                    raise AssertionError(f"{name}: {result.stdout}\n{result.stderr}")
+                with subprocess.Popen([str(ROOT / "test_shim"), env["LUMABRI_VROOT"], str(source)],
+                                      cwd=ROOT, env=env, stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE, text=True) as client:
+                    try:
+                        out, err = client.communicate(timeout=30)
+                    except subprocess.TimeoutExpired:
+                        if sys.platform == "darwin":
+                            sample = tmp / "blocked-reader.log"
+                            subprocess.run(["/usr/bin/sample", str(client.pid), "1", "1", "-file", str(sample)],
+                                           capture_output=True, timeout=10)
+                        client.kill()
+                        out, err = client.communicate(timeout=5)
+                        raise AssertionError(f"{name} reader blocked: {out}\n{err}")
+                    if client.returncode:
+                        raise AssertionError(f"{name}: {out}\n{err}")
             assert any((tmp / "cas").rglob("*")), "CAS was not populated"
             print("NATIVE SHIM: PASS (encrypted byte-exact libc reads, cold transfer, fresh mirror with origin offline)")
         except Exception:

--- a/tests/integration/native_shim_test.py
+++ b/tests/integration/native_shim_test.py
@@ -1,0 +1,96 @@
+"""Native libc interposition and signed CAS; no engine or Python ML dependency.
+
+Compares bytes through the actual .so/.dylib, then rebuilds a fresh mirror
+with the origin offline. All keys, ports and cache files are test-owned.
+"""
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="lumabri-native-shim-") as directory:
+        tmp = Path(directory)
+        source = tmp / "source"
+        source.mkdir()
+        (source / "weights.bin").write_bytes(os.urandom(2 * 1024 * 1024 + 777))
+        (source / "config.json").write_text('{"model":"native-cas"}\n')
+        children = []
+
+        def environment(name):
+            home = tmp / name
+            home.mkdir(exist_ok=True)
+            return {**os.environ, "HOME": str(home), "LUMABRI_ENCRYPT": "1",
+                    "LUMABRI_TOKEN": "native-shim-test", "LUMABRI_PEER_KEY": str(home / "identity"),
+                    "LUMABRI_KNOWN_HOSTS": str(home / "known"),
+                    "LUMABRI_PEER_BINDINGS": str(tmp / "bindings")}
+
+        def launch(name, arguments):
+            with open(tmp / f"{name}.log", "wb") as log:
+                child = subprocess.Popen(arguments, cwd=ROOT, env=environment(name),
+                                         stdout=log, stderr=subprocess.STDOUT)
+            children.append(child)
+            return child
+
+        def free_port():
+            with socket.socket() as probe:
+                probe.bind(("127.0.0.1", 0))
+                return probe.getsockname()[1]
+
+        def ready(child, port):
+            deadline = time.monotonic() + 15
+            while time.monotonic() < deadline and child.poll() is None:
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=.2):
+                        return
+                except OSError:
+                    time.sleep(.05)
+            raise AssertionError("test service did not listen")
+
+        try:
+            port = free_port()
+            tracker = launch("tracker", ["./tracker", "--port", str(port), "--token", "native-shim-test"])
+            ready(tracker, port)
+            origin_port = free_port()
+            origin = launch("origin", ["./maintainer", "--root", str(source), "--port", str(origin_port),
+                "--tracker", f"127.0.0.1:{port}", "--name", "native-origin", "--model-name", "native-cas"])
+            ready(origin, origin_port)
+            loader, library = (("DYLD_INSERT_LIBRARIES", "liblumabri.dylib") if sys.platform == "darwin"
+                               else ("LD_PRELOAD", "liblumabri.so"))
+            for name in ("cold", "offline-origin"):
+                if name == "offline-origin":
+                    origin.terminate(); origin.wait(timeout=10)
+                env = {**environment(name), loader: str(ROOT / library),
+                       "LUMABRI_MODEL": "native-cas", "LUMABRI_TRACKER": f"127.0.0.1:{port}",
+                       "LUMABRI_CAS": str(tmp / "cas"), "LUMABRI_BLOCK_MIB": "1",
+                       "LUMABRI_CACHE": str(tmp / f"cache-{name}"),
+                       "LUMABRI_VROOT": str(tmp / f"vroot-{name}")}
+                result = subprocess.run([str(ROOT / "test_shim"), env["LUMABRI_VROOT"], str(source)],
+                                        cwd=ROOT, env=env, capture_output=True, text=True, timeout=60)
+                if result.returncode:
+                    raise AssertionError(f"{name}: {result.stdout}\n{result.stderr}")
+            assert any((tmp / "cas").rglob("*")), "CAS was not populated"
+            print("NATIVE SHIM: PASS (encrypted byte-exact libc reads, cold transfer, fresh mirror with origin offline)")
+        except Exception:
+            for log in tmp.glob("*.log"):
+                print(log.name, log.read_text(errors="replace"), file=sys.stderr)
+            raise
+        finally:
+            for child in children:
+                if child.poll() is None:
+                    child.terminate()
+            for child in children:
+                try:
+                    child.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    child.kill(); child.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/setup-household-firewall.ps1
+++ b/tools/setup-household-firewall.ps1
@@ -52,7 +52,7 @@ foreach ($protocol in @('TCP', 'UDP')) {
         Set-NetFirewallHyperVRule -Name $hyperName -Enabled True -Direction Inbound -Action Allow `
             -Protocol $protocol -LocalPorts $ports -RemoteAddresses $Subnet | Out-Null
     } else {
-        New-NetFirewallHyperVRule -Name $hyperName -VMCreatorId $creator `
+        New-NetFirewallHyperVRule -Name $hyperName -DisplayName $hyperName -VMCreatorId $creator `
             -Direction Inbound -Action Allow -Protocol $protocol -LocalPorts $ports `
             -RemoteAddresses $Subnet | Out-Null
     }

--- a/tracker.c
+++ b/tracker.c
@@ -19,7 +19,7 @@
 #include <arpa/inet.h>
 #include <poll.h>
 #include <pthread.h>
-#include <sys/eventfd.h>
+#include "lumabri_wakeup.h"
 #include <time.h>
 
 #include "lumabri_proto.h"
@@ -100,6 +100,7 @@ typedef struct {
      * forwards it and completes it. evfd wakes the control thread. */
     int ctrl_fd;                /* the live control connection, -1 if none */
     int evfd;
+    int evwrite;
     pthread_mutex_t rq_lk;
     pthread_cond_t rq_cv;
     int rq_busy, rq_sent, rq_done, rq_ok;
@@ -513,12 +514,13 @@ static Peer *peer_slot_new(int is_expert, int *idx) {
         }
         for (int r = 0; r < REXEC_INFLIGHT; r++) free(p->rex[r].resp);
         if (p->evfd >= 0) close(p->evfd);
+        if (p->evwrite >= 0) close(p->evwrite);
         pthread_mutex_destroy(&p->rq_lk);
         pthread_cond_destroy(&p->rq_cv);
     }
     memset(p, 0, sizeof *p);
     p->ctrl_fd = -1;
-    p->evfd = eventfd(0, EFD_NONBLOCK);
+    p->evfd = lmb_wakeup_open(&p->evwrite);
     pthread_mutex_init(&p->rq_lk, NULL);
     pthread_cond_init(&p->rq_cv, NULL);
     g_known_logged[pick] = 0;
@@ -2086,7 +2088,7 @@ static int handle_rread(int fd, LmbMsg *m) {
     pthread_mutex_unlock(&p->rq_lk);
 
     uint64_t one = 1;
-    if (write(p->evfd, &one, 8) != 8) { /* control thread also polls the socket */ }
+    if (write(p->evwrite, &one, 8) != 8) { /* control thread also polls the socket */ }
 
     struct timespec dl;
     clock_gettime(CLOCK_REALTIME, &dl);
@@ -2158,7 +2160,7 @@ static int relay_forward(Peer *p, uint32_t fwd_op,
     if (p->outq_tail) p->outq_tail->next = f; else p->outq_head = f;
     p->outq_tail = f;
     pthread_mutex_unlock(&p->rq_lk);
-    uint64_t one = 1; if (write(p->evfd, &one, 8) != 8) {}
+    uint64_t one = 1; if (write(p->evwrite, &one, 8) != 8) {}
 
     pthread_mutex_lock(&p->rq_lk);
     while (!p->rex[slot].done && p->rex[slot].id == id)
@@ -2479,7 +2481,7 @@ static int handle_rseg(int fd, LmbMsg *m) {
     free(p->rq_resp_pay); p->rq_resp_pay = NULL; p->rq_resp_pay_len = 0;
     p->rq_resp_op = 0;
     pthread_mutex_unlock(&p->rq_lk);
-    uint64_t one = 1; if (write(p->evfd, &one, sizeof one) != sizeof one) {}
+    uint64_t one = 1; if (write(p->evwrite, &one, sizeof one) != sizeof one) {}
 
     struct timespec deadline;
     clock_gettime(CLOCK_REALTIME, &deadline); deadline.tv_sec += RELAY_WAIT_S;


### PR DESCRIPTION
Fixes native macOS household blockers: real RAM/CPU detection, signed-CAS Mach-O interposition, matching engine/shim libc feature flags, complete household runtime builds, executable discovery outside the working directory, supervised donor children, persistent acknowledged authentication/startup errors, and the Hyper-V firewall DisplayName. Existing system-memory reserves remain enforced. All six CI checks passed at 209cbbc697003b2880694efda94da4ad553ba467: Linux regression/sanitizer and real household tests; macOS Intel and Apple Silicon workspace plus real Tiny OLMoE request/accept/weight-fetch/chat and abrupt donor-loss cleanup; Windows firewall helper contract tests. Native signed-cache tests compare every byte and reopen with an offline origin. Tested native runners are macOS 15; physical Windows/WSL-to-macOS 12.6 LAN verification on the user machines remains necessary. This does not certify native Windows inference, GPU execution, or all large models.