### PR TITLE
LAN 3/8: align catalogue and runtime memory reservations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,9 @@ jobs:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
         run: |
-          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
+          ./test_memory_budget
           make test-runtime-probe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           python3 tests/integration/native_shim_test.py
           python3 tests/integration/household_network_test.py

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_calibration \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget test_calibration \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate test_inventory test_home test_chat_ui \
@@ -62,7 +62,7 @@ MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
 
 lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
 		lumabri_inventory.h lumabri_home.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h \
-		lumabri_families.h lumabri_planner.h lumabri_cluster.h \
+		lumabri_families.h lumabri_planner.h lumabri_cluster.h lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h \
 		lumabri_calibration.h $(SECURE_DEPS) $(MACHINE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread lumabri.c src/ui/lumabri_tui.c $(MACHINE_SRC) -o $@
 
@@ -442,8 +442,11 @@ test_model_family: tests/c/test_model_family.c lumabri_families.h
 test_planner: tests/c/test_planner.c lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_planner.c -o $@
 
-test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_planner.h lumabri_families.h lumabri_machine.h
+test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h lumabri_planner.h lumabri_families.h lumabri_machine.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_cluster.c -o $@
+
+test_memory_budget: tests/c/test_memory_budget.c lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h lumabri_cluster.h lumabri_planner.h lumabri_families.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_memory_budget.c -o $@
 
 test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_planner.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_calibration.c -o $@
@@ -454,7 +457,7 @@ test_inventory: tests/c/test_inventory.c lumabri_inventory.h lumabri_machine.h l
 test_home: tests/c/test_home.c lumabri_home.h lumabri_inventory.h lumabri_families.h lumabri_proto.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_home.c -o $@
 
-test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h
+test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_chat_ui.c src/ui/lumabri_tui.c lumabri_machine.c -o $@
 
 test-ready-pipe: tests/c/test_ready_pipe.c lumabri_ready.h
@@ -613,7 +616,7 @@ $(COLIBRI_SEGMENT_LIB): $(HYBRID_ENGINE_DIR)/.prepared build/segment_hybrid_brid
 		segment-edge-library
 	$(AR) rcs $@ build/segment_hybrid_bridge.o
 
-segment_node: segment_node.c $(HOME_NET_DEPS) lumabri_planner.h lumabri_families.h lumabri_ready.h \
+segment_node: segment_node.c $(HOME_NET_DEPS) lumabri_planner.h lumabri_memory_budget.h lumabri_families.h lumabri_ready.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB) $(MACHINE_DEPS) \
 		lumabri_run_gate.c lumabri_run_gate.h
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread segment_node.c lumabri_segment.c \
@@ -708,7 +711,7 @@ test-adapters: tracker segment_node segment_chat
 test-segment-discovery: tracker test_segment_discovery
 	bash ./tests/integration/segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster \
+test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget \
 		test_inventory test_home test_chat_ui test_calibration \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
@@ -753,6 +756,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	bash ./tests/integration/tui_test.sh
 	./test_planner
 	./test_cluster
+	./test_memory_budget
 	./test_calibration
 	./test_nat_adopt
 	bash ./tests/integration/rtt_refresh_test.sh
@@ -796,7 +800,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so liblumabri.dylib test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
-	      test_model_family test_planner test_cluster test_calibration test_inventory test_home test_chat_ui segment_budget_probe \
+	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_inventory test_home test_chat_ui segment_budget_probe \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -64,10 +64,14 @@ One PR per numbered gate above; all merges preserve commits (no squash), and
 require green checks on the exact reviewed head. Partial implementation is
 not a completed gate.
 
-1. In progress: approved layer-allocation view, named execution evidence,
+1. PR #152 merged: approved layer-allocation view, named execution evidence,
    two-donor checks; physical two-computer oracle and timings still required.
 2. Pending: verified family sizing and checkpoint conformance.
-3. Pending: planner/runtime budget and placement consistency.
+3. In progress: shared conservative resident admission for catalogue, request
+   and launch, with a stat-only checkpoint preview and a signed-inventory
+   recheck before offers. Edge and Segment budgets are separately MiB-aligned.
+   Measured-cost placement remains pending; this does not enable disk mode or
+   certify additional model families.
 4. Pending: connected, persisted lightweight calibration and advice.
 5. Pending: model acquisition, cache reuse and verified disk execution.
 6. Pending: upstream-only GPU capability integration, CPU otherwise.

