### PR TITLE
Fix household runtime capability, RAM reserve and preflight diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
+          make test-runtime-probe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           python3 tests/integration/native_shim_test.py
           python3 tests/integration/household_network_test.py
       - name: Readiness descriptors and portable fallback
@@ -66,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: JustVugg/colibri
-          ref: dev
+          ref: 12a5c464b5c1f8292d578c62458706bc32d6ac95
           path: colibri
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -85,7 +86,9 @@ jobs:
         run: make check-warnings ENGINE=../colibri/c
       - name: Unit and integration gates
         working-directory: lumabri
-        run: make test ENGINE=../colibri/c
+        run: |
+          make test ENGINE=../colibri/c
+          make test-runtime-probe CFLAGS='-O2 -Wall -Wextra -Werror'
       - name: Sanitizers
         working-directory: lumabri
         run: make test-sanitize
@@ -131,6 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [macos-15-intel, macos-15]
+        openmp: [enabled, disabled]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 35
     steps:
@@ -140,15 +144,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: JustVugg/colibri
-          ref: dev
+          ref: 12a5c464b5c1f8292d578c62458706bc32d6ac95
           path: colibri
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: brew install libomp
+      - if: matrix.openmp == 'enabled'
+        run: brew install libomp
       - name: Build the native household runtime
         working-directory: lumabri
-        run: make household ENGINE=../colibri/c CC=clang -j3
+        env:
+          OPENMP_MODE: ${{ matrix.openmp }}
+        run: |
+          if [ "$OPENMP_MODE" = disabled ]; then
+            make household ENGINE=../colibri/c CC=clang OMP_FLAGS= OMP_LIBS= -j3
+            test "$(./segment_node --thread-capacity)" = 1
+          else
+            make household ENGINE=../colibri/c CC=clang -j3
+          fi
       - uses: actions/download-artifact@v4
         with:
           name: tiny-olmoe-checkpoint
@@ -163,6 +176,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: household-logs-${{ matrix.runner }}
+          name: household-logs-${{ matrix.runner }}-${{ matrix.openmp }}
           path: ${{ runner.temp }}/lumabri-home-flow-*/**/*.log
           retention-days: 3

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ all: tracker maintainer $(SHIM_LIB) test_shim swarm_probe lumabri
 # Native household runtime (Colibri sources are a build-time dependency).
 household: tracker maintainer $(SHIM_LIB) lumabri segment_node segment_chat
 
+.PHONY: test-runtime-probe
+test-runtime-probe: tests/c/test_runtime_probe.c lumabri_runtime_probe.h
+	mkdir -p build/tests
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_runtime_probe.c -o build/tests/runtime-probe
+	./build/tests/runtime-probe
+	python3 tests/integration/build_stamp_test.py
+
 
 # A checkout with Colibri's additive ABI gets the transparent Segment path
 # from the ordinary `make`; older/release Colibri trees keep the exact legacy
@@ -49,7 +56,7 @@ check-warnings:
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
-HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h lumabri_platform.h lumabri_wakeup.h
+HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h lumabri_platform.h lumabri_wakeup.h lumabri_runtime_probe.h
 MACHINE_SRC = lumabri_machine.c
 MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
@@ -572,7 +579,15 @@ HYBRID_PATCH_INPUTS = engine_patches/make_patches.py \
 	lumabri_proto.h lumabri_sign.h lumabri_secure.h lumabri_crypto.h \
 	lumabri_sha.h
 
-$(HYBRID_ENGINE_DIR)/.prepared: Makefile $(HYBRID_PATCH_INPUTS) \
+.PHONY: segment-options-force
+segment-options-force:
+
+# An installed libomp or changed build flags must invalidate both the runtime
+# archive and its bridge, without requiring users to discover make -B.
+build/segment-options: segment-options-force tools/update_build_stamp.py
+	python3 tools/update_build_stamp.py $@ '$(CC)' '$(CPPFLAGS)' '$(CFLAGS)' '$(OMP_FLAGS)' '$(OMP_LIBS)' '$(abspath $(ENGINE))'
+
+$(HYBRID_ENGINE_DIR)/.prepared: Makefile build/segment-options $(HYBRID_PATCH_INPUTS) \
 		$(ENGINE)/colibri.c $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c \
 		$(ENGINE)/olmoe.c $(ENGINE)/qwen36.c $(ENGINE)/deepseek_v4.c
 	rm -rf $(HYBRID_ENGINE_DIR)
@@ -587,7 +602,7 @@ $(HYBRID_ENGINE_DIR)/.prepared: Makefile $(HYBRID_PATCH_INPUTS) \
 	python3 engine_patches/deepseek_v4_p2p.py $(ENGINE)/deepseek_v4.c $(HYBRID_ENGINE_DIR)/deepseek_v4.c
 	touch $@
 
-build/segment_hybrid_bridge.o: lumi_v4_bridge.c $(HYBRID_PATCH_INPUTS)
+build/segment_hybrid_bridge.o: build/segment-options lumi_v4_bridge.c $(HYBRID_PATCH_INPUTS)
 	mkdir -p build
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(OMP_FLAGS) -pthread -I. -I$(ENGINE) -c lumi_v4_bridge.c -o $@
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ distributes contiguous layer ranges, not isolated experts. Each donor keeps
 the state for its layers; the chosen chat host receives the conversation text.
 The chat connection itself does not mount or download a checkpoint.
 
+The donor queries its installed Segment runtime before sharing. A runtime
+built without OpenMP uses one execution thread; CPU core count is not a
+promise of engine parallelism. The default system RAM reserve is one quarter
+of physical RAM, bounded to 1–4 GiB (2 GiB on an 8 GiB computer). The sharing
+limit is an additional cap, not permission to consume the system reserve.
+
 Adding computers can make a model fit when it would not fit on one machine.
 It does not automatically make each chat faster.
 
