### PR TITLE
LAN 1/8: show approved layer placement and verify donor execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,18 @@ jobs:
       - name: Household TUI — approvals through real Segment generation
         working-directory: lumabri
         run: |
+          test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
+          test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           mkdir -p build/home-flow-models
           cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
+      - name: Same greedy tokens with one and two real Segment ranges
+        working-directory: lumabri
+        run: |
+          SPLIT_MODEL_DIR=build/home-flow-models/olmoe-tiny \
+          SPLIT_THREADS=2 SPLIT_CONTEXT=128 SPLIT_ROUNDS=2 \
+            bash tests/integration/segment_split_test.sh
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -171,6 +179,8 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
+          test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
+          test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
       - uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h lumabri_platform.h l
 MACHINE_SRC = lumabri_machine.c
 MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
-lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_proto.h lumabri_sign.h \
+lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
 		lumabri_inventory.h lumabri_home.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h \
 		lumabri_families.h lumabri_planner.h lumabri_cluster.h \
 		lumabri_calibration.h $(SECURE_DEPS) $(MACHINE_DEPS)
@@ -454,7 +454,7 @@ test_inventory: tests/c/test_inventory.c lumabri_inventory.h lumabri_machine.h l
 test_home: tests/c/test_home.c lumabri_home.h lumabri_inventory.h lumabri_families.h lumabri_proto.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_home.c -o $@
 
-test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h
+test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_chat_ui.c src/ui/lumabri_tui.c lumabri_machine.c -o $@
 
 test-ready-pipe: tests/c/test_ready_pipe.c lumabri_ready.h

--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ Type **/** for command suggestions, use arrows to choose and Tab to complete.
 **/help**, **/debug**, **/reset** and **/quit** provide help, diagnostics, a new
 conversation and exit.
 
+Household chat also shows the approved layer allocation. **/plan** displays
+each compute donor, its layer range, reserved RAM and the Edge/chat host.
+**/experts** queries activity on the same household tracker. Serving checkpoint
+files is not the same as executing model layers; a chat process runs no layers,
+even when a separate approved donor runs on that computer. The allocation is
+a READY-time snapshot, not a live utilization or speed measurement.
+
 ## What has actually been checked?
 
 - Linux-environment build with warnings treated as errors.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -6,10 +6,10 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
 
 ## Current release work
 
-- [ ] Runtime/preflight PR: installed engine thread-capacity query; no-OpenMP
+- [x] Runtime/preflight PR #151: installed engine thread-capacity query; no-OpenMP
   single-thread execution; adaptive RAM reserve; acknowledged actionable
   failure; pre-index donor reachability; build-option invalidation.