--- a/lumabri.c
+++ b/lumabri.c
@@ -4922,42 +4922,16 @@ static int cmd_peer_key(int argc, char **argv) {
  * because a plan knows what fits and only a calibration knows what it does,
  * and printing them in the same voice is how a catalogue starts lying. */
 
+#include "lumabri_checkpoint_inventory.h"
+
 typedef struct {
     char dir[512];
     char name[64];
     LmbModelShape shape;
     int has_weights;
+    uint64_t checkpoint_bytes;
+    int inventory_ok;
 } CatalogEntry;
-
-static int catalog_has_weights(const char *root, unsigned depth) {
-    if (depth > 3) return 0;
-    DIR *d = opendir(root);
-    if (!d) return 0;
-    int found = 0;
-    struct dirent *e;
-    while (!found && (e = readdir(d))) {
-        if (e->d_name[0] == '.') continue;
-        char path[1024];
-        int n = snprintf(path, sizeof path, "%s/%s", root, e->d_name);
-        if (n < 0 || (size_t)n >= sizeof path) continue;
-        struct stat st;
-        if (stat(path, &st)) continue;
-        if (S_ISDIR(st.st_mode)) {
-            found = catalog_has_weights(path, depth + 1);
-            continue;
-        }
-        /* A config-side metadata stub is not a weight container. Four KiB is
-         * still only a presence check—the adapter validates the real format
-         * before READY—but it rejects empty and token-sized placeholders. */
-        if (!S_ISREG(st.st_mode) || st.st_size < 4096) continue;
-        const char *dot = strrchr(e->d_name, '.');
-        if (dot && (!strcmp(dot, ".safetensors") || !strcmp(dot, ".bin") ||
-                    !strcmp(dot, ".gguf") || !strcmp(dot, ".coli")))
-            found = 1;
-    }
-    closedir(d);
-    return found;
-}
 
 static int catalog_scan(const char *root, CatalogEntry *out, int cap) {
     DIR *d = opendir(root);
@@ -4974,7 +4948,10 @@ static int catalog_scan(const char *root, CatalogEntry *out, int cap) {
         if (lmb_shape_from_config(path, &out[n].shape)) continue;
         snprintf(out[n].dir, sizeof out[n].dir, "%.511s", path);
         snprintf(out[n].name, sizeof out[n].name, "%.63s", e->d_name);
-        out[n].has_weights = catalog_has_weights(path, 0);
+        LmbCheckpointInventory inventory;
+        out[n].inventory_ok = !lmb_checkpoint_inventory(path, &inventory);
+        out[n].has_weights = inventory.has_weights;
+        out[n].checkpoint_bytes = inventory.bytes;
         n++;
     }
     closedir(d);
@@ -5066,6 +5043,8 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
         snprintf(m->dir, sizeof m->dir, "%.511s", found[i].dir);
         m->shape = found[i].shape;
         m->weights_present = found[i].has_weights;
+        m->checkpoint_bytes = found[i].checkpoint_bytes;
+        m->checkpoint_inventory_ok = found[i].inventory_ok;
         st->nodes[0].has_checkpoint = found[i].has_weights;
         LmbClusterNode selected[LMB_CLUSTER_MAX_NODES];
         uint32_t mapping[LMB_CLUSTER_MAX_NODES], nselected = 0;
@@ -5080,6 +5059,9 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
         m->planned = st->inventory_ok && !lmb_plan_cluster_source(&m->shape, selected, nselected,
                                        st->context, st->sessions,
                                        LMB_GOAL_ONE_SESSION, household && found[i].has_weights, &m->plan);
+        if (m->planned && household && m->weights_present)
+            m->planned = m->checkpoint_inventory_ok && !lmb_home_plan_budgets(
+                &m->shape, m->checkpoint_bytes, selected, nselected, st->context, &m->plan);
         if (m->planned) {
             m->plan.edge_node = mapping[m->plan.edge_node];
             for (uint32_t j = 0; j < m->plan.nslices; j++)
@@ -5103,6 +5085,8 @@ static void catalog_row(const LmbTuiModel *m) {
     char detail[96] = "";
     if (!m->shape.sizing_verified)
         snprintf(detail, sizeof detail, "adapter sizing unavailable");
+    else if (!m->checkpoint_inventory_ok)
+        snprintf(detail, sizeof detail, "checkpoint inventory unavailable");
     else if (!m->weights_present)
         snprintf(detail, sizeof detail, "checkpoint weights missing");
     else if (ok && plan.state == LMB_PLAN_UNRUNNABLE && plan.missing_bytes)
@@ -5174,9 +5158,12 @@ static void catalog_json(const LmbTuiState *st) {
         fputs(",\"adapter\":", stdout);
         json_string(stdout, model->shape.segment_id);
         printf(",\"sizing_verified\":%s,\"weights_present\":%s,"
+               "\"checkpoint_inventory_ok\":%s,\"checkpoint_bytes\":%llu,"
                "\"planned\":%s,\"state\":",
                model->shape.sizing_verified ? "true" : "false",
                model->weights_present ? "true" : "false",
+               model->checkpoint_inventory_ok ? "true" : "false",
+               (unsigned long long)model->checkpoint_bytes,
                planned ? "true" : "false");
         json_string(stdout, planned ? lmb_plan_state_name(plan->state) :
                                      "cannot plan");

--- a/lumabri_checkpoint_inventory.h
+++ b/lumabri_checkpoint_inventory.h
@@ -1,0 +1,71 @@
+/* Stat-only preview: no hashing or reading model weights. The signed source
+ * inventory is still authoritative and is checked again before offers. */
+#ifndef LUMABRI_CHECKPOINT_INVENTORY_H
+#define LUMABRI_CHECKPOINT_INVENTORY_H
+#include <dirent.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "lumabri_content.h"
+
+typedef struct {
+    uint64_t bytes;
+    uint32_t files;
+    int has_weights;
+} LmbCheckpointInventory;
+
+static int lmb_checkpoint_walk(const char *root, const char *rel, unsigned depth,
+                                LmbCheckpointInventory *out) {
+    if (depth > 32) return -1;
+    char directory[1024];
+    int len = snprintf(directory, sizeof directory, "%s%s%s", root, *rel ? "/" : "", rel);
+    if (len < 0 || (size_t)len >= sizeof directory) return -1;
+    DIR *dir = opendir(directory);
+    if (!dir) return -1;
+    int rc = 0;
+    for (;;) {
+        errno = 0;
+        struct dirent *entry = readdir(dir);
+        if (!entry) { if (errno) rc = -1; break; }
+        const char *name = entry->d_name;
+        if (!strcmp(name, ".") || !strcmp(name, "..") ||
+            lmb_content_runtime_local_name(name)) continue;
+        char child[512], path[1024];
+        len = snprintf(child, sizeof child, "%s%s%s", rel, *rel ? "/" : "", name);
+        if (len < 0 || (size_t)len >= sizeof child) { rc = -1; break; }
+        len = snprintf(path, sizeof path, "%s/%s", root, child);
+        if (len < 0 || (size_t)len >= sizeof path) { rc = -1; break; }
+        struct stat link, st;
+        if (lstat(path, &link) || stat(path, &st)) { rc = -1; break; }
+        if (S_ISDIR(st.st_mode)) {
+            /* Weight-file symlinks (HF caches) work; directory symlinks may
+             * form cycles and are not accepted by this bounded preview. */
+            if (S_ISLNK(link.st_mode) || lmb_checkpoint_walk(root, child, depth + 1, out)) {
+                rc = -1; break;
+            }
+        } else if (S_ISREG(st.st_mode)) {
+            if (st.st_size < 0 || out->files == LMB_CONTENT_MAX_FILES ||
+                UINT64_MAX - out->bytes < (uint64_t)st.st_size) { rc = -1; break; }
+            out->files++;
+            out->bytes += (uint64_t)st.st_size;
+            const char *dot = strrchr(name, '.');
+            if (st.st_size >= 4096 && dot && (!strcmp(dot, ".safetensors") ||
+                !strcmp(dot, ".bin") || !strcmp(dot, ".gguf") || !strcmp(dot, ".coli")))
+                out->has_weights = 1;
+        }
+    }
+    closedir(dir);
+    return rc;
+}
+
+static int lmb_checkpoint_inventory(const char *root, LmbCheckpointInventory *out) {
+    if (!out) return -1;
+    memset(out, 0, sizeof *out);
+    if (!root || !*root || lmb_checkpoint_walk(root, "", 0, out)) {
+        memset(out, 0, sizeof *out);
+        return -1;
+    }
+    return 0;
+}
+#endif

--- a/lumabri_cluster.h
+++ b/lumabri_cluster.h
@@ -22,6 +22,7 @@
 
 #include "lumabri_machine.h"   /* LMB_GPU_* : the backends an engine can use */
 #include "lumabri_planner.h"
+#include "lumabri_memory_budget.h"
 
 #define LMB_CLUSTER_MAX_NODES 32
 
@@ -196,6 +197,51 @@ static LMB_UNUSED int lmb_plan_cluster(const LmbModelShape *m,
     const LmbClusterNode *nodes, uint32_t n, uint32_t context,
     uint32_t sessions, LmbPlanGoal goal, LmbClusterPlan *out) {
     return lmb_plan_cluster_source(m, nodes, n, context, sessions, goal, 0, out);
+}
+
+/* Household resident admission uses the same process budgets as launch.
+ * Keep this separate from adapter arithmetic: guard overhead is neither a
+ * tensor nor a measured working set. No speed/optimality claim is made. */
+static LMB_UNUSED int lmb_home_plan_budgets(const LmbModelShape *shape,
+    uint64_t checkpoint_bytes, const LmbClusterNode *nodes, uint32_t count,
+    uint32_t context, LmbClusterPlan *plan) {
+    if (!shape || !nodes || !plan || !count || count > LMB_CLUSTER_MAX_NODES ||
+        !plan->nslices || plan->nslices > count || plan->edge_node >= count ||
+        plan->sessions != 1 || !plan->data_available) return -1;
+    LmbClusterPlan updated = *plan;
+    LmbClusterPlan *destination = plan;
+    plan = &updated; /* Invalid input never leaves a partially updated plan. */
+    uint32_t next = 0, has_edge = 0;
+    uint64_t total_budget = 0, missing = 0;
+    for (uint32_t i = 0; i < count; i++)
+        total_budget = lmb_budget_add(total_budget, nodes[i].ram_budget_bytes);
+    for (uint32_t i = 0; i < plan->nslices; i++) {
+        LmbSlice *s = &plan->slices[i];
+        if (s->node >= count || s->layer_begin != next) return -1;
+        for (uint32_t j = 0; j < i; j++)
+            if (plan->slices[j].node == s->node) return -1;
+        LmbHomeReservation r;
+        int edge = s->node == plan->edge_node;
+        if (lmb_home_reservation(shape, checkpoint_bytes, s->layer_begin,
+                                s->layer_end, context, edge, &r)) return -1;
+        next = s->layer_end; has_edge += (uint32_t)edge;
+        s->bytes_resident = r.total_bytes;
+        s->state = r.total_bytes <= nodes[s->node].ram_budget_bytes ?
+                   LMB_PLAN_RESIDENT : LMB_PLAN_UNRUNNABLE;
+        if (s->state == LMB_PLAN_UNRUNNABLE)
+            missing = lmb_budget_add(missing, r.total_bytes - nodes[s->node].ram_budget_bytes);
+    }
+    if (next != shape->layers || has_edge != 1) return -1;
+    plan->missing_bytes = missing;
+    plan->missing_nodes = 0;
+    uint64_t average = total_budget / count;
+    if (missing && average) {
+        uint64_t additional = missing / average + (missing % average != 0);
+        plan->missing_nodes = additional > UINT32_MAX ? UINT32_MAX : (uint32_t)additional;
+    }
+    plan->state = missing ? LMB_PLAN_UNRUNNABLE : LMB_PLAN_RESIDENT;
+    *destination = updated;
+    return 0;
 }
 
 /* Would adding this machine help, and at what?

--- a/lumabri_content.h
+++ b/lumabri_content.h
@@ -3,6 +3,8 @@
 
 #include <string.h>
 
+#define LMB_CONTENT_MAX_FILES 4096
+
 /* Files created and mutated by a running engine belong to that machine, not
  * to the signed model inventory. Publishing one makes its next heartbeat
  * look like a model-integrity violation. Keep the prefix future-proof: every

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -605,6 +605,8 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         !st->inventory_ok || home_private_network())
         return home_fail("Cannot prepare chat: refresh the household inventory and select a model.");
     LmbTuiModel *m = &st->models[selected];
+    if (!m->checkpoint_inventory_ok)
+        return home_fail("Cannot inventory the source checkpoint. Check its files and refresh the model list.");
     if (!m->weights_present || !m->shape.sizing_verified || st->sessions != 1) {
         return home_fail("This checkpoint needs verified sizing, local source weights and a one-session plan.");
     }
@@ -617,7 +619,9 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     }
     LmbClusterPlan plan;
     if (!count || lmb_plan_cluster_source(&m->shape, nodes, count, st->context, 1,
-                                   LMB_GOAL_ONE_SESSION, 1, &plan) || plan.state != LMB_PLAN_RESIDENT) {
+                                   LMB_GOAL_ONE_SESSION, 1, &plan) ||
+        lmb_home_plan_budgets(&m->shape, m->checkpoint_bytes, nodes, count, st->context, &plan) ||
+        plan.state != LMB_PLAN_RESIDENT) {
         return home_fail("No complete resident plan fits the selected computers. Keep Share resources open and check their offered RAM.");
     }
     /* Discovery is not proof that inbound connections work. Authenticate the
@@ -691,8 +695,11 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     }
     if (!found) goto done;
     stage = "validating the indexed plan";
-    LmbRangeCost edge_cost = lmb_estimate_edge(&m->shape, st->context, 1);
-    uint64_t edge_ram = edge_cost.resident_bytes + edge_cost.state_bytes + edge_cost.scratch_bytes + (64u << 20);
+    if (lmb_home_plan_budgets(&m->shape, swarm.total_bytes, nodes, count,
+                             st->context, &plan) || plan.state != LMB_PLAN_RESIDENT) {
+        home_fail("The indexed checkpoint does not fit the selected budgets. Refresh the plan; no allocation was committed.");
+        goto done;
+    }
     uint8_t edge_pk[32];
     if (lmb_unhex(edge_pk, st->identities[indices[plan.edge_node]], 32)) goto done;
     /* Each recipient gets one exact range, and only the selected Edge owner
@@ -710,17 +717,20 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         o->context = st->context; o->threads = nodes[n].threads ? nodes[n].threads : 1;
         if (o->threads > 256) o->threads = 256;
         o->max_new = st->max_new ? st->max_new : 256; o->model_bytes = swarm.total_bytes;
-        o->runs_edge = n == plan.edge_node; o->edge_ram_bytes = o->runs_edge ? edge_ram : 0;
-        /* Use the runtime's conservative preflight, not the smaller generic
-         * shape estimate. Include state, Edge and a process overhead margin. */
-        uint64_t runtime = swarm.total_bytes / o->layers * (o->end - o->begin) +
-                           swarm.total_bytes / 20 + (128u << 20);
-        LmbRangeCost cost = lmb_estimate_segment(&m->shape, o->begin, o->end, o->context, 1);
-        runtime += cost.state_bytes + cost.scratch_bytes;
-        if (runtime < slice->bytes_resident) runtime = slice->bytes_resident;
-        o->ram_bytes = runtime + o->edge_ram_bytes;
-        o->ram_bytes = (o->ram_bytes + ((1u << 20) - 1)) & ~((uint64_t)(1u << 20) - 1);
-        o->disk_bytes = swarm.total_bytes * 2 + (256u << 20);
+        o->runs_edge = n == plan.edge_node;
+        LmbHomeReservation reservation;
+        if (lmb_home_reservation(&m->shape, swarm.total_bytes, o->begin, o->end,
+                                o->context, o->runs_edge, &reservation)) {
+            home_fail("The model's memory requirements cannot be represented safely.");
+            goto done;
+        }
+        o->ram_bytes = reservation.total_bytes;
+        o->edge_ram_bytes = reservation.edge_bytes;
+        o->disk_bytes = lmb_budget_add(lmb_budget_add(swarm.total_bytes, swarm.total_bytes), UINT64_C(256) << 20);
+        if (o->disk_bytes == UINT64_MAX) {
+            home_fail("The model's disk requirements exceed the supported size.");
+            goto done;
+        }
         if (o->ram_bytes > nodes[n].ram_budget_bytes) {
             home_fail("%.64s needs %.2f GB for this plan, but offers %.2f GB. No allocation was committed.",
                       nodes[n].name, o->ram_bytes / 1e9, nodes[n].ram_budget_bytes / 1e9);

--- a/lumabri_memory_budget.h
+++ b/lumabri_memory_budget.h
@@ -1,0 +1,63 @@
+/* Shared conservative resident admission policy. This is NOT a verified
+ * streaming working-set contract and must not enable disk execution. */
+#ifndef LUMABRI_MEMORY_BUDGET_H
+#define LUMABRI_MEMORY_BUDGET_H
+#include "lumabri_planner.h"
+
+typedef struct {
+    uint64_t segment_bytes, edge_bytes, total_bytes;
+} LmbHomeReservation;
+
+static LMB_UNUSED uint64_t lmb_budget_add(uint64_t a, uint64_t b) {
+    return UINT64_MAX - a < b ? UINT64_MAX : a + b;
+}
+
+static LMB_UNUSED uint64_t lmb_budget_mib(uint64_t bytes) {
+    const uint64_t mask = (UINT64_C(1) << 20) - 1;
+    uint64_t rounded = lmb_budget_add(bytes, mask);
+    return rounded == UINT64_MAX ? UINT64_MAX : rounded & ~mask;
+}
+
+/* ceil-by-MiB is deliberately left to the caller. The proportional share
+ * keeps its remainder; bytes/layers*count alone silently drops it. */
+static LMB_UNUSED uint64_t lmb_checkpoint_floor(uint64_t bytes,
+                                               uint32_t layers,
+                                               uint32_t begin, uint32_t end) {
+    if (!bytes || !layers || begin >= end || end > layers) return UINT64_MAX;
+    uint64_t count = end - begin;
+    uint64_t share = bytes / layers * count + (bytes % layers) * count / layers;
+    return lmb_budget_add(share, bytes / 20u);
+}
+
+static LMB_UNUSED int lmb_home_reservation(const LmbModelShape *shape,
+    uint64_t checkpoint_bytes, uint32_t begin, uint32_t end,
+    uint32_t context, int runs_edge, LmbHomeReservation *out) {
+    if (!out) return -1;
+    memset(out, 0, sizeof *out);
+    if (!shape || (runs_edge != 0 && runs_edge != 1)) return -1;
+    LmbRangeCost segment = lmb_estimate_segment(shape, begin, end, context, 1);
+    if (!segment.ok) return -1;
+    uint64_t floor = lmb_checkpoint_floor(checkpoint_bytes, shape->layers, begin, end);
+    uint64_t live = lmb_budget_add(segment.state_bytes, segment.scratch_bytes);
+    uint64_t guarded = lmb_budget_add(lmb_budget_add(floor, UINT64_C(128) << 20), live);
+    uint64_t described = lmb_budget_add(segment.resident_bytes, live);
+    out->segment_bytes = lmb_budget_mib(guarded > described ? guarded : described);
+    if (runs_edge) {
+        LmbRangeCost edge = lmb_estimate_edge(shape, context, 1);
+        if (!edge.ok) return -1;
+        uint64_t cost = lmb_budget_add(edge.resident_bytes,
+                        lmb_budget_add(edge.state_bytes, edge.scratch_bytes));
+        out->edge_bytes = lmb_budget_mib(lmb_budget_add(cost, UINT64_C(64) << 20));
+    }
+    out->total_bytes = lmb_budget_add(out->segment_bytes, out->edge_bytes);
+    /* Both process budgets are individually aligned. Subtracting an
+     * unaligned Edge budget and truncating it in --memory-limit-mb could
+     * otherwise give Segment less memory than the approved calculation. */
+    if (out->segment_bytes == UINT64_MAX || out->edge_bytes == UINT64_MAX ||
+        out->total_bytes == UINT64_MAX) {
+        memset(out, 0, sizeof *out);
+        return -1;
+    }
+    return 0;
+}
+#endif

--- a/maintainer.c
+++ b/maintainer.c
@@ -34,7 +34,7 @@
 #include "lumabri_secure.h"
 #include "lumabri_home_net.h"
 
-#define MAX_FILES          4096
+#define MAX_FILES          LMB_CONTENT_MAX_FILES
 #define MAX_INCLUDES       64
 #define MAX_READ_LEN       LMB_MAX_PAY
 #define HEARTBEAT_S        10

--- a/segment_node.c
+++ b/segment_node.c
@@ -7,6 +7,7 @@
 #include "lumabri_machine.h"
 #include "lumabri_run_gate.h"
 #include "lumabri_planner.h"
+#include "lumabri_memory_budget.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
 #include "segment_colibri.h"
@@ -1369,14 +1370,7 @@ int main(int argc, char **argv) {
     if (!model_layers && shaped) model_layers = shape.layers;
     if (!model_bytes && model_dir) model_bytes = directory_bytes(model_dir, 0);
     if (process_limit && model_bytes && model_layers) {
-        uint64_t range_layers = end - begin;
-        uint64_t proportional = model_bytes / model_layers * range_layers;
-        uint64_t remainder = model_bytes % model_layers * range_layers /
-                             model_layers;
-        uint64_t overhead = model_bytes / 20u;
-        uint64_t estimated = proportional + remainder;
-        if (estimated <= UINT64_MAX - overhead) estimated += overhead;
-        else estimated = UINT64_MAX;
+        uint64_t estimated = lmb_checkpoint_floor(model_bytes, model_layers, begin, end);
         if (estimated > process_limit) {
             fprintf(stderr, "[segment-node] assigned range %u:%u needs about "
                     "%.1f GB but the donor budget is %.1f GB; releasing it "

--- a/src/ui/lumabri_tui.c
+++ b/src/ui/lumabri_tui.c
@@ -496,7 +496,7 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
         if (m->planned && m->plan.state != LMB_PLAN_UNRUNNABLE) {
             for (uint32_t i = 0; i < m->plan.nslices && 16 + (int)i * 2 < ui_h - 7; i++) {
                 const LmbSlice *s = &m->plan.slices[i];
-                ui_printf(16 + (int)i * 2, 5, UI_TEXT, "%s%s · layers %u–%u · %.2f GB resident",
+                ui_printf(16 + (int)i * 2, 5, UI_TEXT, "%s%s · layers %u–%u · %.2f GB reserved",
                     st->nodes[s->node].name, s->node == m->plan.edge_node ? " (chat host)" : "",
                     s->layer_begin, s->layer_end - 1, s->bytes_resident / 1e9);
             }
@@ -505,7 +505,9 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
             ui_printf(16, 5, UI_TEXT, "Missing: %.2f GB · sizing %s · local source weights %s",
                 m->plan.missing_bytes / 1e9, m->planned ? "available" : "unavailable",
                 m->weights_present ? "present" : "missing");
-            ui_text(19, 5, UI_MUTED, "Select computers in Share resources, then review the updated plan.");
+            ui_text(19, 5, UI_MUTED, m->checkpoint_inventory_ok ?
+                "Select computers in Share resources, then review the updated plan." :
+                "Checkpoint inventory unavailable. Check source files and refresh.");
         }
     } else if (tab) {
         int rows = (ui_h - 15) / 3; if (rows < 1) rows = 1;

--- a/src/ui/lumabri_tui.h
+++ b/src/ui/lumabri_tui.h
@@ -26,6 +26,8 @@ typedef struct {
     LmbClusterPlan plan;
     int planned;                    /* 0 when the cluster cannot be planned */
     int weights_present;
+    uint64_t checkpoint_bytes;
+    int checkpoint_inventory_ok;
     const LmbCalibration *calibration;   /* NULL until something is measured */
     LmbCalKey calibration_key;      /* exact current conditions */
     int calibration_key_valid;

--- a/tests/c/test_memory_budget.c
+++ b/tests/c/test_memory_budget.c
@@ -1,0 +1,103 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "lumabri_cluster.h"
+#include "lumabri_checkpoint_inventory.h"
+
+static void sized_file(const char *path, off_t size) {
+    int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+    assert(fd >= 0 && !ftruncate(fd, size));
+    assert(!close(fd));
+}
+
+int main(void) {
+    LmbModelShape m = {0};
+    strcpy(m.model_type, "olmoe");
+    m.layers = 4; m.hidden = 64; m.intermediate = 32;
+    m.moe_intermediate = 32; m.experts = 8; m.experts_per_tok = 2;
+    m.heads = 4; m.kv_heads = 4; m.vocab = 128;
+    m.bits_per_weight = 16; m.sizing_verified = 1;
+    const uint64_t mib = UINT64_C(1) << 20, bytes = 620001;
+    LmbHomeReservation r;
+    assert(!lmb_home_reservation(&m, bytes, 0, 4, 128, 1, &r));
+    assert(r.segment_bytes >= 128 * mib && r.edge_bytes >= 64 * mib);
+    assert(!(r.segment_bytes % mib) && !(r.edge_bytes % mib));
+    assert(r.total_bytes == r.segment_bytes + r.edge_bytes);
+    assert(lmb_checkpoint_floor(101, 4, 1, 4) == 75 + 5);
+    assert(lmb_checkpoint_floor(1, 0, 0, 1) == UINT64_MAX);
+    assert(lmb_budget_add(UINT64_MAX, 1) == UINT64_MAX);
+    assert(lmb_budget_mib(UINT64_MAX - 1) == UINT64_MAX);
+    assert(lmb_budget_mib(mib) == mib && lmb_budget_mib(mib + 1) == 2 * mib);
+    LmbHomeReservation invalid;
+    assert(lmb_home_reservation(&m, UINT64_MAX, 0, 4, 128, 1, &invalid));
+    assert(!invalid.total_bytes);
+    assert(lmb_home_reservation(&m, bytes, 2, 1, 128, 1, &invalid));
+    assert(lmb_home_reservation(&m, bytes, 0, 4, 128, 2, &invalid));
+
+    LmbClusterNode node = {0};
+    node.ram_budget_bytes = r.total_bytes;
+    LmbClusterPlan p;
+    assert(!lmb_plan_cluster_source(&m, &node, 1, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(!lmb_home_plan_budgets(&m, bytes, &node, 1, 128, &p));
+    assert(p.state == LMB_PLAN_RESIDENT && p.slices[0].bytes_resident == r.total_bytes);
+    node.ram_budget_bytes--;
+    assert(!lmb_home_plan_budgets(&m, bytes, &node, 1, 128, &p));
+    assert(p.state == LMB_PLAN_UNRUNNABLE && p.missing_bytes == 1);
+    node.vram_budget_bytes = UINT64_C(100) << 30;
+    assert(!lmb_home_plan_budgets(&m, bytes, &node, 1, 128, &p));
+    assert(p.state == LMB_PLAN_UNRUNNABLE); /* VRAM is not CPU RAM. */
+    p.slices[0].layer_begin = 1;
+    LmbClusterPlan before = p;
+    assert(lmb_home_plan_budgets(&m, bytes, &node, 1, 128, &p));
+    assert(!memcmp(&p, &before, sizeof p));
+    p.slices[0].layer_begin = 0; p.data_available = 0;
+    assert(lmb_home_plan_budgets(&m, bytes, &node, 1, 128, &p));
+    p.data_available = 1; p.sessions = 2;
+    assert(lmb_home_plan_budgets(&m, bytes, &node, 1, 128, &p));
+
+    LmbClusterNode pair[2];
+    memset(pair, 0, sizeof pair);
+    pair[0].ram_budget_bytes = pair[1].ram_budget_bytes = 1u << 30;
+    assert(!lmb_plan_cluster_source(&m, pair, 2, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(p.nslices == 2);
+    assert(!lmb_home_plan_budgets(&m, bytes, pair, 2, 128, &p));
+    for (uint32_t i = 0; i < p.nslices; i++) {
+        LmbSlice *s = &p.slices[i];
+        assert(!lmb_home_reservation(&m, bytes, s->layer_begin, s->layer_end,
+                                     128, s->node == p.edge_node, &r));
+        assert(s->bytes_resident == r.total_bytes);
+    }
+    p.slices[1].node = p.slices[0].node;
+    before = p;
+    assert(lmb_home_plan_budgets(&m, bytes, pair, 2, 128, &p));
+    assert(!memcmp(&p, &before, sizeof p));
+    p.slices[1].node = 2;
+    assert(lmb_home_plan_budgets(&m, bytes, pair, 2, 128, &p));
+
+    char temp[] = "/tmp/lumabri-inventory-test-XXXXXX";
+    assert(mkdtemp(temp));
+    char config[512], weights[512], runtime[512], link[512];
+    snprintf(config, sizeof config, "%s/config.json", temp);
+    snprintf(weights, sizeof weights, "%s/model.safetensors", temp);
+    snprintf(runtime, sizeof runtime, "%s/.coli_kv", temp);
+    snprintf(link, sizeof link, "%s/alias.bin", temp);
+    sized_file(config, 100); sized_file(weights, 8192); sized_file(runtime, 65536);
+    LmbCheckpointInventory inv;
+    assert(!lmb_checkpoint_inventory(temp, &inv));
+    assert(inv.bytes == 8292 && inv.files == 2 && inv.has_weights);
+    assert(!symlink("model.safetensors", link));
+    assert(!lmb_checkpoint_inventory(temp, &inv));
+    assert(inv.bytes == 16484 && inv.files == 3 && inv.has_weights);
+    assert(!unlink(link) && !symlink(".", link));
+    assert(lmb_checkpoint_inventory(temp, &inv));
+    assert(!inv.bytes && !inv.files && !inv.has_weights);
+    assert(!unlink(link) && !symlink("missing", link));
+    assert(lmb_checkpoint_inventory(temp, &inv));
+    assert(!unlink(link));
+    assert(!unlink(config) && !unlink(weights) && !unlink(runtime) && !rmdir(temp));
+    assert(lmb_checkpoint_inventory(temp, &inv));
+    puts("HOUSEHOLD MEMORY BUDGET: PASS");
+    return 0;
+}

--- a/tests/integration/catalog_test.sh
+++ b/tests/integration/catalog_test.sh
@@ -75,6 +75,9 @@ doc = json.loads(sys.argv[1])
 assert doc["schema"] == "lumabri.models.v1"
 assert {m["name"] for m in doc["models"]} >= {"huge", "tiny", "config-only"}
 assert next(m for m in doc["models"] if m["name"] == "config-only")["weights_present"] is False
+tiny = next(m for m in doc["models"] if m["name"] == "tiny")
+assert tiny["checkpoint_inventory_ok"] is True
+assert tiny["checkpoint_bytes"] > 4096  # includes config, not just weights
 PY
 
 # A directory with no checkpoints says so instead of printing an empty table.


### PR DESCRIPTION
## Scope — roadmap gate 3 (partial)

The household catalogue used the generic tensor estimate while launch added a checkpoint guard, process overhead, state/scratch and Edge. A plan could therefore look resident and fail after indexing. Total-only MiB rounding could also underfund Segment after subtracting an unaligned Edge reservation.

- Share the conservative resident reservation between catalogue, pre-index request validation and post-index allocation; reuse the checkpoint floor in Segment preflight.
- Align Edge and Segment process budgets individually. Reject saturated arithmetic, invalid coverage and unsupported session counts without partially updating the plan.
- Preview checkpoint bytes with bounded stat-only traversal (no weight reads/hashing); exclude runtime-local artifacts, support weight-file symlinks and reject incomplete/cyclic inventories.
- Recheck against the indexed source before any donor offer. Preserve the existing memory guard; no disk-mode or new model-support claim.
- Show reservation rather than tensor-only memory in the live detail and expose inventory status/bytes in the JSON snapshot.

## Verification

- Strict-warning frontend/unit builds; memory-budget and cluster unit tests passed.
- Catalogue JSON/presence tests and chat UI integration passed.
- Native macOS Intel/ARM CI now executes the same memory tests; Linux warning/full-test gates include them.
- Full two-donor approval/generation/cleanup tests and final CI are required before ready/merge.

This is not the completion of gate 3: measured-cost placement remains pending. Physical PC+Mac split-compute proof, large-model conformance and native Windows runtime validation remain separate release gates. Colibri is unchanged. Merge commits only, no squash.