@@ -102,14 +108,34 @@ conversation and exit.
 - The images above are frames from that integration test, not performance
   claims for a large model or a multi-computer LAN.
 
-**Not yet certified:** a physical household LAN, native Windows or macOS
-(including Intel Macs), GPU household execution, all model families,
+Native macOS Intel and Apple Silicon CI covers the real Tiny household flow.
+A user-operated Windows/WSL-to-macOS 12.6 Intel trial also completed two Tiny
+responses with all model computation on the Mac and source weights on the PC.
+This is a smoke test, not a performance or large-model certification.
+
+**Not yet certified:** general physical-LAN reliability, native Windows,
+GPU household execution, all model families,
 multi-session household use, or transparent recovery after losing a donor.
 WSL testing is not native Windows certification.
 
 Adapter registration is broader than tested household execution. A checkpoint
 appearing in the catalogue does not make its sizing or backend supported.
 There are no promised tok/s or automatic “best model” recommendations.
+
+### Native runtime build
+
+Build the complete runtime with `make household ENGINE=/path/to/colibri/c`.
+Building only `lumabri` does not install the model services. macOS builds use
+Homebrew `libomp` when available and work single-threaded without it. Changing
+OpenMP flags invalidates the generated engine build automatically. CI pins
+Colibri to `12a5c464b5c1f8292d578c62458706bc32d6ac95` for reproducibility.
+
+Discovery and outbound reporting do not prove inbound connectivity. Before
+indexing, Lumabri checks each selected donor's address and identity. Keep the
+household owner's window open; it owns the tracker. Allow the installed
+`lumabri` and `segment_node` executables through the donor's application
+firewall rather than disabling the firewall. Rebuilding an unsigned executable
+may require reviewing its application permission again.
 
 ## Development and diagnostics
 

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -1,0 +1,55 @@
+# Household release acceptance
+
+This is a verification ledger, not a declaration that the full roadmap is
+finished. Tests against tiny checkpoints do not certify large models, GPU
+execution, cross-platform numerical compatibility, or concurrent capacity.
+
+## Current release work
+
+- [ ] Runtime/preflight PR: installed engine thread-capacity query; no-OpenMP
+  single-thread execution; adaptive RAM reserve; acknowledged actionable
+  failure; pre-index donor reachability; build-option invalidation.
+- [ ] Native Intel/ARM CI with and without OpenMP and isolated two-donor flow.
+- [ ] Rerun the physical Windows/WSL + macOS 12.6 trial on the final build.
+
+## Remaining roadmap gates
+
+1. Actual two-compute-node physical LAN chain: local oracle, split oracle,
+   per-node layer ranges and memory, fixed-thread and full-hardware timings.
+   Current physical trial has PC source and Mac computation, not two compute
+   nodes. Mac deployment/approval is user-operated; CI loopback is separate.
+2. Complete verified sizing for every registered family and supported weight
+   encoding. Currently only OLMoE and DeepSeek V4 enable sizing. Require real
+   checkpoint/adapter conformance before promoting support.
+3. Consistent planner/runtime reservations, explicit local-compute consent,
+   reusable content cache, authorized model acquisition and resumable transfer.
+   Disk execution requires a verified adapter working-set contract; keep the
+   current memory guard until that exists.
+4. Persist real chat measurements against exact checkpoint/build/hardware/
+   topology/context keys; bounded optional warm calibration, stale-data UI,
+   resource-based recommendations. Do not estimate tok/s from Tiny's speed.
+5. Real GPU backend execution and VRAM/scratch/state budgeting. Capability bits
+   are not implementation. The pinned OLMoE Edge/Segment adapter rejects
+   non-CPU backends; implementing one is upstream runtime work, not a planner
+   toggle. Colibri remains read-only under the agreed boundary.
+6. Multi-session admission based on memory and measured compute capacity;
+   isolated state, fair scheduling, 1/2/4/8-session tests and node-loss replay
+   with no duplicate or silently lost user-visible output.
+7. Native Windows model runtime and packaging; macOS Intel/ARM and Linux
+   release artifacts tested from clean machines. WSL is not native Windows.
+8. Incremental repository cleanup backed by dependency/build/test evidence;
+   remove only genuinely unused paths, preserve model adapters and regression
+   tests. Keep public-network trust/credits separate from the LAN product.
+
+## Evidence already obtained
+
+- PR #150: native Intel/ARM macOS CI, Linux regression gates, Windows firewall
+  helper contracts; Tiny signed CAS, all-party approval, generation and cleanup.
+- User household trial: macOS 12.6 Intel Mac with 8 GiB RAM, Windows/WSL source;
+  two completed synthetic Tiny responses. Reported ~52 tok/s is Tiny-only.
+- Physical trial exposed missing no-OpenMP coverage, a fixed 4 GiB reserve,
+  inbound application firewall permissions and insufficient failure details.
+
+No purchase, remote Mac shell access, model-license acceptance or public
+service deployment is inferred from implementation authority. Native hardware
+and compatible checkpoints are required to close their respective gates.

--- a/lumabri.c
+++ b/lumabri.c
@@ -3922,7 +3922,7 @@ static int role_start_segment(const Role *r, const char *tracker,
     uint64_t reserve = (uint64_t)lmb_env_int(
         getenv("LUMABRI_SEGMENT_RAM_RESERVE_MB") ?
         "LUMABRI_SEGMENT_RAM_RESERVE_MB" : "LUMABRI_RAM_RESERVE_MB",
-        4096, 256, 262144) << 20;
+        (int)lmb_machine_default_reserve_mb(profile.ram_total_bytes), 256, 262144) << 20;
     if (!available || reserve >= available)
         return 0;
     uint64_t memory_budget = available - reserve;
