### PR TITLE
LAN 3/8: reject overflowing planner memory calculations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
         run: |
-          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
           ./test_memory_budget
+          ./test_planner
+          ./test_cluster
           make test-runtime-probe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           python3 tests/integration/native_shim_test.py
           python3 tests/integration/household_network_test.py

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -67,9 +67,11 @@ not a completed gate.
 1. PR #152 merged: approved layer-allocation view, named execution evidence,
    two-donor checks; physical two-computer oracle and timings still required.
 2. Pending: verified family sizing and checkpoint conformance.
-3. In progress: shared conservative resident admission for catalogue, request
+3. PR #153: shared conservative resident admission for catalogue, request
    and launch, with a stat-only checkpoint preview and a signed-inventory
    recheck before offers. Edge and Segment budgets are separately MiB-aligned.
+   Follow-up: checked tensor/state arithmetic and aggregate budgets reject
+   overflow instead of wrapping into apparently small allocations.
    Measured-cost placement remains pending; this does not enable disk mode or
    certify additional model families.
 4. Pending: connected, persisted lightweight calibration and advice.

--- a/lumabri_cluster.h
+++ b/lumabri_cluster.h
@@ -77,19 +77,21 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
                                        LmbPlanGoal goal,
                                        int external_checkpoint,
                                        LmbClusterPlan *out) {
+    if (!out) return -1;
     memset(out, 0, sizeof *out);
     out->goal = goal;
     out->sessions = sessions ? sessions : 1;
     out->state = LMB_PLAN_UNRUNNABLE;
     out->data_available = external_checkpoint != 0;
-    if (!m->layers || !n || n > LMB_CLUSTER_MAX_NODES) return -1;
+    if (!m || !nodes || !m->layers || !n || n > LMB_CLUSTER_MAX_NODES) return -1;
 
     /* Until an adapter declares a working GPU backend, RAM and VRAM are not
      * interchangeable. Counting both can accept a plan no engine can load. */
     LmbRangeCost edge = lmb_estimate_edge(m, context, sessions);
     if (!edge.ok) return -1;
-    uint64_t edge_need = edge.resident_bytes + edge.state_bytes +
-                         edge.scratch_bytes;
+    uint64_t edge_need = lmb_size_add(edge.resident_bytes,
+                         lmb_size_add(edge.state_bytes, edge.scratch_bytes));
+    if (edge_need == UINT64_MAX) return -1;
     uint32_t best_edge = UINT32_MAX;
     uint64_t best_edge_room = 0;
     for (uint32_t i = 0; i < n; i++) {
@@ -107,10 +109,10 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
     for (uint32_t i = 0; i < n; i++) {
         effective[i] = nodes[i].ram_budget_bytes;
         if (i == best_edge) effective[i] -= edge_need;
-        total_budget += effective[i];
+        total_budget = lmb_size_add(total_budget, effective[i]);
         if (nodes[i].has_checkpoint) out->data_available = 1;
     }
-    if (!total_budget) return -1;
+    if (!total_budget || total_budget == UINT64_MAX) return -1;
 
     /* Hand out layers in proportion to budget, in one pass, never leaving a
      * layer unassigned: the last node takes whatever rounding left over. */
@@ -118,10 +120,12 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
     uint64_t whole_resident = 0;
     for (uint32_t i = 0; i < n && assigned < m->layers; i++) {
         uint64_t budget = effective[i];
-        uint32_t take = (uint32_t)((uint64_t)m->layers * budget / total_budget);
+        uint64_t scaled = lmb_size_mul(m->layers, budget);
+        if (scaled == UINT64_MAX) return -1;
+        uint32_t take = (uint32_t)(scaled / total_budget);
         if (i + 1 == n) take = m->layers - assigned;
         if (!take) continue;
-        if (assigned + take > m->layers) take = m->layers - assigned;
+        if (take > m->layers - assigned) take = m->layers - assigned;
 
         LmbSlice *s = &out->slices[out->nslices];
         s->node = i;
@@ -129,7 +133,8 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
         s->layer_end = assigned + take;
         LmbRangeCost c = lmb_estimate_segment(m, s->layer_begin, s->layer_end,
                                               context, sessions);
-        uint64_t live = c.state_bytes + c.scratch_bytes;
+        if (!c.ok) return -1;
+        uint64_t live = lmb_size_add(c.state_bytes, c.scratch_bytes);
         s->state = lmb_plan_state(m, &c, budget);
         s->bytes_resident = s->state == LMB_PLAN_DISK
                           ? c.working_set_bytes + live
@@ -137,7 +142,7 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
         uint64_t needed_weights = s->state == LMB_PLAN_DISK
                                 ? c.working_set_bytes : c.resident_bytes;
         s->bytes_to_fetch = nodes[i].has_checkpoint ? 0 : needed_weights;
-        whole_resident += c.resident_bytes + live;
+        whole_resident = lmb_size_add(whole_resident, c.resident_bytes + live);
         if (s->state == LMB_PLAN_UNRUNNABLE) {
             /* Missing is measured against what this node would ACTUALLY have
              * to hold, which is the resident cost unless the adapter has
@@ -148,9 +153,11 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
              * tells a person nothing they can act on. */
             uint64_t need = m->disk_streaming ? c.working_set_bytes + live
                                               : c.resident_bytes + live;
-            out->missing_bytes += need > budget ? need - budget : 0;
+            out->missing_bytes = lmb_size_add(out->missing_bytes, need > budget ? need - budget : 0);
         }
-        out->fetch_bytes += s->bytes_to_fetch;
+        out->fetch_bytes = lmb_size_add(out->fetch_bytes, s->bytes_to_fetch);
+        if (whole_resident == UINT64_MAX || out->missing_bytes == UINT64_MAX ||
+            out->fetch_bytes == UINT64_MAX) return -1;
         out->nslices++;
         assigned += take;
     }
@@ -169,13 +176,15 @@ static LMB_UNUSED int lmb_plan_cluster_source(const LmbModelShape *m,
     }
     if (!out->data_available) {
         out->state = LMB_PLAN_UNRUNNABLE;
-        out->missing_bytes = whole_resident + edge.resident_bytes;
+        out->missing_bytes = lmb_size_add(whole_resident, edge.resident_bytes);
+        if (out->missing_bytes == UINT64_MAX) return -1;
     }
 
     if (out->state == LMB_PLAN_UNRUNNABLE && out->missing_bytes) {
         uint64_t median = total_budget / n;
-        out->missing_nodes = median ?
-            (uint32_t)((out->missing_bytes + median - 1) / median) : 0;
+        uint64_t additional = median ? out->missing_bytes / median +
+            (out->missing_bytes % median != 0) : 0;
+        out->missing_nodes = additional > UINT32_MAX ? UINT32_MAX : (uint32_t)additional;
     }
 
     /* How long before it can answer, which is bytes over measured bandwidth

--- a/lumabri_memory_budget.h
+++ b/lumabri_memory_budget.h
@@ -9,7 +9,7 @@ typedef struct {
 } LmbHomeReservation;
 
 static LMB_UNUSED uint64_t lmb_budget_add(uint64_t a, uint64_t b) {
-    return UINT64_MAX - a < b ? UINT64_MAX : a + b;
+    return lmb_size_add(a, b);
 }
 
 static LMB_UNUSED uint64_t lmb_budget_mib(uint64_t bytes) {

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -68,19 +68,33 @@ typedef struct {
     int ok;                     /* 0 when the shape cannot answer */
 } LmbRangeCost;
 
+/* UINT64_MAX is an invalid-size sentinel, never an admissible allocation.
+ * Propagate it through all intermediate calculations instead of wrapping. */
+static uint64_t LMB_UNUSED lmb_size_add(uint64_t a, uint64_t b) {
+    return UINT64_MAX - a < b ? UINT64_MAX : a + b;
+}
+
+static uint64_t LMB_UNUSED lmb_size_mul(uint64_t a, uint64_t b) {
+    if (a == UINT64_MAX || b == UINT64_MAX) return UINT64_MAX;
+    return b && a > UINT64_MAX / b ? UINT64_MAX : a * b;
+}
+
 /* bits→bytes with the rounding the stores actually use: block scales and
  * alignment add roughly a fifth on the fp4 path, which is the figure
  * lmbe_expert_bytes has used since the expert store was written. */
 static uint64_t LMB_UNUSED lmb_weight_bytes(uint64_t elements, uint32_t bits) {
     if (!bits) bits = 16;
-    uint64_t raw = elements * bits / 8u;
-    return bits < 8 ? raw + raw / 5u : raw;
+    if (elements == UINT64_MAX) return UINT64_MAX;
+    uint64_t tail = (elements % 8u) * (uint64_t)bits;
+    uint64_t raw = lmb_size_add(lmb_size_mul(elements / 8u, bits),
+                                tail / 8u + (tail % 8u != 0));
+    return bits < 8 ? lmb_size_add(raw, raw / 5u) : raw;
 }
 
 static uint64_t LMB_UNUSED lmb_expert_bytes_of(const LmbModelShape *m) {
     if (!m->experts || !m->moe_intermediate) return 0;
     /* gate, up, down: three hidden × moe_intermediate matrices */
-    return lmb_weight_bytes((uint64_t)m->hidden * m->moe_intermediate * 3u,
+    return lmb_weight_bytes(lmb_size_mul((uint64_t)m->hidden * m->moe_intermediate, 3u),
                             m->bits_per_weight);
 }
 
@@ -90,18 +104,17 @@ static uint64_t LMB_UNUSED lmb_expert_bytes_of(const LmbModelShape *m) {
 static uint64_t LMB_UNUSED lmb_dense_layer_bytes(const LmbModelShape *m) {
     uint64_t head_dim = m->heads ? (uint64_t)m->hidden / m->heads : 0;
     uint64_t kv = m->kv_heads ? (uint64_t)m->kv_heads * head_dim : m->hidden;
-    uint64_t attn = (uint64_t)m->hidden * m->hidden      /* q */
-                  + (uint64_t)m->hidden * kv * 2u        /* k, v */
-                  + (uint64_t)m->hidden * m->hidden;     /* o */
+    uint64_t attn = lmb_size_add(lmb_size_mul((uint64_t)m->hidden * m->hidden, 2u),
+                                 lmb_size_mul(lmb_size_mul(m->hidden, kv), 2u));
     uint64_t ffn = m->experts ? 0u
-                 : (uint64_t)m->hidden * m->intermediate * 3u;
-    return lmb_weight_bytes(attn + ffn, m->bits_per_weight);
+                 : lmb_size_mul((uint64_t)m->hidden * m->intermediate, 3u);
+    return lmb_weight_bytes(lmb_size_add(attn, ffn), m->bits_per_weight);
 }
 
 /* Embedding and head, which live wherever Edge runs and nowhere else. */
 static uint64_t LMB_UNUSED lmb_edge_bytes(const LmbModelShape *m) {
     if (!m->vocab || !m->hidden) return 0;
-    return lmb_weight_bytes((uint64_t)m->vocab * m->hidden * 2u,
+    return lmb_weight_bytes(lmb_size_mul((uint64_t)m->vocab * m->hidden, 2u),
                             m->bits_per_weight);
 }
 
@@ -110,9 +123,10 @@ static uint64_t LMB_UNUSED lmb_edge_bytes(const LmbModelShape *m) {
 static uint64_t LMB_UNUSED lmb_kv_bytes(const LmbModelShape *m, uint32_t layers,
                              uint32_t context, uint32_t sessions) {
     uint64_t head_dim = m->heads ? (uint64_t)m->hidden / m->heads : 0;
-    uint64_t per_tok = m->kv_heads ? (uint64_t)m->kv_heads * head_dim * 2u
+    uint64_t per_tok = m->kv_heads ? lmb_size_mul((uint64_t)m->kv_heads * head_dim, 2u)
                                    : (uint64_t)m->hidden * 2u;
-    return per_tok * context * layers * (sessions ? sessions : 1) * 4u;
+    return lmb_size_mul(lmb_size_mul(lmb_size_mul(lmb_size_mul(per_tok, context),
+        layers), sessions ? sessions : 1), 4u);
 }
 
 /* What one node pays to hold layers [begin, end). */
@@ -125,24 +139,26 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_segment(const LmbModelShape *m,
         end > m->layers || !m->hidden) return c;
     uint32_t n = end - begin;
 
-    uint64_t dense = lmb_dense_layer_bytes(m) * n;
+    uint64_t dense = lmb_size_mul(lmb_dense_layer_bytes(m), n);
     uint64_t expert = lmb_expert_bytes_of(m);
-    uint64_t all_experts = expert * m->experts * n;
+    uint64_t all_experts = lmb_size_mul(lmb_size_mul(expert, m->experts), n);
 
     /* The floor: the dense part, plus enough expert slots for the top-k of
      * every layer in the range. A cache below that thrashes on a single
      * token — it is not a slower mode, it is a broken one. */
     uint32_t topk = m->experts_per_tok ? m->experts_per_tok : 1;
     if (topk > m->experts && m->experts) topk = m->experts;
-    uint64_t floor_experts = expert * topk * n;
+    uint64_t floor_experts = lmb_size_mul(lmb_size_mul(expert, topk), n);
 
     c.state_bytes = lmb_kv_bytes(m, n, context ? context : 4096, sessions);
     /* scratch is dominated by the widest matmul the layer runs */
     uint64_t widest = m->experts ? m->moe_intermediate : m->intermediate;
     c.scratch_bytes = (uint64_t)widest * 4u * 8u;   /* f32, a few rows */
-    c.resident_bytes = dense + all_experts;
-    c.working_set_bytes = dense + floor_experts;
-    c.ok = 1;
+    c.resident_bytes = lmb_size_add(dense, all_experts);
+    c.working_set_bytes = lmb_size_add(dense, floor_experts);
+    uint64_t live = lmb_size_add(c.state_bytes, c.scratch_bytes);
+    c.ok = lmb_size_add(c.resident_bytes, live) != UINT64_MAX &&
+           lmb_size_add(c.working_set_bytes, live) != UINT64_MAX;
     return c;
 }
 
@@ -154,9 +170,9 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_edge(const LmbModelShape *m,
     memset(&c, 0, sizeof c);
     if (!m->sizing_verified || !m->vocab || !m->hidden) return c;
     c.resident_bytes = c.working_set_bytes = lmb_edge_bytes(m);
-    c.state_bytes = (uint64_t)(context ? context : 4096) * m->hidden * 4u *
-                    (sessions ? sessions : 1);
-    c.ok = 1;
+    c.state_bytes = lmb_size_mul(lmb_size_mul((uint64_t)(context ? context : 4096) *
+                    m->hidden, 4u), sessions ? sessions : 1);
+    c.ok = lmb_size_add(c.resident_bytes, c.state_bytes) != UINT64_MAX;
     return c;
 }
 
@@ -173,9 +189,11 @@ static LmbPlanState LMB_UNUSED lmb_plan_state(const LmbModelShape *m,
                                    const LmbRangeCost *cost,
                                    uint64_t budget_bytes) {
     if (!cost->ok) return LMB_PLAN_UNRUNNABLE;
-    uint64_t live = cost->state_bytes + cost->scratch_bytes;
-    if (cost->resident_bytes + live <= budget_bytes) return LMB_PLAN_RESIDENT;
-    if (m->disk_streaming && cost->working_set_bytes + live <= budget_bytes)
+    uint64_t live = lmb_size_add(cost->state_bytes, cost->scratch_bytes);
+    uint64_t resident = lmb_size_add(cost->resident_bytes, live);
+    uint64_t working = lmb_size_add(cost->working_set_bytes, live);
+    if (resident != UINT64_MAX && resident <= budget_bytes) return LMB_PLAN_RESIDENT;
+    if (m->disk_streaming && working != UINT64_MAX && working <= budget_bytes)
         return LMB_PLAN_DISK;
     return LMB_PLAN_UNRUNNABLE;
 }

--- a/tests/c/test_cluster.c
+++ b/tests/c/test_cluster.c
@@ -32,6 +32,17 @@ int main(void) {
     LmbModelShape m = v4();
     LmbClusterPlan p;
 
+    LmbClusterNode overflow_nodes[2] = { node("a", 32, 0), node("b", 32, 0) };
+    overflow_nodes[0].ram_budget_bytes = UINT64_MAX - 1;
+    overflow_nodes[1].ram_budget_bytes = UINT64_MAX - 1;
+    CHECK(lmb_plan_cluster(&m, overflow_nodes, 2, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "overflowing aggregate machine budgets produced a plan");
+    overflow_nodes[0].ram_budget_bytes = UINT64_MAX / 2;
+    CHECK(lmb_plan_cluster(&m, overflow_nodes, 1, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "overflowing layer-share multiplication produced a plan");
+    CHECK(lmb_plan_cluster(NULL, overflow_nodes, 1, 4096, 1, LMB_GOAL_ONE_SESSION, &p),
+          "NULL shape accepted");
+
     /* A realistic house: four computers, 96 GB between them, against a model
      * that needs about 150. It does not fit, and the plan has to SAY it does
      * not fit rather than produce a split that would fail on first use. */

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -29,6 +29,31 @@ static LmbModelShape v4(void) {
 int main(void) {
     LmbModelShape m = v4();
 
+    CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,
+          "size addition wrapped");
+    CHECK(lmb_size_mul(UINT64_C(1) << 63, 2) == UINT64_MAX,
+          "size multiplication wrapped");
+    CHECK(lmb_size_mul(UINT64_MAX, 0) == UINT64_MAX,
+          "a later zero hid an invalid intermediate size");
+    CHECK(lmb_weight_bytes(3, 4) == 2, "partial packed byte was truncated");
+    CHECK(lmb_weight_bytes(UINT64_C(1) << 60, 16) == (UINT64_C(1) << 61),
+          "valid byte size was rejected because a bit-size intermediate overflowed");
+    LmbModelShape enormous = m;
+    enormous.hidden = enormous.vocab = UINT32_C(1) << 31;
+    enormous.bits_per_weight = 16;
+    CHECK(!lmb_estimate_edge(&enormous, 4096, 1).ok,
+          "overflowed Edge weights became a small allocation");
+    CHECK(!lmb_estimate_segment(&enormous, 0, 43, 4096, 1).ok,
+          "overflowed layer tensors became a small allocation");
+    CHECK(!lmb_estimate_segment(&m, 0, 43, UINT32_MAX, UINT32_MAX).ok,
+          "overflowed KV state became a small allocation");
+    CHECK(!lmb_estimate_edge(&m, UINT32_MAX, UINT32_MAX).ok,
+          "overflowed Edge session state became a small allocation");
+    LmbRangeCost invalid = { .resident_bytes = UINT64_MAX - 3,
+        .state_bytes = 4, .ok = 1 };
+    CHECK(lmb_plan_state(&m, &invalid, UINT64_MAX) == LMB_PLAN_UNRUNNABLE,
+          "state plus weights overflow was accepted by admission");
+
     /* An expert of this shape measured ~13.4 MB on the real checkpoint. The
      * estimate has to land near that or every figure built on it is wrong. */
     uint64_t e = lmb_expert_bytes_of(&m);


### PR DESCRIPTION
## Scope — roadmap gate 3 hardening

Follow-up to #153. Its reservation sums were checked, but the underlying planner could already have overflowed while multiplying tensor dimensions, quantization bits, context or sessions. An apparently tiny allocation could therefore originate from an invalid size before admission.

- Propagate an invalid-size sentinel through tensor, expert, KV and Edge arithmetic.
- Reject unrepresentable range totals and cluster budget/share calculations.
- Round packed partial bytes upward; compute bytes without requiring a representable intermediate bit count.
- Keep ordinary model estimates and CPU/VRAM separation unchanged. No new adapter, disk or GPU capability is enabled.
- Extend native macOS Intel/ARM CI to run planner and cluster arithmetic tests.

## Verification

- Strict-warning planner, cluster and household budget unit tests passed.
- AddressSanitizer + UndefinedBehaviorSanitizer planner/cluster tests passed.
- Catalogue JSON, chat UI and UI copy checks passed.
- Actual Tiny OLMoE two-donor approval/generation passed, with normal cleanup and killed-donor cleanup (separate runs).
- An additional local deterministic property check compared 1,000,000 arithmetic cases with a 128-bit reference; passed. This diagnostic is not a native-platform certification.
- Native CI remains required before merge.

The roadmap is not declared complete. Additional family sizing, calibrated placement, model acquisition, multi-session/replay and platform release gates remain tracked in `docs/LAN_RELEASE_CHECKLIST.md`. Colibri is unchanged. Merge commits only; no squash.