-- [ ] Native Intel/ARM CI with and without OpenMP and isolated two-donor flow.
+- [x] Native Intel/ARM CI with and without OpenMP and isolated two-donor flow (#151).
 - [ ] Rerun the physical Windows/WSL + macOS 12.6 trial on the final build.
 
 ## Remaining roadmap gates
@@ -22,22 +22,26 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    encoding. Currently only OLMoE and DeepSeek V4 enable sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
-   reusable content cache, authorized model acquisition and resumable transfer.
-   Disk execution requires a verified adapter working-set contract; keep the
-   current memory guard until that exists.
+   and placement informed by measured execution costs, not just RAM totals.
 4. Persist real chat measurements against exact checkpoint/build/hardware/
    topology/context keys; bounded optional warm calibration, stale-data UI,
    resource-based recommendations. Do not estimate tok/s from Tiny's speed.
-5. Real GPU backend execution and VRAM/scratch/state budgeting. Capability bits
-   are not implementation. The pinned OLMoE Edge/Segment adapter rejects
-   non-CPU backends; implementing one is upstream runtime work, not a planner
-   toggle. Colibri remains read-only under the agreed boundary.
-6. Multi-session admission based on memory and measured compute capacity;
+5. Authorized model acquisition, resumable transfer and reusable content cache.
+   Disk execution requires a verified adapter working-set contract; keep the
+   current memory guard until that exists. Checkpoint source selection must
+   not require every chatting device to download a complete model.
+6. Consume actual Colibri GPU backends with VRAM/scratch/state budgeting and
+   execution tests. Capability bits are not implementation. Colibri remains
+   read-only: models without a working upstream Edge/Segment GPU backend stay
+   on CPU and explicitly say so. No missing GPU kernels are to be invented or
+   patched into Colibri. Future compatible backends require Lumabri integration
+   and conformance tests, not a promise that every GPU/model already works.
+7. Multi-session admission based on memory and measured compute capacity;
    isolated state, fair scheduling, 1/2/4/8-session tests and node-loss replay
    with no duplicate or silently lost user-visible output.
-7. Native Windows model runtime and packaging; macOS Intel/ARM and Linux
+8. Native Windows model runtime and packaging; macOS Intel/ARM and Linux
    release artifacts tested from clean machines. WSL is not native Windows.
-8. Incremental repository cleanup backed by dependency/build/test evidence;
+   Incremental repository cleanup backed by dependency/build/test evidence:
    remove only genuinely unused paths, preserve model adapters and regression
    tests. Keep public-network trust/credits separate from the LAN product.
 
@@ -53,3 +57,19 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
 No purchase, remote Mac shell access, model-license acceptance or public
 service deployment is inferred from implementation authority. Native hardware
 and compatible checkpoints are required to close their respective gates.
+
+## Delivery tracking
+
+One PR per numbered gate above; all merges preserve commits (no squash), and
+require green checks on the exact reviewed head. Partial implementation is
+not a completed gate.
+
+1. In progress: approved layer-allocation view, named execution evidence,
+   two-donor checks; physical two-computer oracle and timings still required.
+2. Pending: verified family sizing and checkpoint conformance.
+3. Pending: planner/runtime budget and placement consistency.
+4. Pending: connected, persisted lightweight calibration and advice.
+5. Pending: model acquisition, cache reuse and verified disk execution.
+6. Pending: upstream-only GPU capability integration, CPU otherwise.
+7. Pending: concurrent sessions and actual replay after failure.
+8. Pending: native releases, platform validation and dependency-backed cleanup.

--- a/lumabri.c
+++ b/lumabri.c
@@ -57,6 +57,7 @@
 #include "lumabri_cluster.h"
 #include "src/ui/lumabri_tui.h"
 #include "src/ui/lumabri_visual.h"
+#include "src/ui/lumabri_execution_view.h"
 #include "lumabri_machine.h"
 
 #ifdef __linux__
@@ -71,6 +72,9 @@
 /* ---- terminal ----------------------------------------------------------- */
 
 static int g_tty = 0;
+/* Borrowed only during the synchronous household cmd_chat call. The plan is
+ * immutable while the chat's input/status workers can read it. */
+static const LmbExecutionView *g_execution_view;
 /* Snapshot the shell's terminal state once, before either line editor can
  * touch it.  Taking live_begin's "old" value from the current tty created a
  * narrow hand-off race where it could inherit the previous editor's cbreak
@@ -118,13 +122,14 @@ static int term_h(void) {
 
 static const char *const CHAT_COMMANDS[] = {
     "/swarm", "/experts", "/hosts", "/model", "/debug", "/storage",
-    "/reset", "/help", "/quit",
+    "/reset", "/help", "/quit", "/plan",
 };
 static int g_slash_completion;
 static const char *const CHAT_COMMAND_HELP[] = {
     "Show cluster activity", "Show expert execution", "Show computers",
     "Show the current model", "Open diagnostics", "Show cache storage",
     "Start a fresh conversation", "List chat commands", "Close this chat",
+    "Show the approved layer allocation",
 };
 _Static_assert(sizeof CHAT_COMMANDS / sizeof *CHAT_COMMANDS ==
                sizeof CHAT_COMMAND_HELP / sizeof *CHAT_COMMAND_HELP, "command help parity");
@@ -1784,6 +1789,7 @@ static void render_help(void) {
     printf("  %-12s compact alias for /swarm\n", "/hosts");
     printf("  %-12s list or switch models (hosted: current model only)\n", "/model");
     printf("  %-12s engine and donor diagnostics\n", "/debug");
+    printf("  %-12s approved household layer allocation\n", "/plan");
     printf("  %-12s mirror and CAS disk usage\n", "/storage");
     printf("  %-12s new conversation\n", "/reset");
     printf("  %-12s close chat\n", "/quit");
@@ -1937,13 +1943,15 @@ static void live_complete_locked(void) {
 static int live_immediate_command_locked(const char *command) {
     if (strcmp(command, "/swarm") && strcmp(command, "/hosts") &&
         strcmp(command, "/experts") && strcmp(command, "/debug") &&
-        strcmp(command, "/storage") && strcmp(command, "/help")) return 0;
+        strcmp(command, "/storage") && strcmp(command, "/help") &&
+        strcmp(command, "/plan")) return 0;
     putchar('\n');
     if (!strcmp(command, "/swarm") || !strcmp(command, "/hosts"))
         render_swarm(g_live.tracker);
     else if (!strcmp(command, "/experts")) render_experts(g_live.tracker);
     else if (!strcmp(command, "/debug")) render_debug();
     else if (!strcmp(command, "/storage")) render_storage();
+    else if (!strcmp(command, "/plan")) lmb_execution_print(stdout, g_execution_view);
     else render_help();
     printf("\x1b[%d;1H\r\n\r\n\r\n\r\n\x1b[%d;1H",
            g_live.rows, g_live.rows - 3);
@@ -4573,6 +4581,7 @@ static int cmd_chat(int argc, char **argv) {
     if (host_addr) {
         memset(&sw, 0, sizeof sw);
         if (host_connect(host_addr, NULL, host_key, &eng, &max_new)) return 1;
+        if (g_execution_view) lmb_execution_print(stdout, g_execution_view);
     } else if (model_boot(tracker, model, shim, engines_dir, engine_path,
                           local_dir, ctx, max_new, cap_experts, &eng, &sw))
         return 1;
@@ -4617,6 +4626,7 @@ static int cmd_chat(int argc, char **argv) {
         if (!strcmp(line, "/hosts")) { render_swarm(tracker); continue; }
         if (!strcmp(line, "/experts")) { render_experts(tracker); continue; }
         if (!strcmp(line, "/debug")) { render_debug(); continue; }
+        if (!strcmp(line, "/plan")) { lmb_execution_print(stdout, g_execution_view); continue; }
         if (!strcmp(line, "/storage")) { render_storage(); continue; }
         if (!strcmp(line, "/help")) { render_help(); continue; }
         if (!strncmp(line, "/model", 6)) {

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -782,6 +782,19 @@ static int home_request_chat(LmbTuiState *st, int selected) {
             host_started = 1;
         }
         if (host_started && s.phase[s.edge] == LMB_HOME_READY && s.host_port[s.edge]) {
+            LmbExecutionView execution = { .count = s.count, .layers = m->shape.layers };
+            for (uint32_t i = 0; i < s.count; i++) {
+                LmbExecutionNode *node = &execution.nodes[i];
+                snprintf(node->name, sizeof node->name, "%s", s.names[i]);
+                snprintf(node->address, sizeof node->address, "%s", s.addresses[i]);
+                node->begin = s.offers[i].begin; node->end = s.offers[i].end;
+                node->edge = s.offers[i].runs_edge;
+                node->reserved_bytes = s.offers[i].ram_bytes;
+            }
+            if (!lmb_execution_valid(&execution)) {
+                home_fail("The approved layer allocation is incomplete. Chat was not started.");
+                goto done;
+            }
             char host[64], ctx[20], token_limit[20];
             const char *colon = strrchr(s.addresses[s.edge], ':');
             if (!colon) goto done;
@@ -794,8 +807,11 @@ static int home_request_chat(LmbTuiState *st, int selected) {
             if (pthread_create(&heartbeat, NULL, home_session_keepalive, &s)) goto done;
             char expected_host[65]; lmb_hex(expected_host, edge_pk, 32);
             char *chat_argv[] = {"--host", host, "--model", model, "--ctx", ctx,
-                                 "--role", "chat", "--max-new", token_limit, "--host-key", expected_host};
-            result = cmd_chat(12, chat_argv);
+                                 "--role", "chat", "--max-new", token_limit, "--host-key", expected_host,
+                                 "--tracker", st->tracker};
+            g_execution_view = &execution;
+            result = cmd_chat(14, chat_argv);
+            g_execution_view = NULL;
             atomic_store(&s.stop, 1); pthread_join(heartbeat, NULL);
             if (atomic_load(&s.failed)) result = -1;
             break;

--- a/segment_node.c
+++ b/segment_node.c
@@ -16,6 +16,7 @@
 #include <pthread.h>
 #include <dirent.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -108,6 +109,7 @@ typedef struct {
     uint64_t process_memory_limit_bytes;
     uint64_t session_memory_limit_bytes;
     LmbGovernor governor;
+    _Atomic uint64_t committed_runs;
     TrackerRegistration registration;
 } Node;
 
@@ -768,6 +770,17 @@ static int handle_run(Node *node, int fd, const LmbMsg *msg) {
         } else {
             status = lmb_seg_table_run_commit(node->table, &run, now_ms());
             if (status == LMB_SEG_STATUS_OK && slot) {
+                /* Log the first and then power-of-two successful commits.
+                 * This distinguishes an idle weight holder from a node that
+                 * actually executed this range, without logging user data or
+                 * flooding stderr once per token. Cached retries do not count. */
+                uint64_t completed = atomic_fetch_add_explicit(
+                    &node->committed_runs, 1, memory_order_relaxed) + 1;
+                if (completed && !(completed & (completed - 1)))
+                    fprintf(stderr, "[segment-node %s %u:%u] committed_runs=%llu backend_mask=0x%llx\n",
+                            node->advert.peer_name, node->advert.layer_begin,
+                            node->advert.layer_end, (unsigned long long)completed,
+                            (unsigned long long)(node->cap.flags & COLI_SEGMENT_CAP_BACKEND_MASK));
                 free(slot->cached_output);
                 slot->cached_output = output;
                 slot->cached_bytes = bytes;
@@ -1143,6 +1156,13 @@ int main(int argc, char **argv) {
     if (argc == 2 && !strcmp(argv[1], "--thread-capacity")) {
 #ifdef _OPENMP
         int capacity = omp_get_num_procs();
+        /* A donor inherits the operator's OpenMP limits. Reporting hardware
+         * cores alone would overwrite OMP_NUM_THREADS=2 with --threads=12
+         * when the household launches the real engine. */
+        int configured = omp_get_max_threads();
+        int limit = omp_get_thread_limit();
+        if (configured > 0 && configured < capacity) capacity = configured;
+        if (limit > 0 && limit < capacity) capacity = limit;
         if (capacity < 1) capacity = 1;
         if (capacity > 256) capacity = 256;
         printf("%d\n", capacity);
@@ -1373,6 +1393,7 @@ int main(int argc, char **argv) {
     preflight_signal(&preflight_fd, 'P');
     Node node;
     memset(&node, 0, sizeof node);
+    atomic_init(&node.committed_runs, 0);
     for (size_t i = 0; i < NODE_CONNECTIONS_MAX; i++) node.connection_fds[i] = -1;
     pthread_mutex_init(&node.sessions_lock, NULL);
     if (lmb_run_gate_init(&node.run_gate, 1, run_queue)) {

--- a/src/ui/lumabri_execution_view.h
+++ b/src/ui/lumabri_execution_view.h
@@ -1,0 +1,66 @@
+/* Immutable view of an approved household plan. It is not a performance
+ * measurement, a live counter, or proof that two donors are physical PCs. */
+#ifndef LUMABRI_EXECUTION_VIEW_H
+#define LUMABRI_EXECUTION_VIEW_H
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "lumabri_cluster.h"
+
+typedef struct {
+    char name[64], address[64];
+    uint32_t begin, end;
+    uint64_t reserved_bytes;
+    int edge;
+} LmbExecutionNode;
+
+typedef struct {
+    uint32_t count, layers;
+    LmbExecutionNode nodes[LMB_CLUSTER_MAX_NODES];
+} LmbExecutionView;
+
+static int lmb_execution_valid(const LmbExecutionView *view) {
+    if (!view || !view->count || view->count > LMB_CLUSTER_MAX_NODES || !view->layers)
+        return 0;
+    uint32_t next = 0, edges = 0;
+    for (uint32_t i = 0; i < view->count; i++) {
+        const LmbExecutionNode *n = &view->nodes[i];
+        if (!n->name[0] || !n->address[0] || !n->reserved_bytes ||
+            !memchr(n->name, 0, sizeof n->name) ||
+            !memchr(n->address, 0, sizeof n->address) ||
+            n->begin != next || n->end <= n->begin || n->end > view->layers ||
+            (n->edge != 0 && n->edge != 1)) return 0;
+        next = n->end; edges += (uint32_t)n->edge;
+    }
+    return next == view->layers && edges == 1;
+}
+
+/* Names come from network inventory. Never let terminal control bytes in a
+ * peer name turn this read-only view into terminal commands. */
+static void lmb_execution_label(FILE *out, const char *text) {
+    for (const unsigned char *p = (const unsigned char *)text; *p; p++)
+        fputc(*p >= 32 && *p < 127 ? *p : '?', out);
+}
+
+static void lmb_execution_print(FILE *out, const LmbExecutionView *view) {
+    if (!lmb_execution_valid(view)) {
+        fputs("  No approved household plan is attached to this chat.\n", out);
+        return;
+    }
+    fprintf(out, "\n  Approved Segment plan: %u compute donor%s, %u layers\n",
+            view->count, view->count == 1 ? "" : "s", view->layers);
+    fputs("  All listed segments acknowledged READY before this chat opened.\n", out);
+    for (uint32_t i = 0; i < view->count; i++) {
+        const LmbExecutionNode *n = &view->nodes[i];
+        fputs("  ", out); lmb_execution_label(out, n->name);
+        fputs(" (", out); lmb_execution_label(out, n->address);
+        fprintf(out, ") · layers [%u,%u) · %.2f GB reserved%s\n",
+                n->begin, n->end, n->reserved_bytes / 1e9,
+                n->edge ? " · Edge / chat host" : "");
+    }
+    fputs("  Each Segment executes attention and experts for its own layers.\n"
+          "  This chat process runs no model layers; it supplies checkpoint files.\n"
+          "  A separate approved donor may run on the same computer.\n"
+          "  /plan shows this allocation; /experts shows tracker activity.\n", out);
+}
+#endif

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,29 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    LmbExecutionView execution = { .count = 2, .layers = 4 };
+    for (uint32_t i = 0; i < 2; i++) {
+        snprintf(execution.nodes[i].name, 64, "donor-%u", i);
+        snprintf(execution.nodes[i].address, 64, "127.0.0.1:%u", 47301 + i);
+        execution.nodes[i].begin = i * 2; execution.nodes[i].end = i * 2 + 2;
+        execution.nodes[i].reserved_bytes = 128u << 20;
+    }
+    execution.nodes[0].edge = 1;
+    assert(lmb_execution_valid(&execution));
+    execution.nodes[1].begin = 1; assert(!lmb_execution_valid(&execution));
+    execution.nodes[1].begin = 3; assert(!lmb_execution_valid(&execution));
+    execution.nodes[1].begin = 2;
+    execution.nodes[1].edge = 1; assert(!lmb_execution_valid(&execution));
+    execution.nodes[1].edge = 0;
+    execution.count = LMB_CLUSTER_MAX_NODES + 1; assert(!lmb_execution_valid(&execution));
+    execution.count = 2;
+    assert(!lmb_execution_valid(NULL));
+    if (argc > 1 && !strcmp(argv[1], "plan")) {
+        snprintf(execution.nodes[1].name, 64, "donor-1\033[2J");
+        lmb_execution_print(stdout, &execution);
+        lmb_execution_print(stdout, NULL);
+        return 0;
+    }
     if (argc > 1 && !strcmp(argv[1], "help")) {
         render_help();
         return 0;

--- a/tests/integration/chat_ui_test.py
+++ b/tests/integration/chat_ui_test.py
@@ -17,6 +17,13 @@ import unicodedata
 
 ROOT = Path(__file__).resolve().parents[2]
 
+plan = subprocess.check_output(["./test_chat_ui", "plan"], cwd=ROOT, text=True)
+assert "Approved Segment plan: 2 compute donors" in plan
+assert "layers [0,2)" in plan and "layers [2,4)" in plan
+assert "This chat process runs no model layers" in plan
+assert "No approved household plan" in plan
+assert "\x1b" not in plan, "a peer name injected terminal controls"
+
 
 class Screen:
     def __init__(self, rows=16, cols=90):

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import pty
+import re
 import select
 import signal
 import socket
@@ -179,6 +180,13 @@ def main():
         until(lambda: chat.has("receives the text") or chat.p.poll() is not None, seconds=180,
               message="accepted plan did not reach real hosted chat")
         assert chat.p.poll() is None, "accepted plan failed; inspect donor engine logs"
+        until(lambda: chat.has("/experts shows tracker activity."),
+              message="the accepted compute allocation is missing from chat")
+        assert "Approved Segment plan: 2 compute donors" in chat.text
+        assert "This chat process runs no model layers" in chat.text
+        announced_ranges = sorted((int(begin), int(end)) for begin, end in
+                                  re.findall(r"layers \[(\d+),(\d+)\)", chat.text))
+        assert len(announced_ranges) == 2, announced_ranges
         chat.send("/he")
         until(lambda: chat.has("List chat commands"), message="slash suggestions did not appear")
         chat.send("\t\n")
@@ -188,6 +196,21 @@ def main():
               message="real model did not finish a response")
         assert chat.has("tok/s"), "engine failed during generation"
         assert "hosted stream · no local checkpoint" in chat.text
+        executed_ranges = []
+        for donor in ("donor-a", "donor-b"):
+            log = (tmp / donor / ".lumabri/home/engines.log").read_text(errors="replace")
+            commits = re.findall(r"\[segment-node [^\]\n]+ (\d+):(\d+)\] committed_runs=(\d+)", log)
+            assert commits, f"{donor} did not report any committed model execution"
+            ranges = {(int(begin), int(end)) for begin, end, _ in commits}
+            assert len(ranges) == 1, ranges
+            executed_ranges.extend(ranges)
+        assert sorted(executed_ranges) == announced_ranges, (executed_ranges, announced_ranges)
+        chat.send("/plan\n")
+        until(lambda: chat.text.count("Approved Segment plan: 2 compute donors") >= 2,
+              message="/plan did not show the same accepted allocation")
+        chat.send("/experts\n")
+        until(lambda: chat.has("executor activity"),
+              message="hosted chat did not retain its household tracker for diagnostics")
         owned_groups = set()
         if args.kill_donor:
             rows = subprocess.check_output(["ps", "-axo", "pid=,ppid=,pgid="], text=True)
@@ -234,7 +257,7 @@ def main():
             until(lambda: donor.has("your workspace"))
             donor.send("\x1b")
         until(lambda: a.p.poll() is not None and b.p.poll() is not None)
-        print(f"HOME FLOW: PASS (consent, real Segment generation, {'killed donor recovery' if args.kill_donor else 'normal cleanup'})", flush=True)
+        print(f"HOME FLOW: PASS (consent, two executing ranges match the plan, real Segment generation, {'killed donor cleanup' if args.kill_donor else 'normal cleanup'})", flush=True)
     except Exception:
         # Only test-owned engine logs: no shell environment or real keys.
         for log in tmp.rglob("engines.log"):


### PR DESCRIPTION
First dedicated PR for the eight LAN release gates. Colibri remains read-only. Models without an upstream GPU backend stay on CPU; GPU kernel implementation is explicitly out of scope.

Adds an immutable approved Segment allocation to hosted chat and /plan, including donor names, ranges, reserved RAM and Edge ownership. The hosted client retains the household tracker so /experts and /swarm query the correct network. Successful Segment commits produce bounded first/power-of-two evidence logs; cached retries and failed runs are not counted. The integration test verifies that both donor processes executed exactly the ranges shown. OpenMP capability probing now respects inherited OMP_NUM_THREADS and OMP_THREAD_LIMIT: a loaded-machine test exposed 12-thread teams overriding a requested limit of two.

Local verification on 218f2c4: strict-warning household build, TUI transcript/autocomplete/control-byte tests, normal two-donor generation and release, killed-donor cleanup, and identical greedy tokens across whole and split Tiny OLMoE runs with no relay. Timing conclusions withheld because the local host was loaded. CI adds the whole/split token oracle and native OpenMP-limit contracts.

This is not a claim that gate 1 is fully closed: physical PC+Mac split-compute oracle and timings remain user-operated evidence, distinct from loopback tests. The remaining seven gates are tracked explicitly in docs/LAN_RELEASE_CHECKLIST.md. No model quality or large-model speed is inferred from synthetic Tiny. Merge only with a normal merge commit, never squash, after all final-head checks pass.