@@ -4983,8 +4983,7 @@ static void catalog_self(LmbClusterNode *n, LmbMachineProfile *profile,
     } else if (lmb_machine_probe(&p, disk, NULL)) return;
     *profile = p;
     snprintf(n->name, sizeof n->name, "%s", p.hostname);
-    uint64_t reserve = (uint64_t)lmb_env_int("LUMABRI_RAM_RESERVE_MB",
-                                             4096, 256, 262144) << 20;
+    uint64_t reserve = lmb_machine_ram_reserve();
     n->ram_budget_bytes = p.ram_available_bytes > reserve
                         ? p.ram_available_bytes - reserve : 0;
     n->vram_budget_bytes = p.vram_available_bytes;
@@ -5311,7 +5310,7 @@ static int cmd_worker(int argc, char **argv) {
             lmb_machine_refresh_resources(&profile, disk);
             report.machine = profile;
             if (name) snprintf(report.machine.hostname, sizeof report.machine.hostname, "%s", name);
-            uint64_t reserve = (uint64_t)lmb_env_int("LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+            uint64_t reserve = lmb_machine_ram_reserve();
             uint64_t available = report.machine.ram_available_bytes;
             report.ram_budget_bytes = available > reserve ? available - reserve : 0;
             if (report.ram_budget_bytes > limit) report.ram_budget_bytes = limit;
@@ -5367,8 +5366,7 @@ static int cmd_machine(int argc, char **argv) {
     }
     lmb_machine_print(stdout, &profile, json);
     if (!json) {
-        uint64_t reserve = (uint64_t)lmb_env_int(
-            "LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+        uint64_t reserve = lmb_machine_ram_reserve();
         LmbGovernor governor;
         lmb_governor_init(&governor, reserve);
         printf("governor %s · %.1f GB system reserve\n",
@@ -5381,8 +5379,7 @@ static int cmd_machine(int argc, char **argv) {
 static int cmd_limits(int argc, char **argv) {
     (void)argv;
     if (argc) { fprintf(stderr, "usage: lumabri limits\n"); return 2; }
-    uint64_t reserve = (uint64_t)lmb_env_int(
-        "LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+    uint64_t reserve = lmb_machine_ram_reserve();
     LmbMachineProfile profile;
     (void)lmb_machine_probe(&profile, ".", NULL);
     uint64_t donate = profile.ram_available_bytes > reserve ?
@@ -5470,8 +5467,7 @@ static int cmd_doctor(int argc, char **argv) {
                machine_ok ? "CPU, RAM, GPU, disk and network probed" :
                             "machine probe failed");
     if (machine_ok) {
-        uint64_t reserve = (uint64_t)lmb_env_int(
-            "LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+        uint64_t reserve = lmb_machine_ram_reserve();
         doctor_add(checks, &count, "ram-reserve",
                    profile.ram_available_bytes > reserve, 0,
                    profile.ram_available_bytes > reserve ?

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -3,6 +3,7 @@
 #ifndef LUMABRI_HOME_RUNTIME_H
 #define LUMABRI_HOME_RUNTIME_H
 #include "lumabri_home_net.h"
+#include "lumabri_runtime_probe.h"
 
 static char home_error[512];
 static int home_fail(const char *fmt, ...) {
@@ -181,6 +182,7 @@ static int home_status_send(int fd, const LmbHomeTransaction *t, int segment_por
 
 typedef struct {
     LmbHomeTransaction transaction;
+    unsigned thread_capacity;
     int client, lease, segment_port, host_port, segment_ready, host_ready;
     pid_t segment, host;
     char bin_dir[1024], cache_base[1024], disk[512], ip[INET_ADDRSTRLEN];
@@ -214,7 +216,7 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     char e_shim[1232], e_vroot[1232], e_cache[1232], e_cas[1232];
     char e_tracker[300], e_model[100], e_root[100], e_key[100], e_limit[100], e_log[1232];
     char range[40], port[20], addr[64], name[64], context[20], threads[20], ram[32];
-    char bytes[32], layers[20], max_new[20];
+    char bytes[32], layers[20], max_new[20], e_omp[64], e_omp_limit[64];
     if (checked_printf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, d->bin_dir) ||
         checked_printf(binary, sizeof binary, "%s/%s", d->bin_dir, edge ? "lumabri" : "segment_node") ||
         checked_printf(vroot, sizeof vroot, "%s/%.16s/vroot", d->cache_base, id) ||
@@ -235,10 +237,14 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     snprintf(e_key, sizeof e_key, "LUMABRI_SEGMENT_CLIENT_PK=%s", edge_peer);
     snprintf(e_limit, sizeof e_limit, "LUMABRI_EDGE_RAM_BYTES=%llu", (unsigned long long)o->edge_ram_bytes);
     snprintf(e_log, sizeof e_log, "LUMABRI_ENGINE_LOG=%s/edge.log", d->cache_base);
+    unsigned usable_threads = o->threads < d->thread_capacity ? o->threads : d->thread_capacity;
+    if (!usable_threads) return -1;
+    snprintf(e_omp, sizeof e_omp, "OMP_NUM_THREADS=%u", usable_threads);
+    snprintf(e_omp_limit, sizeof e_omp_limit, "OMP_THREAD_LIMIT=%u", usable_threads);
     char *envv[] = {e_shim, e_vroot, e_cache, e_cas, e_tracker, e_model, e_root,
                    e_key, "LUMABRI_SEGMENT_REQUIRED=1", "LUMABRI_VERIFY=0",
                    "LUMABRI_PREFETCH=0", "LUMABRI_NO_EXEC=1", e_log,
-                   edge ? e_limit : "LUMABRI_HOME_SEGMENT=1", NULL};
+                   edge ? e_limit : "LUMABRI_HOME_SEGMENT=1", e_omp, e_omp_limit, NULL};
     int chosen_port = 0, listener = home_listen(&chosen_port);
     if (listener < 0) return -1;
     snprintf(port, sizeof port, "%d", chosen_port);
@@ -246,7 +252,7 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     snprintf(name, sizeof name, "home-%.12s-%u", id, o->begin);
     snprintf(range, sizeof range, "%u:%u", o->begin, o->end);
     snprintf(context, sizeof context, "%u", o->context);
-    snprintf(threads, sizeof threads, "%u", o->threads);
+    snprintf(threads, sizeof threads, "%u", usable_threads);
     snprintf(ram, sizeof ram, "%llu", (unsigned long long)((o->ram_bytes - o->edge_ram_bytes) >> 20));
     snprintf(bytes, sizeof bytes, "%llu", (unsigned long long)o->model_bytes);
     snprintf(layers, sizeof layers, "%u", o->layers);
@@ -286,13 +292,14 @@ static void home_donor_screen(const HomeDonor *d, const char *name, uint64_t ram
             ui_printf(12, 5, UI_MUTED, "Requester identity: %.24s…", who);
             ui_printf(14, 5, UI_TEXT, "Layers %u–%u of %u · %.2f GB RAM · %.2f GB disk headroom",
                 t->offer.begin, t->offer.end - 1, t->offer.layers, t->offer.ram_bytes / 1e9, t->offer.disk_bytes / 1e9);
-            ui_printf(16, 5, UI_MUTED, "%u context · one session · %u threads", t->offer.context, t->offer.threads);
+            ui_printf(16, 5, UI_MUTED, "%u context · one session · %u execution threads", t->offer.context,
+                      t->offer.threads < d->thread_capacity ? t->offer.threads : d->thread_capacity);
             ui_text(18, 5, UI_MUTED, t->offer.runs_edge ?
                 "This computer hosts chat and receives the conversation text." :
                 "This computer processes activations and keeps state for its layers.");
         } else {
             ui_text(11, 5, UI_TEXT, "Visible to your household. Waiting for a request.");
-            ui_text(14, 5, UI_MUTED, "Being visible is not permission to load a model.");
+            ui_printf(14, 5, UI_MUTED, "Runtime supports up to %u thread(s). Nothing loads without approval.", d->thread_capacity);
         }
         int y = ui_h >= 34 ? 23 : 20;
         if (t->phase == LMB_HOME_PENDING) {
@@ -315,7 +322,8 @@ static void home_donor_screen(const HomeDonor *d, const char *name, uint64_t ram
                "Context: %u · one session · %u threads\n",
                who, t->offer.model, t->offer.model_type, t->offer.begin,
                t->offer.end - 1, t->offer.layers, t->offer.ram_bytes / 1e9,
-               t->offer.disk_bytes / 1e9, t->offer.context, t->offer.threads);
+               t->offer.disk_bytes / 1e9, t->offer.context,
+               t->offer.threads < d->thread_capacity ? t->offer.threads : d->thread_capacity);
         if (t->offer.runs_edge)
             puts("This computer also hosts chat and receives the conversation text.");
         else puts("This computer processes activations and keeps state for its layers.");
@@ -421,6 +429,9 @@ static int cmd_donor(int argc, char **argv) {
          (checked_printf(service_path, sizeof service_path, "%s/../lib/lumabri/" LMB_SHIM_NAME, d.bin_dir) ||
           access(service_path, R_OK))))
         return home_fail("The household weight loader (%s) is missing. Install or build the complete household runtime.", LMB_SHIM_NAME);
+    if (checked_printf(service_path, sizeof service_path, "%s/segment_node", d.bin_dir) ||
+        lmb_runtime_thread_capacity(service_path, &d.thread_capacity))
+        return home_fail("Cannot query the installed Segment runtime. Rebuild the complete household runtime; no resources were shared.");
     if (checked_printf(d.cache_base, sizeof d.cache_base, "%s/%s", disk ? disk :
                        (getenv("HOME") ? getenv("HOME") : "."), disk ? "lumabri-home" : ".lumabri/home") ||
         home_local_ip(tracker, d.ip))
@@ -435,7 +446,7 @@ static int cmd_donor(int argc, char **argv) {
     LmbMachineProfile profile;
     if (lmb_machine_probe(&profile, d.cache_base, NULL) || !profile.ram_total_bytes)
         return home_fail("Cannot read this computer's memory. Sharing is disabled until hardware detection succeeds.");
-    uint64_t reserve = (uint64_t)lmb_env_int("LUMABRI_RAM_RESERVE_MB", 4096, 256, 262144) << 20;
+    uint64_t reserve = lmb_machine_ram_reserve();
     uint64_t ram = profile.ram_available_bytes > reserve ? profile.ram_available_bytes - reserve : 0;
     if (limit < ram) ram = limit;
     if (ram < (32u << 20)) return home_fail("Not enough available RAM to share safely: %.2f GB available, %.2f GB system reserve. Close other applications and retry.", profile.ram_available_bytes / 1e9, reserve / 1e9);
@@ -589,11 +600,13 @@ static void home_session_close(HomeSession *s) {
 }
 
 static int home_request_chat(LmbTuiState *st, int selected) {
+    home_error[0] = 0;
     if (selected < 0 || selected >= st->nmodels || !st->tracker[0] ||
-        !st->inventory_ok || home_private_network()) return -1;
+        !st->inventory_ok || home_private_network())
+        return home_fail("Cannot prepare chat: refresh the household inventory and select a model.");
     LmbTuiModel *m = &st->models[selected];
     if (!m->weights_present || !m->shape.sizing_verified || st->sessions != 1) {
-        fprintf(stderr, "This checkpoint needs verified sizing, local source weights and a one-session plan.\n"); return -1;
+        return home_fail("This checkpoint needs verified sizing, local source weights and a one-session plan.");
     }
     LmbClusterNode nodes[LMB_CLUSTER_MAX_NODES];
     uint32_t indices[LMB_CLUSTER_MAX_NODES], count = 0;
@@ -605,13 +618,30 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     LmbClusterPlan plan;
     if (!count || lmb_plan_cluster_source(&m->shape, nodes, count, st->context, 1,
                                    LMB_GOAL_ONE_SESSION, 1, &plan) || plan.state != LMB_PLAN_RESIDENT) {
-        fprintf(stderr, "No complete resident plan fits the computers running Share resources.\n"); return -1;
+        return home_fail("No complete resident plan fits the selected computers. Keep Share resources open and check their offered RAM.");
+    }
+    /* Discovery is not proof that inbound connections work. Authenticate the
+     * selected donors before indexing/starting a source, without any OFFER,
+     * reservation or engine launch. Recheck again when actually sending. */
+    for (uint32_t i = 0; i < count; i++) {
+        uint8_t expected[32];
+        if (lmb_unhex(expected, st->identities[indices[i]], 32))
+            return home_fail("Invalid identity for %.64s. Refresh the computer list.", nodes[i].name);
+        int fd = lmb_connect_ms_io(nodes[i].addr, 2000, 2000);
+        if (fd < 0) return home_fail("Cannot reach %.64s at %.64s: %s. Check inbound permissions on that computer; no model was loaded.",
+                                    nodes[i].name, nodes[i].addr, lmb_connect_why());
+        int matched = lmb_secure_peer_matches(fd, expected);
+        int authenticated = matched && !lmb_auth(fd);
+        lmb_close(fd);
+        if (!authenticated) return home_fail("Cannot authenticate %.64s at %.64s. %s No model was loaded.",
+            nodes[i].name, nodes[i].addr, matched ? "Check the household key." : "The donor identity changed; refresh the computer list.");
     }
     HomeSession s = {0};
     for (uint32_t i = 0; i < LMB_CLUSTER_MAX_NODES; i++) s.fd[i] = -1;
     char kp[1024], pkhex[65], idhex[65];
     uint8_t sk[64], pk[32], id[32];
-    if (lmb_peer_identity(lmb_peer_key_path(kp, sizeof kp), sk, pk)) return -1;
+    if (lmb_peer_identity(lmb_peer_key_path(kp, sizeof kp), sk, pk))
+        return home_fail("Cannot load this computer's identity. Check home-directory permissions.");
     memset(sk, 0, sizeof sk); lmb_hex(pkhex, pk, 32);
     lmb_random(id, sizeof id); lmb_hex(idhex, id, 32);
     char model[64]; snprintf(model, sizeof model, "home-%.12s-%.12s-%.24s", pkhex, idhex, m->name);
@@ -621,9 +651,10 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     char dir[1024], maintainer[1200], ip[INET_ADDRSTRLEN], port[20], addr[64], name[64];
     char logdir[1100], logfile[1200];
     exe_dir(dir, sizeof dir); snprintf(maintainer, sizeof maintainer, "%s/maintainer", dir);
-    if (access(maintainer, X_OK) || home_local_ip(st->tracker, ip)) return -1;
+    if (access(maintainer, X_OK)) return home_fail("The checkpoint source service is missing. Build the complete household runtime.");
+    if (home_local_ip(st->tracker, ip)) return home_fail("Cannot reach the household tracker. Keep Lumabri open on the household owner.");
     int source_port = 0, source_listener = home_listen(&source_port);
-    if (source_listener < 0) return -1;
+    if (source_listener < 0) return home_fail("Cannot open a checkpoint source port: %s.", strerror(errno));
     snprintf(port, sizeof port, "%d", source_port); snprintf(addr, sizeof addr, "%s:%d", ip, source_port);
     snprintf(name, sizeof name, "home-source-%.16s", idhex);
     snprintf(logdir, sizeof logdir, "%s/.lumabri/logs", getenv("HOME") ? getenv("HOME") : ".");
@@ -635,11 +666,13 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     g_stopping = 0; install_chat_signal_handlers(); signal(SIGPIPE, SIG_IGN);
     s.source = home_spawn(source_argv, NULL, logfile, NULL, source_listener);
     int result = -1;
+    const char *stage = "starting the checkpoint source";
     if (s.source <= 0) goto done;
     LmbModelIdentity identity;
     Swarm swarm = {0};
     double started = nowd(), pulse = 0;
     int found = 0;
+    stage = "indexing and verifying the checkpoint source";
     while (!g_stopping && nowd() - started < 600) {
         if (term.active) { ui_begin("prepare chat");
             ui_printf(7, 5, UI_TEXT, "Indexing %s", m->name);
@@ -657,6 +690,7 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         (void)poll(NULL, 0, 200);
     }
     if (!found) goto done;
+    stage = "validating the indexed plan";
     LmbRangeCost edge_cost = lmb_estimate_edge(&m->shape, st->context, 1);
     uint64_t edge_ram = edge_cost.resident_bytes + edge_cost.state_bytes + edge_cost.scratch_bytes + (64u << 20);
     uint8_t edge_pk[32];
@@ -687,19 +721,30 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         o->ram_bytes = runtime + o->edge_ram_bytes;
         o->ram_bytes = (o->ram_bytes + ((1u << 20) - 1)) & ~((uint64_t)(1u << 20) - 1);
         o->disk_bytes = swarm.total_bytes * 2 + (256u << 20);
-        if (o->ram_bytes > nodes[n].ram_budget_bytes || !lmb_home_offer_valid(o)) goto done;
+        if (o->ram_bytes > nodes[n].ram_budget_bytes) {
+            home_fail("%.64s needs %.2f GB for this plan, but offers %.2f GB. No allocation was committed.",
+                      nodes[n].name, o->ram_bytes / 1e9, nodes[n].ram_budget_bytes / 1e9);
+            goto done;
+        }
+        if (!lmb_home_offer_valid(o)) { home_fail("The proposed allocation failed validation. No allocation was committed."); goto done; }
         snprintf(s.names[s.count], sizeof s.names[0], "%s", nodes[n].name);
         snprintf(s.addresses[s.count], sizeof s.addresses[0], "%s", nodes[n].addr);
         uint8_t recipient[32];
         if (lmb_unhex(recipient, st->identities[indices[n]], 32)) goto done;
         int fd = lmb_connect_ms_io(nodes[n].addr, 1500, 1000);
-        if (fd < 0) goto done;
+        if (fd < 0) {
+            home_fail("Cannot reach %.64s at %.64s while sending the request: %s.", nodes[n].name, nodes[n].addr, lmb_connect_why());
+            goto done;
+        }
         (void)fcntl(fd, F_SETFD, FD_CLOEXEC);
-        if (!lmb_secure_peer_matches(fd, recipient) || lmb_auth(fd)) { lmb_close(fd); goto done; }
+        if (!lmb_secure_peer_matches(fd, recipient) || lmb_auth(fd)) {
+            home_fail("Authentication failed while requesting %.64s. Refresh the household identity and key.", nodes[n].name);
+            lmb_close(fd); goto done;
+        }
         LmbBuf b = {0};
         int bad = lmb_home_offer_pack(&b, o) || lmb_send(fd, LMB_HOME_OFFER, b.p, (uint32_t)b.len, NULL, 0);
         free(b.p);
-        if (bad) { lmb_close(fd); goto done; }
+        if (bad) { home_fail("Cannot send the request to %.64s. Check its connection.", nodes[n].name); lmb_close(fd); goto done; }
         s.fd[s.count] = fd; s.phase[s.count] = LMB_HOME_PENDING;
         if (o->runs_edge) { s.edge = s.count; have_edge = 1; }
         s.count++;
@@ -708,6 +753,8 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     int committed = 0, host_started = 0;
     started = nowd();
     while (!g_stopping && nowd() - started < 900) {
+        stage = !committed ? "waiting for donor approval" :
+                !host_started ? "loading the approved segments" : "starting the chat host";
         int send_pulse = nowd() - pulse >= 1;
         if (send_pulse) pulse = nowd();
         if (home_session_poll(&s, send_pulse)) goto done;
@@ -758,6 +805,13 @@ done:
     home_terminal_end(&term);
     home_session_close(&s);
     if (result) {
+        if (!home_error[0]) {
+            for (uint32_t i = 0; i < s.count; i++) if (s.reason[i][0]) {
+                home_fail("%.64s: %.240s", s.names[i], s.reason[i]);
+                break;
+            }
+        }
+        if (!home_error[0]) home_fail("Chat stopped while %s. Resources were released. Source log: %.240s", stage, logfile);
         fprintf(stderr, "Household plan did not complete; allocations have been cancelled. Source log: %s\n", logfile);
         for (uint32_t i = 0; i < s.count; i++) if (s.reason[i][0])
             fprintf(stderr, "%s: %s\n", s.names[i], s.reason[i]);

--- a/lumabri_machine.c
+++ b/lumabri_machine.c
@@ -127,6 +127,19 @@ uint64_t lmb_machine_available_ram(void) {
     return value;
 }
 
+uint32_t lmb_machine_default_reserve_mb(uint64_t total) {
+    if (!total) return 4096; /* unknown hardware is not a reason to lower safety */
+    uint64_t mib = total >> 22;
+    if (mib < 1024) mib = 1024;
+    if (mib > 4096) mib = 4096;
+    return (uint32_t)mib;
+}
+
+uint64_t lmb_machine_ram_reserve(void) {
+    return (uint64_t)lmb_env_int("LUMABRI_RAM_RESERVE_MB",
+        (int)lmb_machine_default_reserve_mb(lmb_machine_total_ram()), 256, 262144) << 20;
+}
+
 uint64_t lmb_machine_total_ram(void) {
     uint64_t value = 0;
     meminfo(&value, NULL, NULL, NULL);

--- a/lumabri_machine.h
+++ b/lumabri_machine.h
@@ -6,6 +6,12 @@
 #include <stdint.h>
 #include <stdio.h>
 
+/* Household default: keep one quarter of physical RAM, bounded to 1–4 GiB.
+ * Explicit operator overrides remain authoritative; available RAM is still
+ * checked at admission and continuously by the governor. */
+uint32_t lmb_machine_default_reserve_mb(uint64_t total);
+uint64_t lmb_machine_ram_reserve(void);
+
 typedef struct {
     char hostname[64];
     char os[64];

--- a/lumabri_runtime_probe.h
+++ b/lumabri_runtime_probe.h
@@ -1,0 +1,63 @@
+/* Query the installed executable, never infer its capabilities from the TUI
+ * compiler or the presence of a GPU/OpenMP library on disk. No model is opened. */
+#ifndef LUMABRI_RUNTIME_PROBE_H
+#define LUMABRI_RUNTIME_PROBE_H
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int lmb_runtime_thread_capacity(const char *binary, unsigned *capacity) {
+    int fds[2];
+    *capacity = 0;
+    if (pipe(fds)) return -1;
+    (void)fcntl(fds[0], F_SETFD, FD_CLOEXEC);
+    (void)fcntl(fds[1], F_SETFD, FD_CLOEXEC);
+    pid_t child = fork();
+    if (!child) {
+        if (dup2(fds[1], STDOUT_FILENO) < 0) _exit(127);
+        close(fds[0]); close(fds[1]);
+        execl(binary, binary, "--thread-capacity", (char *)NULL);
+        _exit(127);
+    }
+    close(fds[1]);
+    if (child < 0) { close(fds[0]); return -1; }
+    char reply[32] = {0}; size_t used = 0;
+    int status = 0, finished = 0, bad = 0;
+    (void)fcntl(fds[0], F_SETFL, O_NONBLOCK);
+    /* Both output and process exit are bounded, including a broken binary
+     * which emits a plausible answer and then hangs. */
+    for (int tick = 0; tick < 200; tick++) {
+        ssize_t n = read(fds[0], reply + used, sizeof reply - 1 - used);
+        if (n > 0) used += (size_t)n;
+        else if (n < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) bad = 1;
+        if (used == sizeof reply - 1) bad = 1;
+        pid_t rc = waitpid(child, &status, WNOHANG);
+        if (rc == child) {
+            finished = 1;
+            n = read(fds[0], reply + used, sizeof reply - 1 - used);
+            if (n > 0) used += (size_t)n;
+            break;
+        }
+        if (bad || (rc < 0 && errno != EINTR)) break;
+        (void)poll(NULL, 0, 10);
+    }
+    close(fds[0]);
+    if (!finished) {
+        (void)kill(child, SIGKILL);
+        while (waitpid(child, &status, 0) < 0 && errno == EINTR) { }
+        return -1;
+    }
+    if (bad || !WIFEXITED(status) || WEXITSTATUS(status) || !used) return -1;
+    reply[used] = 0;
+    for (size_t i = 0; i + 1 < used; i++) if (reply[i] < '0' || reply[i] > '9') return -1;
+    if (reply[used - 1] != '\n') return -1;
+    char *end; unsigned long value = strtoul(reply, &end, 10);
+    if (end != reply + used - 1 || !value || value > 256) return -1;
+    *capacity = (unsigned)value;
+    return 0;
+}
+#endif

--- a/segment_node.c
+++ b/segment_node.c
@@ -1140,6 +1140,17 @@ static void preflight_signal(int *fd, char status) {
 }
 
 int main(int argc, char **argv) {
+    if (argc == 2 && !strcmp(argv[1], "--thread-capacity")) {
+#ifdef _OPENMP
+        int capacity = omp_get_num_procs();
+        if (capacity < 1) capacity = 1;
+        if (capacity > 256) capacity = 256;
+        printf("%d\n", capacity);
+#else
+        puts("1");
+#endif
+        return 0;
+    }
     const char *engine_id = arg_value(argc, argv, "--engine");
     const char *model_dir = arg_value(argc, argv, "--model-dir");
     const char *model = arg_value(argc, argv, "--model");
@@ -1324,7 +1335,7 @@ int main(int argc, char **argv) {
                                "LUMABRI_SEGMENT_RAM_RESERVE_MB" :
                                "LUMABRI_RAM_RESERVE_MB";
     uint64_t reserve = (uint64_t)lmb_env_int(
-        reserve_name, 4096, 256, 262144) << 20;
+        reserve_name, (int)lmb_machine_default_reserve_mb(lmb_machine_total_ram()), 256, 262144) << 20;
     if (!process_limit && available != UINT64_MAX && available > reserve)
         process_limit = available - reserve;
     /* The runtime preflight must be conservative. The generic catalogue

--- a/src/ui/lumabri_home_ui.h
+++ b/src/ui/lumabri_home_ui.h
@@ -380,7 +380,10 @@ static int cmd_home(void) {
                 snprintf(notice, sizeof notice, "RAM limit must be a positive number of GB."); continue;
             }
             if (home_settings_save(&next)) home_error_dialog("Could not save settings", "Check that your home directory is writable, then retry.");
-            else s = next;
+            else {
+                s = next;
+                snprintf(notice, sizeof notice, "Settings saved. Models: %.110s · RAM limit: %.20s GB", s.models, s.ram);
+            }
         } else if (key == 'n') {
             if (tracker_child <= 0 && home_tracker_resume(&s, &tracker_child, notice, sizeof notice)) continue;
             char identity[65]; lmb_hex(identity, g_sec_pk, 32);

--- a/tests/c/test_machine.c
+++ b/tests/c/test_machine.c
@@ -6,6 +6,14 @@
 #include <unistd.h>
 
 int main(void) {
+    assert(lmb_machine_default_reserve_mb(0) == 4096);
+    assert(lmb_machine_default_reserve_mb(2ull << 30) == 1024);
+    assert(lmb_machine_default_reserve_mb(8ull << 30) == 2048);
+    assert(lmb_machine_default_reserve_mb(16ull << 30) == 4096);
+    assert(lmb_machine_default_reserve_mb(64ull << 30) == 4096);
+    setenv("LUMABRI_RAM_RESERVE_MB", "3072", 1);
+    assert(lmb_machine_ram_reserve() == (3072ull << 20));
+    unsetenv("LUMABRI_RAM_RESERVE_MB");
     LmbMachineProfile profile;
     assert(lmb_machine_probe(&profile, ".", NULL) == 0);
     assert(profile.logical_cpus > 0);

--- a/tests/c/test_runtime_probe.c
+++ b/tests/c/test_runtime_probe.c
@@ -1,0 +1,26 @@
+#define _GNU_SOURCE
+#include "lumabri_runtime_probe.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    if (argc == 2 && !strcmp(argv[1], "--thread-capacity")) {
+        const char *mode = getenv("LMB_TEST_CAPACITY");
+        if (mode && !strcmp(mode, "hang")) { puts("1"); fflush(stdout); for (;;) pause(); }
+        puts(mode ? mode : "1");
+        return 0;
+    }
+    unsigned value = 99;
+    assert(!lmb_runtime_thread_capacity(argv[0], &value) && value == 1);
+    setenv("LMB_TEST_CAPACITY", "8", 1);
+    assert(!lmb_runtime_thread_capacity(argv[0], &value) && value == 8);
+    const char *bad[] = {"0", "257", "garbage", "8 trailing", "", "999999999999999999999999999999999999", "hang"};
+    for (unsigned i = 0; i < sizeof bad / sizeof *bad; i++) {
+        setenv("LMB_TEST_CAPACITY", bad[i], 1);
+        assert(lmb_runtime_thread_capacity(argv[0], &value) && value == 0);
+    }
+    assert(lmb_runtime_thread_capacity("/nonexistent/lumabri-test-runtime", &value));
+    puts("runtime probe: valid, malformed, missing and hung executable PASS");
+    return 0;
+}

--- a/tests/integration/build_stamp_test.py
+++ b/tests/integration/build_stamp_test.py
@@ -1,0 +1,19 @@
+"""Changing effective engine options invalidates the build; unchanged options do not."""
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+with tempfile.TemporaryDirectory(prefix="lumabri-build-stamp-") as directory:
+    stamp = Path(directory) / "options"
+    command = [sys.executable, str(ROOT / "tools/update_build_stamp.py"), str(stamp)]
+    subprocess.run(command + ["clang", "", ""], check=True)
+    before = stamp.stat().st_mtime_ns
+    subprocess.run(command + ["clang", "", ""], check=True)
+    assert stamp.stat().st_mtime_ns == before
+    subprocess.run(command + ["clang", "-Xclang -fopenmp", "-lomp"], check=True)
+    assert "fopenmp" in stamp.read_text()
+    subprocess.run(command + ["clang", "", ""], check=True)
+    assert "fopenmp" not in stamp.read_text()
+print("BUILD STAMP: PASS (stable, OpenMP enabled, OpenMP disabled)")

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -112,6 +112,28 @@ def main():
             except OSError:
                 return False
         until(listening)
+
+        # A signed inventory advert does not prove the donor port is reachable.
+        # Fail before indexing or sending an allocation, with a useful reason.
+        with socket.socket() as closed_port:
+            closed_port.bind(("127.0.0.1", 0))
+            unreachable = closed_port.getsockname()[1]
+        with open(tmp / "offline-worker.log", "wb") as log:
+            offline_worker = subprocess.Popen(["./lumabri", "worker", "--join", addr,
+                "--name", "offline-test-donor", "--ram-gb", "0.5", "--disk", str(tmp),
+                "--control-address", f"127.0.0.1:{unreachable}"], cwd=ROOT,
+                env=env("offline-worker"), stdout=log, stderr=subprocess.STDOUT)
+        children.append(offline_worker)
+        offline = Terminal("offline-request", base)
+        until(lambda: offline.has("2 computers"), message="offline worker advert missing")
+        offline.send("\t\x1b[B\r\t")
+        time.sleep(.5)
+        offline.send("\r\r")
+        until(lambda: offline.p.poll() is not None, message="unreachable donor did not fail preflight")
+        assert offline.p.returncode != 0 and offline.has("Cannot reach offline-test-donor")
+        assert not list((tmp / "offline-request").rglob("home-source-*.log")), "indexed before reachability check"
+        offline_worker.terminate(); offline_worker.wait(timeout=5)
+
         a = Terminal("donor-a", ["./lumabri"])
         b = Terminal("donor-b", ["./lumabri"])
         until(lambda: a.has("your workspace") and b.has("your workspace"))

--- a/tests/integration/household_network_test.py
+++ b/tests/integration/household_network_test.py
@@ -108,6 +108,16 @@ def main():
 
         try:
             owner = start("owner")
+            owner.action(2)
+            owner.expect("Folder containing your model directories")
+            model_folder = str(Path(tmp) / "models with spaces")
+            Path(model_folder).mkdir()
+            owner.send(model_folder.encode() + b"\n")
+            owner.expect("Maximum RAM to offer")
+            owner.send(b"0.5\n")
+            owner.expect("Settings saved.")
+            assert owner.settings()["models"] == model_folder
+            assert owner.settings()["ram"] == "0.5"
             owner.action(0)
             owner.expect("Host identity:")
             saved = owner.settings()

--- a/tools/update_build_stamp.py
+++ b/tools/update_build_stamp.py
@@ -1,0 +1,26 @@
+"""Update a generated build-options stamp only when the effective options change."""
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+
+def main():
+    path = Path(sys.argv[1])
+    data = (json.dumps(sys.argv[2:], ensure_ascii=True) + "\n").encode()
+    if path.exists() and path.read_bytes() == data:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=path.name + ".", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as output:
+            output.write(data)
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes household runtime blockers from the physical WSL-to-macOS 12.6 trial: installed Segment thread-capability probe; safe single-thread launch without OpenMP; adaptive system RAM reserve; authenticated reachability before indexing; actionable TUI failure phases and donor reasons; settings confirmation; engine rebuild when OpenMP/options change. Colibri source is unchanged and CI pins revision 12a5c464b5c1f8292d578c62458706bc32d6ac95.

Verification on final head bd1ce82a679e0044cc76df0db03809c9313bdad9: all eight GitHub checks passed, including real two-donor Tiny flows on native Mac Intel and Apple Silicon, each with and without OpenMP, normal cleanup and killed-donor cleanup; Linux and Windows network-helper checks passed. Local make test completed with exit 0, check-warnings passed, no-OpenMP two-donor flow passed, and runtime probe passed UBSan. One local staggered RTT timing subcase explicitly skipped for loopback noise; no native Windows model-runtime or large-model certification is claimed.

Remaining roadmap gates are documented in docs/LAN_RELEASE_CHECKLIST.md: real physical two-compute-node oracle, verified family-specific sizing, persisted calibration, GPU execution, disk/cache/model acquisition, concurrency/replay, native Windows packaging and incremental cleanup. This PR closes the listed runtime blockers, not the entire roadmap.