### PR TITLE
planner: implement adapter memory contracts (roadmap gate 2, in progress)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,25 @@ jobs:
           SPLIT_MODEL_DIR=build/home-flow-models/olmoe-tiny \
           SPLIT_THREADS=2 SPLIT_CONTEXT=128 SPLIT_ROUNDS=2 \
             bash tests/integration/segment_split_test.sh
+      - name: Qwen hybrid memory contract — real int8 and grouped int4
+        working-directory: lumabri
+        run: |
+          python3 ../colibri/c/tools/make_qwen36_tiny.py --out build/qwen36-hf --ref-mode full --emit-ref build/qwen36-ref.json
+          python3 ../colibri/c/tools/convert_qwen36.py --model build/qwen36-hf --out build/qwen-int8/qwen36-tiny --ebits 8 --no-readme
+          python3 ../colibri/c/tools/convert_qwen36.py --model build/qwen36-hf --out build/qwen-int4/qwen36-tiny --ebits 4 --gs 16 --no-readme
+          python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/qwen-int8/qwen36-tiny --vocab-size 320
+          python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/qwen-int4/qwen36-tiny --vocab-size 320
+          cc -O2 -fopenmp -pthread ../colibri/c/tests/test_edge_adapters_real.c build/segment-hybrid-colibri/build/segment/libcolibri_segment_edge.a -o build/qwen-edge-oracle -lm
+          OMP_NUM_THREADS=2 build/qwen-edge-oracle qwen36 build/qwen-int8/qwen36-tiny build/qwen36-ref.json 3
+          python3 tests/integration/home_flow_test.py --models-dir build/qwen-int8
+          python3 tests/integration/home_flow_test.py --models-dir build/qwen-int4 --kill-donor
+          SPLIT_MODEL_DIR=build/qwen-int4/qwen36-tiny SPLIT_ENGINE=qwen36 SPLIT_MODEL=qwen-int4 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=8940 bash tests/integration/segment_split_test.sh
+          OLMOE_EDGE_MODEL=build/home-flow-models/olmoe-tiny OLMOE_EDGE_REF=../colibri/c/olmoe_tiny_src/ref_olmoe.json bash tests/integration/segment_relay_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-qwen36-checkpoint
+          path: lumabri/build/qwen-int4/qwen36-tiny/*
+          retention-days: 3
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -186,6 +205,13 @@ jobs:
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-qwen36-checkpoint
+          path: lumabri/build/qwen-home-models/qwen36-tiny
+      - name: Native Qwen grouped-int4 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/qwen-home-models
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,21 @@ jobs:
           name: tiny-qwen38-checkpoint
           path: lumabri/build/qwen38-contract/qwen38-tiny/*
           retention-days: 3
+      - name: Qwen3.8 real block-FP8 experts and independent dequantized oracle
+        working-directory: lumabri
+        run: |
+          python3 tests/integration/prepare_qwen38_fixture.py --engine ../colibri/c --out build/qwen38-fp8-contract/qwen38-tiny --fp8-experts
+          python3 tests/integration/planner_tensor_contract_test.py --family qwen38 --model build/qwen38-fp8-contract/qwen38-tiny
+          for native in 0 1; do
+            Q38_NATIVE_FP8=$native OMP_NUM_THREADS=2 build/qwen38-greedy-oracle qwen38 build/qwen38-fp8-contract/qwen38-tiny build/qwen38-fp8-contract/qwen38-tiny/ref.json
+          done
+          python3 tests/integration/home_flow_test.py --models-dir build/qwen38-fp8-contract --context 512 --expect-greedy --kill-donor
+          SPLIT_MODEL_DIR=build/qwen38-fp8-contract/qwen38-tiny SPLIT_ENGINE=qwen38 SPLIT_MODEL=qwen38-fp8 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=11040 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-qwen38-fp8-checkpoint
+          path: lumabri/build/qwen38-fp8-contract/qwen38-tiny/*
+          retention-days: 3
       - name: DeepSeek V4 native memory contract and compressed-state oracles
         working-directory: lumabri
         run: |
@@ -350,6 +365,13 @@ jobs:
       - name: Native Qwen3.8 request and execution
         working-directory: lumabri
         run: python3 tests/integration/home_flow_test.py --models-dir build/qwen38-home-models --context 512 --expect-greedy
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-qwen38-fp8-checkpoint
+          path: lumabri/build/qwen38-fp8-home-models/qwen38-tiny
+      - name: Native Qwen3.8 FP8 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/qwen38-fp8-home-models --context 512 --expect-greedy
       - uses: actions/download-artifact@v4
         with:
           name: tiny-v4-checkpoint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           mkdir -p build/home-flow-models
           cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
+          make segment_budget_probe
           python3 tests/integration/planner_tensor_contract_test.py --family olmoe --model build/home-flow-models/olmoe-tiny
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,20 @@ jobs:
           name: tiny-inkling-checkpoint
           path: lumabri/build/inkling-contract/int4/inkling-tiny/*
           retention-days: 3
+      - name: Kimi memory contract — MXFP4 and AttnRes boundaries
+        working-directory: lumabri
+        run: |
+          python3 ../colibri/c/tools/make_kimi_k3_tiny.py --output build/kimi-contract/kimi-tiny
+          python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/kimi-contract/kimi-tiny --vocab-size 320
+          K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 OMP_NUM_THREADS=2 build/qwen-edge-oracle kimi build/kimi-contract/kimi-tiny ../colibri/c/kimi_k3_tiny/ref.json 8
+          K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract
+          python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract --kill-donor
+          SPLIT_MODEL_DIR=build/kimi-contract/kimi-tiny SPLIT_ENGINE=kimi SPLIT_MODEL=kimi-mxfp4 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=9740 K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-kimi-checkpoint
+          path: lumabri/build/kimi-contract/kimi-tiny/*
+          retention-days: 3
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -233,6 +247,13 @@ jobs:
       - name: Native Inkling packed-int4 request and execution
         working-directory: lumabri
         run: python3 tests/integration/home_flow_test.py --models-dir build/inkling-home-models
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-kimi-checkpoint
+          path: lumabri/build/kimi-home-models/kimi-tiny
+      - name: Native Kimi MXFP4 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/kimi-home-models
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,8 @@ jobs:
         run: |
           python3 -m pip install transformers==5.16.1
           python3 tests/integration/prepare_inkling_fixture.py --engine ../colibri/c --out build/inkling-contract
+          make segment_budget_probe
+          python3 tests/integration/planner_tensor_contract_test.py --family inkling --model build/inkling-contract/int4/inkling-tiny
           INK_SEGMENT_BITS=0 OMP_NUM_THREADS=2 build/qwen-edge-oracle inkling build/inkling-contract/float/inkling-tiny build/inkling-contract/float/inkling-tiny/ref_inkling.json 24
           INK_SEGMENT_BITS=0 python3 tests/integration/home_flow_test.py --models-dir build/inkling-contract/float
           python3 tests/integration/home_flow_test.py --models-dir build/inkling-contract/int4 --kill-donor
@@ -175,14 +177,44 @@ jobs:
         run: |
           python3 ../colibri/c/tools/make_kimi_k3_tiny.py --output build/kimi-contract/kimi-tiny
           python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/kimi-contract/kimi-tiny --vocab-size 320
+          python3 tests/integration/planner_tensor_contract_test.py --family kimi --model build/kimi-contract/kimi-tiny
           K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 OMP_NUM_THREADS=2 build/qwen-edge-oracle kimi build/kimi-contract/kimi-tiny ../colibri/c/kimi_k3_tiny/ref.json 8
-          K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract
-          python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract --kill-donor
+          python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract --expect-no-fit
+          K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract --donor-ram-gb 4.5
+          python3 tests/integration/home_flow_test.py --models-dir build/kimi-contract --donor-ram-gb 4.5 --kill-donor
           SPLIT_MODEL_DIR=build/kimi-contract/kimi-tiny SPLIT_ENGINE=kimi SPLIT_MODEL=kimi-mxfp4 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=9740 K3_BITS=32 K3_MLA_BITS=32 K3_HEAD_BITS=32 K3_IDOT=0 bash tests/integration/segment_split_test.sh
       - uses: actions/upload-artifact@v4
         with:
           name: tiny-kimi-checkpoint
           path: lumabri/build/kimi-contract/kimi-tiny/*
+          retention-days: 3
+      - name: GLM memory contract — float source, MLA and DSA
+        working-directory: lumabri
+        run: |
+          python3 tests/integration/prepare_glm_fixture.py --engine ../colibri/c --out build/glm-contract
+          python3 tests/integration/planner_tensor_contract_test.py --family glm --model build/glm-contract/glm_tiny
+          GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16 OMP_NUM_THREADS=2 build/qwen-edge-oracle glm build/glm-contract/glm_tiny build/glm-contract/ref_glm.json 20
+          GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16 python3 tests/integration/home_flow_test.py --models-dir build/glm-contract
+          python3 tests/integration/home_flow_test.py --models-dir build/glm-contract --kill-donor
+          SPLIT_MODEL_DIR=build/glm-contract/glm_tiny SPLIT_ENGINE=glm SPLIT_MODEL=glm-float SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=10140 GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-glm-checkpoint
+          path: lumabri/build/glm-contract/glm_tiny/*
+          retention-days: 3
+      - name: GLM5.3 contract — replicated session state and stateless Edge
+        working-directory: lumabri
+        run: |
+          python3 tests/integration/prepare_glm53_fixture.py --engine ../colibri/c --out build/glm53-contract/glm53-tiny
+          python3 tests/integration/planner_tensor_contract_test.py --family glm53 --model build/glm53-contract/glm53-tiny
+          GLM53_BITS=32 OMP_NUM_THREADS=2 build/qwen-edge-oracle glm53 build/glm53-contract/glm53-tiny build/glm53-contract/glm53-tiny/edge_ref.json 4
+          GLM53_BITS=32 python3 tests/integration/home_flow_test.py --models-dir build/glm53-contract
+          python3 tests/integration/home_flow_test.py --models-dir build/glm53-contract --kill-donor
+          SPLIT_MODEL_DIR=build/glm53-contract/glm53-tiny SPLIT_ENGINE=glm53 SPLIT_MODEL=glm53-float SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=10540 GLM53_BITS=32 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-glm53-checkpoint
+          path: lumabri/build/glm53-contract/glm53-tiny/*
           retention-days: 3
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
@@ -251,9 +283,29 @@ jobs:
         with:
           name: tiny-kimi-checkpoint
           path: lumabri/build/kimi-home-models/kimi-tiny
-      - name: Native Kimi MXFP4 request and execution
+      - name: Native Kimi insufficient-memory admission
         working-directory: lumabri
-        run: python3 tests/integration/home_flow_test.py --models-dir build/kimi-home-models
+        run: python3 tests/integration/home_flow_test.py --models-dir build/kimi-home-models --expect-no-fit
+      # The standard ARM runner cannot provide two native Kimi 3.7 GB floors.
+      # Exercise refusal there; do not override the engine's RAM safeguard.
+      - name: Native Kimi MXFP4 execution on sufficient-memory runner
+        if: matrix.runner == 'macos-15-intel'
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/kimi-home-models --donor-ram-gb 4.5
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-glm-checkpoint
+          path: lumabri/build/glm-home-models/glm_tiny
+      - name: Native GLM request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/glm-home-models
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-glm53-checkpoint
+          path: lumabri/build/glm53-home-models/glm53-tiny
+      - name: Native GLM5.3 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/glm53-home-models
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           mkdir -p build/home-flow-models
           cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
+          python3 tests/integration/planner_tensor_contract_test.py --family olmoe --model build/home-flow-models/olmoe-tiny
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
       - name: Same greedy tokens with one and two real Segment ranges

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,20 @@ jobs:
           name: tiny-qwen36-checkpoint
           path: lumabri/build/qwen-int4/qwen36-tiny/*
           retention-days: 3
+      - name: Inkling memory contract — float oracle and packed int4
+        working-directory: lumabri
+        run: |
+          python3 -m pip install transformers==5.16.1
+          python3 tests/integration/prepare_inkling_fixture.py --engine ../colibri/c --out build/inkling-contract
+          INK_SEGMENT_BITS=0 OMP_NUM_THREADS=2 build/qwen-edge-oracle inkling build/inkling-contract/float/inkling-tiny build/inkling-contract/float/inkling-tiny/ref_inkling.json 24
+          INK_SEGMENT_BITS=0 python3 tests/integration/home_flow_test.py --models-dir build/inkling-contract/float
+          python3 tests/integration/home_flow_test.py --models-dir build/inkling-contract/int4 --kill-donor
+          SPLIT_MODEL_DIR=build/inkling-contract/int4/inkling-tiny SPLIT_ENGINE=inkling SPLIT_MODEL=inkling-int4 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=9340 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-inkling-checkpoint
+          path: lumabri/build/inkling-contract/int4/inkling-tiny/*
+          retention-days: 3
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -212,6 +226,13 @@ jobs:
       - name: Native Qwen grouped-int4 request and execution
         working-directory: lumabri
         run: python3 tests/integration/home_flow_test.py --models-dir build/qwen-home-models
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-inkling-checkpoint
+          path: lumabri/build/inkling-home-models/inkling-tiny
+      - name: Native Inkling packed-int4 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/inkling-home-models
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,25 @@ jobs:
           name: tiny-qwen38-checkpoint
           path: lumabri/build/qwen38-contract/qwen38-tiny/*
           retention-days: 3
+      - name: DeepSeek V4 native memory contract and compressed-state oracles
+        working-directory: lumabri
+        run: |
+          python3 ../colibri/c/tools/make_deepseek_v4_tiny.py --output build/v4-contract/deepseek-v4-tiny
+          python3 tests/integration/prepare_v4_oracles.py build/v4-contract/deepseek-v4-tiny
+          python3 tests/integration/planner_tensor_contract_test.py --family deepseek_v4 --model build/v4-contract/deepseek-v4-tiny
+          for case in short compressed long; do
+            OMP_NUM_THREADS=2 build/qwen38-greedy-oracle deepseek_v4 build/v4-contract/deepseek-v4-tiny build/v4-contract/deepseek-v4-tiny/edge_ref_$case.json
+          done
+          mkdir -p build/v4-chat
+          cp -a build/v4-contract/deepseek-v4-tiny build/v4-chat/deepseek-v4-tiny
+          python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/v4-chat/deepseek-v4-tiny --vocab-size 128
+          python3 tests/integration/home_flow_test.py --models-dir build/v4-chat --donor-ram-gb 1.0 --kill-donor
+          SPLIT_REFERENCE=build/v4-contract/deepseek-v4-tiny/edge_ref_short.json SPLIT_MODEL_DIR=build/v4-contract/deepseek-v4-tiny SPLIT_ENGINE=deepseek_v4 SPLIT_MODEL=v4-native SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=10940 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-v4-checkpoint
+          path: lumabri/build/v4-chat/deepseek-v4-tiny/*
+          retention-days: 3
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -331,6 +350,13 @@ jobs:
       - name: Native Qwen3.8 request and execution
         working-directory: lumabri
         run: python3 tests/integration/home_flow_test.py --models-dir build/qwen38-home-models --context 512 --expect-greedy
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-v4-checkpoint
+          path: lumabri/build/v4-home-models/deepseek-v4-tiny
+      - name: Native V4 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/v4-home-models --donor-ram-gb 1.0
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
           python3 ../colibri/c/tools/convert_qwen36.py --model build/qwen36-hf --out build/qwen-int4/qwen36-tiny --ebits 4 --gs 16 --no-readme
           python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/qwen-int8/qwen36-tiny --vocab-size 320
           python3 ../colibri/c/tools/make_edge_tiny_tokenizer.py build/qwen-int4/qwen36-tiny --vocab-size 320
+          python3 tests/integration/planner_tensor_contract_test.py --family qwen36 --model build/qwen-int8/qwen36-tiny
+          python3 tests/integration/planner_tensor_contract_test.py --family qwen36 --model build/qwen-int4/qwen36-tiny
           cc -O2 -fopenmp -pthread ../colibri/c/tests/test_edge_adapters_real.c build/segment-hybrid-colibri/build/segment/libcolibri_segment_edge.a -o build/qwen-edge-oracle -lm
           OMP_NUM_THREADS=2 build/qwen-edge-oracle qwen36 build/qwen-int8/qwen36-tiny build/qwen36-ref.json 3
           python3 tests/integration/home_flow_test.py --models-dir build/qwen-int8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,22 @@ jobs:
           name: tiny-glm53-checkpoint
           path: lumabri/build/glm53-contract/glm53-tiny/*
           retention-days: 3
+      - name: Qwen3.8 contract — DeltaNet, QSA and checked PLE metadata
+        working-directory: lumabri
+        run: |
+          python3 tests/integration/prepare_qwen38_fixture.py --engine ../colibri/c --out build/qwen38-contract/qwen38-tiny
+          python3 tests/integration/planner_tensor_contract_test.py --family qwen38 --model build/qwen38-contract/qwen38-tiny
+          cc -I../colibri/c -O2 -Wall -Wextra -Werror -fopenmp -pthread tests/c/edge_segment_greedy.c build/segment-hybrid-colibri/build/segment/libcolibri_segment_edge.a -o build/qwen38-greedy-oracle -lm
+          cc -I. -I../colibri/c -O2 -Wall -Wextra -Werror -fopenmp -pthread tests/c/test_segment_stream.c lumabri_segment.c lumabri_segment_discovery.c lumabri_sampling.c build/segment-hybrid-colibri/build/segment/libcolibri_segment_edge.a -o build/test-segment-stream -lm
+          build/test-segment-stream
+          OMP_NUM_THREADS=2 build/qwen38-greedy-oracle qwen38 build/qwen38-contract/qwen38-tiny build/qwen38-contract/qwen38-tiny/ref.json
+          python3 tests/integration/home_flow_test.py --models-dir build/qwen38-contract --context 512 --expect-greedy --kill-donor
+          SPLIT_MODEL_DIR=build/qwen38-contract/qwen38-tiny SPLIT_ENGINE=qwen38 SPLIT_MODEL=qwen38-bf16 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=10740 bash tests/integration/segment_split_test.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tiny-qwen38-checkpoint
+          path: lumabri/build/qwen38-contract/qwen38-tiny/*
+          retention-days: 3
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
@@ -306,6 +322,13 @@ jobs:
       - name: Native GLM5.3 request and execution
         working-directory: lumabri
         run: python3 tests/integration/home_flow_test.py --models-dir build/glm53-home-models
+      - uses: actions/download-artifact@v4
+        with:
+          name: tiny-qwen38-checkpoint
+          path: lumabri/build/qwen38-home-models/qwen38-tiny
+      - name: Native Qwen3.8 request and execution
+        working-directory: lumabri
+        run: python3 tests/integration/home_flow_test.py --models-dir build/qwen38-home-models --context 512 --expect-greedy
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ test_residency_report: tests/c/test_residency_report.c lumabri_client.h lumabri_
 test_model_family: tests/c/test_model_family.c lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_model_family.c -o $@
 
-test_planner: tests/c/test_planner.c tests/c/test_planner_qwen36.h lumabri_planner.h lumabri_families.h
+test_planner: tests/c/test_planner.c tests/c/test_planner_qwen36.h tests/c/test_planner_inkling.h lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_planner.c -o $@
 
 test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h lumabri_planner.h lumabri_families.h lumabri_machine.h

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ test_residency_report: tests/c/test_residency_report.c lumabri_client.h lumabri_
 test_model_family: tests/c/test_model_family.c lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_model_family.c -o $@
 
-test_planner: tests/c/test_planner.c tests/c/test_planner_qwen36.h tests/c/test_planner_inkling.h lumabri_planner.h lumabri_families.h
+test_planner: tests/c/test_planner.c $(wildcard tests/c/test_planner_*.h) lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_planner.c -o $@
 
 test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h lumabri_planner.h lumabri_families.h lumabri_machine.h

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,11 @@ SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
 HOME_NET_DEPS = lumabri_home_net.h lumabri_home_discovery.h lumabri_platform.h lumabri_wakeup.h lumabri_runtime_probe.h
 MACHINE_SRC = lumabri_machine.c
 MACHINE_DEPS = lumabri_machine.h $(MACHINE_SRC)
+PLANNER_ADAPTER_DEPS = $(wildcard planner_adapters/*.h)
+
+# Adapter contracts are included transitively by the planner. Rebuild every
+# consumer when one changes, including when a new contract is introduced.
+lumabri test_chat_ui test_planner test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
 
 lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
 		lumabri_inventory.h lumabri_home.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h \
@@ -439,7 +444,7 @@ test_residency_report: tests/c/test_residency_report.c lumabri_client.h lumabri_
 test_model_family: tests/c/test_model_family.c lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_model_family.c -o $@
 
-test_planner: tests/c/test_planner.c lumabri_planner.h lumabri_families.h
+test_planner: tests/c/test_planner.c tests/c/test_planner_qwen36.h lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_planner.c -o $@
 
 test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h lumabri_planner.h lumabri_families.h lumabri_machine.h

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    nodes. Mac deployment/approval is user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
    encoding. OLMoE, DeepSeek V4, converted Qwen3.6, Inkling and float-dense/MXFP4
-   Kimi, float-source GLM, text-only float-source GLM5.3 and BF16/float-source
+   Kimi, float-source GLM, text-only float-source GLM5.3 and BF16/float/block-FP8-expert
    Qwen3.8 enable conservative sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
@@ -118,7 +118,15 @@ not a completed gate.
    A separate byte-tokenizer copy exercises ordinary text through the TUI;
    the upstream special-token oracle fixture is preserved unchanged. Approvals,
    two actual ranges, generation and lost-donor cleanup pass locally.
-   Additional encodings (including Qwen3.8 FP8), vision and large checkpoints
+   Qwen3.8 block-FP8 experts additionally validate partial 128x128 scale
+   geometry and complete sidecars. Conservative admission bounds both native
+   FP8 and optional f32 expansion, including shared and per-slot scales.
+   A real quantized synthetic fixture is compared with a Transformers oracle
+   using the exact reconstructed weights, not the original BF16 model. Both
+   native and expanded paths pass one/two-range token tests; direct TCP split
+   and TUI approval/generation/lost-donor cleanup pass locally. Timing is
+   withheld on the loaded test host. Native macOS checks run in CI.
+   Additional encodings, vision and large checkpoints
    remain untested; gate 2 is not complete merely because all families have
    an initial memory contract.
 3. PR #153: shared conservative resident admission for catalogue, request

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -107,6 +107,17 @@ not a completed gate.
    Unconverted HF experts and GQA geometry are not compatible with the pinned
    runtime and are rejected before offers. Header-only negative fixtures are
    explicitly separate from the real one/two-range token oracle.
+   DeepSeek V4 now validates native FP8 dense/scale tensors, mHC boundaries,
+   packed FP4 expert geometry and the store's same-shard/two-contiguous-bank
+   layout. Large token-to-expert I64 router tables are header-inspected, not
+   read as metadata. Resident allowances distinguish raw expert scales from
+   expanded dense scales, window/compressor/indexer state, snapshot/growth
+   allowance and conservative native workspace. No disk or GPU mode is enabled.
+   Local synthetic short/compressed/long independent oracles pass with one
+   and two ranges and fresh sessions (8/4/4 generated tokens respectively).
+   A separate byte-tokenizer copy exercises ordinary text through the TUI;
+   the upstream special-token oracle fixture is preserved unchanged. Approvals,
+   two actual ranges, generation and lost-donor cleanup pass locally.
    Additional encodings (including Qwen3.8 FP8), vision and large checkpoints
    remain untested; gate 2 is not complete merely because all families have
    an initial memory contract.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -72,6 +72,11 @@ not a completed gate.
    and Edge, int8 expert slots even for packed int4 files, grouped scales,
    per-layer attention/DeltaNet state). Real synthetic int8 and grouped-int4
    fixtures exercise approval, two compute donors, generation and cleanup.
+   Metadata alone is insufficient: the bounded header inspector requires Edge,
+   per-layer dense/attention/DeltaNet tensors, every merged expert and the exact
+   row/group scale count. Source payload sizes, not the potentially stale ebits
+   metadata flag, distinguish int8 from packed int4. Missing or mismatched
+   tensors are refused before any donor allocation.
    Inkling adds header-based retained weights, packed int4/int8 experts, and
    separate full/sliding attention and convolution state; float and int4
    fixtures cover the independent oracle and household path.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -19,7 +19,7 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    Current physical trial has PC source and Mac computation, not two compute
    nodes. Mac deployment/approval is user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
-   encoding. Currently only OLMoE and DeepSeek V4 enable sizing. Require real
+   encoding. OLMoE, DeepSeek V4 and converted Qwen3.6 enable sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
    and placement informed by measured execution costs, not just RAM totals.
@@ -66,7 +66,12 @@ not a completed gate.
 
 1. PR #152 merged: approved layer-allocation view, named execution evidence,
    two-donor checks; physical two-computer oracle and timings still required.
-2. Pending: verified family sizing and checkpoint conformance.
+2. In progress: Qwen3.6 has an explicit CPU resident contract (float32 dense
+   and Edge, int8 expert slots even for packed int4 files, grouped scales,
+   per-layer attention/DeltaNet state). Real synthetic int8 and grouped-int4
+   fixtures exercise approval, two compute donors, generation and cleanup.
+   This does not close gate 2: GLM, GLM5.3, Inkling, Kimi and Qwen3.8 still
+   need their own verified memory contracts. Large checkpoints remain untested.
 3. PR #153: shared conservative resident admission for catalogue, request
    and launch, with a stat-only checkpoint preview and a signed-inventory
    recheck before offers. Edge and Segment budgets are separately MiB-aligned.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    nodes. Mac deployment/approval is user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
    encoding. OLMoE, DeepSeek V4, converted Qwen3.6, Inkling and float-dense/MXFP4
-   Kimi enable conservative sizing. Require real
+   Kimi, float-source GLM and text-only float-source GLM5.3 enable conservative sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
    and placement informed by measured execution costs, not just RAM totals.
@@ -78,8 +78,16 @@ not a completed gate.
    and the full AttnRes boundary width. Prepared U8 dense containers are not
    yet admitted by this contract. Native cache policy may reserve less than
    the upper bound; full warm residency still needs execution evidence.
-   This does not close gate 2: GLM, GLM5.3 and Qwen3.8 still
-   need their own verified memory contracts. Large checkpoints remain untested.
+   Its native 3.7 GB policy floor is included in admission. Standard ARM CI
+   validates low-memory refusal, not two-range Kimi execution; sufficient-RAM
+   native ARM execution remains open. No overcommit override is enabled.
+   GLM float source adds latent MLA/DSA state and separate miss/load workspace;
+   prepared quantized GLM containers remain unverified.
+   GLM5.3 accounts for its engine-wide replicated session state and context-sized
+   workspace. Its stateless Edge context convention is handled by the caller.
+   Packed/vision GLM5.3 and the native pool=1 path remain unverified.
+   This does not close gate 2: Qwen3.8 still needs its own memory contract;
+   additional encodings and large checkpoints remain untested.
 3. PR #153: shared conservative resident admission for catalogue, request
    and launch, with a stat-only checkpoint preview and a signed-inventory
    recheck before offers. Edge and Segment budgets are separately MiB-aligned.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -20,7 +20,8 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    nodes. Mac deployment/approval is user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
    encoding. OLMoE, DeepSeek V4, converted Qwen3.6, Inkling and float-dense/MXFP4
-   Kimi, float-source GLM and text-only float-source GLM5.3 enable conservative sizing. Require real
+   Kimi, float-source GLM, text-only float-source GLM5.3 and BF16/float-source
+   Qwen3.8 enable conservative sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
    and placement informed by measured execution costs, not just RAM totals.
@@ -86,8 +87,24 @@ not a completed gate.
    GLM5.3 accounts for its engine-wide replicated session state and context-sized
    workspace. Its stateless Edge context convention is handled by the caller.
    Packed/vision GLM5.3 and the native pool=1 path remain unverified.
-   This does not close gate 2: Qwen3.8 still needs its own memory contract;
-   additional encodings and large checkpoints remain untested.
+   Qwen3.8 adds DeltaNet/QSA state, hyper-connection boundaries, checked I64
+   PLE layout metadata and a full source-cache allowance for its row-read PLE
+   tables. This budget is not a claim of warm or pinned residency and does
+   not enable a smaller disk working set. Its greedy-only Edge is tested
+   through the public selection ABI, not an assumed LOGITS capability.
+   Segment now reports that capability before READY, and Hosted forwards an
+   optional sampling-capability word. The client explicitly displays greedy
+   decoding and sends temperature zero; explicit stochastic Segment CLI
+   requests still fail on backends without logits. Upgrade host and client
+   together: an older client rejects the extended greedy-only greeting.
+   Real BF16 fixture: one/two-range independent greedy oracle (8 tokens,
+   repeated with fresh sessions), direct TCP split equality, TUI approvals,
+   generation and lost-donor cleanup pass locally. Streaming defers incomplete
+   decoder prefixes but requires final decoding to succeed; it never rewrites
+   already emitted bytes or reports a permanent decoder error as success.
+   Additional encodings (including Qwen3.8 FP8), vision and large checkpoints
+   remain untested; gate 2 is not complete merely because all families have
+   an initial memory contract.
 3. PR #153: shared conservative resident admission for catalogue, request
    and launch, with a stat-only checkpoint preview and a signed-inventory
    recheck before offers. Edge and Segment budgets are separately MiB-aligned.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -102,6 +102,11 @@ not a completed gate.
    generation and lost-donor cleanup pass locally. Streaming defers incomplete
    decoder prefixes but requires final decoding to succeed; it never rewrites
    already emitted bytes or reports a permanent decoder error as success.
+   The historical OLMoE formula is replaced with validated merged-int8 expert
+   payloads and row scales, f32-expanded dense/Edge weights and full-MHA state.
+   Unconverted HF experts and GQA geometry are not compatible with the pinned
+   runtime and are rejected before offers. Header-only negative fixtures are
+   explicitly separate from the real one/two-range token oracle.
    Additional encodings (including Qwen3.8 FP8), vision and large checkpoints
    remain untested; gate 2 is not complete merely because all families have
    an initial memory contract.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -19,7 +19,8 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    Current physical trial has PC source and Mac computation, not two compute
    nodes. Mac deployment/approval is user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
-   encoding. OLMoE, DeepSeek V4, converted Qwen3.6 and Inkling enable sizing. Require real
+   encoding. OLMoE, DeepSeek V4, converted Qwen3.6, Inkling and float-dense/MXFP4
+   Kimi enable conservative sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
    and placement informed by measured execution costs, not just RAM totals.
@@ -73,7 +74,11 @@ not a completed gate.
    Inkling adds header-based retained weights, packed int4/int8 experts, and
    separate full/sliding attention and convolution state; float and int4
    fixtures cover the independent oracle and household path.
-   This does not close gate 2: GLM, GLM5.3, Kimi and Qwen3.8 still
+   Kimi adds validated MXFP4 banks, fixed KDA and context-sized MLA/DSA state,
+   and the full AttnRes boundary width. Prepared U8 dense containers are not
+   yet admitted by this contract. Native cache policy may reserve less than
+   the upper bound; full warm residency still needs execution evidence.
+   This does not close gate 2: GLM, GLM5.3 and Qwen3.8 still
    need their own verified memory contracts. Large checkpoints remain untested.
 3. PR #153: shared conservative resident admission for catalogue, request
    and launch, with a stat-only checkpoint preview and a signed-inventory

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -19,7 +19,7 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    Current physical trial has PC source and Mac computation, not two compute
    nodes. Mac deployment/approval is user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
-   encoding. OLMoE, DeepSeek V4 and converted Qwen3.6 enable sizing. Require real
+   encoding. OLMoE, DeepSeek V4, converted Qwen3.6 and Inkling enable sizing. Require real
    checkpoint/adapter conformance before promoting support.
 3. Consistent planner/runtime reservations, explicit local-compute consent,
    and placement informed by measured execution costs, not just RAM totals.
@@ -70,7 +70,10 @@ not a completed gate.
    and Edge, int8 expert slots even for packed int4 files, grouped scales,
    per-layer attention/DeltaNet state). Real synthetic int8 and grouped-int4
    fixtures exercise approval, two compute donors, generation and cleanup.
-   This does not close gate 2: GLM, GLM5.3, Inkling, Kimi and Qwen3.8 still
+   Inkling adds header-based retained weights, packed int4/int8 experts, and
+   separate full/sliding attention and convolution state; float and int4
+   fixtures cover the independent oracle and household path.
+   This does not close gate 2: GLM, GLM5.3, Kimi and Qwen3.8 still
    need their own verified memory contracts. Large checkpoints remain untested.
 3. PR #153: shared conservative resident admission for catalogue, request
    and launch, with a stat-only checkpoint preview and a signed-inventory

--- a/lumabri.c
+++ b/lumabri.c
@@ -5032,7 +5032,14 @@ static int catalog_inventory(LmbTuiState *st) {
 
 static int catalog_state_refresh(LmbTuiState *st, void *unused) {
     (void)unused;
-    CatalogEntry found[LMB_TUI_MAX_MODELS];
+    /* Per-layer contracts make each entry larger. Do not place the entire
+     * 64-model catalogue on a small native/thread stack. */
+    CatalogEntry *found = calloc(LMB_TUI_MAX_MODELS, sizeof *found);
+    if (!found) {
+        st->nmodels = 0;
+        st->inventory_ok = 0;
+        return -1;
+    }
     int n = catalog_scan(st->root, found, LMB_TUI_MAX_MODELS);
     st->nmodels = 0;
     (void)catalog_inventory(st);
@@ -5072,6 +5079,7 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
         m->calibration = NULL;
         st->nmodels++;
     }
+    free(found);
     return 0;
 }
 

--- a/lumabri.c
+++ b/lumabri.c
@@ -2401,6 +2401,7 @@ typedef struct {
     Proto proto;
     EngKind kind;
     int segment;
+    int greedy_only; /* actual Edge capability, not a model-name assumption */
     EngineTransport transport;
 } Engine;
 
@@ -2468,6 +2469,7 @@ static char *read_until_prompt(int fd) {
 /* Wait for readiness in either dialect, and remember which one it was.
  * Returns 0, or -1 if the child died first. */
 static int engine_wait_ready(Engine *e) {
+    e->greedy_only = 0;
     size_t cap = 8192, len = 0;
     char *buf = malloc(cap);
     if (!buf) return -1;
@@ -2482,8 +2484,10 @@ static int engine_wait_ready(Engine *e) {
         if (r <= 0) { free(buf); return -1; }
         len += (size_t)r;
         buf[len] = 0;
-        if (memmem(buf, len, FRAME_READY, strlen(FRAME_READY)))
-            { e->proto = PROTO_FRAMED; free(buf); return 0; }
+        if (memmem(buf, len, FRAME_READY, strlen(FRAME_READY))) {
+            e->greedy_only = strstr(buf, "\nLUMABRI_SAMPLING GREEDY\n") != NULL;
+            e->proto = PROTO_FRAMED; free(buf); return 0;
+        }
         if ((len >= 3 && !memcmp(buf + len - 3, "\n> ", 3)) ||
             (len == 2 && !memcmp(buf, "> ", 2)))
             { e->proto = PROTO_LINE; free(buf); return 0; }
@@ -2821,8 +2825,8 @@ static int submit_serve2(Engine *e, const char *history, const char *prompt, int
     if (serve2_prefix(&c, e->kind) || cap_str(&c, history) ||
         serve2_turn(&c, e->kind, history[0] == 0, prompt, NULL)) { free(c.p); return -1; }
     char hdr[128];
-    int hn = snprintf(hdr, sizeof hdr, "SUBMIT %u 0 %zu %d 0.7 0.95\n",
-                      ++id, c.len, max_new < 1 ? 1 : max_new);
+    int hn = snprintf(hdr, sizeof hdr, "SUBMIT %u 0 %zu %d %.1f 0.95\n",
+                      ++id, c.len, max_new < 1 ? 1 : max_new, e->greedy_only ? 0.0 : 0.7);
     int ok = hn >= 0 && (size_t)hn < sizeof hdr &&
              !engine_write_full(e->to, hdr, (size_t)hn) &&
              !engine_write_full(e->to, c.p, c.len) &&
@@ -3220,6 +3224,9 @@ static int host_greet(int fd, const HostState *h, int busy) {
     lmb_buf_u32(&b, h->max_new);
     lmb_buf_u32(&b, h->max_frame);
     lmb_buf_u32(&b, 2);       /* SUBMIT/DATA/DONE, independent of model family */
+    /* Optional capability word after codec. Older clients reject the extra
+     * field rather than silently request unsupported stochastic sampling. */
+    if (h->engine->greedy_only) lmb_buf_u32(&b, 1);
     int rc = lmb_send(fd, LMB_HOST_HELLO_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
@@ -3573,6 +3580,11 @@ static int host_connect(const char *addr, const char *model_type, const char *ex
         fprintf(stderr, "[lumabri] unsupported hosted codec\n");
         lmb_msg_free(&m); lmb_close(fd); return -1;
     }
+    uint32_t sampling_flags = 0;
+    if (c.off < c.len && (lmb_cur_u32(&c, &sampling_flags) || sampling_flags > 1)) {
+        fprintf(stderr, "[lumabri] unsupported host sampling capabilities\n");
+        lmb_msg_free(&m); lmb_close(fd); return -1;
+    }
     if (c.off != c.len || m.pay_len) { lmb_msg_free(&m); lmb_close(fd); return -1; }
     lmb_msg_free(&m);
     if (model_type && model_type[0] && strcmp(model_type, mtype)) {
@@ -3610,11 +3622,14 @@ static int host_connect(const char *addr, const char *model_type, const char *ex
     pthread_detach(thread);
     e->to = e->from = pair[0];
     e->kind = kind_id;
+    e->greedy_only = (int)sampling_flags;
     e->proto = codec == 2 || kind_is_serve2(e->kind) ? PROTO_SERVE2 : PROTO_FRAMED;
     g_signal_engine_fd = (sig_atomic_t)pair[0];
 
     printf("  %shost %s · %s · %s%s\n", C_DIM, addr, mtype,
            backend[0] ? backend : "cpu", C_R);
+    if (e->greedy_only)
+        printf("  greedy decoding · this backend does not expose sampling logits\n");
     /* Speed is shown only when the host has measured one. "unknown" is the
      * honest state for a host nobody has run yet, and a CPU host is slow
      * rather than broken — saying so before the first prompt is the whole
@@ -4334,6 +4349,8 @@ static int model_boot(const char *tracker, const char *model, const char *shim,
                            "/storage /reset /quit%s\n",
                            C_GRN, model, nowd() - segment_started, C_R,
                            C_DIM, C_R);
+                    if (e->greedy_only)
+                        printf("  greedy decoding · this backend does not expose sampling logits\n");
                     return 0;
                 }
                 engine_stop(e);

--- a/lumabri.c
+++ b/lumabri.c
@@ -5108,12 +5108,12 @@ static void catalog_row(const LmbTuiModel *m) {
     const char *mark = !ok || plan.state == LMB_PLAN_UNRUNNABLE ? "x"
                      : plan.state == LMB_PLAN_DISK ? "!" : "+";
     char detail[96] = "";
-    if (!m->shape.sizing_verified)
-        snprintf(detail, sizeof detail, "adapter sizing unavailable");
-    else if (!m->checkpoint_inventory_ok)
+    if (!m->checkpoint_inventory_ok)
         snprintf(detail, sizeof detail, "checkpoint inventory unavailable");
     else if (!m->weights_present)
         snprintf(detail, sizeof detail, "checkpoint weights missing");
+    else if (!m->shape.sizing_verified)
+        snprintf(detail, sizeof detail, "adapter sizing unavailable");
     else if (ok && plan.state == LMB_PLAN_UNRUNNABLE && plan.missing_bytes)
         snprintf(detail, sizeof detail, "%.0f GB short (~%u more machine%s)",
                  (double)plan.missing_bytes / 1e9, plan.missing_nodes,

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -73,6 +73,7 @@ typedef struct {
     uint64_t edge_resident_bytes;
     uint64_t edge_scratch_fixed_bytes;
     uint64_t segment_fixed_bytes;
+    uint64_t session_fixed_bytes, session_token_bytes; /* engine-wide session allocations */
     uint64_t scratch_fixed_bytes, scratch_token_bytes;
     LmbLayerMemory memory[LMB_PLAN_LAYER_MAX];
 } LmbModelShape;
@@ -161,6 +162,8 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_segment(const LmbModelShape *m,
         if (m->memory_contract != 1 || m->layers > LMB_PLAN_LAYER_MAX ||
             !m->max_context || ctx > m->max_context) return c;
         c.resident_bytes = m->segment_fixed_bytes;
+        c.state_bytes = lmb_size_add(m->session_fixed_bytes,
+                                    lmb_size_mul(m->session_token_bytes, ctx));
         for (uint32_t i = begin; i < end; i++) {
             const LmbLayerMemory *l = &m->memory[i];
             uint32_t rows = l->state_context_limit && ctx > l->state_context_limit
@@ -332,6 +335,8 @@ static int LMB_UNUSED lmb_json_string(const char *object, const char *key,
 #include "planner_adapters/qwen36.h"
 #include "planner_adapters/inkling.h"
 #include "planner_adapters/kimi.h"
+#include "planner_adapters/glm.h"
+#include "planner_adapters/glm53.h"
 
 static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                                             LmbModelShape *out) {
@@ -401,6 +406,10 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
         out->sizing_verified = !lmb_inkling_memory(model_dir, cfg, out);
     if (!strcmp(fam->segment_id, "kimi"))
         out->sizing_verified = !lmb_kimi_memory(model_dir, cfg, out);
+    if (!strcmp(fam->segment_id, "glm"))
+        out->sizing_verified = !lmb_glm_memory(model_dir, cfg, out);
+    if (!strcmp(fam->segment_id, "glm53"))
+        out->sizing_verified = !lmb_glm53_memory(model_dir, buf, cfg, out);
     return out->layers && out->hidden ? 0 : -1;
 }
 

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -47,6 +47,7 @@ typedef struct {
     uint64_t resident_bytes;
     uint64_t state_fixed_bytes;
     uint64_t state_token_bytes;
+    uint32_t state_context_limit; /* zero: full context; otherwise a sliding ring */
 } LmbLayerMemory;
 
 /* How a family's weights are laid out, in the terms the estimates need. All
@@ -160,9 +161,11 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_segment(const LmbModelShape *m,
         c.resident_bytes = m->segment_fixed_bytes;
         for (uint32_t i = begin; i < end; i++) {
             const LmbLayerMemory *l = &m->memory[i];
+            uint32_t rows = l->state_context_limit && ctx > l->state_context_limit
+                ? l->state_context_limit : ctx;
             c.resident_bytes = lmb_size_add(c.resident_bytes, l->resident_bytes);
             c.state_bytes = lmb_size_add(c.state_bytes, lmb_size_add(l->state_fixed_bytes,
-                lmb_size_mul(l->state_token_bytes, ctx)));
+                lmb_size_mul(l->state_token_bytes, rows)));
         }
         c.state_bytes = lmb_size_mul(c.state_bytes, sessions ? sessions : 1);
         c.scratch_bytes = lmb_size_add(m->scratch_fixed_bytes,
@@ -324,6 +327,7 @@ static int LMB_UNUSED lmb_json_string(const char *object, const char *key,
 }
 
 #include "planner_adapters/qwen36.h"
+#include "planner_adapters/inkling.h"
 
 static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                                             LmbModelShape *out) {
@@ -389,6 +393,8 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                            !strcmp(fam->segment_id, "deepseek_v4");
     if (!strcmp(fam->segment_id, "qwen36"))
         out->sizing_verified = !lmb_qwen36_memory(model_dir, out);
+    if (!strcmp(fam->segment_id, "inkling"))
+        out->sizing_verified = !lmb_inkling_memory(model_dir, cfg, out);
     return out->layers && out->hidden ? 0 : -1;
 }
 

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -339,13 +339,18 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
     memset(out, 0, sizeof *out);
     if (!model_dir || !model_dir[0]) return -1;
     char path[1024];
-    snprintf(path, sizeof path, "%s/config.json", model_dir);
+    int path_len=snprintf(path, sizeof path, "%s/config.json", model_dir);
+    if(path_len<0 || (size_t)path_len>=sizeof path) return -1;
     FILE *f = fopen(path, "rb");
     if (!f) return -1;
     char buf[65536];
     size_t n = fread(buf, 1, sizeof buf - 1, f);
+    int invalid=ferror(f) || (n==sizeof buf-1 && fgetc(f)!=EOF);
     fclose(f);
+    if(invalid || memchr(buf,0,n)) return -1;
     buf[n] = 0;
+    const char *end=lmb_plan_object_end(lmb_plan_space(buf));
+    if(!end || *lmb_plan_space(end)) return -1;
 
     if (lmb_json_string(buf, "model_type", out->model_type,
                         sizeof out->model_type)) return -1;
@@ -389,11 +394,8 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
      * in the working set and make disk mode indistinguishable from resident. */
     if (out->experts && !out->moe_intermediate)
         out->moe_intermediate = out->intermediate;
-    /* The historical formula is verified only for the two fixtures against
-     * which it was written. Explicit per-adapter contracts follow below.
-     * Other adapters remain visible through the family table,
-     * but cannot produce a fit decision until their adapter-specific sizing
-     * callback lands. This is preferable to a confident under-allocation. */
+    /* A registered family is not proof that this checkpoint encoding is
+     * compatible. Only its explicit inspector may enable a fit decision. */
     out->sizing_verified = !lmb_describe_memory(fam->segment_id, model_dir, buf, cfg, out);
     return out->layers && out->hidden ? 0 : -1;
 }

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -41,6 +41,14 @@
 #endif
 #include "lumabri_families.h"
 
+#define LMB_PLAN_LAYER_MAX 512
+
+typedef struct {
+    uint64_t resident_bytes;
+    uint64_t state_fixed_bytes;
+    uint64_t state_token_bytes;
+} LmbLayerMemory;
+
 /* How a family's weights are laid out, in the terms the estimates need. All
  * of it comes out of config.json; a field the checkpoint does not carry is
  * zero, and an estimate that needs a zero field says it cannot answer. */
@@ -58,6 +66,12 @@ typedef struct {
     uint32_t bits_per_weight;   /* 16 bf16, 8, 4 for fp4 checkpoints */
     int disk_streaming;         /* the adapter has DEMONSTRATED disk mode */
     int sizing_verified;        /* adapter-specific arithmetic was verified */
+    uint32_t memory_contract;   /* 0: historical estimate, 1: explicit layer map */
+    uint32_t max_context;
+    uint64_t edge_resident_bytes;
+    uint64_t segment_fixed_bytes;
+    uint64_t scratch_fixed_bytes, scratch_token_bytes;
+    LmbLayerMemory memory[LMB_PLAN_LAYER_MAX];
 } LmbModelShape;
 
 typedef struct {
@@ -139,6 +153,27 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_segment(const LmbModelShape *m,
         end > m->layers || !m->hidden) return c;
     uint32_t n = end - begin;
 
+    if (m->memory_contract) {
+        uint32_t ctx = context ? context : 4096;
+        if (m->memory_contract != 1 || m->layers > LMB_PLAN_LAYER_MAX ||
+            !m->max_context || ctx > m->max_context) return c;
+        c.resident_bytes = m->segment_fixed_bytes;
+        for (uint32_t i = begin; i < end; i++) {
+            const LmbLayerMemory *l = &m->memory[i];
+            c.resident_bytes = lmb_size_add(c.resident_bytes, l->resident_bytes);
+            c.state_bytes = lmb_size_add(c.state_bytes, lmb_size_add(l->state_fixed_bytes,
+                lmb_size_mul(l->state_token_bytes, ctx)));
+        }
+        c.state_bytes = lmb_size_mul(c.state_bytes, sessions ? sessions : 1);
+        c.scratch_bytes = lmb_size_add(m->scratch_fixed_bytes,
+            lmb_size_mul(m->scratch_token_bytes, ctx));
+        /* No disk capability is inferred from a resident contract. */
+        c.working_set_bytes = c.resident_bytes;
+        c.ok = lmb_size_add(c.resident_bytes, lmb_size_add(c.state_bytes,
+            c.scratch_bytes)) != UINT64_MAX;
+        return c;
+    }
+
     uint64_t dense = lmb_size_mul(lmb_dense_layer_bytes(m), n);
     uint64_t expert = lmb_expert_bytes_of(m);
     uint64_t all_experts = lmb_size_mul(lmb_size_mul(expert, m->experts), n);
@@ -169,6 +204,17 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_edge(const LmbModelShape *m,
     LmbRangeCost c;
     memset(&c, 0, sizeof c);
     if (!m->sizing_verified || !m->vocab || !m->hidden) return c;
+    if (m->memory_contract) {
+        uint32_t ctx = context ? context : 4096;
+        if (m->memory_contract != 1 || !m->max_context || ctx > m->max_context) return c;
+        c.resident_bytes = c.working_set_bytes = m->edge_resident_bytes;
+        c.state_bytes = lmb_size_mul(lmb_size_mul((uint64_t)ctx * m->hidden, 4),
+                                     sessions ? sessions : 1);
+        c.scratch_bytes = lmb_size_mul(m->vocab, 16);
+        c.ok = lmb_size_add(c.resident_bytes, lmb_size_add(c.state_bytes,
+            c.scratch_bytes)) != UINT64_MAX;
+        return c;
+    }
     c.resident_bytes = c.working_set_bytes = lmb_edge_bytes(m);
     c.state_bytes = lmb_size_mul(lmb_size_mul((uint64_t)(context ? context : 4096) *
                     m->hidden, 4u), sessions ? sessions : 1);
@@ -277,6 +323,8 @@ static int LMB_UNUSED lmb_json_string(const char *object, const char *key,
     return 0;
 }
 
+#include "planner_adapters/qwen36.h"
+
 static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                                             LmbModelShape *out) {
     memset(out, 0, sizeof *out);
@@ -332,12 +380,15 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
      * in the working set and make disk mode indistinguishable from resident. */
     if (out->experts && !out->moe_intermediate)
         out->moe_intermediate = out->intermediate;
-    /* The current formula is verified only for the two fixtures against which
-     * it was written. Other adapters remain visible through the family table,
+    /* The historical formula is verified only for the two fixtures against
+     * which it was written. Explicit per-adapter contracts follow below.
+     * Other adapters remain visible through the family table,
      * but cannot produce a fit decision until their adapter-specific sizing
      * callback lands. This is preferable to a confident under-allocation. */
     out->sizing_verified = !strcmp(fam->segment_id, "olmoe") ||
                            !strcmp(fam->segment_id, "deepseek_v4");
+    if (!strcmp(fam->segment_id, "qwen36"))
+        out->sizing_verified = !lmb_qwen36_memory(model_dir, out);
     return out->layers && out->hidden ? 0 : -1;
 }
 

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -332,11 +332,7 @@ static int LMB_UNUSED lmb_json_string(const char *object, const char *key,
     return 0;
 }
 
-#include "planner_adapters/qwen36.h"
-#include "planner_adapters/inkling.h"
-#include "planner_adapters/kimi.h"
-#include "planner_adapters/glm.h"
-#include "planner_adapters/glm53.h"
+#include "planner_adapters/registry.h"
 
 static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                                             LmbModelShape *out) {
@@ -398,18 +394,7 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
      * Other adapters remain visible through the family table,
      * but cannot produce a fit decision until their adapter-specific sizing
      * callback lands. This is preferable to a confident under-allocation. */
-    out->sizing_verified = !strcmp(fam->segment_id, "olmoe") ||
-                           !strcmp(fam->segment_id, "deepseek_v4");
-    if (!strcmp(fam->segment_id, "qwen36"))
-        out->sizing_verified = !lmb_qwen36_memory(model_dir, out);
-    if (!strcmp(fam->segment_id, "inkling"))
-        out->sizing_verified = !lmb_inkling_memory(model_dir, cfg, out);
-    if (!strcmp(fam->segment_id, "kimi"))
-        out->sizing_verified = !lmb_kimi_memory(model_dir, cfg, out);
-    if (!strcmp(fam->segment_id, "glm"))
-        out->sizing_verified = !lmb_glm_memory(model_dir, cfg, out);
-    if (!strcmp(fam->segment_id, "glm53"))
-        out->sizing_verified = !lmb_glm53_memory(model_dir, buf, cfg, out);
+    out->sizing_verified = !lmb_describe_memory(fam->segment_id, model_dir, buf, cfg, out);
     return out->layers && out->hidden ? 0 : -1;
 }
 

--- a/lumabri_planner.h
+++ b/lumabri_planner.h
@@ -69,7 +69,9 @@ typedef struct {
     int sizing_verified;        /* adapter-specific arithmetic was verified */
     uint32_t memory_contract;   /* 0: historical estimate, 1: explicit layer map */
     uint32_t max_context;
+    uint32_t boundary_width;    /* zero: hidden; otherwise the actual Edge/Segment state width */
     uint64_t edge_resident_bytes;
+    uint64_t edge_scratch_fixed_bytes;
     uint64_t segment_fixed_bytes;
     uint64_t scratch_fixed_bytes, scratch_token_bytes;
     LmbLayerMemory memory[LMB_PLAN_LAYER_MAX];
@@ -211,9 +213,10 @@ static LmbRangeCost LMB_UNUSED lmb_estimate_edge(const LmbModelShape *m,
         uint32_t ctx = context ? context : 4096;
         if (m->memory_contract != 1 || !m->max_context || ctx > m->max_context) return c;
         c.resident_bytes = c.working_set_bytes = m->edge_resident_bytes;
-        c.state_bytes = lmb_size_mul(lmb_size_mul((uint64_t)ctx * m->hidden, 4),
+        uint32_t width = m->boundary_width ? m->boundary_width : m->hidden;
+        c.state_bytes = lmb_size_mul(lmb_size_mul((uint64_t)ctx * width, 4),
                                      sessions ? sessions : 1);
-        c.scratch_bytes = lmb_size_mul(m->vocab, 16);
+        c.scratch_bytes = lmb_size_add(m->edge_scratch_fixed_bytes, lmb_size_mul(m->vocab, 16));
         c.ok = lmb_size_add(c.resident_bytes, lmb_size_add(c.state_bytes,
             c.scratch_bytes)) != UINT64_MAX;
         return c;
@@ -328,6 +331,7 @@ static int LMB_UNUSED lmb_json_string(const char *object, const char *key,
 
 #include "planner_adapters/qwen36.h"
 #include "planner_adapters/inkling.h"
+#include "planner_adapters/kimi.h"
 
 static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
                                             LmbModelShape *out) {
@@ -395,6 +399,8 @@ static LMB_UNUSED int lmb_shape_from_config(const char *model_dir,
         out->sizing_verified = !lmb_qwen36_memory(model_dir, out);
     if (!strcmp(fam->segment_id, "inkling"))
         out->sizing_verified = !lmb_inkling_memory(model_dir, cfg, out);
+    if (!strcmp(fam->segment_id, "kimi"))
+        out->sizing_verified = !lmb_kimi_memory(model_dir, cfg, out);
     return out->layers && out->hidden ? 0 : -1;
 }
 

--- a/planner_adapters/README.md
+++ b/planner_adapters/README.md
@@ -1,0 +1,34 @@
+# Adapter memory contracts
+
+These are Lumabri-side descriptions, not changes to Colibri. They read small
+checkpoint metadata before donor approval; they do not initialize an engine.
+The implementation under test is pinned by CI to Colibri
+`12a5c464b5c1f8292d578c62458706bc32d6ac95`.
+
+## Qwen3.6 converted CPU checkpoints
+
+`qwen36_meta.json` is authoritative for projection dimensions and layer kinds.
+The contract accounts separately for:
+
+- float32 dense matrices, norms and shared experts;
+- all routed expert slots, including float32 group scales; packed int4 source
+  weights expand to int8 in the CPU cache, so file size is not the RAM size;
+- fixed DeltaNet recurrence/convolution state versus context-sized attention KV;
+- float32 embedding, output head and final norm on Edge;
+- per-engine structures and conservative bounded prefill/load workspace.
+
+Scratch assumes at most 128 rows per engine request and 256 OpenMP threads,
+the respective pinned adapter and Lumabri household limits. The process-level
+reservation guard remains in force. Session state is multiplied by session
+count; engine weights and workspace are shared under the serialized run gate.
+
+Tests use synthetic converted int8 and grouped-int4 checkpoints. Linux checks
+the int8 output against an independent PyTorch oracle; both encodings exercise
+the complete household approval/execution path. Grouped int4 also exercises
+split-token equivalence and lost-donor cleanup. macOS CI runs the int4 household
+path on Intel/Apple Silicon with and without OpenMP. These are not large-model
+performance results, and do not certify GPU or disk execution.
+
+Other families must supply their own retained-weight and state contracts.
+Do not promote them by changing `sizing_verified` alone, or reuse ordinary GQA
+KV arithmetic for recurrent/latent/hyper-connection architectures.

--- a/planner_adapters/README.md
+++ b/planner_adapters/README.md
@@ -8,6 +8,10 @@ The implementation under test is pinned by CI to Colibri
 ## Qwen3.6 converted CPU checkpoints
 
 `qwen36_meta.json` is authoritative for projection dimensions and layer kinds.
+It is not sufficient by itself: a bounded header inventory must also find every
+required dense/DeltaNet/attention tensor, both Edge boundaries, all merged
+experts and their exact row/group scales. The actual byte count distinguishes
+int4 from int8 even when the converter's `ebits` label is stale.
 The contract accounts separately for:
 
 - float32 dense matrices, norms and shared experts;
@@ -128,6 +132,56 @@ The tiny fixture has four independent Transformers continuation tokens.
 Whole/split and household execution are separate tests in Linux and native
 macOS CI; they do not prove full-size memory or performance.
 
-Other families must supply their own retained-weight and state contracts.
-Do not promote them by changing `sizing_verified` alone, or reuse ordinary GQA
-KV arithmetic for recurrent/latent/hyper-connection architectures.
+## Qwen3.8 text-only checkpoints
+
+The contract accepts float/BF16/F16 dense tensors and float or block-E4M3
+experts. It validates the hyper-connection boundary width, DeltaNet recurrence,
+QSA context state and the PLE table's I64 layout metadata. PLE row reads receive
+a whole-source cache allowance; this does not claim that pages are warm/pinned.
+FP8 experts require correctly shaped 128x128 scale sidecars, including partial
+blocks. Admission conservatively covers optional f32 expansion and coexistence
+of a compact shared scale bank with per-slot scales. Vision is not admitted.
+
+The greedy-only Edge capability is used through its actual public ABI and
+propagated to the client, which sends temperature zero. Tests compare BF16 and
+real FP8 fixtures with independent Transformers greedy tokens on one/two ranges
+and fresh sessions. The FP8 oracle uses reconstructed quantized weights, never
+the unquantized original. Native FP8 and expanded-f32 execution are tested
+separately. TCP split and household approval/generation/cleanup are additional
+tests, not substitutes for numerical comparison. Native macOS CI receives the
+same generated fixtures.
+
+## OLMoE merged-int8 CPU checkpoints
+
+The native runtime consumes merged int8 experts with row scales, not arbitrary
+unconverted HF expert matrices. Dense and Edge weights expand to f32; full-MHA
+state grows with context. GQA geometry is rejected because this pinned adapter
+does not implement that layout. Header-only sparse fixtures test admission
+errors and must never be presented as model execution. Independent real-model
+token tests and complete household tests remain separate.
+
+## DeepSeek V4 native CPU checkpoints
+
+FP8 dense weights and exponent scales expand to f32. Routed FP4 experts keep
+their encoded scales; every expert's three weight tensors and three scale
+tensors must form the two contiguous ranges in one shard expected by the
+native store. Token-to-expert I64 tables are header-inspected without loading
+large payloads as metadata. Boundary width includes mHC streams, not only the
+hidden dimension.
+
+State distinguishes the attention window, compressor/overlap state, growing
+compressed/indexer caches and snapshot/reallocation allowance. Scratch includes
+the native workspace floor and conservative loading/prefill temporaries. These
+resident allowances do not enable disk mode. Short/compressed/long independent
+oracles cover one/two ranges and fresh sessions. The upstream special-token
+math fixture is preserved; ordinary text tests use a separate tokenizer copy.
+
+## Support boundary
+
+Every registered family now has an initial contract, not every checkpoint
+encoding or full-size model a certification. New encodings must supply their
+own validated retained-weight and state descriptions. Do not promote them by
+changing `sizing_verified` alone, or reuse ordinary GQA KV arithmetic for
+recurrent/latent/hyper-connection architectures. All current contracts remain
+CPU/resident-only. GPU and smaller disk working sets need actual upstream
+capability and corresponding execution evidence.

--- a/planner_adapters/README.md
+++ b/planner_adapters/README.md
@@ -53,6 +53,28 @@ retags its synthetic `inkling_text` export as the pinned registry's `inkling`;
 this is not a new runtime alias or a claim about arbitrary exports. The tests
 do not certify large checkpoints or GPU performance.
 
+## Kimi CPU checkpoints with float dense source and MXFP4 experts
+
+The initial contract validates the complete MXFP4 expert tensor bank (packed
+nibbles and byte exponent scales), including native per-slot alignment padding.
+Dense tensors reserve a conservative float32 upper bound plus scales, covering
+the native load-time quantization profiles; prepared U8 dense containers remain
+unverified rather than being mistaken for float tensors. Embedding row reads
+are conservatively covered by a whole-boundary reservation, not disk-mode admission.
+
+KDA recurrence and convolution state are fixed per session. MLA latent/rotary
+and optional DSA index caches grow with context. Edge/Segment exchange AttnRes
+state with width `hidden * (1 + ceil(layers / block_size))`, not just `hidden`;
+both boundary buffers and loading workspace are reserved. Expert capacity is
+an upper bound: native `K3_EXPERT_GB`/RAM policy can choose a smaller cache, so
+this contract does not certify that every admitted weight was warmed into RAM.
+
+The numpy-generated tiny fixture retains native MXFP4 experts. Its eight-token
+independent oracle comes from upstream's hash-pinned Moonshot reference, in the
+explicit exact numeric profile. Linux also checks whole/split equivalence and
+the household flow, including cleanup under the default numeric profile.
+macOS Intel/ARM CI runs household execution with and without OpenMP.
+
 Other families must supply their own retained-weight and state contracts.
 Do not promote them by changing `sizing_verified` alone, or reuse ordinary GQA
 KV arithmetic for recurrent/latent/hyper-connection architectures.

--- a/planner_adapters/README.md
+++ b/planner_adapters/README.md
@@ -53,6 +53,12 @@ retags its synthetic `inkling_text` export as the pinned registry's `inkling`;
 this is not a new runtime alias or a claim about arbitrary exports. The tests
 do not certify large checkpoints or GPU performance.
 
+Fixture correction: the first version of the int4 test passed HF-named tensors
+straight to a converter that quantizes TML-named tensors only. That output was
+still float; those earlier runs are not packed-format evidence. The generator
+now uses the upstream reverse-mapping helper and checks U8 payload and F32 scale
+byte counts for every routed tensor before any engine test can run.
+
 ## Kimi CPU checkpoints with float dense source and MXFP4 experts
 
 The initial contract validates the complete MXFP4 expert tensor bank (packed
@@ -69,11 +75,58 @@ both boundary buffers and loading workspace are reserved. Expert capacity is
 an upper bound: native `K3_EXPERT_GB`/RAM policy can choose a smaller cache, so
 this contract does not certify that every admitted weight was warmed into RAM.
 
+Admission also reserves the pinned initializer's unconditional 3.7 GB policy
+floor, plus its whole-model KV projection. The policy is not measured tiny-model
+RSS, but ignoring it produces plans the native engine refuses to open. We do not
+enable `COLI_RAM_OVERCOMMIT` to bypass it. The standard macOS ARM CI runner tests
+insufficient-memory refusal; two-range Kimi execution needs a larger machine.
+
 The numpy-generated tiny fixture retains native MXFP4 experts. Its eight-token
 independent oracle comes from upstream's hash-pinned Moonshot reference, in the
 explicit exact numeric profile. Linux also checks whole/split equivalence and
 the household flow, including cleanup under the default numeric profile.
-macOS Intel/ARM CI runs household execution with and without OpenMP.
+macOS Intel CI runs household execution with and without OpenMP. Native ARM
+Kimi execution remains unverified on a sufficient-memory machine.
+
+## GLM CPU float-source checkpoints
+
+The initial contract accepts separate float/BF16/F16 expert matrices and dense
+weights. It reserves float32 plus a conservative scale/padding bound, latent MLA
+and rotary state, optional per-layer DSA state, and both loader temporaries and
+the native `ws[64]` miss slabs. Edge load quantization gets a separate temporary.
+Prepared `.qs` containers are not silently treated as ordinary tensors: their
+format stamps and mixed quantization layouts still need dedicated validation.
+This initial bound requires all matrix contraction dimensions to be at least
+32; smaller synthetic geometries need separate packed-row padding accounting.
+
+An incomplete DSA bank is rejected: Edge detects indexer support globally,
+whereas each Segment detects it for its interval. Admitting only part of that
+bank would give incompatible numerical classes after splitting.
+
+The generated float fixture matches 20 independent PyTorch oracle tokens with
+native `GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16`. Linux checks whole/split
+equivalence and approvals; default CPU quantization also exercises lost-donor
+cleanup. Native macOS Intel/ARM runs household execution in both OpenMP modes.
+
+## GLM5.3 text-only float-source checkpoints
+
+This contract counts hyper-connection boundary width, separate KDA and latent
+DSA state, conservative float/quantization workspace, and context-sized prefill.
+The pinned adapter allocates state for every model layer in every Segment
+session, even for a one-layer interval. That allocation is represented as
+engine-wide session state, not divided by the number of owned layers.
+
+The stateless Edge advertises a zero context limit (caller-selected). Lumabri
+uses its protocol ceiling in that case and still negotiates the actual Segment
+limits. It no longer rejects every GLM5.3 household chat at argument parsing.
+
+The initial contract rejects packed containers and vision-config checkpoints:
+the native loader replicates the vision tower on each process, even for text
+chat. It also refuses the pinned loader's incomplete pool=1 path. These need
+their own validated layouts; they are not promoted by the text-only oracle.
+The tiny fixture has four independent Transformers continuation tokens.
+Whole/split and household execution are separate tests in Linux and native
+macOS CI; they do not prove full-size memory or performance.
 
 Other families must supply their own retained-weight and state contracts.
 Do not promote them by changing `sizing_verified` alone, or reuse ordinary GQA

--- a/planner_adapters/README.md
+++ b/planner_adapters/README.md
@@ -29,6 +29,30 @@ split-token equivalence and lost-donor cleanup. macOS CI runs the int4 household
 path on Intel/Apple Silicon with and without OpenMP. These are not large-model
 performance results, and do not certify GPU or disk execution.
 
+## Inkling CPU checkpoints
+
+The planner reads bounded safetensors headers, not weight payloads. It reserves
+the tensors that the native adapter actually loads for each interval and Edge:
+BF16 dense matrices stay BF16; F16 dense matrices expand to float32; converted
+int4/int8 experts stay packed, with float32 row scales. Float-source experts
+reserve their float32 upper bound. Optional dense-quantization sidecars reserve
+both banks conservatively because the native loader can fall back per tensor.
+
+Per-layer KV uses either the full context or the configured sliding ring.
+Convolution state is separate, and each session gets independent state. Scratch
+includes bounded 128-row prefill, up to 256 threads, relative-attention buffers,
+and a loading temporary. Missing tensors, duplicate used tensors, truncated
+files, incoherent packed encodings, and invalid scale sizes reject sizing.
+Disk execution is not enabled by this resident contract.
+
+Linux checks 24 generated float tokens against an independent PyTorch oracle,
+then runs approved two-donor household execution. Packed int4 additionally
+checks whole/split equivalence and lost-donor cleanup. Native macOS Intel/ARM
+CI runs the int4 household flow with and without OpenMP. The fixture generator
+retags its synthetic `inkling_text` export as the pinned registry's `inkling`;
+this is not a new runtime alias or a claim about arbitrary exports. The tests
+do not certify large checkpoints or GPU performance.
+
 Other families must supply their own retained-weight and state contracts.
 Do not promote them by changing `sizing_verified` alone, or reuse ordinary GQA
 KV arithmetic for recurrent/latent/hyper-connection architectures.

--- a/planner_adapters/deepseek_v4.h
+++ b/planner_adapters/deepseek_v4.h
@@ -1,0 +1,206 @@
+#ifndef LUMABRI_PLAN_DEEPSEEK_V4_H
+#define LUMABRI_PLAN_DEEPSEEK_V4_H
+/* Native V4: FP8 dense matrices with expanded scale banks, packed MXFP4
+ * experts, mHC boundaries, window/compressor/indexer session state. */
+typedef struct { char name[80]; const char *dtype; uint64_t rows,cols; } LmbV4Spec;
+typedef struct { uint64_t offset[6]; uint32_t file; uint8_t seen; } LmbV4Expert;
+typedef struct {
+    LmbModelShape *m;
+    uint32_t h,heads,hd,qr,og,orr,inter,hc,ih,id,window,topk,hash;
+    uint64_t ratios[LMB_PLAN_LAYER_MAX],seen[LMB_PLAN_LAYER_MAX],largest;
+    uint8_t edge;
+    LmbV4Expert *expert;
+} LmbV4Inventory;
+
+static unsigned lmb_v4_specs(const LmbV4Inventory *v,uint32_t layer,LmbV4Spec *s) {
+    unsigned n=0;
+    uint64_t H=v->h,D=v->hd,Q=v->qr,HC=v->hc,P=(2+HC)*HC;
+#define V4_SPEC(name_,dt,r,c) do { \
+    snprintf(s[n].name,sizeof s[n].name,"%s",name_); s[n].dtype=dt; \
+    s[n].rows=(r); s[n].cols=(c); n++; } while(0)
+#define V4_FP8(prefix,r,c) do { V4_SPEC(prefix ".weight","F8_E4M3",r,c); \
+    V4_SPEC(prefix ".scale","F8_E8M0",((r)+127)/128,((c)+127)/128); } while(0)
+    V4_SPEC("attn.attn_sink","F32",v->heads,0);
+    V4_SPEC("attn.kv_norm.weight","BF16",D,0);
+    V4_SPEC("attn.q_norm.weight","BF16",Q,0);
+    V4_FP8("attn.wkv",D,H);
+    V4_FP8("attn.wo_a",(uint64_t)v->og*v->orr,(uint64_t)(v->heads/v->og)*D);
+    V4_FP8("attn.wo_b",H,(uint64_t)v->og*v->orr);
+    V4_FP8("attn.wq_a",Q,H); V4_FP8("attn.wq_b",(uint64_t)v->heads*D,Q);
+    V4_SPEC("attn_norm.weight","BF16",H,0);
+    uint64_t ratio=v->ratios[layer];
+    if(ratio) {
+        uint64_t coff=ratio==4 ? 2 : 1;
+        V4_SPEC("attn.compressor.ape","F32",ratio,coff*D);
+        V4_SPEC("attn.compressor.norm.weight","BF16",D,0);
+        V4_SPEC("attn.compressor.wgate.weight","BF16",coff*D,H);
+        V4_SPEC("attn.compressor.wkv.weight","BF16",coff*D,H);
+    }
+    if(ratio==4) {
+        V4_SPEC("attn.indexer.compressor.ape","F32",4,2u*v->id);
+        V4_SPEC("attn.indexer.compressor.norm.weight","BF16",v->id,0);
+        V4_SPEC("attn.indexer.compressor.wgate.weight","BF16",2u*v->id,H);
+        V4_SPEC("attn.indexer.compressor.wkv.weight","BF16",2u*v->id,H);
+        V4_SPEC("attn.indexer.weights_proj.weight","BF16",v->ih,H);
+        V4_FP8("attn.indexer.wq_b",(uint64_t)v->ih*v->id,Q);
+    }
+    V4_SPEC("ffn.gate.weight","BF16",v->m->experts,H);
+    if(layer<v->hash) { V4_SPEC("ffn.gate.tid2eid","I64",v->m->vocab,v->m->experts_per_tok); }
+    else { V4_SPEC("ffn.gate.bias","F32",v->m->experts,0); }
+    V4_FP8("ffn.shared_experts.w1",v->inter,H);
+    V4_FP8("ffn.shared_experts.w2",H,v->inter);
+    V4_FP8("ffn.shared_experts.w3",v->inter,H);
+    V4_SPEC("ffn_norm.weight","BF16",H,0);
+    V4_SPEC("hc_attn_base","F32",P,0); V4_SPEC("hc_attn_fn","F32",P,HC*H);
+    V4_SPEC("hc_attn_scale","F32",3,0);
+    V4_SPEC("hc_ffn_base","F32",P,0); V4_SPEC("hc_ffn_fn","F32",P,HC*H);
+    V4_SPEC("hc_ffn_scale","F32",3,0);
+#undef V4_FP8
+#undef V4_SPEC
+    return n;
+}
+static int lmb_v4_shape(const LmbPlanTensor *t,const LmbV4Spec *s) {
+    return !strcmp(t->dtype,s->dtype) && t->rank==(s->cols ? 2u : 1u) &&
+        t->shape[0]==s->rows && (!s->cols || t->shape[1]==s->cols);
+}
+static int lmb_v4_tensor(const LmbPlanTensor *t,void *opaque) {
+    LmbV4Inventory *v=opaque; LmbModelShape *m=v->m;
+    const LmbV4Spec globals[]={
+        {"embed.weight","BF16",m->vocab,v->h},{"head.weight","BF16",m->vocab,v->h},
+        {"norm.weight","BF16",v->h,0},{"hc_head_fn","F32",v->hc,(uint64_t)v->hc*v->h},
+        {"hc_head_base","F32",v->hc,0},{"hc_head_scale","F32",1,0}};
+    for(unsigned i=0;i<6;i++) if(!strcmp(t->name,globals[i].name)) {
+        if((v->edge&(1u<<i)) || !lmb_v4_shape(t,&globals[i])) return -1;
+        v->edge|=1u<<i;
+        /* Embedding and head are row-read by Edge. Full source-cache allowance
+         * is deliberate, not a claim that the runtime pins the entire file. */
+        uint64_t cost=i<2 ? t->bytes : lmb_size_mul(t->elements,4);
+        m->edge_resident_bytes=lmb_size_add(m->edge_resident_bytes,cost);
+        return m->edge_resident_bytes==UINT64_MAX ? -1 : 0;
+    }
+    if(strncmp(t->name,"layers.",7)) return 0;
+    uint64_t layer; const char *field=lmb_plan_uint(t->name+7,&layer);
+    if(!field || *field++!='.') return -1;
+    if(layer>=m->layers) return 0; /* MTP is not part of a target Segment. */
+    uint64_t cost;
+    if(!strncmp(field,"ffn.experts.",12)) {
+        uint64_t eid; const char *kind=lmb_plan_uint(field+12,&eid);
+        if(!kind || *kind++!='.' || eid>=m->experts) return -1;
+        static const char *const names[]={"w1.weight","w1.scale","w2.weight","w2.scale","w3.weight","w3.scale"};
+        unsigned i; for(i=0;i<6;i++) if(!strcmp(kind,names[i])) break;
+        if(i==6) return -1;
+        uint64_t rows=i/2==1 ? v->h : v->inter, cols=i/2==1 ? v->inter : v->h;
+        LmbV4Spec s={.dtype=i%2 ? "F8_E8M0" : "I8",.rows=rows,.cols=cols/(i%2 ? 32 : 2)};
+        LmbV4Expert *e=&v->expert[layer*m->experts+eid];
+        if(!lmb_v4_shape(t,&s) || (e->seen&(1u<<i)) || (e->seen && e->file!=t->file_id)) return -1;
+        e->file=t->file_id; e->seen|=1u<<i; e->offset[i]=t->offset;
+        cost=t->bytes; /* native expert scales remain encoded UE8M0 */
+    } else {
+        LmbV4Spec specs[48]; unsigned count=lmb_v4_specs(v,(uint32_t)layer,specs),i;
+        for(i=0;i<count;i++) if(!strcmp(field,specs[i].name)) break;
+        if(i==count) return 0;
+        if((v->seen[layer]&(UINT64_C(1)<<i)) || !lmb_v4_shape(t,&specs[i])) return -1;
+        v->seen[layer]|=UINT64_C(1)<<i;
+        cost=!strcmp(t->dtype,"F8_E8M0") ? lmb_size_mul(t->elements,4) : t->bytes;
+    }
+    if(cost>v->largest) v->largest=cost;
+    m->memory[layer].resident_bytes=lmb_size_add(m->memory[layer].resident_bytes,cost);
+    return m->memory[layer].resident_bytes==UINT64_MAX ? -1 : 0;
+}
+static int lmb_v4_string(const char *cfg,const char *key,const char *expected) {
+    char text[64]; return lmb_json_string(cfg,key,text,sizeof text) || strcmp(text,expected);
+}
+static int lmb_v4_memory(const char *root,const char *cfg,LmbModelShape *m) {
+    LmbV4Inventory v={.m=m}; uint32_t layers,experts,k,vocab,shared,rope,ctx,mtp,iters;
+#define V4_NEED(key,dst,lo,hi) if(lmb_plan_u32(cfg,key,lo,hi,&dst)) return -1
+    V4_NEED("hidden_size",v.h,128,1048576); V4_NEED("num_hidden_layers",layers,1,128);
+    V4_NEED("num_attention_heads",v.heads,1,1024); V4_NEED("head_dim",v.hd,2,65536);
+    V4_NEED("q_lora_rank",v.qr,128,1048576); V4_NEED("qk_rope_head_dim",rope,2,65536);
+    V4_NEED("o_groups",v.og,1,v.heads); V4_NEED("o_lora_rank",v.orr,1,1048576);
+    V4_NEED("sliding_window",v.window,1,1048576); V4_NEED("index_n_heads",v.ih,1,1024);
+    V4_NEED("index_head_dim",v.id,2,65536); V4_NEED("index_topk",v.topk,1,1048576);
+    V4_NEED("n_routed_experts",experts,1,4096); V4_NEED("num_experts_per_tok",k,1,256);
+    V4_NEED("moe_intermediate_size",v.inter,128,16777216); V4_NEED("n_shared_experts",shared,1,1);
+    V4_NEED("num_hash_layers",v.hash,0,layers); V4_NEED("hc_mult",v.hc,1,16);
+    V4_NEED("vocab_size",vocab,1,16777216); V4_NEED("max_position_embeddings",ctx,4,1048576);
+    V4_NEED("num_nextn_predict_layers",mtp,0,16); V4_NEED("hc_sinkhorn_iters",iters,1,1024);
+#undef V4_NEED
+    (void)shared;(void)mtp;(void)iters;
+    if(v.h!=m->hidden || layers!=m->layers || vocab!=m->vocab || k>experts ||
+       v.h%128 || v.inter%128 || v.qr%128 || v.heads%v.og || rope%2 || rope>v.hd || rope>v.id ||
+       ((uint64_t)(v.heads/v.og)*v.hd)%128 || ((uint64_t)v.og*v.orr)%128 ||
+       lmb_v4_string(cfg,"expert_dtype","fp4") || lmb_v4_string(cfg,"scoring_func","sqrtsoftplus") ||
+       lmb_v4_string(cfg,"topk_method","noaux_tc")) return -1;
+    const char *quant=lmb_json_member(cfg,"quantization_config");
+    if(!quant || *quant!='{' || lmb_v4_string(quant,"fmt","e4m3") || lmb_v4_string(quant,"scale_fmt","ue8m0")) return -1;
+    static const char *const real_fields[]={"rms_norm_eps","hc_eps","routed_scaling_factor",
+        "swiglu_limit","rope_theta","compress_rope_theta"};
+    for(unsigned i=0;i<sizeof real_fields/sizeof *real_fields;i++) {
+        double value;
+        if(!lmb_json_member(cfg,real_fields[i]) || lmb_plan_number(cfg,real_fields[i],0,&value) ||
+           value>FLT_MAX || (i==3 ? value<0 : (float)value<=0)) return -1;
+    }
+    const char *rp=lmb_json_member(cfg,"rope_scaling");
+    uint32_t orig,fast,slow; double factor;
+    if(!rp || *rp!='{' || lmb_plan_u32(rp,"original_max_position_embeddings",1,1048576,&orig) ||
+       lmb_plan_u32(rp,"beta_fast",1,INT32_MAX,&fast) || lmb_plan_u32(rp,"beta_slow",1,INT32_MAX,&slow) ||
+       !lmb_json_member(rp,"factor") || lmb_plan_number(rp,"factor",0,&factor) || factor>FLT_MAX ||
+       (float)factor<=0 || fast<slow) return -1;
+    unsigned nr; if(lmb_plan_array(lmb_json_member(cfg,"compress_ratios"),v.ratios,128,&nr) || nr<layers) return -1;
+    for(unsigned i=0;i<nr;i++) if(v.ratios[i]!=0 && v.ratios[i]!=4 && v.ratios[i]!=8 && v.ratios[i]!=128) return -1;
+    m->experts=experts;m->experts_per_tok=k;m->moe_intermediate=v.inter;
+    v.expert=calloc((size_t)layers*experts,sizeof *v.expert);
+    if(!v.expert) return -1;
+    int rc=lmb_plan_tensors(root,lmb_v4_tensor,&v);
+    if(v.edge!=63) rc=-1;
+    uint64_t cells=(uint64_t)v.h*v.inter;
+    for(uint32_t i=0;i<layers && !rc;i++) {
+        LmbV4Spec specs[48];unsigned n=lmb_v4_specs(&v,i,specs);
+        if(v.seen[i]!=(UINT64_C(1)<<n)-1) {rc=-1;break;}
+        for(uint32_t e=0;e<experts;e++) {
+            LmbV4Expert *r=&v.expert[i*experts+e];
+            if(r->seen!=63) {rc=-1;break;}
+            /* Native store reads three matrices/scales as two contiguous
+             * ranges in one shard. Equal sizes alone do not prove loadability. */
+            for(unsigned bank=0;bank<2;bank++) {
+                uint64_t a[3]={r->offset[bank],r->offset[bank+2],r->offset[bank+4]};
+                for(unsigned x=0;x<3;x++) for(unsigned y=x+1;y<3;y++) if(a[y]<a[x]) {
+                    uint64_t swap=a[x];a[x]=a[y];a[y]=swap;
+                }
+                uint64_t bytes=cells/(bank ? 32 : 2);
+                if(a[1]-a[0]!=bytes || a[2]-a[1]!=bytes) rc=-1;
+            }
+        }
+        LmbLayerMemory *l=&m->memory[i];uint64_t ratio=v.ratios[i];
+        l->state_fixed_bytes=(uint64_t)v.window*v.hd*4+4096;
+        if(ratio) {
+            uint64_t overlap=ratio==4 ? 2 : 1;
+            l->state_fixed_bytes=lmb_size_add(l->state_fixed_bytes,
+                ratio*overlap*overlap*v.hd*8+(uint64_t)16*v.hd*4);
+            /* Geometric cache growth and temporary snapshot/reallocation. */
+            l->state_token_bytes=(uint64_t)v.hd*16/ratio+16;
+        }
+        if(ratio==4) {
+            uint64_t wide=(uint64_t)v.ih*v.id+v.ih+v.qr+v.id;
+            l->state_fixed_bytes=lmb_size_add(l->state_fixed_bytes,
+                (uint64_t)128*v.id*4+(uint64_t)128*v.id+65536+wide*128*16);
+            /* Persistent per-session batch indexer scratch grows with count. */
+            l->state_token_bytes=lmb_size_add(l->state_token_bytes,(uint64_t)v.id*4+256);
+        }
+        l->state_fixed_bytes=lmb_size_mul(l->state_fixed_bytes,2);
+    }
+    free(v.expert);if(rc) return -1;
+    uint64_t record=cells*3/2+cells*3/32;
+    uint64_t wide=(uint64_t)v.h*v.hc+(uint64_t)v.heads*v.hd*3+v.qr+(uint64_t)v.og*v.orr+
+        (uint64_t)k*(v.h+v.inter)+experts+(uint64_t)v.ih*v.id;
+    m->scratch_fixed_bytes=lmb_size_add(UINT64_C(512)<<20,lmb_size_mul(wide,128u*16u*4u));
+    m->scratch_fixed_bytes=lmb_size_add(m->scratch_fixed_bytes,lmb_size_add(v.largest*2,
+        lmb_size_mul(record,experts<256 ? experts : 256)));
+    m->scratch_token_bytes=(uint64_t)v.hd*4+256u*4u;
+    m->segment_fixed_bytes=(uint64_t)layers*(8192u+(uint64_t)experts*2048u);
+    m->session_fixed_bytes=(uint64_t)layers*16;
+    m->edge_scratch_fixed_bytes=(uint64_t)m->vocab*8+(uint64_t)v.h*128*8;
+    m->boundary_width=v.h*v.hc;m->max_context=ctx;m->memory_contract=1;
+    return m->scratch_fixed_bytes==UINT64_MAX ? -1 : 0;
+}
+#endif

--- a/planner_adapters/glm.h
+++ b/planner_adapters/glm.h
@@ -1,0 +1,145 @@
+#ifndef LUMABRI_PLAN_GLM_H
+#define LUMABRI_PLAN_GLM_H
+/* Float-source GLM/MLA contract. Prepared quantized containers must not be
+ * inferred from file bytes: their per-tensor format stamps need validation. */
+typedef struct {
+    LmbModelShape *model;
+    uint32_t seen[128], first, inter, experts;
+    uint8_t index[128], edge_seen, *expert_seen;
+    uint64_t largest_dense, largest_expert;
+} LmbGlmInventory;
+
+static int lmb_glm_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbGlmInventory *v = opaque;
+    LmbModelShape *m = v->model;
+    const char *name = t->name;
+    size_t name_len = strlen(name);
+    if (name_len >= 3 && !strcmp(name + name_len - 3, ".qs")) return -1;
+    int global = !strcmp(name, "model.embed_tokens.weight") ? 0 :
+        !strcmp(name, "lm_head.weight") ? 1 : !strcmp(name, "model.norm.weight") ? 2 : -1;
+    int floating = !strcmp(t->dtype, "F32") || !strcmp(t->dtype, "BF16") || !strcmp(t->dtype, "F16");
+    if (global >= 0) {
+        if (!floating || (v->edge_seen & (1u << global)) || t->elements !=
+            (global < 2 ? (uint64_t)m->vocab * m->hidden : m->hidden)) return -1;
+        v->edge_seen |= 1u << global;
+        uint64_t cost = lmb_size_mul(t->elements, 4);
+        m->edge_resident_bytes = lmb_size_add(m->edge_resident_bytes,
+            lmb_size_add(cost, (uint64_t)m->vocab * 4));
+        if (cost > m->edge_scratch_fixed_bytes) m->edge_scratch_fixed_bytes = cost;
+        return m->edge_resident_bytes == UINT64_MAX ? -1 : 0;
+    }
+    if (strncmp(name, "model.layers.", 13)) return 0;
+    uint64_t layer;
+    const char *field = lmb_plan_uint(name + 13, &layer);
+    if (!field || *field++ != '.') return -1;
+    if (layer >= m->layers) return 0;
+    static const char *const fields[] = {
+        "input_layernorm.weight", "post_attention_layernorm.weight",
+        "self_attn.q_a_proj.weight", "self_attn.q_a_layernorm.weight",
+        "self_attn.q_b_proj.weight", "self_attn.kv_a_proj_with_mqa.weight",
+        "self_attn.kv_a_layernorm.weight", "self_attn.kv_b_proj.weight", "self_attn.o_proj.weight",
+        "mlp.gate_proj.weight", "mlp.up_proj.weight", "mlp.down_proj.weight",
+        "mlp.gate.weight", "mlp.gate.e_score_correction_bias",
+        "mlp.shared_experts.gate_proj.weight", "mlp.shared_experts.up_proj.weight", "mlp.shared_experts.down_proj.weight",
+        "self_attn.indexer.wq_b.weight", "self_attn.indexer.wk.weight",
+        "self_attn.indexer.weights_proj.weight", "self_attn.indexer.k_norm.weight", "self_attn.indexer.k_norm.bias"
+    };
+    const char *ep = "mlp.experts.";
+    int expert_tensor = !strncmp(field, ep, strlen(ep));
+    if (expert_tensor) {
+        uint64_t expert;
+        const char *kind = lmb_plan_uint(field + strlen(ep), &expert);
+        if (!kind || *kind++ != '.' || expert >= v->experts || layer < v->first) return -1;
+        unsigned i = !strcmp(kind, "gate_proj.weight") ? 0 :
+            !strcmp(kind, "up_proj.weight") ? 1 : !strcmp(kind, "down_proj.weight") ? 2 : 3;
+        if (i == 3 || !floating || t->elements != (uint64_t)v->inter * m->hidden) return -1;
+        uint8_t *seen = &v->expert_seen[layer * v->experts + expert];
+        if (*seen & (1u << i)) return -1;
+        *seen |= 1u << i;
+    } else {
+        unsigned i;
+        for (i = 0; i < sizeof fields / sizeof *fields; i++) if (!strcmp(field, fields[i])) break;
+        if (i == sizeof fields / sizeof *fields) return 0;
+        if (!floating || (v->seen[layer] & (1u << i))) return -1;
+        v->seen[layer] |= 1u << i;
+    }
+    uint64_t cost = lmb_size_mul(t->elements, 4);
+    uint64_t *largest = expert_tensor ? &v->largest_expert : &v->largest_dense;
+    if (cost > *largest) *largest = cost;
+    /* f32 + a conservative scale bound also covers int3 grouped row padding
+     * and all native load-time precision choices for this source encoding. */
+    cost = lmb_size_add(cost, lmb_size_mul(t->elements, 1));
+    m->memory[layer].resident_bytes = lmb_size_add(m->memory[layer].resident_bytes, cost);
+    return m->memory[layer].resident_bytes == UINT64_MAX ? -1 : 0;
+}
+
+static int LMB_UNUSED lmb_glm_memory(const char *root, const char *json, LmbModelShape *m) {
+    LmbGlmInventory v = { .model = m };
+    uint32_t h, layers, heads, qrank, kvrank, nope, rope, vd, experts, topk, inter;
+    uint32_t dense, shared, first, groups, index, ih, ik, freq, offset;
+#define NEED(key, dst, lo, hi) if (lmb_plan_u32(json, key, lo, hi, &dst)) return -1
+    NEED("hidden_size", h, 32, 1048576); NEED("num_hidden_layers", layers, 1, 128);
+    NEED("num_attention_heads", heads, 1, 1024); NEED("q_lora_rank", qrank, 32, 1048576);
+    NEED("kv_lora_rank", kvrank, 32, 1048576); NEED("qk_nope_head_dim", nope, 1, 65536);
+    NEED("qk_rope_head_dim", rope, 2, 65536); NEED("v_head_dim", vd, 1, 65536);
+    NEED("n_routed_experts", experts, 1, 4096); NEED("num_experts_per_tok", topk, 1, 64);
+    NEED("moe_intermediate_size", inter, 32, 1048576); NEED("intermediate_size", dense, 32, 16777216);
+    NEED("n_shared_experts", shared, 1, 64); NEED("first_k_dense_replace", first, 0, layers);
+    NEED("n_group", groups, 1, 1);
+#undef NEED
+    if (h != m->hidden || layers != m->layers || !m->vocab || topk > experts || rope % 2 ||
+        (uint64_t)heads * vd < 32 ||
+        lmb_plan_optional(json, "index_head_dim", 0, 0, 256, &index) ||
+        lmb_plan_optional(json, "index_n_heads", 0, 0, 65536, &ih) ||
+        lmb_plan_optional(json, "index_topk", 0, 0, 1048576, &ik) ||
+        lmb_plan_optional(json, "index_topk_freq", 1, 1, 128, &freq) ||
+        lmb_plan_optional(json, "index_skip_topk_offset", 2, 0, 128, &offset)) return -1;
+    for (uint32_t i = 0; i < layers; i++) {
+        uint32_t pos = i + 1 > offset ? i + 1 - offset : 0;
+        v.index[i] = pos % freq == 0;
+    }
+    if (lmb_json_member(json, "indexer_types") &&
+        lmb_plan_kinds(json, "indexer_types", "shared", "full", v.index, layers)) return -1;
+    v.first = first; v.inter = inter; v.experts = experts;
+    v.expert_seen = calloc((size_t)layers * experts, 1);
+    if (!v.expert_seen) return -1;
+    int rc = lmb_plan_tensors(root, lmb_glm_tensor, &v);
+    if (v.edge_seen != 7) rc = -1;
+    int indexed = 0, missing = 0;
+    if (index && ih && ik) for (uint32_t i = 0; i < layers; i++) {
+        if (!v.index[i]) continue;
+        uint32_t bank = v.seen[i] & (31u << 17);
+        if (bank && bank != (31u << 17)) rc = -1;
+        if (bank == (31u << 17)) indexed++;
+        else missing++;
+    }
+    /* Edge detects DSA globally, while a Segment detects it for its interval.
+     * A partial indexer bank would produce incompatible numeric classes. */
+    if (indexed && missing) rc = -1;
+    for (uint32_t i = 0; i < layers && !rc; i++) {
+        uint32_t required = 511u | (i < first ? 7u << 9 : 31u << 12);
+        if ((v.seen[i] & required) != required) { rc = -1; break; }
+        if (i >= first) for (uint32_t e = 0; e < experts; e++)
+            if (v.expert_seen[i * experts + e] != 7) rc = -1;
+        m->memory[i].state_token_bytes = (uint64_t)(kvrank + rope + (indexed && v.index[i] ? index : 0)) * 4u;
+    }
+    free(v.expert_seen);
+    if (rc) return -1;
+    uint64_t wide = h + (uint64_t)heads * (nope + rope + vd) + qrank + kvrank + dense +
+        (uint64_t)shared * inter + (uint64_t)topk * (h + inter) + experts + (uint64_t)ih * index;
+    uint64_t loaders = experts < 256 ? experts : 256; /* up to one load per engine-team worker */
+    uint64_t miss_slots = experts < 64 ? experts : 64;
+    uint64_t misses = lmb_size_mul(lmb_size_mul(v.largest_expert, 15u), miss_slots);
+    if (misses == UINT64_MAX) return -1;
+    misses /= 4u;
+    /* Native ws[64] owns additional gate/up/down slabs, separate from the
+     * per-layer LRU. They persist after prefill; reserve them explicitly. */
+    m->scratch_fixed_bytes = lmb_size_add(lmb_size_mul(wide, 512u * 16u * 4u),
+        lmb_size_add(misses, lmb_size_add(v.largest_dense, lmb_size_mul(v.largest_expert, loaders))));
+    m->scratch_token_bytes = 256u * 32u;
+    m->segment_fixed_bytes = (uint64_t)(layers + 1u) * (8192u + (uint64_t)experts * 2048u);
+    m->max_context = 1048576;
+    m->memory_contract = 1;
+    return 0;
+}
+#endif

--- a/planner_adapters/glm53.h
+++ b/planner_adapters/glm53.h
@@ -16,7 +16,7 @@ static int lmb_glm53_tensor(const LmbPlanTensor *t, void *opaque) {
     LmbModelShape *m = v->model;
     const char *name = t->name;
     if (!strncmp(name, "model.visual.", 13)) return -1;
-    if (!strcmp(t->dtype, "U8") || !strcmp(t->dtype, "I8")) return -1;
+    if (strcmp(t->dtype, "F32") && strcmp(t->dtype, "BF16") && strcmp(t->dtype, "F16")) return -1;
     if (strncmp(name, "lm_head.weight", 14)) {
         uint8_t prefix = !strncmp(name, "model.language_model.", 21) ? 2 :
                          !strncmp(name, "model.", 6) ? 1 : 0;

--- a/planner_adapters/glm53.h
+++ b/planner_adapters/glm53.h
@@ -1,0 +1,199 @@
+#ifndef LUMABRI_PLAN_GLM53_H
+#define LUMABRI_PLAN_GLM53_H
+/* Initial float-source text contract. Packed containers and the vision tower
+ * are deliberately not inferred from this contract. Colibri remains unchanged. */
+typedef struct {
+    LmbModelShape *model;
+    uint32_t h, heads, qrank, kvrank, nope, vd, inter, dense, experts, shared;
+    uint32_t first, kh, kd, conv, ih, id, pool, hc;
+    uint8_t full[120], prefix, edge_seen, *experts_seen;
+    uint64_t seen[120], largest;
+    uint32_t low[120][4];
+} LmbGlm53Inventory;
+
+static int lmb_glm53_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbGlm53Inventory *v = opaque;
+    LmbModelShape *m = v->model;
+    const char *name = t->name;
+    if (!strncmp(name, "model.visual.", 13)) return -1;
+    if (!strcmp(t->dtype, "U8") || !strcmp(t->dtype, "I8")) return -1;
+    if (strncmp(name, "lm_head.weight", 14)) {
+        uint8_t prefix = !strncmp(name, "model.language_model.", 21) ? 2 :
+                         !strncmp(name, "model.", 6) ? 1 : 0;
+        if (!prefix) return 0;
+        if (v->prefix && v->prefix != prefix) return -1;
+        v->prefix = prefix;
+        name += prefix == 2 ? 21 : 6;
+    }
+    int global = !strcmp(name, "embed_tokens.weight") ? 0 :
+        !strcmp(name, "norm.weight") ? 1 : !strcmp(name, "lm_head.weight") ? 2 : -1;
+    if (global >= 0) {
+        uint64_t count = global == 1 ? m->hidden : (uint64_t)m->vocab * m->hidden;
+        if ((v->edge_seen & (1u << global)) || t->elements != count ||
+            (global != 1 && (t->rank != 2 || t->shape[1] != m->hidden))) return -1;
+        v->edge_seen |= 1u << global;
+        m->edge_resident_bytes = lmb_size_add(m->edge_resident_bytes, lmb_size_mul(count, 8));
+        if (count * 4 > m->edge_scratch_fixed_bytes) m->edge_scratch_fixed_bytes = count * 4;
+        return m->edge_resident_bytes == UINT64_MAX ? -1 : 0;
+    }
+    if (strncmp(name, "layers.", 7)) return 0;
+    uint64_t layer;
+    const char *field = lmb_plan_uint(name + 7, &layer);
+    if (!field || *field++ != '.') return -1;
+    if (layer >= m->layers) return 0;
+    uint64_t H = v->h, P = (uint64_t)v->kh * v->kd, HC = v->hc;
+    uint64_t hyper = HC * HC + 2 * HC;
+    static const char *const names[] = {
+        "input_layernorm.weight", "post_attention_layernorm.weight",
+        "hc_attn_fn", "hc_attn_base", "hc_attn_scale", "hc_ffn_fn", "hc_ffn_base", "hc_ffn_scale",
+        "self_attn.q_a_proj.weight", "self_attn.q_a_layernorm.weight", "self_attn.q_b_proj.weight",
+        "self_attn.kv_a_proj_with_mqa.weight", "self_attn.kv_a_layernorm.weight", "self_attn.kv_b_proj.weight",
+        "self_attn.o_proj.weight", "self_attn.indexer.wq_b.weight", "self_attn.indexer.wk.weight",
+        "self_attn.indexer.weights_proj.weight", "self_attn.indexer.k_norm.weight", "self_attn.indexer.k_norm.bias",
+        "self_attn.indexer.index_kpool_compress_ape", "self_attn.indexer.index_kpool_compress_gate",
+        "self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight",
+        "self_attn.g_a_proj.weight", "self_attn.g_b_proj.weight", "self_attn.f_a_proj.weight", "self_attn.f_b_proj.weight",
+        "self_attn.b_proj.weight", "self_attn.dt_bias", "self_attn.A_log", "self_attn.o_norm.weight",
+        "self_attn.q_conv1d.weight", "self_attn.k_conv1d.weight", "self_attn.v_conv1d.weight",
+        "mlp.gate_proj.weight", "mlp.up_proj.weight", "mlp.down_proj.weight",
+        "mlp.gate.weight", "mlp.gate.e_score_correction_bias",
+        "mlp.shared_experts.gate_proj.weight", "mlp.shared_experts.up_proj.weight", "mlp.shared_experts.down_proj.weight"
+    };
+    uint64_t counts[] = {
+        H,H, hyper*HC*H,hyper,3,hyper*HC*H,hyper,3,
+        (uint64_t)v->qrank*H,v->qrank,(uint64_t)v->heads*v->nope*v->qrank,
+        (uint64_t)v->kvrank*H,v->kvrank,(uint64_t)v->heads*(v->nope+v->vd)*v->kvrank,
+        H*(v->full[layer] ? (uint64_t)v->heads*v->vd : P),
+        (uint64_t)v->ih*v->id*v->qrank,(uint64_t)v->id*H,(uint64_t)v->ih*H,v->id,v->id,
+        (uint64_t)v->pool*v->id,(uint64_t)v->id*H,
+        P*H,P*H,P*H,0,0,0,0,(uint64_t)v->kh*H,P,v->kh,v->kd,
+        P*v->conv,P*v->conv,P*v->conv,
+        (uint64_t)v->dense*H,(uint64_t)v->dense*H,(uint64_t)v->dense*H,
+        (uint64_t)v->experts*H,v->experts,
+        (uint64_t)v->shared*v->inter*H,(uint64_t)v->shared*v->inter*H,(uint64_t)v->shared*v->inter*H
+    };
+    if (!strncmp(field, "mlp.experts.", 12)) {
+        uint64_t expert;
+        const char *suffix = lmb_plan_uint(field + 12, &expert);
+        if (!suffix || *suffix++ != '.' || expert >= v->experts || layer < v->first) return -1;
+        unsigned k = !strcmp(suffix,"gate_proj.weight") ? 0 : !strcmp(suffix,"up_proj.weight") ? 1 :
+                     !strcmp(suffix,"down_proj.weight") ? 2 : 3;
+        uint8_t *seen = &v->experts_seen[layer * v->experts + expert];
+        if (k == 3 || (*seen & (1u << k)) || t->elements != H * v->inter ||
+            t->rank != 2 || t->shape[1] != (k == 2 ? v->inter : H)) return -1;
+        *seen |= 1u << k;
+    } else {
+        unsigned i;
+        for (i=0; i<sizeof names / sizeof *names; i++) if (!strcmp(field,names[i])) break;
+        if (i==sizeof names / sizeof *names) return 0;
+        if (v->seen[layer] & (UINT64_C(1)<<i)) return -1;
+        v->seen[layer] |= UINT64_C(1)<<i;
+        if (i >=25 && i<=28) {
+            /* Native low-rank work buffers have hidden-size capacity. */
+            if (t->rank != 2) return -1;
+            uint64_t low = (i==25 || i==27) ? t->shape[0] : t->shape[1];
+            if (!low || low > H || t->elements != low * ((i==25 || i==27) ? H : P)) return -1;
+            v->low[layer][i-25] = (uint32_t)low;
+        } else {
+            if (t->elements != counts[i]) return -1;
+            uint64_t columns = 0;
+            if (i==8 || i==11 || i==16 || i==17 || i==21 || (i>=22 && i<=24) ||
+                i==29 || i==36 || i==37 || i==39 || i==41 || i==42) columns=H;
+            else if (i==10 || i==15) columns=v->qrank;
+            else if (i==13) columns=v->kvrank;
+            else if (i==14) columns=v->full[layer] ? (uint64_t)v->heads*v->vd : P;
+            else if (i==38) columns=v->dense;
+            else if (i==43) columns=(uint64_t)v->shared*v->inter;
+            if (columns && (t->rank!=2 || t->shape[1]!=columns)) return -1;
+        }
+    }
+    /* f32 + per-row scale upper bound also covers int8 fallback for tiny
+     * contraction dimensions; do not estimate packed source by file size. */
+    uint64_t bytes = lmb_size_mul(t->elements, 8);
+    m->memory[layer].resident_bytes = lmb_size_add(m->memory[layer].resident_bytes, bytes);
+    if (bytes > v->largest) v->largest = bytes;
+    return bytes == UINT64_MAX || m->memory[layer].resident_bytes == UINT64_MAX ? -1 : 0;
+}
+
+static int LMB_UNUSED lmb_glm53_memory(const char *root, const char *whole,
+                                       const char *json, LmbModelShape *m) {
+    if (lmb_json_member(whole, "vision_config")) return -1;
+    LmbGlm53Inventory v = { .model=m };
+    uint32_t layers, topk, rope, index_topk;
+#define NEED(key,dst,lo,hi) if (lmb_plan_u32(json,key,lo,hi,&dst)) return -1
+    NEED("hidden_size",v.h,1,65536); NEED("num_hidden_layers",layers,1,120);
+    NEED("num_attention_heads",v.heads,1,1024); NEED("q_lora_rank",v.qrank,1,1048576);
+    NEED("kv_lora_rank",v.kvrank,1,4096); NEED("qk_nope_head_dim",v.nope,1,65536);
+    NEED("v_head_dim",v.vd,1,65536); NEED("intermediate_size",v.dense,1,16777216);
+    NEED("moe_intermediate_size",v.inter,32,1048576); NEED("n_routed_experts",v.experts,1,4096);
+    NEED("num_experts_per_tok",topk,1,64);
+    NEED("index_topk",index_topk,1,1048576);
+#undef NEED
+    if (v.h!=m->hidden || layers!=m->layers || !m->vocab || m->vocab > (1u<<22) || v.inter%32 || topk>v.experts ||
+        lmb_plan_optional(json,"qk_rope_head_dim",0,0,0,&rope) ||
+        lmb_plan_optional(json,"n_shared_experts",1,1,64,&v.shared) ||
+        lmb_plan_optional(json,"hc_mult",1,1,8,&v.hc) ||
+        lmb_plan_optional(json,"index_head_dim",0,1,65536,&v.id) ||
+        lmb_plan_optional(json,"index_n_heads",0,1,65536,&v.ih) ||
+        lmb_plan_optional(json,"index_kpool",1,2,64,&v.pool)) return -1;
+    /* The pinned MLA path calls the k-pool gate unconditionally; the loader
+     * only loads it for pool > 1. Do not admit that incomplete native path. */
+    if (v.pool < 2 || !v.id || !v.ih ||
+        (uint64_t)v.shared*v.inter > (v.dense > v.inter ? v.dense : v.inter)) return -1;
+    const char *linear = lmb_json_member(json,"linear_attn_config");
+    if (!linear || *linear!='{' || lmb_plan_u32(linear,"num_heads",1,1048576,&v.kh) ||
+        lmb_plan_u32(linear,"head_dim",1,512,&v.kd) ||
+        lmb_plan_u32(linear,"short_conv_kernel_size",1,8,&v.conv) ||
+        (uint64_t)v.kh*v.kd > 1048576) return -1;
+    if (lmb_plan_kinds(json,"layer_types","linear_attention","deepseek_sparse_attention",v.full,layers)) return -1;
+    uint8_t sparse[120];
+    if (lmb_json_member(json,"first_k_dense_replace")) {
+        if (lmb_plan_u32(json,"first_k_dense_replace",0,layers,&v.first)) return -1;
+    } else {
+        if (lmb_plan_kinds(json,"mlp_layer_types","dense","sparse",sparse,layers)) return -1;
+        v.first=layers;
+        for (uint32_t i=0;i<layers;i++) if (sparse[i]) {v.first=i; break;}
+        for (uint32_t i=v.first;i<layers;i++) if (!sparse[i]) return -1;
+    }
+    /* The optional alternate layout must agree with the native loader. */
+    if (lmb_json_member(linear,"full_attn_layers")) {
+        uint8_t alternate[120]={0};
+        if (lmb_plan_indices(linear,"full_attn_layers",alternate,layers,0) ||
+            memcmp(alternate,v.full,layers)) return -1;
+    }
+    v.experts_seen=calloc((size_t)layers*v.experts,1);
+    if (!v.experts_seen) return -1;
+    int rc=lmb_plan_tensors(root,lmb_glm53_tensor,&v);
+    if ((v.edge_seen & 3)!=3) rc=-1; /* missing head means tied embedding */
+    for (uint32_t i=0;i<layers && !rc;i++) {
+        uint64_t required=255u | (UINT64_C(1)<<14);
+        if (v.full[i]) required |= ((UINT64_C(1)<<20)-(UINT64_C(1)<<8)) |
+            (v.pool>1 ? (UINT64_C(3)<<20) : 0);
+        else required |= (UINT64_C(1)<<36)-(UINT64_C(1)<<22);
+        required |= i<v.first ? (UINT64_C(7)<<36) : (UINT64_C(1)<<39)|(UINT64_C(7)<<41);
+        if ((v.seen[i]&required)!=required) {rc=-1;break;}
+        if (!v.full[i] && (v.low[i][0]!=v.low[i][1] || v.low[i][2]!=v.low[i][3])) {rc=-1;break;}
+        if (i>=v.first) for (uint32_t e=0;e<v.experts;e++) if (v.experts_seen[i*v.experts+e]!=7) rc=-1;
+        /* Pinned session_open allocates EVERY layer's state on EVERY range. */
+        if (v.full[i]) m->session_token_bytes=lmb_size_add(m->session_token_bytes,(uint64_t)(v.kvrank+2*v.id)*4);
+        else m->session_fixed_bytes=lmb_size_add(m->session_fixed_bytes,
+            ((uint64_t)v.kh*v.kd*v.kd+3u*(uint64_t)v.kh*v.kd*v.conv)*4);
+    }
+    free(v.experts_seen);
+    if (rc) return -1;
+    m->session_fixed_bytes=lmb_size_add(m->session_fixed_bytes,
+        ((uint64_t)3*v.kh*v.kd+v.kd)*4 + (uint64_t)layers*1024);
+    m->boundary_width=v.h*v.hc;
+    uint64_t wide=m->boundary_width+(uint64_t)v.heads*(v.nope+v.kvrank+v.vd)+
+        (uint64_t)v.ih*v.id+v.qrank+v.kvrank+v.h+(uint64_t)v.kh*v.kd+v.dense+
+        (uint64_t)v.shared*v.inter+v.experts+topk+(uint64_t)index_topk*v.pool+v.pool;
+    /* This adapter permits context-sized prefill requests, unlike the
+     * 128-row adapters. Bound buffers by context, not by a shared assumption. */
+    m->scratch_token_bytes=lmb_size_mul(wide,64);
+    m->scratch_fixed_bytes=lmb_size_add(v.largest,lmb_size_mul(wide,64));
+    m->segment_fixed_bytes=(uint64_t)layers*(8192u+(uint64_t)v.experts*512);
+    m->max_context=1048576;
+    m->memory_contract=1;
+    return 0;
+}
+#endif

--- a/planner_adapters/inkling.h
+++ b/planner_adapters/inkling.h
@@ -1,0 +1,196 @@
+#ifndef LUMABRI_PLAN_INKLING_H
+#define LUMABRI_PLAN_INKLING_H
+#include "tensors.h"
+
+static int lmb_plan_optional(const char *json, const char *key, uint32_t fallback,
+                              uint32_t low, uint32_t high, uint32_t *out) {
+    if (!lmb_json_member(json, key)) { *out = fallback; return 0; }
+    return lmb_plan_u32(json, key, low, high, out);
+}
+
+static int lmb_plan_kinds(const char *json, const char *key, const char *zero,
+                           const char *one, uint8_t *values, uint32_t count) {
+    const char *p = lmb_json_member(json, key);
+    if (!p || *p++ != '[') return -1;
+    for (uint32_t i = 0; i < count; i++) {
+        char kind[64];
+        if (!(p = lmb_plan_string(lmb_plan_space(p), kind, sizeof kind))) return -1;
+        if (!strcmp(kind, zero)) values[i] = 0;
+        else if (!strcmp(kind, one)) values[i] = 1;
+        else return -1;
+        p = lmb_plan_space(p);
+        if (*p++ != (i + 1 == count ? ']' : ',')) return -1;
+    }
+    return 0;
+}
+
+typedef struct {
+    LmbModelShape *model;
+    uint8_t sparse[256], local[256], packed[256];
+    uint8_t encoding[256][2];
+    uint32_t seen[256], edge_seen;
+    uint32_t hidden, inter, experts;
+    int sidecar;
+} LmbInklingInventory;
+
+static int lmb_inkling_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbInklingInventory *v = opaque;
+    LmbModelShape *m = v->model;
+    uint64_t cost;
+    int packed = !strcmp(t->dtype, "U8") || !strcmp(t->dtype, "I8");
+    const char *name = t->name;
+    int global = !strcmp(name, "model.embed_tokens.weight") ? 0 :
+        !strcmp(name, "lm_head.weight") ? 1 : !strcmp(name, "model.norm.weight") ? 2 :
+        !strcmp(name, "model.embed_norm.weight") ? 3 : -1;
+    if (global >= 0) {
+        if (!v->sidecar && (v->edge_seen & (1u << global))) return -1;
+        if (!v->sidecar) v->edge_seen |= 1u << global;
+        if (!v->sidecar && (packed || t->elements !=
+            (global < 2 ? (uint64_t)m->vocab * m->hidden : m->hidden))) return -1;
+        cost = global < 2 && !strcmp(t->dtype, "BF16") ? t->bytes :
+            packed ? t->bytes : lmb_size_mul(t->elements, 4);
+        m->edge_resident_bytes = lmb_size_add(m->edge_resident_bytes, cost);
+        return m->edge_resident_bytes == UINT64_MAX ? -1 : 0;
+    }
+    if (strncmp(name, "model.layers.", 13)) {
+        if (v->sidecar) {
+            cost = packed ? t->bytes : lmb_size_mul(t->elements, 4);
+            m->edge_resident_bytes = lmb_size_add(m->edge_resident_bytes, cost);
+            if (m->edge_resident_bytes == UINT64_MAX) return -1;
+        }
+        return 0;
+    }
+    uint64_t layer;
+    const char *suffix = lmb_plan_uint(name + 13, &layer);
+    if (!suffix || *suffix++ != '.') return -1;
+    if (layer >= m->layers) return 0; /* unexecuted MTP/auxiliary tensors */
+    static const char *const fields[] = {
+        "input_layernorm.weight", "post_attention_layernorm.weight",
+        "self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight",
+        "self_attn.r_proj.weight", "self_attn.o_proj.weight", "self_attn.q_norm.weight",
+        "self_attn.k_norm.weight", "self_attn.rel_logits_proj.proj",
+        "self_attn.k_sconv.conv1d.weight", "self_attn.v_sconv.conv1d.weight",
+        "attn_sconv.conv1d.weight", "mlp_sconv.conv1d.weight",
+        "mlp.gate_proj.weight", "mlp.up_proj.weight", "mlp.down_proj.weight",
+        "mlp.gate.weight", "mlp.gate.e_score_correction_bias",
+        "mlp.shared_experts.gate_proj", "mlp.shared_experts.up_proj", "mlp.shared_experts.down_proj",
+        "mlp.experts.gate_up_proj", "mlp.experts.down_proj",
+        "mlp.experts.gate_up_proj.qs", "mlp.experts.down_proj.qs"
+    };
+    unsigned field;
+    for (field = 0; field < sizeof fields / sizeof *fields; field++)
+        if (!strcmp(suffix, fields[field])) break;
+    if (v->sidecar) {
+        /* Optional dense quantization may fall back per tensor. Reserve both
+         * banks, rather than assuming the compressed tensor will be selected. */
+        cost = packed ? t->bytes : lmb_size_mul(t->elements, 4);
+    } else {
+        if (field == sizeof fields / sizeof *fields) return 0;
+        if (v->seen[layer] & (1u << field)) return -1;
+        v->seen[layer] |= 1u << field;
+        int matrix = (field >= 2 && field <= 6) || (field >= 14 && field <= 16) ||
+                     (field >= 19 && field <= 21);
+        if (field == 22 || field == 23) {
+            uint64_t expected = (uint64_t)v->experts * v->inter * v->hidden * (field == 22 ? 2u : 1u);
+            if ((!packed && t->elements != expected) ||
+                (packed && t->bytes != expected && t->bytes != expected / 2)) return -1;
+            if (packed) {
+                cost = t->bytes;
+                v->packed[layer] |= field == 22 ? 1u : 2u;
+                v->encoding[layer][field == 22 ? 0 : 1] = t->bytes == expected ? 8 : 4;
+            } else {
+                /* Float source may be loaded exact or quantized by an explicit
+                 * runtime profile; include f32 plus possible row scales. */
+                uint64_t rows = (uint64_t)v->experts * (field == 22 ? 2u * v->inter : v->hidden);
+                cost = lmb_size_add(lmb_size_mul(t->elements, 4), rows * 4);
+            }
+        } else {
+            if (packed) return -1;
+            if ((field == 24 || field == 25) && t->elements !=
+                (uint64_t)v->experts * (field == 24 ? 2u * v->inter : v->hidden)) return -1;
+            cost = matrix && !strcmp(t->dtype, "BF16") ? t->bytes : lmb_size_mul(t->elements, 4);
+        }
+    }
+    m->memory[layer].resident_bytes = lmb_size_add(m->memory[layer].resident_bytes, cost);
+    return m->memory[layer].resident_bytes == UINT64_MAX ? -1 : 0;
+}
+
+static int LMB_UNUSED lmb_inkling_memory(const char *root, const char *json, LmbModelShape *m) {
+    LmbInklingInventory v = { .model = m };
+    uint32_t h, layers, heads, kv, hd, sh, sk, sd, window, rel, extent, conv, experts, topk;
+    uint32_t shared, dense, inter, first, unpadded;
+#define NEED(key, field, lo, hi) if (lmb_plan_u32(json, key, lo, hi, &field)) return -1
+#define OPT(key, field, def, lo, hi) if (lmb_plan_optional(json, key, def, lo, hi, &field)) return -1
+    NEED("hidden_size", h, 1, 65536); NEED("num_hidden_layers", layers, 1, 256);
+    NEED("num_attention_heads", heads, 1, 65536); NEED("num_key_value_heads", kv, 1, 65536);
+    NEED("head_dim", hd, 1, 65536); NEED("n_routed_experts", experts, 1, 4096);
+    NEED("num_experts_per_tok", topk, 1, 256);
+    OPT("unpadded_vocab_size", unpadded, m->vocab, 1, m->vocab);
+    OPT("swa_num_attention_heads", sh, heads, 1, 65536); OPT("swa_num_key_value_heads", sk, 16, 1, 65536);
+    OPT("swa_head_dim", sd, hd, 1, 65536); OPT("sliding_window_size", window, 512, 1, 1048576);
+    OPT("d_rel", rel, 16, 1, 65536); OPT("rel_extent", extent, 1024, 1, 1048576);
+    OPT("conv_kernel_size", conv, 4, 2, 65536); OPT("sconv_kernel_size", conv, conv, 2, 65536);
+    OPT("n_shared_experts", shared, 2, 1, 65536); OPT("dense_mlp_idx", first, 0, 0, layers);
+    if (lmb_json_member(json, "dense_intermediate_size")) {
+        NEED("dense_intermediate_size", dense, 1, 1048576);
+        NEED("intermediate_size", inter, 1, 1048576);
+    } else {
+        NEED("intermediate_size", dense, 1, 1048576);
+        NEED("moe_intermediate_size", inter, 1, 1048576);
+    }
+#undef NEED
+#undef OPT
+    if (!m->vocab || m->vocab > INT32_MAX || !unpadded || h != m->hidden ||
+        layers != m->layers || heads % kv || sh % sk || topk > experts) return -1;
+    for (uint32_t i = 0; i < layers; i++) { v.local[i] = (i + 1) % 6 != 0; v.sparse[i] = i >= first; }
+    if (lmb_json_member(json, "layer_types")) {
+        if (lmb_plan_kinds(json, "layer_types", "hybrid", "hybrid_sliding", v.local, layers)) return -1;
+    } else if (lmb_json_member(json, "local_layer_ids")) {
+        uint64_t ids[256]; unsigned count;
+        if (lmb_plan_array(lmb_json_member(json, "local_layer_ids"), ids, 256, &count)) return -1;
+        memset(v.local, 0, sizeof v.local);
+        for (unsigned i = 0; i < count; i++) { if (ids[i] >= layers) return -1; v.local[ids[i]] = 1; }
+    }
+    if (lmb_json_member(json, "mlp_layer_types") &&
+        lmb_plan_kinds(json, "mlp_layer_types", "dense", "sparse", v.sparse, layers)) return -1;
+    v.hidden = h; v.inter = inter; v.experts = experts;
+    if (lmb_plan_tensors(root, lmb_inkling_tensor, &v) || (v.edge_seen & 7) != 7) return -1;
+    int first_sparse = -1;
+    for (uint32_t i = 0; i < layers; i++) {
+        uint32_t required = (1u << 14) - 1;
+        required |= v.sparse[i] ? ((1u << 24) - (1u << 17)) : 7u << 14;
+        if (v.packed[i]) {
+            if (v.packed[i] != 3) return -1;
+            required |= 3u << 24;
+        }
+        if ((v.seen[i] & required) != required) return -1;
+        if (v.sparse[i]) {
+            if (first_sparse >= 0 && memcmp(v.encoding[i], v.encoding[first_sparse], 2)) return -1;
+            first_sparse = (int)i;
+        }
+        uint64_t kvdim = (uint64_t)(v.local[i] ? sk : kv) * (v.local[i] ? sd : hd);
+        m->memory[i].state_token_bytes = kvdim * 8;
+        m->memory[i].state_context_limit = v.local[i] ? window : 0;
+        m->memory[i].state_fixed_bytes = lmb_size_mul(2 * (kvdim + h), (uint64_t)(conv - 1) * 4);
+        m->memory[i].resident_bytes = lmb_size_add(m->memory[i].resident_bytes, 32768);
+    }
+    char path[1024]; struct stat st;
+    int len = snprintf(path, sizeof path, "%s/dense-int4g64", root);
+    if (len < 0 || (size_t)len >= sizeof path) return -1;
+    if (!stat(path, &st)) {
+        v.sidecar = 1;
+        if (!S_ISDIR(st.st_mode) || lmb_plan_tensors(path, lmb_inkling_tensor, &v)) return -1;
+    } else if (errno != ENOENT) return -1;
+    uint64_t wide = h + (uint64_t)(heads + 2u * kv) * hd + (uint64_t)(sh + 2u * sk) * sd +
+        (uint64_t)(heads + sh) * rel + (uint64_t)shared * (h + inter) +
+        (uint64_t)topk * (h + inter) + experts + dense;
+    m->scratch_fixed_bytes = lmb_size_add(lmb_size_mul(wide, 128u * 16u * 4u),
+        lmb_size_add((uint64_t)h * inter * 24u, (uint64_t)(extent + window + conv + 128u) * 256u * 4u));
+    m->scratch_token_bytes = 256u * 4u;
+    m->segment_fixed_bytes = (uint64_t)layers * (4096u + (uint64_t)experts * 256u);
+    m->max_context = 1048576; /* household admission ceiling */
+    m->experts = experts; m->experts_per_tok = topk; m->moe_intermediate = inter;
+    m->memory_contract = 1;
+    return 0;
+}
+#endif

--- a/planner_adapters/inkling.h
+++ b/planner_adapters/inkling.h
@@ -39,6 +39,7 @@ static int lmb_inkling_tensor(const LmbPlanTensor *t, void *opaque) {
     LmbModelShape *m = v->model;
     uint64_t cost;
     int packed = !strcmp(t->dtype, "U8") || !strcmp(t->dtype, "I8");
+    if (!packed && strcmp(t->dtype,"F32") && strcmp(t->dtype,"BF16") && strcmp(t->dtype,"F16")) return -1;
     const char *name = t->name;
     int global = !strcmp(name, "model.embed_tokens.weight") ? 0 :
         !strcmp(name, "lm_head.weight") ? 1 : !strcmp(name, "model.norm.weight") ? 2 :

--- a/planner_adapters/inkling.h
+++ b/planner_adapters/inkling.h
@@ -34,6 +34,7 @@ typedef struct {
 } LmbInklingInventory;
 
 static int lmb_inkling_tensor(const LmbPlanTensor *t, void *opaque) {
+    if (!strcmp(t->dtype, "I64")) return -1;
     LmbInklingInventory *v = opaque;
     LmbModelShape *m = v->model;
     uint64_t cost;

--- a/planner_adapters/kimi.h
+++ b/planner_adapters/kimi.h
@@ -1,0 +1,175 @@
+#ifndef LUMABRI_PLAN_KIMI_H
+#define LUMABRI_PLAN_KIMI_H
+
+/* Float/BF16 dense source with native MXFP4 routed experts. Prepared dense
+ * quantization needs its own retained-layout validation before admission. */
+static const char *const lmb_kimi_fields[] = {
+    "input_layernorm.weight", "post_attention_layernorm.weight",
+    "self_attention_res_norm.weight", "self_attention_res_proj.weight",
+    "mlp_res_norm.weight", "mlp_res_proj.weight",
+    "self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight",
+    "self_attn.g_proj.weight", "self_attn.o_proj.weight",
+    "self_attn.q_conv1d.weight", "self_attn.k_conv1d.weight", "self_attn.v_conv1d.weight",
+    "self_attn.f_a_proj.weight", "self_attn.f_b_proj.weight", "self_attn.b_proj.weight",
+    "self_attn.dt_bias", "self_attn.o_norm.weight", "self_attn.A_log",
+    "self_attn.q_a_proj.weight", "self_attn.q_b_proj.weight",
+    "self_attn.kv_a_proj_with_mqa.weight", "self_attn.kv_b_proj.weight",
+    "self_attn.q_a_layernorm.weight", "self_attn.kv_a_layernorm.weight",
+    "self_attn.w_k.weight", "self_attn.w_q.weight", "self_attn.w_p.weight",
+    "self_attn.kn_w", "self_attn.kn_b",
+    "mlp.gate_proj.weight", "mlp.up_proj.weight", "mlp.down_proj.weight",
+    "block_sparse_moe.gate.weight", "block_sparse_moe.gate.e_score_correction_bias",
+    "block_sparse_moe.routed_expert_norm.weight",
+    "block_sparse_moe.routed_expert_down_proj.weight", "block_sparse_moe.routed_expert_up_proj.weight",
+    "block_sparse_moe.shared_experts.gate_proj.weight",
+    "block_sparse_moe.shared_experts.up_proj.weight", "block_sparse_moe.shared_experts.down_proj.weight"
+};
+typedef struct {
+    LmbModelShape *model;
+    uint64_t seen[128];
+    uint8_t kda[128], index[128], edge_seen, prefix_seen;
+    uint8_t *expert_seen;
+    uint32_t first, latent, inter, experts;
+} LmbKimiInventory;
+
+static int lmb_kimi_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbKimiInventory *v = opaque;
+    LmbModelShape *m = v->model;
+    const char *name = t->name;
+    unsigned prefix = 1;
+    if (!strncmp(name, "language_model.", 15)) { name += 15; prefix = 2; }
+    int global = !strcmp(name, "model.embed_tokens.weight") ? 0 :
+        !strcmp(name, "lm_head.weight") ? 1 : !strcmp(name, "model.norm.weight") ? 2 :
+        !strcmp(name, "model.output_attn_res_norm.weight") ? 3 :
+        !strcmp(name, "model.output_attn_res_proj.weight") ? 4 : -1;
+    int is_float = !strcmp(t->dtype, "F32") || !strcmp(t->dtype, "BF16") || !strcmp(t->dtype, "F16");
+    if (global >= 0) {
+        v->prefix_seen |= prefix;
+        if (!is_float || v->prefix_seen == 3 || (v->edge_seen & (1u << global)) ||
+            t->elements != (global < 2 ? (uint64_t)m->vocab * m->hidden : m->hidden)) return -1;
+        v->edge_seen |= 1u << global;
+        /* Embeddings are read per row; reserve their complete source footprint
+         * as well as the f32 head upper bound, not a fictitious small Edge. */
+        m->edge_resident_bytes = lmb_size_add(m->edge_resident_bytes, lmb_size_mul(t->elements, 4));
+        return m->edge_resident_bytes == UINT64_MAX ? -1 : 0;
+    }
+    if (strncmp(name, "model.layers.", 13)) return 0;
+    uint64_t layer;
+    const char *field = lmb_plan_uint(name + 13, &layer);
+    if (!field || *field++ != '.') return -1;
+    if (layer >= m->layers) return 0;
+    v->prefix_seen |= prefix;
+    if (v->prefix_seen == 3) return -1;
+    uint64_t cost;
+    const char *ep = "block_sparse_moe.experts.";
+    if (!strncmp(field, ep, strlen(ep))) {
+        uint64_t expert;
+        const char *kind = lmb_plan_uint(field + strlen(ep), &expert);
+        if (!kind || *kind++ != '.' || expert >= v->experts || layer < v->first) return -1;
+        const char *const names[] = {"w1.weight_packed", "w1.weight_scale",
+            "w2.weight_packed", "w2.weight_scale", "w3.weight_packed", "w3.weight_scale"};
+        unsigned i;
+        for (i = 0; i < 6; i++) if (!strcmp(kind, names[i])) break;
+        if (i == 6) return -1;
+        uint64_t expected = (uint64_t)v->latent * v->inter / (i % 2 ? 32u : 2u);
+        uint8_t *seen = &v->expert_seen[layer * v->experts + expert];
+        if ((*seen & (1u << i)) || strcmp(t->dtype, "U8") || t->bytes != expected) return -1;
+        *seen |= 1u << i;
+        cost = t->bytes; /* native MXFP4 packed nibbles and e8m0 scales */
+    } else {
+        unsigned i;
+        for (i = 0; i < sizeof lmb_kimi_fields / sizeof *lmb_kimi_fields; i++)
+            if (!strcmp(field, lmb_kimi_fields[i])) break;
+        if (i == sizeof lmb_kimi_fields / sizeof *lmb_kimi_fields) return 0;
+        if (!is_float || (v->seen[layer] & (UINT64_C(1) << i))) return -1;
+        v->seen[layer] |= UINT64_C(1) << i;
+        /* Upper bound for all supported dense numeric profiles: f32 plus row
+         * scales. Never assume that a donor inherited the source's K3_BITS. */
+        cost = lmb_size_add(lmb_size_mul(t->elements, 4), lmb_size_mul(t->shape[0], 4));
+    }
+    m->memory[layer].resident_bytes = lmb_size_add(m->memory[layer].resident_bytes, cost);
+    return m->memory[layer].resident_bytes == UINT64_MAX ? -1 : 0;
+}
+
+static int lmb_plan_indices(const char *json, const char *key, uint8_t *dst,
+                             uint32_t layers, unsigned origin) {
+    uint64_t ids[128]; unsigned count;
+    if (lmb_plan_array(lmb_json_member(json, key), ids, 128, &count)) return -1;
+    memset(dst, 0, layers);
+    for (unsigned i = 0; i < count; i++) {
+        if (ids[i] < origin || ids[i] - origin >= layers) return -1;
+        dst[ids[i] - origin] = 1;
+    }
+    return 0;
+}
+
+static int LMB_UNUSED lmb_kimi_memory(const char *root, const char *json, LmbModelShape *m) {
+    LmbKimiInventory v = { .model = m };
+    uint32_t h, layers, heads, qrank, kvrank, nope, rope, vd, experts, topk, inter, latent;
+    uint32_t dense, shared, first, block, kh, kd, conv, index, index_heads, index_topk;
+#define NEED(key, dst, lo, hi) if (lmb_plan_u32(json, key, lo, hi, &dst)) return -1
+    NEED("hidden_size", h, 1, 65536); NEED("num_hidden_layers", layers, 1, 128);
+    NEED("num_attention_heads", heads, 1, 65536); NEED("q_lora_rank", qrank, 1, 65536);
+    NEED("kv_lora_rank", kvrank, 1, 4096); NEED("qk_nope_head_dim", nope, 1, 65536);
+    NEED("qk_rope_head_dim", rope, 2, 256); NEED("v_head_dim", vd, 1, 65536);
+    NEED("num_experts", experts, 1, 4096); NEED("num_experts_per_token", topk, 1, 64);
+    NEED("moe_intermediate_size", inter, 32, 1048576); NEED("routed_expert_hidden_size", latent, 32, 1048576);
+    NEED("intermediate_size", dense, 1, 1048576); NEED("num_shared_experts", shared, 1, 65536);
+    NEED("first_k_dense_replace", first, 0, layers); NEED("attn_res_block_size", block, 1, layers);
+#undef NEED
+    const char *linear = lmb_json_member(json, "linear_attn_config");
+    if (!linear || *linear != '{' || lmb_plan_u32(linear, "num_heads", 1, 65536, &kh) ||
+        lmb_plan_u32(linear, "head_dim", 1, 512, &kd) ||
+        lmb_plan_u32(linear, "short_conv_kernel_size", 1, 8, &conv) ||
+        lmb_plan_indices(linear, "kda_layers", v.kda, layers, 1) ||
+        lmb_plan_optional(json, "index_hd", 0, 0, 65536, &index) ||
+        lmb_plan_optional(json, "index_nh", 0, 0, 65536, &index_heads) ||
+        lmb_plan_optional(json, "index_topk", 0, 0, 1048576, &index_topk)) return -1;
+    uint32_t blocks = (layers + block - 1) / block;
+    uint64_t proj = (uint64_t)kh * kd;
+    if (h != m->hidden || layers != m->layers || !m->vocab || m->vocab > (1u << 22) ||
+        topk > experts || latent % 32 || inter % 32 || rope % 2 || blocks + 1 > 16 ||
+        proj > (1u << 20) || (index && (!index_heads || !index_topk))) return -1;
+    for (uint32_t i = 0; i < layers; i++) v.index[i] = index && !v.kda[i];
+    if (index && lmb_json_member(json, "index_layers") &&
+        lmb_plan_indices(json, "index_layers", v.index, layers, 1)) return -1;
+    v.first = first; v.latent = latent; v.inter = inter; v.experts = experts;
+    v.expert_seen = calloc((size_t)layers * experts, 1);
+    if (!v.expert_seen) return -1;
+    int rc = lmb_plan_tensors(root, lmb_kimi_tensor, &v);
+    if (v.edge_seen != 31) rc = -1;
+    for (uint32_t i = 0; i < layers && !rc; i++) {
+        uint64_t required = 63; /* norms and AttnRes scores */
+        required |= v.kda[i] ? ((UINT64_C(1) << 20) - (UINT64_C(1) << 6)) :
+            ((UINT64_C(1) << 26) - (UINT64_C(1) << 20)) | (3u << 9);
+        if (!v.kda[i] && v.index[i]) required |= (UINT64_C(31) << 26);
+        required |= i < first ? (UINT64_C(7) << 31) : (UINT64_C(255) << 34);
+        if ((v.seen[i] & required) != required) { rc = -1; break; }
+        if (i >= first) {
+            for (uint32_t e = 0; e < experts; e++)
+                if (v.expert_seen[i * experts + e] != 63) rc = -1;
+            /* Every native slot allocates e_slot + 8192 for aligned O_DIRECT
+             * leading/trailing padding, even on its buffered-read fallback. */
+            m->memory[i].resident_bytes = lmb_size_add(m->memory[i].resident_bytes,
+                                                       (uint64_t)experts * 8192u);
+        }
+        if (v.kda[i]) m->memory[i].state_fixed_bytes = (proj * kd + 3u * proj * conv) * 4;
+        else m->memory[i].state_token_bytes = (kvrank + rope + (v.index[i] ? index : 0u)) * 4u;
+    }
+    free(v.expert_seen);
+    if (rc) return -1;
+    m->boundary_width = h * (1u + blocks);
+    m->edge_scratch_fixed_bytes = (uint64_t)h * 1024u * 4u; /* native head load quantization */
+    uint64_t wide = m->boundary_width + (uint64_t)heads * (nope + rope + 2u * vd) +
+        proj * (kd + 8u) + (uint64_t)shared * inter + dense + latent + qrank + kvrank +
+        (uint64_t)index * (index_heads + 1u) + experts + (uint64_t)topk * (latent + inter);
+    m->scratch_fixed_bytes = lmb_size_add(lmb_size_mul(wide, 128u * 16u * 4u),
+        lmb_size_mul(wide, 1024u * 4u)); /* conservative QCHUNK loading workspace */
+    m->scratch_token_bytes = 256u * 32u; /* score + DSA entries and selections per team */
+    m->segment_fixed_bytes = (uint64_t)layers * (4096u + (uint64_t)experts * 512u);
+    m->max_context = 1048576;
+    m->experts = experts; m->experts_per_tok = topk; m->moe_intermediate = inter;
+    m->memory_contract = 1;
+    return 0;
+}
+#endif

--- a/planner_adapters/kimi.h
+++ b/planner_adapters/kimi.h
@@ -163,9 +163,15 @@ static int LMB_UNUSED lmb_kimi_memory(const char *root, const char *json, LmbMod
     uint64_t wide = m->boundary_width + (uint64_t)heads * (nope + rope + 2u * vd) +
         proj * (kd + 8u) + (uint64_t)shared * inter + dense + latent + qrank + kvrank +
         (uint64_t)index * (index_heads + 1u) + experts + (uint64_t)topk * (latent + inter);
-    m->scratch_fixed_bytes = lmb_size_add(lmb_size_mul(wide, 128u * 16u * 4u),
-        lmb_size_mul(wide, 1024u * 4u)); /* conservative QCHUNK loading workspace */
-    m->scratch_token_bytes = 256u * 32u; /* score + DSA entries and selections per team */
+    /* The pinned native initializer refuses even tiny ranges below its
+     * unconditional 2.5 GB page-cache + 1.2 GB activation policy reserve.
+     * Keep this floor in admission; never bypass COLI_RAM_OVERCOMMIT to make
+     * an optimistic plan start. Its KV projection includes unowned layers. */
+    m->scratch_fixed_bytes = lmb_size_add(UINT64_C(3700000000),
+        lmb_size_add(lmb_size_mul(wide, 128u * 16u * 4u),
+                     lmb_size_mul(wide, 1024u * 4u)));
+    m->scratch_token_bytes = lmb_size_add(256u * 32u,
+        (uint64_t)layers * (kvrank + rope) * 4u);
     m->segment_fixed_bytes = (uint64_t)layers * (4096u + (uint64_t)experts * 512u);
     m->max_context = 1048576;
     m->experts = experts; m->experts_per_tok = topk; m->moe_intermediate = inter;

--- a/planner_adapters/olmoe.h
+++ b/planner_adapters/olmoe.h
@@ -1,0 +1,106 @@
+#ifndef LUMABRI_PLAN_OLMOE_H
+#define LUMABRI_PLAN_OLMOE_H
+/* The pinned Segment runtime consumes merged int8 experts, not arbitrary HF
+ * expert matrices. Dense tensors are expanded to f32 even from BF16/F16. */
+typedef struct {
+    LmbModelShape *m;
+    uint16_t seen[LMB_PLAN_LAYER_MAX];
+    uint8_t edge_seen, *experts;
+    uint32_t inter;
+    uint64_t largest;
+} LmbOlmoeInventory;
+
+static int lmb_olmoe_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbOlmoeInventory *v=opaque;
+    LmbModelShape *m=v->m;
+    int floating=!strcmp(t->dtype,"F32") || !strcmp(t->dtype,"BF16") || !strcmp(t->dtype,"F16");
+    int edge=!strcmp(t->name,"model.embed_tokens.weight") ? 0 :
+        !strcmp(t->name,"lm_head.weight") ? 1 : !strcmp(t->name,"model.norm.weight") ? 2 : -1;
+    uint64_t expected, cost;
+    if(edge>=0) {
+        expected=edge<2 ? (uint64_t)m->vocab*m->hidden : m->hidden;
+        if(!floating || t->elements!=expected || (v->edge_seen&(1u<<edge)) ||
+           t->rank!=(edge<2 ? 2u : 1u) || t->shape[0]!=(edge<2 ? m->vocab : m->hidden) ||
+           (edge<2 && t->shape[1]!=m->hidden)) return -1;
+        v->edge_seen|=1u<<edge;
+        cost=lmb_size_mul(expected,4);
+        m->edge_resident_bytes=lmb_size_add(m->edge_resident_bytes,cost);
+        if(cost>m->edge_scratch_fixed_bytes) m->edge_scratch_fixed_bytes=cost;
+        return m->edge_resident_bytes==UINT64_MAX ? -1 : 0;
+    }
+    if(strncmp(t->name,"model.layers.",13)) return 0;
+    uint64_t layer;
+    const char *field=lmb_plan_uint(t->name+13,&layer);
+    if(!field || *field++!='.' || layer>=m->layers) return -1;
+    if(!strncmp(field,"mlp.experts.",12)) {
+        uint64_t expert;
+        const char *kind=lmb_plan_uint(field+12,&expert);
+        if(!kind || *kind++!='.' || expert>=m->experts) return -1;
+        unsigned bit;
+        if(!strcmp(kind,"merged_weight")) {
+            expected=lmb_size_mul((uint64_t)v->inter*m->hidden,3);
+            if((strcmp(t->dtype,"I8") && strcmp(t->dtype,"U8")) || t->bytes!=expected) return -1;
+            cost=expected; bit=1;
+        } else if(!strcmp(kind,"qs")) {
+            expected=(uint64_t)v->inter*2+m->hidden;
+            if(!floating || t->elements!=expected) return -1;
+            cost=lmb_size_mul(expected,4); bit=2;
+        } else return -1;
+        uint8_t *seen=&v->experts[layer*m->experts+expert];
+        if(*seen&bit) return -1;
+        *seen|=bit;
+    } else {
+        static const char *const names[]={"input_layernorm.weight","post_attention_layernorm.weight",
+            "self_attn.q_proj.weight","self_attn.k_proj.weight","self_attn.v_proj.weight",
+            "self_attn.o_proj.weight","self_attn.q_norm.weight","self_attn.k_norm.weight","mlp.gate.weight"};
+        unsigned i;
+        for(i=0;i<sizeof names/sizeof *names;i++) if(!strcmp(field,names[i])) break;
+        if(i==sizeof names/sizeof *names) return -1;
+        int matrix=(i>=2 && i<=5) || i==8;
+        uint64_t rows=i==8 ? m->experts : m->hidden;
+        expected=matrix ? rows*m->hidden : m->hidden;
+        if(!floating || t->elements!=expected || (v->seen[layer]&(1u<<i)) ||
+           t->rank!=(matrix ? 2u : 1u) || t->shape[0]!=rows || (matrix && t->shape[1]!=m->hidden)) return -1;
+        v->seen[layer]|=1u<<i;
+        cost=lmb_size_mul(expected,4);
+    }
+    if(cost>v->largest) v->largest=cost;
+    m->memory[layer].resident_bytes=lmb_size_add(m->memory[layer].resident_bytes,cost);
+    return m->memory[layer].resident_bytes==UINT64_MAX ? -1 : 0;
+}
+
+static int lmb_olmoe_memory(const char *root,const char *cfg,LmbModelShape *m) {
+    uint32_t h,layers,heads,kv,inter,experts,k,vocab;
+#define OLM_NEED(key,dst,lo,hi) if(lmb_plan_u32(cfg,key,lo,hi,&dst)) return -1
+    OLM_NEED("hidden_size",h,2,1048576); OLM_NEED("num_hidden_layers",layers,1,LMB_PLAN_LAYER_MAX);
+    OLM_NEED("num_attention_heads",heads,1,65536); OLM_NEED("num_key_value_heads",kv,1,65536);
+    OLM_NEED("intermediate_size",inter,1,16777216); OLM_NEED("num_experts",experts,1,4096);
+    OLM_NEED("num_experts_per_tok",k,1,64); OLM_NEED("vocab_size",vocab,1,16777216);
+#undef OLM_NEED
+    /* Attention allocates full MHA; GQA-shaped checkpoints are not compatible
+     * with this runtime just because config contains num_key_value_heads. */
+    if(h!=m->hidden || layers!=m->layers || vocab!=m->vocab || h%heads || (h/heads)%2 ||
+       kv!=heads || k>experts) return -1;
+    m->experts=experts; m->experts_per_tok=k; m->moe_intermediate=inter;
+    LmbOlmoeInventory v={.m=m,.inter=inter};
+    v.experts=calloc((size_t)layers*experts,1);
+    if(!v.experts) return -1;
+    int rc=lmb_plan_tensors(root,lmb_olmoe_tensor,&v);
+    if(v.edge_seen!=7) rc=-1;
+    for(uint32_t i=0;i<layers && !rc;i++) {
+        if(v.seen[i]!=511) rc=-1;
+        for(uint32_t e=0;e<experts;e++) if(v.experts[i*experts+e]!=3) rc=-1;
+        m->memory[i].state_token_bytes=(uint64_t)h*8;
+    }
+    free(v.experts);
+    if(rc) return -1;
+    /* Full resident expert bank plus metadata. No disk claim follows merely
+     * from the runtime having an LRU. Prefill supports at most 128 rows. */
+    m->segment_fixed_bytes=(uint64_t)layers*(8192u+(uint64_t)experts*512u);
+    m->scratch_fixed_bytes=lmb_size_add(v.largest,
+        lmb_size_mul((uint64_t)h*8+inter*3u+experts,128u*4u));
+    m->scratch_token_bytes=256u*4u; /* bounded CPU attention worker team */
+    m->max_context=4096; m->memory_contract=1;
+    return m->scratch_fixed_bytes==UINT64_MAX ? -1 : 0;
+}
+#endif

--- a/planner_adapters/qwen36.h
+++ b/planner_adapters/qwen36.h
@@ -4,6 +4,61 @@
 #ifndef LUMABRI_PLAN_QWEN36_H
 #define LUMABRI_PLAN_QWEN36_H
 #include <errno.h>
+#include "tensors.h"
+
+typedef struct {
+    LmbModelShape *m;
+    uint64_t counts[23], weight_bytes, scale_elements;
+    uint32_t seen[LMB_PLAN_LAYER_MAX];
+    uint8_t full[LMB_PLAN_LAYER_MAX], edge, *experts;
+} LmbQwen36Inventory;
+
+static int lmb_q36_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbQwen36Inventory *v=opaque; LmbModelShape *m=v->m;
+    unsigned floating=!strcmp(t->dtype,"F32") || !strcmp(t->dtype,"F16") || !strcmp(t->dtype,"BF16");
+    int edge=!strcmp(t->name,"model.embed_tokens.weight") ? 0 :
+        !strcmp(t->name,"lm_head.weight") ? 1 : !strcmp(t->name,"model.norm.weight") ? 2 : -1;
+    if(edge>=0) {
+        uint64_t count=edge<2 ? (uint64_t)m->vocab*m->hidden : m->hidden;
+        if(!floating || t->elements!=count || (v->edge&(1u<<edge))) return -1;
+        v->edge|=1u<<edge; return 0;
+    }
+    if(strncmp(t->name,"model.layers.",13)) return 0;
+    uint64_t layer;
+    const char *field=lmb_plan_uint(t->name+13,&layer);
+    if(!field || *field++!='.' || layer>=m->layers) return -1;
+    if(!strncmp(field,"mlp.experts.",12)) {
+        uint64_t expert;
+        const char *kind=lmb_plan_uint(field+12,&expert);
+        if(!kind || *kind++!='.' || expert>=m->experts) return -1;
+        unsigned bit;
+        if(!strcmp(kind,"merged_weight")) {
+            if((strcmp(t->dtype,"I8") && strcmp(t->dtype,"U8")) ||
+               (t->bytes!=v->weight_bytes &&
+                ((v->weight_bytes&1) || t->bytes!=v->weight_bytes/2))) return -1;
+            bit=1;
+        } else if(!strcmp(kind,"qs")) {
+            if(!floating || t->elements!=v->scale_elements) return -1;
+            bit=2;
+        } else return -1;
+        uint8_t *seen=&v->experts[layer*m->experts+expert];
+        if(*seen&bit) return -1;
+        *seen|=bit; return 0;
+    }
+    static const char *const names[]={"input_layernorm.weight","post_attention_layernorm.weight",
+        "mlp.gate.weight","mlp.shared_expert.gate_proj.weight","mlp.shared_expert.up_proj.weight",
+        "mlp.shared_expert.down_proj.weight","mlp.shared_expert_gate.weight","self_attn.q_norm.weight",
+        "self_attn.k_norm.weight","mlp.gate.e_score_correction_bias",
+        "self_attn.q_proj.weight","self_attn.k_proj.weight","self_attn.v_proj.weight","self_attn.o_proj.weight",
+        "linear_attn.in_proj_qkv.weight","linear_attn.in_proj_z.weight","linear_attn.in_proj_b.weight",
+        "linear_attn.in_proj_a.weight","linear_attn.conv1d.weight","linear_attn.dt_bias","linear_attn.A_log",
+        "linear_attn.norm.weight","linear_attn.out_proj.weight"};
+    unsigned i;
+    for(i=0;i<23;i++) if(!strcmp(field,names[i])) break;
+    if(i==23) return 0;
+    if(!floating || t->elements!=v->counts[i] || (v->seen[layer]&(1u<<i))) return -1;
+    v->seen[layer]|=1u<<i; return 0;
+}
 
 static int LMB_UNUSED lmb_plan_u32(const char *json, const char *key,
                                   uint32_t minimum, uint32_t maximum, uint32_t *out) {
@@ -19,7 +74,7 @@ static int LMB_UNUSED lmb_plan_u32(const char *json, const char *key,
     return 0;
 }
 
-static int LMB_UNUSED lmb_qwen36_memory(const char *root, LmbModelShape *m) {
+static int LMB_UNUSED lmb_qwen36_metadata(const char *root, LmbModelShape *m, LmbQwen36Inventory *v) {
     char path[1024], json[65536];
     int length = snprintf(path, sizeof path, "%s/qwen36_meta.json", root);
     if (length < 0 || (size_t)length >= sizeof path) return -1;
@@ -28,7 +83,9 @@ static int LMB_UNUSED lmb_qwen36_memory(const char *root, LmbModelShape *m) {
     size_t n = fread(json, 1, sizeof json - 1, file);
     int invalid = ferror(file) || !feof(file);
     fclose(file); json[n] = 0;
-    if (invalid || !n || json[0] != '{') return -1;
+    if (invalid || !n || memchr(json,0,n) || *lmb_plan_space(json)!='{') return -1;
+    const char *finish=lmb_plan_object_end(lmb_plan_space(json));
+    if(!finish || *lmb_plan_space(finish)) return -1;
     uint32_t hidden, layers, experts, topk, inter, shared, heads, kv_heads, hd;
     uint32_t qd, kd, vd, oi, gs, vh, kh, kdim, vdim, convk, convdim;
 #define NEED(key, field, lo, hi) if (lmb_plan_u32(json, key, lo, hi, &field)) return -1
@@ -90,6 +147,29 @@ static int LMB_UNUSED lmb_qwen36_memory(const char *root, LmbModelShape *m) {
     m->experts = experts; m->experts_per_tok = topk; m->moe_intermediate = inter;
     m->heads = heads; m->kv_heads = kv_heads;
     m->memory_contract = 1;
+    *v=(LmbQwen36Inventory){.m=m,.weight_bytes=3u*(uint64_t)hidden*inter,.scale_elements=scales};
+    memcpy(v->full,full,layers);
+    uint64_t H=hidden, DV=(uint64_t)vh*vdim;
+    uint64_t counts[]={H,H,(uint64_t)experts*H,H*shared,H*shared,H*shared,H,hd,hd,experts,
+        (uint64_t)heads*qd*H,(uint64_t)kv_heads*kd*H,(uint64_t)kv_heads*vd*H,H*oi,
+        (uint64_t)convdim*H,DV*H,(uint64_t)vh*H,(uint64_t)vh*H,(uint64_t)convdim*convk,
+        vh,vh,vdim,H*DV};
+    memcpy(v->counts,counts,sizeof counts);
     return 0;
+}
+
+static int LMB_UNUSED lmb_qwen36_memory(const char *root, LmbModelShape *m) {
+    LmbQwen36Inventory v;
+    if(lmb_qwen36_metadata(root,m,&v)) return -1;
+    v.experts=calloc((size_t)m->layers*m->experts,1);
+    if(!v.experts) return -1;
+    int rc=lmb_plan_tensors(root,lmb_q36_tensor,&v);
+    if(v.edge!=7) rc=-1;
+    for(unsigned i=0;i<m->layers && !rc;i++) {
+        uint32_t required=63u | (v.full[i] ? (15u<<10) : (511u<<14));
+        if((v.seen[i]&required)!=required) rc=-1;
+        for(unsigned e=0;e<m->experts;e++) if(v.experts[i*m->experts+e]!=3) rc=-1;
+    }
+    free(v.experts); return rc;
 }
 #endif

--- a/planner_adapters/qwen36.h
+++ b/planner_adapters/qwen36.h
@@ -1,0 +1,95 @@
+/* Resident CPU contract for Colibri qwen36's converted container.
+ * Derived from load_meta/model_init_range, Segment session_create and Edge
+ * engine_open at upstream 12a5c464. No runtime source is modified. */
+#ifndef LUMABRI_PLAN_QWEN36_H
+#define LUMABRI_PLAN_QWEN36_H
+#include <errno.h>
+
+static int LMB_UNUSED lmb_plan_u32(const char *json, const char *key,
+                                  uint32_t minimum, uint32_t maximum, uint32_t *out) {
+    const char *p = lmb_json_member(json, key);
+    if (!p || *p < '0' || *p > '9') return -1;
+    if (*p == '0' && p[1] >= '0' && p[1] <= '9') return -1;
+    errno = 0; char *end;
+    unsigned long long value = strtoull(p, &end, 10);
+    if (errno || value < minimum || value > maximum) return -1;
+    while (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r') end++;
+    if (*end != ',' && *end != '}' && *end != ']') return -1;
+    *out = (uint32_t)value;
+    return 0;
+}
+
+static int LMB_UNUSED lmb_qwen36_memory(const char *root, LmbModelShape *m) {
+    char path[1024], json[65536];
+    int length = snprintf(path, sizeof path, "%s/qwen36_meta.json", root);
+    if (length < 0 || (size_t)length >= sizeof path) return -1;
+    FILE *file = fopen(path, "rb");
+    if (!file) return -1;
+    size_t n = fread(json, 1, sizeof json - 1, file);
+    int invalid = ferror(file) || !feof(file);
+    fclose(file); json[n] = 0;
+    if (invalid || !n || json[0] != '{') return -1;
+    uint32_t hidden, layers, experts, topk, inter, shared, heads, kv_heads, hd;
+    uint32_t qd, kd, vd, oi, gs, vh, kh, kdim, vdim, convk, convdim;
+#define NEED(key, field, lo, hi) if (lmb_plan_u32(json, key, lo, hi, &field)) return -1
+    NEED("hidden", hidden, 1, 65536); NEED("n_layers", layers, 1, LMB_PLAN_LAYER_MAX);
+    NEED("num_experts", experts, 1, 1024); NEED("topk", topk, 1, 256);
+    NEED("moe_inter", inter, 1, 65536); NEED("shared_inter", shared, 1, 65536);
+    NEED("q_heads", heads, 1, 65536); NEED("kv_heads", kv_heads, 1, 65536);
+    NEED("head_dim", hd, 1, 65536); NEED("q_head_dim", qd, 1, 131072);
+    NEED("k_head_dim", kd, 1, 65536); NEED("v_head_dim", vd, 1, 65536);
+    NEED("o_in", oi, 1, 1048576); NEED("expert_gs", gs, 0, 65536);
+    NEED("dn_vheads", vh, 1, 65536); NEED("dn_kheads", kh, 1, 65536);
+    NEED("dn_kdim", kdim, 1, 65536); NEED("dn_vdim", vdim, 1, 512);
+    NEED("dn_convk", convk, 2, 65536); NEED("dn_conv_dim", convdim, 1, 1048576);
+#undef NEED
+    if (hidden != m->hidden || layers != m->layers || !m->vocab ||
+        experts < topk || heads % kv_heads || vh % kh || kd != vd || kd != hd ||
+        oi != (uint64_t)heads * hd ||
+        convdim != 2u * (uint64_t)kh * kdim + (uint64_t)vh * vdim) return -1;
+    const char *kinds = lmb_json_member(json, "layer_types");
+    if (!kinds || *kinds++ != '[') return -1;
+    uint8_t full[LMB_PLAN_LAYER_MAX];
+    for (uint32_t i = 0; i < layers; i++) {
+        while (*kinds == ' ' || *kinds == '\n' || *kinds == '\r' || *kinds == '\t') kinds++;
+        if (!strncmp(kinds, "\"full_attention\"", 16)) { full[i] = 1; kinds += 16; }
+        else if (!strncmp(kinds, "\"linear_attention\"", 18)) { full[i] = 0; kinds += 18; }
+        else return -1;
+        while (*kinds == ' ' || *kinds == '\n' || *kinds == '\r' || *kinds == '\t') kinds++;
+        if (*kinds++ != (i + 1 == layers ? ']' : ',')) return -1;
+    }
+    uint64_t scales = gs ? 2u * (uint64_t)inter * ((hidden + gs - 1) / gs) +
+        (uint64_t)hidden * ((inter + gs - 1) / gs) : 2u * (uint64_t)inter + hidden;
+    /* CPU caches keep unpacked int8 even for packed int4 source weights. */
+    uint64_t slot = lmb_size_add(3u * (uint64_t)hidden * inter, scales * 4);
+    uint64_t expert_bytes = lmb_size_mul(slot, experts);
+    uint64_t common = 3u * (uint64_t)hidden + (uint64_t)experts * hidden + experts +
+        3u * (uint64_t)hidden * shared + 2u * hd;
+    uint64_t attn = (uint64_t)heads * qd * hidden +
+        (uint64_t)kv_heads * (kd + vd) * hidden + (uint64_t)hidden * oi;
+    uint64_t linear = (uint64_t)convdim * hidden + 2u * (uint64_t)vh * vdim * hidden +
+        2u * (uint64_t)vh * hidden + (uint64_t)convdim * convk + 2u * vh + vdim;
+    uint64_t recurrent = (uint64_t)vh * kdim * vdim + (uint64_t)convdim * (convk - 1);
+    for (uint32_t i = 0; i < layers; i++) {
+        m->memory[i].resident_bytes = lmb_size_add(expert_bytes,
+            lmb_size_mul(lmb_size_add(common, full[i] ? attn : linear), 4));
+        m->memory[i].state_token_bytes = full[i] ? (uint64_t)kv_heads * kd * 8 : 0;
+        m->memory[i].state_fixed_bytes = full[i] ? 0 : recurrent * 4;
+    }
+    m->edge_resident_bytes = lmb_size_mul(lmb_size_add(
+        lmb_size_mul((uint64_t)m->vocab * hidden, 2), hidden), 4);
+    /* Small per-layer structures, expert indices and pilot arrays are kept
+     * for all layers even by an interval engine; bound them independently. */
+    m->segment_fixed_bytes = lmb_size_mul(layers, 4096u + (uint64_t)experts * 256);
+    uint64_t widest = hidden + (uint64_t)heads * qd + (uint64_t)kv_heads * (kd + vd) +
+        oi + convdim + (uint64_t)vh * (kdim + vdim) + inter + shared + experts;
+    m->scratch_fixed_bytes = lmb_size_add(slot,
+        lmb_size_add(lmb_size_mul(widest, 128u * 16u * 4u), 32u << 20));
+    m->scratch_token_bytes = 256u * 4u; /* maximum admitted OpenMP team */
+    m->max_context = 262144; /* QWEN36_ATTN_MAX_CTX in the pinned adapter */
+    m->experts = experts; m->experts_per_tok = topk; m->moe_intermediate = inter;
+    m->heads = heads; m->kv_heads = kv_heads;
+    m->memory_contract = 1;
+    return 0;
+}
+#endif

--- a/planner_adapters/qwen38.h
+++ b/planner_adapters/qwen38.h
@@ -1,0 +1,276 @@
+#ifndef LUMABRI_PLAN_QWEN38_H
+#define LUMABRI_PLAN_QWEN38_H
+/* Text-only float/BF16 Qwen4-Exp contract, pinned Colibri 12a5c464.
+ * PLE tables are row-read by the native engine: reserve their complete source
+ * footprint as well as all expert slots, without advertising a disk mode or
+ * claiming that admission has warmed the filesystem cache. */
+#include <float.h>
+#include <math.h>
+typedef struct {
+    LmbModelShape *m;
+    uint32_t h, hc, rank, qh, kvh, hd, ih, id, budget, ratio;
+    uint32_t e, k, inter, shared, kh, vh, kd, vd, conv, cd;
+    uint32_t pd, pc, nh, nd, parts, ple;
+    uint8_t full[LMB_PLAN_LAYER_MAX], kinds[LMB_PLAN_LAYER_MAX], prefix, edge;
+    uint64_t seen[LMB_PLAN_LAYER_MAX], largest, rows[512], vocab[64], offsets[64];
+    uint8_t *experts;
+    uint32_t ple_seen;
+    int table_whole;
+} LmbQwen38Inventory;
+
+static int lmb_q38_float(const char *s) {
+    return !strcmp(s,"BF16") ? 1 : !strcmp(s,"F16") ? 2 : !strcmp(s,"F32") ? 4 : 0;
+}
+static int lmb_q38_shape(const LmbPlanTensor *t, uint64_t n, uint64_t cols) {
+    return t->elements==n && (!cols || (t->rank==2 && t->shape[1]==cols));
+}
+static int lmb_q38_tensor(const LmbPlanTensor *t, void *opaque) {
+    LmbQwen38Inventory *v=opaque;
+    LmbModelShape *m=v->m;
+    const char *name=t->name;
+    if (strcmp(name,"lm_head.weight")) {
+        uint8_t prefix=!strncmp(name,"model.language_model.",21) ? 2 : !strncmp(name,"model.",6) ? 1 : 0;
+        if (!prefix) return 0;
+        if (v->prefix && v->prefix!=prefix) return -1;
+        v->prefix=prefix; name+=prefix==2 ? 21 : 6;
+    }
+    uint64_t H=v->h, HC=H*v->hc, R=v->rank;
+    static const char *const globals[]={"embed_tokens.weight","lm_head.weight",
+        "hyper_connection_mixer.hc_norm.weight",
+        "hyper_connection_mixer.input_mix_weight_down.weight",
+        "hyper_connection_mixer.input_mix_weight_up.weight"};
+    for (unsigned i=0;i<5;i++) if (!strcmp(name,globals[i])) {
+        uint64_t n=i<2 ? H*m->vocab : i==2 ? HC : HC*R;
+        uint64_t cols=i<2 ? H : i==2 ? 0 : i==3 ? HC : R;
+        if (!lmb_q38_float(t->dtype) || (v->edge&(1u<<i)) || !lmb_q38_shape(t,n,cols)) return -1;
+        v->edge|=1u<<i;
+        m->edge_resident_bytes=lmb_size_add(m->edge_resident_bytes,n*4);
+        if (n*4>m->edge_scratch_fixed_bytes) m->edge_scratch_fixed_bytes=n*4;
+        return m->edge_resident_bytes==UINT64_MAX ? -1 : 0;
+    }
+    if (strncmp(name,"layers.",7)) return 0;
+    uint64_t layer;
+    const char *field=lmb_plan_uint(name+7,&layer);
+    if (!field || *field++!='.' || layer>=m->layers) return -1;
+    uint64_t bytes=0;
+    if (!strncmp(field,"ple.",4)) {
+        if (layer!=v->ple) return -1;
+        static const char *const ple_names[]={"ple.key_proj.weight","ple.value_proj.weight",
+            "ple.norm_key.weight","ple.norm_query.weight","ple.norm_conv.weight","ple.conv1d.weight",
+            "ple.ple_embedding.layer_multipliers","ple.ple_embedding.ngram_heads_vocab_sizes",
+            "ple.ple_embedding.ngram_heads_offsets","ple.ple_embedding.ngram_embedding.weight_scale"};
+        unsigned i;
+        for(i=0;i<10;i++) if(!strcmp(field,ple_names[i])) break;
+        if (i<10) {
+            uint64_t counts[]={HC*v->pd,H*v->pd,HC,HC,HC,HC*v->pc,3,v->nh,v->nh,1};
+            if ((v->ple_seen&(1u<<i)) || !lmb_q38_shape(t,counts[i],i<2 ? v->pd : 0)) return -1;
+            v->ple_seen|=1u<<i;
+            if (i>=6 && i<=8) {
+                if (strcmp(t->dtype,"I64")) return -1;
+                if (i==7) memcpy(v->vocab,t->meta_i64,v->nh*sizeof(uint64_t));
+                if (i==8) memcpy(v->offsets,t->meta_i64,v->nh*sizeof(uint64_t));
+                bytes=t->bytes;
+            } else {
+                if (!lmb_q38_float(t->dtype)) return -1;
+                bytes=t->elements*4;
+            }
+        } else {
+            unsigned part=0;
+            if (!strcmp(field,"ple.ple_embedding.ngram_embedding.weight")) {
+                if (v->table_whole || v->rows[0]) return -1;
+                v->table_whole=1;
+            } else {
+                const char *prefix="ple.ple_embedding.ngram_embedding.shard_";
+                uint64_t index;
+                if (strncmp(field,prefix,strlen(prefix))) return -1;
+                const char *end=lmb_plan_uint(field+strlen(prefix),&index);
+                if (!end || strcmp(end,".weight") || index>=v->parts || v->table_whole) return -1;
+                part=(unsigned)index;
+            }
+            if (v->rows[part] || !lmb_q38_float(t->dtype) || t->rank!=2 ||
+                !t->shape[0] || t->shape[1]!=v->nd) return -1;
+            v->rows[part]=t->shape[0];
+            bytes=t->bytes; /* full PLE source cache allowance, not allocation */
+        }
+    } else if (!strncmp(field,"mlp.experts.",12)) {
+        const char *suffix=field+12;
+        unsigned kind=lmb_q38_float(t->dtype);
+        if (!kind) return -1;
+        uint64_t count=H*v->inter;
+        if (!strcmp(suffix,"gate_up_proj") || !strcmp(suffix,"down_proj")) {
+            unsigned up=!strcmp(suffix,"gate_up_proj");
+            unsigned bit=up ? 1 : 2;
+            if (t->rank!=3 || t->shape[0]!=v->e || t->shape[1]!=(up ? 2u*v->inter : H) ||
+                t->shape[2]!=(up ? H : v->inter)) return -1;
+            for (unsigned e=0;e<v->e;e++) {
+                uint8_t *seen=&v->experts[layer*v->e+e];
+                if ((*seen&7) || (*seen&(bit<<3))) return -1;
+                *seen|=bit<<3;
+            }
+            bytes=lmb_size_mul(lmb_size_mul(count,up ? 2 : 1),4u*v->e);
+        } else {
+            uint64_t expert;
+            const char *end=lmb_plan_uint(suffix,&expert);
+            if (!end || *end++!='.' || expert>=v->e) return -1;
+            unsigned k=!strcmp(end,"gate_proj.weight") ? 0 : !strcmp(end,"up_proj.weight") ? 1 :
+                       !strcmp(end,"down_proj.weight") ? 2 : 3;
+            uint8_t *seen=&v->experts[layer*v->e+expert];
+            if (k==3 || (*seen&24) || (*seen&(1u<<k)) ||
+                !lmb_q38_shape(t,count,k==2 ? v->inter : H)) return -1;
+            *seen|=1u<<k; bytes=count*4;
+        }
+        v->kinds[layer]|=kind;
+    } else {
+        static const char *const names[]={
+            "attn_hyper_connection.hc_norm.weight","attn_hyper_connection.input_mix_weight_down.weight",
+            "attn_hyper_connection.input_mix_weight_up.weight","attn_hyper_connection.block_inject_weight.weight",
+            "mlp_hyper_connection.hc_norm.weight","mlp_hyper_connection.input_mix_weight_down.weight",
+            "mlp_hyper_connection.input_mix_weight_up.weight","mlp_hyper_connection.block_inject_weight.weight",
+            "mlp.gate.weight","mlp.shared_expert.gate_proj.weight","mlp.shared_expert.up_proj.weight",
+            "mlp.shared_expert.down_proj.weight","mlp.shared_expert_gate.weight",
+            "self_attn.q_proj.weight","self_attn.k_proj.weight","self_attn.v_proj.weight","self_attn.o_proj.weight",
+            "self_attn.q_norm.weight","self_attn.k_norm.weight","self_attn.indexer.index_qk_proj.weight",
+            "self_attn.indexer.q_layernorm.weight","self_attn.indexer.k_layernorm.weight",
+            "linear_attn.in_proj_qkv.weight","linear_attn.in_proj_z.weight","linear_attn.in_proj_b.weight",
+            "linear_attn.in_proj_a.weight","linear_attn.conv1d.weight","linear_attn.dt_bias","linear_attn.A_log",
+            "linear_attn.norm.weight","linear_attn.out_proj.weight"};
+        uint64_t Q=(uint64_t)v->qh*v->hd, KV=(uint64_t)v->kvh*v->hd, DV=(uint64_t)v->vh*v->vd;
+        uint64_t counts[]={HC,HC*R,HC*R,HC*v->hc,HC,HC*R,HC*R,HC*v->hc,
+            H*v->e,H*v->shared,H*v->shared,H*v->shared,H,
+            2*Q*H,KV*H,KV*H,H*Q,v->hd,v->hd,(v->ih+1u)*(uint64_t)v->id*H,v->id,v->id,
+            (uint64_t)v->cd*H,DV*H,(uint64_t)v->vh*H,(uint64_t)v->vh*H,
+            (uint64_t)v->cd*v->conv,v->vh,v->vh,v->vd,H*DV};
+        uint64_t cols[]={0,HC,R,HC,0,HC,R,HC,H,H,H,v->shared,0,
+            H,H,H,Q,0,0,H,0,0,H,H,H,H,0,0,0,0,DV};
+        unsigned i;
+        for(i=0;i<31;i++) if(!strcmp(field,names[i])) break;
+        if (i==31) return 0;
+        if (!lmb_q38_float(t->dtype) || (v->seen[layer]&(UINT64_C(1)<<i)) ||
+            !lmb_q38_shape(t,counts[i],cols[i])) return -1;
+        v->seen[layer]|=UINT64_C(1)<<i;
+        bytes=lmb_size_mul(t->elements,4);
+    }
+    m->memory[layer].resident_bytes=lmb_size_add(m->memory[layer].resident_bytes,bytes);
+    if (bytes>v->largest) v->largest=bytes;
+    return bytes==UINT64_MAX || m->memory[layer].resident_bytes==UINT64_MAX ? -1 : 0;
+}
+
+static int lmb_q38_number(const char *json, const char *key, double def, double *out) {
+    const char *p=lmb_json_member(json,key);
+    *out=def;
+    if (!p) return 0;
+    if (*p!='-' && (*p<'0' || *p>'9')) return -1;
+    errno=0; char *end;
+    *out=strtod(p,&end); end=(char *)lmb_plan_space(end);
+    return errno || !isfinite(*out) || (*end!=',' && *end!='}') ? -1 : 0;
+}
+static int LMB_UNUSED lmb_qwen38_memory(const char *root, const char *whole,
+                                        const char *json, LmbModelShape *m) {
+    if (lmb_json_member(whole,"vision_config")) return -1;
+    LmbQwen38Inventory v={.m=m};
+    uint32_t layers, maxctx, eos, ik, ns;
+    char str[64];
+    if (lmb_json_string(json,"output_gate_type",str,sizeof str) || strcmp(str,"sigmoid")) return -1;
+    if (lmb_json_member(json,"hidden_act") &&
+        (lmb_json_string(json,"hidden_act",str,sizeof str) || strcmp(str,"silu"))) return -1;
+    const char *flags[]={"attention_bias","tie_word_embeddings"};
+    for(unsigned i=0;i<2;i++) {
+        const char *p=lmb_json_member(json,flags[i]);
+        if(p && (strncmp(p,"false",5) || (*lmb_plan_space(p+5)!=',' && *lmb_plan_space(p+5)!='}'))) return -1;
+    }
+    const char *norm_topk=lmb_json_member(json,"norm_topk_prob");
+    if(norm_topk) {
+        unsigned n=!strncmp(norm_topk,"true",4) ? 4 : !strncmp(norm_topk,"false",5) ? 5 : 0;
+        if(!n || (*lmb_plan_space(norm_topk+n)!=',' && *lmb_plan_space(norm_topk+n)!='}')) return -1;
+    }
+#define NEED(key,dst,lo,hi) if(lmb_plan_u32(json,key,lo,hi,&dst)) return -1
+    NEED("hidden_size",v.h,1,65536); NEED("num_hidden_layers",layers,1,LMB_PLAN_LAYER_MAX);
+    NEED("max_position_embeddings",maxctx,1,262144); NEED("eos_token_id",eos,0,INT32_MAX);
+    NEED("num_attention_heads",v.qh,1,65536); NEED("num_key_value_heads",v.kvh,1,65536);
+    NEED("head_dim",v.hd,1,65536); NEED("indexer_n_heads",v.ih,1,65536);
+    NEED("indexer_kv_heads",ik,1,1); NEED("indexer_head_dim",v.id,1,65536);
+    NEED("indexer_budget",v.budget,1,262144); NEED("indexer_compress_ratio",v.ratio,1,262144);
+    NEED("num_experts",v.e,1,1024); NEED("num_experts_per_tok",v.k,1,256);
+    NEED("moe_intermediate_size",v.inter,1,1048576); NEED("shared_expert_intermediate_size",v.shared,1,1048576);
+    NEED("linear_num_key_heads",v.kh,1,65536); NEED("linear_num_value_heads",v.vh,1,65536);
+    NEED("linear_key_head_dim",v.kd,1,65536); NEED("linear_value_head_dim",v.vd,1,512);
+    NEED("linear_conv_kernel_dim",v.conv,2,65536);
+#undef NEED
+    if(v.h!=m->hidden || layers!=m->layers || !m->vocab || m->vocab>(1u<<22) || eos>=m->vocab ||
+        v.k>v.e || v.qh%v.kvh || v.vh%v.kh || v.budget%v.ratio ||
+        lmb_plan_optional(json,"hc_count",4,2,16,&v.hc) ||
+        lmb_plan_optional(json,"hc_lowrank",320,1,65536,&v.rank) ||
+        lmb_plan_optional(json,"ple_embed_dim",v.h,1,65536,&v.pd) ||
+        lmb_plan_optional(json,"ple_conv_kernel_size",4,2,65536,&v.pc) ||
+        lmb_plan_optional(json,"ngram_size",3,3,3,&ns) ||
+        lmb_plan_optional(json,"heads_per_ngram",8,1,32,&v.nh) ||
+        lmb_plan_optional(json,"split_ngram_parts",1,1,512,&v.parts)) return -1;
+    v.nh*=2; v.nd=v.pd/v.nh;
+    uint64_t cd=2u*(uint64_t)v.kh*v.kd+(uint64_t)v.vh*v.vd;
+    if(!v.nd || v.nd>512 || v.pd%v.nh || cd>INT32_MAX ||
+        2u*(uint64_t)v.qh*v.hd>INT32_MAX || (v.ih+1u)*(uint64_t)v.id>INT32_MAX) return -1;
+    v.cd=(uint32_t)cd;
+    const char *rp=lmb_json_member(json,"rope_parameters");
+    if(rp && *rp!='{') return -1;
+    if(rp && lmb_json_member(rp,"rope_type") &&
+       (lmb_json_string(rp,"rope_type",str,sizeof str) || strcmp(str,"default"))) return -1;
+    double partial, theta, eps;
+    if(lmb_q38_number(json,"partial_rotary_factor",1,&partial) ||
+       lmb_q38_number(rp ? rp : json,"partial_rotary_factor",partial,&partial) ||
+       lmb_q38_number(rp ? rp : json,"rope_theta",10000,&theta) ||
+       lmb_q38_number(json,"rms_norm_eps",1e-6,&eps) ||
+       theta>FLT_MAX || eps>FLT_MAX || (float)theta<=0 || (float)eps<=0 || partial<=0 || partial>1) return -1;
+    unsigned rotary=(unsigned)(v.hd*partial);
+    if(!rotary || (rotary&1) || v.id<rotary) return -1;
+    uint64_t ple_id[1]; unsigned count;
+    if(lmb_plan_array(lmb_json_member(json,"ple_layer_ids"),ple_id,1,&count) || count!=1 ||
+       !ple_id[0] || ple_id[0]>layers) return -1;
+    v.ple=(uint32_t)ple_id[0]-1;
+    const char *types=lmb_json_member(json,"layer_types");
+    if(!types || *types++!='[') return -1;
+    for(unsigned i=0;i<layers;i++) {
+        types=lmb_plan_space(types);
+        if(!(types=lmb_plan_string(types,str,sizeof str))) return -1;
+        if(!strcmp(str,"linear_attention")) v.full[i]=0;
+        else if(!strcmp(str,"full_attention") || !strcmp(str,"qwen_sparse_attention")) v.full[i]=1;
+        else return -1;
+        types=lmb_plan_space(types);
+        if(*types++!=(i+1==layers ? ']' : ',')) return -1;
+    }
+    v.experts=calloc((size_t)layers*v.e,1);
+    if(!v.experts) return -1;
+    int rc=lmb_plan_tensors(root,lmb_q38_tensor,&v);
+    if(v.edge!=31 || (v.ple_seen&511)!=511) rc=-1;
+    uint64_t rows=0;
+    for(unsigned i=0;i<(v.table_whole ? 1 : v.parts);i++) {
+        if(!v.rows[i]) rc=-1;
+        rows=lmb_size_add(rows,v.rows[i]);
+    }
+    if(v.table_whole) for(unsigned i=1;i<512;i++) if(v.rows[i]) rc=-1;
+    for(unsigned i=0;i<v.nh;i++) if(!v.vocab[i] || v.offsets[i]>INT64_MAX ||
+        v.vocab[i]>(uint64_t)INT64_MAX-v.offsets[i] || v.offsets[i]+v.vocab[i]>rows) rc=-1;
+    for(unsigned i=0;i<layers && !rc;i++) {
+        uint64_t need=8191u | (v.full[i] ? ((UINT64_C(1)<<22)-(UINT64_C(1)<<13)) :
+                                            ((UINT64_C(1)<<31)-(UINT64_C(1)<<22)));
+        if((v.seen[i]&need)!=need || v.kinds[i]!=v.kinds[0]) {rc=-1;break;}
+        uint8_t layout=v.experts[i*v.e];
+        for(unsigned e=0;e<v.e;e++) if((layout!=7 && layout!=24) || v.experts[i*v.e+e]!=layout) rc=-1;
+        if(v.full[i]) m->memory[i].state_token_bytes=(2u*(uint64_t)v.kvh*v.hd+v.id)*4;
+        else m->memory[i].state_fixed_bytes=((uint64_t)v.vh*v.kd*v.vd+cd*(v.conv-1u))*4;
+    }
+    free(v.experts);
+    if(rc || rows>INT64_MAX) return -1;
+    m->boundary_width=v.h*v.hc;
+    m->memory[v.ple].state_fixed_bytes=lmb_size_add(m->memory[v.ple].state_fixed_bytes,
+        (uint64_t)m->boundary_width*(v.pc-1u)*3*4+32);
+    uint64_t wide=(uint64_t)m->boundary_width+v.rank+v.h+v.e+v.k+v.inter+v.shared+
+        cd+(uint64_t)v.qh*v.hd+(uint64_t)v.ih*v.id+v.pd+v.budget;
+    /* 128 input rows, 32-row grouped-MoE workspace capped at 64 MiB;
+     * attention temporaries include per-thread context scores. */
+    m->scratch_fixed_bytes=lmb_size_add(lmb_size_add(v.largest,UINT64_C(64)<<20),lmb_size_mul(wide,128u*64));
+    m->scratch_token_bytes=256u*16;
+    m->segment_fixed_bytes=(uint64_t)layers*(16384u+(uint64_t)v.e*1024u);
+    m->max_context=maxctx; m->memory_contract=1;
+    return 0;
+}
+#endif

--- a/planner_adapters/qwen38.h
+++ b/planner_adapters/qwen38.h
@@ -155,15 +155,6 @@ static int lmb_q38_tensor(const LmbPlanTensor *t, void *opaque) {
     return bytes==UINT64_MAX || m->memory[layer].resident_bytes==UINT64_MAX ? -1 : 0;
 }
 
-static int lmb_q38_number(const char *json, const char *key, double def, double *out) {
-    const char *p=lmb_json_member(json,key);
-    *out=def;
-    if (!p) return 0;
-    if (*p!='-' && (*p<'0' || *p>'9')) return -1;
-    errno=0; char *end;
-    *out=strtod(p,&end); end=(char *)lmb_plan_space(end);
-    return errno || !isfinite(*out) || (*end!=',' && *end!='}') ? -1 : 0;
-}
 static int LMB_UNUSED lmb_qwen38_memory(const char *root, const char *whole,
                                         const char *json, LmbModelShape *m) {
     if (lmb_json_member(whole,"vision_config")) return -1;
@@ -215,10 +206,10 @@ static int LMB_UNUSED lmb_qwen38_memory(const char *root, const char *whole,
     if(rp && lmb_json_member(rp,"rope_type") &&
        (lmb_json_string(rp,"rope_type",str,sizeof str) || strcmp(str,"default"))) return -1;
     double partial, theta, eps;
-    if(lmb_q38_number(json,"partial_rotary_factor",1,&partial) ||
-       lmb_q38_number(rp ? rp : json,"partial_rotary_factor",partial,&partial) ||
-       lmb_q38_number(rp ? rp : json,"rope_theta",10000,&theta) ||
-       lmb_q38_number(json,"rms_norm_eps",1e-6,&eps) ||
+    if(lmb_plan_number(json,"partial_rotary_factor",1,&partial) ||
+       lmb_plan_number(rp ? rp : json,"partial_rotary_factor",partial,&partial) ||
+       lmb_plan_number(rp ? rp : json,"rope_theta",10000,&theta) ||
+       lmb_plan_number(json,"rms_norm_eps",1e-6,&eps) ||
        theta>FLT_MAX || eps>FLT_MAX || (float)theta<=0 || (float)eps<=0 || partial<=0 || partial>1) return -1;
     unsigned rotary=(unsigned)(v.hd*partial);
     if(!rotary || (rotary&1) || v.id<rotary) return -1;

--- a/planner_adapters/qwen38.h
+++ b/planner_adapters/qwen38.h
@@ -1,6 +1,6 @@
 #ifndef LUMABRI_PLAN_QWEN38_H
 #define LUMABRI_PLAN_QWEN38_H
-/* Text-only float/BF16 Qwen4-Exp contract, pinned Colibri 12a5c464.
+/* Text-only float/BF16 and block-FP8-expert Qwen4-Exp contract, pinned Colibri 12a5c464.
  * PLE tables are row-read by the native engine: reserve their complete source
  * footprint as well as all expert slots, without advertising a disk mode or
  * claiming that admission has warmed the filesystem cache. */
@@ -13,7 +13,7 @@ typedef struct {
     uint32_t pd, pc, nh, nd, parts, ple;
     uint8_t full[LMB_PLAN_LAYER_MAX], kinds[LMB_PLAN_LAYER_MAX], prefix, edge;
     uint64_t seen[LMB_PLAN_LAYER_MAX], largest, rows[512], vocab[64], offsets[64];
-    uint8_t *experts;
+    uint16_t *experts; /* weights, fused layout, FP8 weights, scale sidecars */
     uint32_t ple_seen;
     int table_whole;
 } LmbQwen38Inventory;
@@ -95,16 +95,15 @@ static int lmb_q38_tensor(const LmbPlanTensor *t, void *opaque) {
     } else if (!strncmp(field,"mlp.experts.",12)) {
         const char *suffix=field+12;
         unsigned kind=lmb_q38_float(t->dtype);
-        if (!kind) return -1;
         uint64_t count=H*v->inter;
         if (!strcmp(suffix,"gate_up_proj") || !strcmp(suffix,"down_proj")) {
             unsigned up=!strcmp(suffix,"gate_up_proj");
             unsigned bit=up ? 1 : 2;
-            if (t->rank!=3 || t->shape[0]!=v->e || t->shape[1]!=(up ? 2u*v->inter : H) ||
+            if (!kind || t->rank!=3 || t->shape[0]!=v->e || t->shape[1]!=(up ? 2u*v->inter : H) ||
                 t->shape[2]!=(up ? H : v->inter)) return -1;
             for (unsigned e=0;e<v->e;e++) {
-                uint8_t *seen=&v->experts[layer*v->e+e];
-                if ((*seen&7) || (*seen&(bit<<3))) return -1;
+                uint16_t *seen=&v->experts[layer*v->e+e];
+                if ((*seen&~24u) || (*seen&(bit<<3))) return -1;
                 *seen|=bit<<3;
             }
             bytes=lmb_size_mul(lmb_size_mul(count,up ? 2 : 1),4u*v->e);
@@ -112,12 +111,34 @@ static int lmb_q38_tensor(const LmbPlanTensor *t, void *opaque) {
             uint64_t expert;
             const char *end=lmb_plan_uint(suffix,&expert);
             if (!end || *end++!='.' || expert>=v->e) return -1;
-            unsigned k=!strcmp(end,"gate_proj.weight") ? 0 : !strcmp(end,"up_proj.weight") ? 1 :
-                       !strcmp(end,"down_proj.weight") ? 2 : 3;
-            uint8_t *seen=&v->experts[layer*v->e+expert];
-            if (k==3 || (*seen&24) || (*seen&(1u<<k)) ||
-                !lmb_q38_shape(t,count,k==2 ? v->inter : H)) return -1;
-            *seen|=1u<<k; bytes=count*4;
+            static const char *const projection[]={"gate_proj.weight","up_proj.weight","down_proj.weight"};
+            unsigned k, scale=0;
+            for(k=0;k<3;k++) {
+                size_t n=strlen(projection[k]);
+                if(!strcmp(end,projection[k])) break;
+                if(!strncmp(end,projection[k],n) && !strcmp(end+n,"_scale_inv")) {scale=1;break;}
+            }
+            uint16_t *seen=&v->experts[layer*v->e+expert];
+            if(k==3 || (*seen&24)) return -1;
+            uint64_t rows=k==2 ? H : v->inter, cols=k==2 ? v->inter : H;
+            if(scale) {
+                unsigned bit=1u<<(8+k);
+                if(!kind || (*seen&bit) || t->rank!=2 ||
+                   t->shape[0]!=(rows+127)/128 || t->shape[1]!=(cols+127)/128) return -1;
+                /* A compact shared bank may coexist with per-slot scales
+                 * when the corresponding weight ranges are not compact. */
+                *seen|=bit; bytes=t->elements*8;
+                kind=0; /* scale encoding does not change expert arithmetic */
+            } else {
+                unsigned fp8=!strcmp(t->dtype,"F8_E4M3");
+                if((!kind && !fp8) || (*seen&(1u<<k)) || !lmb_q38_shape(t,count,cols)) return -1;
+                *seen|=(1u<<k) | (fp8 ? 1u<<(5+k) : 0);
+                kind=fp8 ? 8 : kind;
+                /* Bound both native FP8 slots and the supported opt-out that
+                 * expands them to f32. Scales are reserved independently,
+                 * including the optional shared resident scale bank. */
+                bytes=count*4;
+            }
         }
         v->kinds[layer]|=kind;
     } else {
@@ -228,7 +249,7 @@ static int LMB_UNUSED lmb_qwen38_memory(const char *root, const char *whole,
         types=lmb_plan_space(types);
         if(*types++!=(i+1==layers ? ']' : ',')) return -1;
     }
-    v.experts=calloc((size_t)layers*v.e,1);
+    v.experts=calloc((size_t)layers*v.e,sizeof(*v.experts));
     if(!v.experts) return -1;
     int rc=lmb_plan_tensors(root,lmb_q38_tensor,&v);
     if(v.edge!=31 || (v.ple_seen&511)!=511) rc=-1;
@@ -244,8 +265,12 @@ static int LMB_UNUSED lmb_qwen38_memory(const char *root, const char *whole,
         uint64_t need=8191u | (v.full[i] ? ((UINT64_C(1)<<22)-(UINT64_C(1)<<13)) :
                                             ((UINT64_C(1)<<31)-(UINT64_C(1)<<22)));
         if((v.seen[i]&need)!=need || v.kinds[i]!=v.kinds[0]) {rc=-1;break;}
-        uint8_t layout=v.experts[i*v.e];
-        for(unsigned e=0;e<v.e;e++) if((layout!=7 && layout!=24) || v.experts[i*v.e+e]!=layout) rc=-1;
+        unsigned layout=v.experts[i*v.e]&31;
+        for(unsigned e=0;e<v.e;e++) {
+            unsigned seen=v.experts[i*v.e+e];
+            if((layout!=7 && layout!=24) || (seen&31)!=layout ||
+               ((seen>>5)&7)!=((seen>>8)&7)) rc=-1;
+        }
         if(v.full[i]) m->memory[i].state_token_bytes=(2u*(uint64_t)v.kvh*v.hd+v.id)*4;
         else m->memory[i].state_fixed_bytes=((uint64_t)v.vh*v.kd*v.vd+cd*(v.conv-1u))*4;
     }

--- a/planner_adapters/registry.h
+++ b/planner_adapters/registry.h
@@ -6,6 +6,7 @@
 #include "glm.h"
 #include "glm53.h"
 #include "qwen38.h"
+#include "olmoe.h"
 
 typedef int (*LmbMemoryDescribe)(const char *, const char *, const char *, LmbModelShape *);
 typedef struct { const char *adapter; LmbMemoryDescribe describe; } LmbMemoryContract;
@@ -20,12 +21,13 @@ LMB_MEMORY_WRAPPER(lmb_describe_qwen36, lmb_qwen36_memory(root,m))
 LMB_MEMORY_WRAPPER(lmb_describe_inkling, lmb_inkling_memory(root,cfg,m))
 LMB_MEMORY_WRAPPER(lmb_describe_kimi, lmb_kimi_memory(root,cfg,m))
 LMB_MEMORY_WRAPPER(lmb_describe_glm, lmb_glm_memory(root,cfg,m))
+LMB_MEMORY_WRAPPER(lmb_describe_olmoe, lmb_olmoe_memory(root,cfg,m))
 #undef LMB_MEMORY_WRAPPER
 
 /* NULL is an explicit legacy formula, not a fallback for an unknown adapter.
  * model_family_test.sh compares these ids to Colibri's registry as well. */
 static const LmbMemoryContract LMB_MEMORY_CONTRACTS[] = {
-    {"olmoe", NULL},
+    {"olmoe", lmb_describe_olmoe},
     {"deepseek_v4", NULL},
     {"qwen36", lmb_describe_qwen36},
     {"inkling", lmb_describe_inkling},

--- a/planner_adapters/registry.h
+++ b/planner_adapters/registry.h
@@ -1,0 +1,46 @@
+#ifndef LUMABRI_PLAN_REGISTRY_H
+#define LUMABRI_PLAN_REGISTRY_H
+#include "qwen36.h"
+#include "inkling.h"
+#include "kimi.h"
+#include "glm.h"
+#include "glm53.h"
+#include "qwen38.h"
+
+typedef int (*LmbMemoryDescribe)(const char *, const char *, const char *, LmbModelShape *);
+typedef struct { const char *adapter; LmbMemoryDescribe describe; } LmbMemoryContract;
+
+/* Keep family-specific source inspection out of the catalogue and transport.
+ * Older inspectors do not need the outer multimodal configuration. */
+#define LMB_MEMORY_WRAPPER(name, expression) \
+    static int name(const char *root, const char *whole, const char *cfg, LmbModelShape *m) { \
+        (void)whole; (void)cfg; return (expression); \
+    }
+LMB_MEMORY_WRAPPER(lmb_describe_qwen36, lmb_qwen36_memory(root,m))
+LMB_MEMORY_WRAPPER(lmb_describe_inkling, lmb_inkling_memory(root,cfg,m))
+LMB_MEMORY_WRAPPER(lmb_describe_kimi, lmb_kimi_memory(root,cfg,m))
+LMB_MEMORY_WRAPPER(lmb_describe_glm, lmb_glm_memory(root,cfg,m))
+#undef LMB_MEMORY_WRAPPER
+
+/* NULL is an explicit legacy formula, not a fallback for an unknown adapter.
+ * model_family_test.sh compares these ids to Colibri's registry as well. */
+static const LmbMemoryContract LMB_MEMORY_CONTRACTS[] = {
+    {"olmoe", NULL},
+    {"deepseek_v4", NULL},
+    {"qwen36", lmb_describe_qwen36},
+    {"inkling", lmb_describe_inkling},
+    {"kimi", lmb_describe_kimi},
+    {"glm", lmb_describe_glm},
+    {"glm53", lmb_glm53_memory},
+    {"qwen38", lmb_qwen38_memory},
+};
+
+static int lmb_describe_memory(const char *id, const char *root, const char *whole,
+                               const char *cfg, LmbModelShape *m) {
+    for(size_t i=0;i<sizeof LMB_MEMORY_CONTRACTS/sizeof *LMB_MEMORY_CONTRACTS;i++) {
+        const LmbMemoryContract *c=&LMB_MEMORY_CONTRACTS[i];
+        if(!strcmp(id,c->adapter)) return c->describe ? c->describe(root,whole,cfg,m) : 0;
+    }
+    return -1;
+}
+#endif

--- a/planner_adapters/registry.h
+++ b/planner_adapters/registry.h
@@ -7,6 +7,7 @@
 #include "glm53.h"
 #include "qwen38.h"
 #include "olmoe.h"
+#include "deepseek_v4.h"
 
 typedef int (*LmbMemoryDescribe)(const char *, const char *, const char *, LmbModelShape *);
 typedef struct { const char *adapter; LmbMemoryDescribe describe; } LmbMemoryContract;
@@ -22,13 +23,13 @@ LMB_MEMORY_WRAPPER(lmb_describe_inkling, lmb_inkling_memory(root,cfg,m))
 LMB_MEMORY_WRAPPER(lmb_describe_kimi, lmb_kimi_memory(root,cfg,m))
 LMB_MEMORY_WRAPPER(lmb_describe_glm, lmb_glm_memory(root,cfg,m))
 LMB_MEMORY_WRAPPER(lmb_describe_olmoe, lmb_olmoe_memory(root,cfg,m))
+LMB_MEMORY_WRAPPER(lmb_describe_v4, lmb_v4_memory(root,cfg,m))
 #undef LMB_MEMORY_WRAPPER
 
-/* NULL is an explicit legacy formula, not a fallback for an unknown adapter.
- * model_family_test.sh compares these ids to Colibri's registry as well. */
+/* model_family_test.sh compares these ids to Colibri's registry as well. */
 static const LmbMemoryContract LMB_MEMORY_CONTRACTS[] = {
     {"olmoe", lmb_describe_olmoe},
-    {"deepseek_v4", NULL},
+    {"deepseek_v4", lmb_describe_v4},
     {"qwen36", lmb_describe_qwen36},
     {"inkling", lmb_describe_inkling},
     {"kimi", lmb_describe_kimi},
@@ -41,7 +42,7 @@ static int lmb_describe_memory(const char *id, const char *root, const char *who
                                const char *cfg, LmbModelShape *m) {
     for(size_t i=0;i<sizeof LMB_MEMORY_CONTRACTS/sizeof *LMB_MEMORY_CONTRACTS;i++) {
         const LmbMemoryContract *c=&LMB_MEMORY_CONTRACTS[i];
-        if(!strcmp(id,c->adapter)) return c->describe ? c->describe(root,whole,cfg,m) : 0;
+        if(!strcmp(id,c->adapter)) return c->describe ? c->describe(root,whole,cfg,m) : -1;
     }
     return -1;
 }

--- a/planner_adapters/tensors.h
+++ b/planner_adapters/tensors.h
@@ -1,4 +1,5 @@
-/* Bounded safetensors-header inventory. No weight payload is read. */
+/* Bounded safetensors inventory. Weight payloads are never read; small I64
+ * layout buffers (e.g. PLE offsets) are metadata and are checked explicitly. */
 #ifndef LUMABRI_PLAN_TENSORS_H
 #define LUMABRI_PLAN_TENSORS_H
 #include <dirent.h>
@@ -7,6 +8,7 @@
 typedef struct {
     char name[512], dtype[32];
     uint64_t elements, bytes, shape[8];
+    uint64_t meta_i64[64];
     unsigned rank;
 } LmbPlanTensor;
 typedef int (*LmbPlanTensorVisit)(const LmbPlanTensor *, void *);
@@ -124,10 +126,21 @@ static int lmb_plan_tensor_file(const char *path, uint64_t *header_budget,
             for (unsigned i = 0; i < t.rank; i++) t.elements = lmb_size_mul(t.elements, t.shape[i]);
             unsigned width = !strcmp(t.dtype, "F32") ? 4 :
                 (!strcmp(t.dtype, "BF16") || !strcmp(t.dtype, "F16")) ? 2 :
-                (!strcmp(t.dtype, "U8") || !strcmp(t.dtype, "I8")) ? 1 : 0;
+                (!strcmp(t.dtype, "U8") || !strcmp(t.dtype, "I8")) ? 1 :
+                !strcmp(t.dtype, "I64") ? 8 : 0;
             t.bytes = offsets[1] - offsets[0];
-            if (!width || lmb_size_mul(t.elements, width) != t.bytes ||
-                visit(&t, opaque)) goto done;
+            if (!width || lmb_size_mul(t.elements, width) != t.bytes) goto done;
+            if (width == 8) {
+                unsigned char metadata[512];
+                if (t.elements > 64 || t.bytes > *header_budget ||
+                    fseeko(f, (off_t)(8 + bytes + offsets[0]), SEEK_SET) ||
+                    fread(metadata, 1, (size_t)t.bytes, f) != t.bytes) goto done;
+                *header_budget -= t.bytes;
+                for (uint64_t i=0; i<t.elements; i++)
+                    for (unsigned j=0; j<8; j++)
+                        t.meta_i64[i] |= (uint64_t)metadata[i*8+j] << (8*j);
+            }
+            if (visit(&t, opaque)) goto done;
         }
         p = lmb_plan_space(end);
         if (*p == '}') { p++; break; }

--- a/planner_adapters/tensors.h
+++ b/planner_adapters/tensors.h
@@ -3,11 +3,15 @@
 #ifndef LUMABRI_PLAN_TENSORS_H
 #define LUMABRI_PLAN_TENSORS_H
 #include <dirent.h>
+#include <math.h>
+#include <float.h>
 #include <sys/stat.h>
 
 typedef struct {
     char name[512], dtype[32];
     uint64_t elements, bytes, shape[8];
+    uint64_t offset;
+    uint32_t file_id;
     uint64_t meta_i64[64];
     unsigned rank;
 } LmbPlanTensor;
@@ -16,6 +20,14 @@ typedef int (*LmbPlanTensorVisit)(const LmbPlanTensor *, void *);
 static const char *lmb_plan_space(const char *p) {
     while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') p++;
     return p;
+}
+
+static int LMB_UNUSED lmb_plan_number(const char *json,const char *key,double def,double *out) {
+    const char *p=lmb_json_member(json,key); *out=def;
+    if(!p) return 0;
+    if(*p!='-' && (*p<'0' || *p>'9')) return -1;
+    errno=0; char *end; *out=strtod(p,&end); end=(char *)lmb_plan_space(end);
+    return errno || !isfinite(*out) || (*end!=',' && *end!='}') ? -1 : 0;
 }
 
 /* Header-generated names are plain ASCII. Reject escaped names rather than
@@ -83,8 +95,8 @@ static const char *lmb_plan_object_end(const char *p) {
     return p;
 }
 
-static int lmb_plan_tensor_file(const char *path, uint64_t *header_budget,
-                                LmbPlanTensorVisit visit, void *opaque) {
+static int lmb_plan_tensor_file_id(const char *path, uint64_t *header_budget,
+                                LmbPlanTensorVisit visit, void *opaque, uint32_t file_id) {
     FILE *f = fopen(path, "rb");
     if (!f) return -1;
     struct stat st;
@@ -105,7 +117,7 @@ static int lmb_plan_tensor_file(const char *path, uint64_t *header_budget,
     if (*p++ != '{') goto done;
     unsigned tensors = 0;
     for (;;) {
-        LmbPlanTensor t = {0};
+        LmbPlanTensor t = {.file_id=file_id};
         p = lmb_plan_space(p);
         if (*p == '}') { p++; break; }
         if (!(p = lmb_plan_string(p, t.name, sizeof t.name))) goto done;
@@ -126,13 +138,18 @@ static int lmb_plan_tensor_file(const char *path, uint64_t *header_budget,
             for (unsigned i = 0; i < t.rank; i++) t.elements = lmb_size_mul(t.elements, t.shape[i]);
             unsigned width = !strcmp(t.dtype, "F32") ? 4 :
                 (!strcmp(t.dtype, "BF16") || !strcmp(t.dtype, "F16")) ? 2 :
-                (!strcmp(t.dtype, "U8") || !strcmp(t.dtype, "I8")) ? 1 :
+                (!strcmp(t.dtype, "U8") || !strcmp(t.dtype, "I8") ||
+                 !strcmp(t.dtype, "F8_E4M3") || !strcmp(t.dtype, "F8_E8M0")) ? 1 :
                 !strcmp(t.dtype, "I64") ? 8 : 0;
             t.bytes = offsets[1] - offsets[0];
+            t.offset = offsets[0];
             if (!width || lmb_size_mul(t.elements, width) != t.bytes) goto done;
-            if (width == 8) {
+            /* Large I64 tensors (V4 token-to-expert router tables) are weights,
+             * not small layout metadata: validate their header, never read the
+             * payload in a catalogue scan. PLE layout banks are <=64 entries. */
+            if (width == 8 && t.elements <= 64) {
                 unsigned char metadata[512];
-                if (t.elements > 64 || t.bytes > *header_budget ||
+                if (t.bytes > *header_budget ||
                     fseeko(f, (off_t)(8 + bytes + offsets[0]), SEEK_SET) ||
                     fread(metadata, 1, (size_t)t.bytes, f) != t.bytes) goto done;
                 *header_budget -= t.bytes;
@@ -153,6 +170,11 @@ done:
     free(json); fclose(f); return rc;
 }
 
+static int LMB_UNUSED lmb_plan_tensor_file(const char *path, uint64_t *header_budget,
+                                LmbPlanTensorVisit visit, void *opaque) {
+    return lmb_plan_tensor_file_id(path,header_budget,visit,opaque,0);
+}
+
 static int lmb_plan_tensors(const char *root, LmbPlanTensorVisit visit, void *opaque) {
     DIR *dir = opendir(root);
     if (!dir) return -1;
@@ -168,7 +190,7 @@ static int lmb_plan_tensors(const char *root, LmbPlanTensorVisit visit, void *op
         char path[1024];
         int len = snprintf(path, sizeof path, "%s/%s", root, e->d_name);
         if (++files > 512 || len < 0 || (size_t)len >= sizeof path ||
-            lmb_plan_tensor_file(path, &budget, visit, opaque)) { rc = -1; break; }
+            lmb_plan_tensor_file_id(path, &budget, visit, opaque, files)) { rc = -1; break; }
     }
     closedir(dir);
     return files ? rc : -1;

--- a/planner_adapters/tensors.h
+++ b/planner_adapters/tensors.h
@@ -1,0 +1,163 @@
+/* Bounded safetensors-header inventory. No weight payload is read. */
+#ifndef LUMABRI_PLAN_TENSORS_H
+#define LUMABRI_PLAN_TENSORS_H
+#include <dirent.h>
+#include <sys/stat.h>
+
+typedef struct {
+    char name[512], dtype[32];
+    uint64_t elements, bytes, shape[8];
+    unsigned rank;
+} LmbPlanTensor;
+typedef int (*LmbPlanTensorVisit)(const LmbPlanTensor *, void *);
+
+static const char *lmb_plan_space(const char *p) {
+    while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') p++;
+    return p;
+}
+
+/* Header-generated names are plain ASCII. Reject escaped names rather than
+ * normalizing them differently from the runtime's tensor lookup. */
+static const char *lmb_plan_string(const char *p, char *out, size_t cap) {
+    if (*p++ != '"') return NULL;
+    size_t n = 0;
+    while (*p && *p != '"') {
+        if ((unsigned char)*p < 32 || *p == '\\' || n + 1 >= cap) return NULL;
+        out[n++] = *p++;
+    }
+    if (*p != '"') return NULL;
+    out[n] = 0;
+    return p + 1;
+}
+
+static const char *lmb_plan_uint(const char *p, uint64_t *n) {
+    if (*p < '0' || *p > '9' || (*p == '0' && p[1] >= '0' && p[1] <= '9')) return NULL;
+    uint64_t v = 0;
+    do {
+        if (v > (UINT64_MAX - (unsigned)(*p - '0')) / 10) return NULL;
+        v = v * 10 + (unsigned)(*p++ - '0');
+    } while (*p >= '0' && *p <= '9');
+    if (*p == 'e' || *p == 'E') return NULL;
+    *n = v;
+    return p;
+}
+
+static int lmb_plan_array(const char *p, uint64_t *values, unsigned cap, unsigned *count) {
+    if (!p || *p++ != '[') return -1;
+    *count = 0;
+    p = lmb_plan_space(p);
+    if (*p == ']') return 0;
+    for (;;) {
+        if (*count == cap || !(p = lmb_plan_uint(p, &values[(*count)++]))) return -1;
+        p = lmb_plan_space(p);
+        if (*p == ']') return 0;
+        if (*p++ != ',') return -1;
+        p = lmb_plan_space(p);
+    }
+}
+
+/* Skip one balanced object, accepting escaped strings only in ignored
+ * metadata. Tensor attributes are parsed strictly below. */
+static const char *lmb_plan_object_end(const char *p) {
+    if (*p != '{') return NULL;
+    char stack[32]; unsigned depth = 0;
+    int string = 0, escape = 0;
+    do {
+        unsigned char ch = (unsigned char)*p++;
+        if (!ch) return NULL;
+        if (string) {
+            if (ch < 32) return NULL;
+            if (escape) escape = 0;
+            else if (ch == '\\') escape = 1;
+            else if (ch == '"') string = 0;
+        } else if (ch == '"') string = 1;
+        else if (ch == '{' || ch == '[') {
+            if (depth == sizeof stack) return NULL;
+            stack[depth++] = ch == '{' ? '}' : ']';
+        } else if (ch == '}' || ch == ']') {
+            if (!depth || stack[--depth] != ch) return NULL;
+        }
+    } while (depth);
+    return p;
+}
+
+static int lmb_plan_tensor_file(const char *path, uint64_t *header_budget,
+                                LmbPlanTensorVisit visit, void *opaque) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    struct stat st;
+    unsigned char prefix[8];
+    uint64_t bytes = 0;
+    int rc = -1;
+    char *json = NULL;
+    if (fstat(fileno(f), &st) || !S_ISREG(st.st_mode) || st.st_size < 10 ||
+        fread(prefix, 1, 8, f) != 8) goto done;
+    for (unsigned i = 0; i < 8; i++) bytes |= (uint64_t)prefix[i] << (8 * i);
+    if (bytes > *header_budget || bytes > (uint64_t)st.st_size - 8 || bytes < 2) goto done;
+    *header_budget -= bytes;
+    json = malloc((size_t)bytes + 1);
+    if (!json || fread(json, 1, (size_t)bytes, f) != bytes) goto done;
+    json[bytes] = 0;
+    if (memchr(json, 0, (size_t)bytes)) goto done;
+    const char *p = lmb_plan_space(json);
+    if (*p++ != '{') goto done;
+    unsigned tensors = 0;
+    for (;;) {
+        LmbPlanTensor t = {0};
+        p = lmb_plan_space(p);
+        if (*p == '}') { p++; break; }
+        if (!(p = lmb_plan_string(p, t.name, sizeof t.name))) goto done;
+        p = lmb_plan_space(p);
+        if (*p++ != ':') goto done;
+        p = lmb_plan_space(p);
+        const char *end = lmb_plan_object_end(p);
+        if (!end) goto done;
+        if (strcmp(t.name, "__metadata__")) {
+            uint64_t offsets[2]; unsigned noffsets;
+            if (++tensors > 131072 ||
+                lmb_json_string(p, "dtype", t.dtype, sizeof t.dtype) ||
+                lmb_plan_array(lmb_json_member(p, "shape"), t.shape, 8, &t.rank) ||
+                lmb_plan_array(lmb_json_member(p, "data_offsets"), offsets, 2, &noffsets) ||
+                noffsets != 2 || offsets[0] > offsets[1] ||
+                offsets[1] > (uint64_t)st.st_size - 8 - bytes) goto done;
+            t.elements = 1;
+            for (unsigned i = 0; i < t.rank; i++) t.elements = lmb_size_mul(t.elements, t.shape[i]);
+            unsigned width = !strcmp(t.dtype, "F32") ? 4 :
+                (!strcmp(t.dtype, "BF16") || !strcmp(t.dtype, "F16")) ? 2 :
+                (!strcmp(t.dtype, "U8") || !strcmp(t.dtype, "I8")) ? 1 : 0;
+            t.bytes = offsets[1] - offsets[0];
+            if (!width || lmb_size_mul(t.elements, width) != t.bytes ||
+                visit(&t, opaque)) goto done;
+        }
+        p = lmb_plan_space(end);
+        if (*p == '}') { p++; break; }
+        if (*p++ != ',') goto done;
+        if (*lmb_plan_space(p) == '}') goto done;
+    }
+    if (*lmb_plan_space(p) || !tensors) goto done;
+    rc = 0;
+done:
+    free(json); fclose(f); return rc;
+}
+
+static int lmb_plan_tensors(const char *root, LmbPlanTensorVisit visit, void *opaque) {
+    DIR *dir = opendir(root);
+    if (!dir) return -1;
+    uint64_t budget = UINT64_C(64) << 20;
+    unsigned files = 0;
+    int rc = 0;
+    for (;;) {
+        errno = 0;
+        struct dirent *e = readdir(dir);
+        if (!e) { if (errno) rc = -1; break; }
+        size_t n = strlen(e->d_name);
+        if (n < 12 || strcmp(e->d_name + n - 12, ".safetensors")) continue;
+        char path[1024];
+        int len = snprintf(path, sizeof path, "%s/%s", root, e->d_name);
+        if (++files > 512 || len < 0 || (size_t)len >= sizeof path ||
+            lmb_plan_tensor_file(path, &budget, visit, opaque)) { rc = -1; break; }
+    }
+    closedir(dir);
+    return files ? rc : -1;
+}
+#endif

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1893,7 +1893,7 @@ int main(int argc, char **argv) {
         return 1;
     }
     if (lmb_colibri_register_all()) {
-        fprintf(stderr, "cannot register all six Colibri adapters\n"); return 1;
+        fprintf(stderr, "cannot register the Colibri adapters\n"); return 1;
     }
     ColiEdgeEngineOptions edge_options = {
         .struct_size = sizeof edge_options,
@@ -1922,11 +1922,16 @@ int main(int argc, char **argv) {
                 engine_error(error));
         return 1;
     }
-    uint32_t context = cap.max_context_tokens < 4096 ? cap.max_context_tokens : 4096;
+    /* A stateless Edge (e.g. GLM5.3) can leave its context limit to the
+     * caller. Zero is not a ban on every prompt. Still enforce the protocol
+     * ceiling and negotiate against the actual Segment session limits. */
+    uint32_t context_limit = cap.max_context_tokens ? cap.max_context_tokens : LMB_SEG_MAX_CONTEXT;
+    if (context_limit > LMB_SEG_MAX_CONTEXT) context_limit = LMB_SEG_MAX_CONTEXT;
+    uint32_t context = context_limit < 4096 ? context_limit : 4096;
     uint32_t max_rows = cap.max_batch_rows < 64 ? cap.max_batch_rows : 64;
     uint32_t discovery_timeout_ms = serve_mode ? 2500u : 15000u;
     if (((value = arg_value(argc, argv, "--context")) &&
-         lmb_parse_u32(value, 1, cap.max_context_tokens, &context)) ||
+         lmb_parse_u32(value, 1, context_limit, &context)) ||
         ((value = arg_value(argc, argv, "--max-rows")) &&
          lmb_parse_u32(value, 1, cap.max_batch_rows, &max_rows)) ||
         ((value = arg_value(argc, argv, "--discovery-timeout-ms")) &&

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1317,9 +1317,12 @@ static int segment_generate(ColiEdgeEngine *edge,
     } else {
         if (!prompt ||
             coli_edge_tokenize(edge, prompt, prompt_bytes, NULL, 0,
-                               &prompt_count, error, error_size) ||
-            !prompt_count || prompt_count > SIZE_MAX / sizeof *prompt_tokens)
+                               &prompt_count, error, error_size))
             goto cleanup;
+        if(!prompt_count || prompt_count > SIZE_MAX / sizeof *prompt_tokens) {
+            snprintf(error,error_size,"Tokenizer produced an invalid token count; verify the checkpoint tokenizer");
+            goto cleanup;
+        }
         prompt_tokens = malloc(prompt_count * sizeof *prompt_tokens);
         size_t actual_count = 0;
         if (!prompt_tokens ||

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1206,10 +1206,10 @@ static void generation_result_free(GenerationResult *result) {
     memset(result, 0, sizeof *result);
 }
 
-/* Detokenize the complete generated prefix and stream only bytes confirmed by
- * two consecutive prefixes. This one-token look-behind handles byte fallback
- * and tokenizers that rewrite their trailing whitespace: unstable tail bytes
- * remain buffered, while already displayed text is never contradicted. */
+/* Detokenize complete prefixes. Some adapters cannot yet decode a prefix that
+ * ends inside a byte-fallback character. A non-final failure only defers text;
+ * the final prefix MUST decode successfully. Never emit a partial UTF-8 scalar
+ * or a trailing replacement which another byte token could still complete. */
 static int generation_stream_prefix(ColiEdgeEngine *edge,
                                     const int32_t *tokens, size_t count,
                                     int32_t eos_token,
@@ -1221,12 +1221,17 @@ static int generation_stream_prefix(ColiEdgeEngine *edge,
     while (count && tokens[count - 1] == eos_token) count--;
     size_t bytes = 0;
     if (count && coli_edge_detokenize(edge, tokens, count, NULL, 0, &bytes,
-                                     error, error_size)) return -1;
+                                     error, error_size)) {
+        if (!flush) { if (error_size) error[0]=0; return 0; }
+        return -1;
+    }
     char *text = malloc(bytes + 1u);
     if (!text) { snprintf(error, error_size, "out of memory streaming token"); return -1; }
     if (count && coli_edge_detokenize(edge, tokens, count, text, bytes + 1u,
                                      &bytes, error, error_size)) {
-        free(text); return -1;
+        free(text);
+        if (!flush) { if (error_size) error[0]=0; return 0; }
+        return -1;
     }
     text[bytes] = 0;
     if (*emitted_bytes > bytes ||
@@ -1242,6 +1247,9 @@ static int generation_stream_prefix(ColiEdgeEngine *edge,
     else if (*previous) {
         size_t common = *previous_bytes < bytes ? *previous_bytes : bytes;
         while (stable < common && (*previous)[stable] == text[stable]) stable++;
+        while (stable && stable < bytes && ((unsigned char)text[stable] & 0xc0)==0x80) stable--;
+        if (stable==bytes)
+            while (stable>=3 && !memcmp(text+stable-3,"\xef\xbf\xbd",3)) stable-=3;
     }
     if (stable < *emitted_bytes) {
         free(text);
@@ -1722,7 +1730,11 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
                               const uint8_t tokenizer_root[32],
                               uint32_t context, uint32_t max_rows,
                               uint64_t seed) {
-    printf(SEGMENT_FRAME_READY "\nSTAT 0 0 0 0\n");
+    /* Report capabilities before READY, so a pipe reader cannot consume
+     * readiness first and lose a later capability line. Direct CLI requests
+     * for unavailable stochastic sampling still fail explicitly. */
+    printf("\nLUMABRI_SAMPLING %s\n" SEGMENT_FRAME_READY "\nSTAT 0 0 0 0\n",
+           cap->flags & COLI_EDGE_CAP_LOGITS ? "LOGITS" : "GREEDY");
     fflush(stdout);
     LmbSampler sampler;
     lmb_sampler_init(&sampler, seed);

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -68,6 +68,7 @@ typedef int (*GenerationEventFn)(void *opaque, GenerationEventKind kind,
                                  const void *data, size_t data_bytes);
 
 static int retry_first_run;
+static int segment_direct_only;
 static const char *segment_tracker;
 static uint64_t segment_wire_bytes;
 
@@ -97,7 +98,7 @@ static void usage(const char *program) {
         "((--prompt TEXT | --prompt-ids CSV) | --serve) "
         "[--expect-ids CSV] [--tokens N] [--context N] [--max-rows N] "
         "[--temperature F --top-p F --seed N] "
-        "[--discovery-timeout-ms N] [--retry-first-run] [--json]\n",
+        "[--discovery-timeout-ms N] [--retry-first-run] [--direct-only] [--json]\n",
         program);
 }
 
@@ -380,7 +381,7 @@ static int remote_relay_request(RemoteSegment *remote, uint32_t op,
                                 const void *body, uint32_t body_len,
                                 const void *pay, uint32_t pay_len,
                                 LmbMsg *response) {
-    if (!segment_tracker ||
+    if (segment_direct_only || !segment_tracker ||
         !(remote->route.transport & LMB_SEG_TRANSPORT_RELAY)) return -1;
     LmbBuf envelope = {0};
     if (lmb_buf_str(&envelope, remote->route.advert.peer_name) ||
@@ -459,6 +460,14 @@ static int remote_request(RemoteSegment *remote, uint32_t op,
         if (remote->fd >= 0) lmb_close(remote->fd);
         remote->fd = -1;
         remote->direct_failed = 1;
+    }
+    if (segment_direct_only) {
+        size_t used = strlen(remote->transport_error);
+        snprintf(remote->transport_error + used,
+                 sizeof remote->transport_error - used,
+                 "%sdirect-only policy forbids tracker relay for %s",
+                 used ? "; " : "", remote->route.advert.peer_name);
+        return -1;
     }
     if (!(remote->route.transport & LMB_SEG_TRANSPORT_RELAY)) return -1;
     if (!remote_relay_request(remote, op, body, body_len,
@@ -1836,6 +1845,7 @@ int main(int argc, char **argv) {
     const char *expect_ids_text = arg_value(argc, argv, "--expect-ids");
     int serve_mode = has_arg(argc, argv, "--serve");
     int json_output = has_arg(argc, argv, "--json");
+    segment_direct_only = has_arg(argc, argv, "--direct-only");
     segment_tracker = tracker;
     for (int i = 1; i < argc; i++)
         if (!strcmp(argv[i], "--retry-first-run")) retry_first_run = 1;

--- a/tests/c/edge_segment_greedy.c
+++ b/tests/c/edge_segment_greedy.c
@@ -92,6 +92,7 @@ int main(int argc, char **argv) {
     int np=ids(root,"prompt_ids",prompt),nf=ids(root,"full_ids",full);
     REQUIRE(np>0 && nf>np && !memcmp(prompt,full,(size_t)np*sizeof(*prompt)));
     REQUIRE(!coli_qwen38_segment_adapter_register() && !coli_qwen38_edge_adapter_register());
+    REQUIRE(!coli_deepseek_v4_segment_adapter_register() && !coli_deepseek_v4_edge_adapter_register());
     ColiEdgeEngineOptions eo={.struct_size=sizeof(eo),.model_dir=argv[2]};
     REQUIRE(!coli_edge_engine_open(argv[1],&eo,&edge,error,sizeof error));
     ColiEdgeCapabilities ec={.struct_size=sizeof(ec)};

--- a/tests/c/edge_segment_greedy.c
+++ b/tests/c/edge_segment_greedy.c
@@ -1,0 +1,107 @@
+/* Independent fixed-token oracle through the public Edge/Segment ABI.
+ * Greedy selection does not require the optional LOGITS capability. Run the
+ * same reference with one range, two ranges, and fresh session state again. */
+#include "edge_adapters.h"
+#include "edge_runtime.h"
+#include "segment_adapters.h"
+#include "segment_runtime.h"
+#include "json.h"
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define REQUIRE(x) do { if(!(x)) { fprintf(stderr,"oracle line %d: %s\n",__LINE__,error); goto done; } } while(0)
+
+static int ids(jval *root, const char *key, int32_t *out) {
+    jval *a=json_get(root,key);
+    if(!a || a->t!=J_ARR || a->len<1 || a->len>512) return -1;
+    for(int i=0;i<a->len;i++) {
+        jval *n=a->kids[i];
+        if(!n || n->t!=J_NUM || n->num<0 || n->num>INT32_MAX || n->num!=(int32_t)n->num) return -1;
+        out[i]=(int32_t)n->num;
+    }
+    return a->len;
+}
+
+static int run_oracle(const char *family, const char *path, ColiEdgeEngine *edge,
+                      const ColiEdgeCapabilities *ec, int ranges,
+                      const int32_t *prompt, int np, const int32_t *full, int nf) {
+    char error[512]="contract mismatch";
+    ColiSegmentEngine *engines[2]={0}; ColiSegmentSession *sessions[2]={0};
+    float *a=NULL,*b=NULL; int rc=1;
+    size_t row=(size_t)ec->state_width*sizeof(float);
+    a=malloc((size_t)np*row); b=malloc((size_t)np*row);
+    REQUIRE(a && b && ec->state_dtype==COLI_EDGE_DTYPE_F32 && ec->num_layers>=2);
+    for(int i=0;i<ranges;i++) {
+        ColiSegmentEngineOptions eo={.struct_size=sizeof(eo),.model_dir=path,
+            .layer_begin=(uint32_t)i*ec->num_layers/(uint32_t)ranges,
+            .layer_end=(uint32_t)(i+1)*ec->num_layers/(uint32_t)ranges,.context_tokens=(uint32_t)nf};
+        REQUIRE(!coli_segment_engine_open(family,&eo,&engines[i],error,sizeof error));
+        ColiSegmentCapabilities sc={.struct_size=sizeof(sc)};
+        REQUIRE(!coli_segment_engine_capabilities(engines[i],&sc,error,sizeof error));
+        REQUIRE(sc.state_width==ec->state_width && sc.state_dtype==ec->state_dtype &&
+                !strcmp(sc.state_schema,ec->state_schema) && !strcmp(sc.numeric_class,ec->numeric_class));
+        ColiSegmentSessionOptions so={.struct_size=sizeof(so),.context_tokens=(uint32_t)nf};
+        REQUIRE(!coli_segment_session_create(engines[i],&so,&sessions[i],error,sizeof error));
+    }
+    for(int token=np;token<nf;token++) {
+        uint32_t rows=token==np ? (uint32_t)np : 1;
+        const int32_t *input=token==np ? prompt : &full[token-1];
+        ColiEdgeEmbedRequest er={.struct_size=sizeof(er),.rows=rows,.token_ids=input,
+            .token_count=rows,.output=a,.output_bytes=rows*row};
+        REQUIRE(!coli_edge_embed(edge,&er,error,sizeof error));
+        for(int i=0;i<ranges;i++) {
+            ColiSegmentRunRequest rr={.struct_size=sizeof(rr),.rows=rows,
+                .position=token==np ? 0 : (uint64_t)token-1,.token_ids=input,.token_count=rows,
+                .input=a,.input_bytes=rows*row,.output=b,.output_bytes=rows*row};
+            REQUIRE(!coli_segment_run(sessions[i],&rr,error,sizeof error));
+            float *swap=a; a=b; b=swap;
+        }
+        int32_t next=-1;
+        ColiEdgeSelectRequest sr={.struct_size=sizeof(sr),.rows=1,
+            .input=a+(rows-1u)*ec->state_width,.input_bytes=row,.token_ids=&next,.token_capacity=1};
+        REQUIRE(!coli_edge_select(edge,&sr,error,sizeof error));
+        if(next!=full[token]) {
+            snprintf(error,sizeof error,"token %d: got %d, oracle %d (%d ranges)",token,next,full[token],ranges);
+            REQUIRE(0);
+        }
+    }
+    printf("%s: %d ranges, %d independent oracle tokens PASS\n",family,ranges,nf-np);
+    rc=0;
+done:
+    for(int i=0;i<2;i++) {
+        coli_segment_session_destroy(sessions[i]);
+        if(engines[i]) (void)coli_segment_engine_close(engines[i],NULL,0);
+    }
+    free(a);free(b);return rc;
+}
+
+int main(int argc, char **argv) {
+    if(argc!=4) {fprintf(stderr,"usage: %s FAMILY CHECKPOINT ORACLE.json\n",argv[0]);return 2;}
+    char error[512]="invalid oracle"; int rc=1;
+    FILE *file=fopen(argv[3],"rb"); if(!file) return 2;
+    char *text=malloc(1u<<20),*arena=NULL; jval *root=NULL;
+    ColiEdgeEngine *edge=NULL;
+    if(!text) {fclose(file);return 2;}
+    size_t n=fread(text,1,(1u<<20)-1,file);
+    int bad=ferror(file)||!feof(file); fclose(file); text[n]=0;
+    REQUIRE(!bad);
+    root=json_parse(text,&arena); REQUIRE(root);
+    int32_t prompt[512],full[512];
+    int np=ids(root,"prompt_ids",prompt),nf=ids(root,"full_ids",full);
+    REQUIRE(np>0 && nf>np && !memcmp(prompt,full,(size_t)np*sizeof(*prompt)));
+    REQUIRE(!coli_qwen38_segment_adapter_register() && !coli_qwen38_edge_adapter_register());
+    ColiEdgeEngineOptions eo={.struct_size=sizeof(eo),.model_dir=argv[2]};
+    REQUIRE(!coli_edge_engine_open(argv[1],&eo,&edge,error,sizeof error));
+    ColiEdgeCapabilities ec={.struct_size=sizeof(ec)};
+    REQUIRE(!coli_edge_engine_capabilities(edge,&ec,error,sizeof error));
+    REQUIRE(ec.flags&COLI_EDGE_CAP_GREEDY);
+    for(int i=0;i<nf;i++) REQUIRE((uint32_t)full[i]<ec.vocab_size);
+    REQUIRE(!run_oracle(argv[1],argv[2],edge,&ec,1,prompt,np,full,nf));
+    REQUIRE(!run_oracle(argv[1],argv[2],edge,&ec,2,prompt,np,full,nf));
+    REQUIRE(!run_oracle(argv[1],argv[2],edge,&ec,2,prompt,np,full,nf));
+    rc=0;
+done:
+    coli_edge_engine_close(edge);json_free(root);free(arena);free(text);return rc;
+}

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -17,6 +17,8 @@ static int bad;
 #include "test_planner_qwen36.h"
 #include "test_planner_inkling.h"
 #include "test_planner_kimi.h"
+#include "test_planner_glm.h"
+#include "test_planner_glm53.h"
 
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
@@ -34,6 +36,8 @@ int main(void) {
     qwen36_contract_test();
     inkling_contract_test();
     kimi_contract_test();
+    glm_contract_test();
+    glm53_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -16,6 +16,7 @@ static int bad;
 
 #include "test_planner_qwen36.h"
 #include "test_planner_inkling.h"
+#include "test_planner_kimi.h"
 
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
@@ -32,6 +33,7 @@ static LmbModelShape v4(void) {
 int main(void) {
     qwen36_contract_test();
     inkling_contract_test();
+    kimi_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -20,6 +20,7 @@ static int bad;
 #include "test_planner_glm.h"
 #include "test_planner_glm53.h"
 #include "test_planner_qwen38.h"
+#include "test_planner_olmoe.h"
 
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
@@ -40,6 +41,7 @@ int main(void) {
     glm_contract_test();
     glm53_contract_test();
     qwen38_contract_test();
+    olmoe_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -14,6 +14,8 @@ static int bad;
 #define CHECK(cond, ...) do { if (!(cond)) { \
     fprintf(stderr, __VA_ARGS__); fputc('\n', stderr); bad = 1; } } while (0)
 
+#include "test_planner_qwen36.h"
+
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
     LmbModelShape m; memset(&m, 0, sizeof m);
@@ -27,6 +29,7 @@ static LmbModelShape v4(void) {
 }
 
 int main(void) {
+    qwen36_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -21,6 +21,7 @@ static int bad;
 #include "test_planner_glm53.h"
 #include "test_planner_qwen38.h"
 #include "test_planner_olmoe.h"
+#include "test_planner_v4.h"
 
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
@@ -42,6 +43,7 @@ int main(void) {
     glm53_contract_test();
     qwen38_contract_test();
     olmoe_contract_test();
+    v4_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -15,6 +15,7 @@ static int bad;
     fprintf(stderr, __VA_ARGS__); fputc('\n', stderr); bad = 1; } } while (0)
 
 #include "test_planner_qwen36.h"
+#include "test_planner_inkling.h"
 
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
@@ -30,6 +31,7 @@ static LmbModelShape v4(void) {
 
 int main(void) {
     qwen36_contract_test();
+    inkling_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner.c
+++ b/tests/c/test_planner.c
@@ -19,6 +19,7 @@ static int bad;
 #include "test_planner_kimi.h"
 #include "test_planner_glm.h"
 #include "test_planner_glm53.h"
+#include "test_planner_qwen38.h"
 
 /* Roughly DeepSeek V4 Flash, at the numbers we measured on the real one. */
 static LmbModelShape v4(void) {
@@ -38,6 +39,7 @@ int main(void) {
     kimi_contract_test();
     glm_contract_test();
     glm53_contract_test();
+    qwen38_contract_test();
     LmbModelShape m = v4();
 
     CHECK(lmb_size_add(UINT64_MAX - 2, 3) == UINT64_MAX,

--- a/tests/c/test_planner_glm.h
+++ b/tests/c/test_planner_glm.h
@@ -1,0 +1,26 @@
+static void glm_contract_test(void) {
+    LmbModelShape m = { .layers = 2, .hidden = 32, .vocab = 8 };
+    uint8_t seen[4] = {0};
+    LmbGlmInventory v = { .model = &m, .first = 1, .inter = 32,
+        .experts = 2, .expert_seen = seen };
+    LmbPlanTensor t = { .rank = 2, .shape = {32, 32}, .elements = 1024, .bytes = 2048 };
+    snprintf(t.dtype, sizeof t.dtype, "BF16");
+    snprintf(t.name, sizeof t.name, "model.layers.1.mlp.experts.0.gate_proj.weight");
+    CHECK(!lmb_glm_tensor(&t, &v) && seen[2] == 1 && m.memory[1].resident_bytes == 5120 &&
+          v.largest_expert == 4096,
+          "GLM float source did not cover f32 runtime weights and scales");
+    CHECK(lmb_glm_tensor(&t, &v) != 0, "duplicate GLM expert accepted");
+    snprintf(t.name, sizeof t.name, "model.layers.1.mlp.experts.0.up_proj.weight");
+    snprintf(t.dtype, sizeof t.dtype, "U8");
+    CHECK(lmb_glm_tensor(&t, &v) != 0, "unverified prepared GLM encoding enabled");
+    snprintf(t.name, sizeof t.name, "model.layers.1.mlp.experts.2.gate_proj.weight");
+    snprintf(t.dtype, sizeof t.dtype, "F32"); t.bytes = 4096;
+    CHECK(lmb_glm_tensor(&t, &v) != 0, "GLM expert ID out of range accepted");
+    snprintf(t.name, sizeof t.name, "model.embed_tokens.weight");
+    t.elements = 256; t.bytes = 1024;
+    CHECK(!lmb_glm_tensor(&t, &v) && m.edge_resident_bytes == 1056 &&
+          m.edge_scratch_fixed_bytes == 1024, "GLM Edge load temporary not reserved");
+    snprintf(t.name, sizeof t.name, "model.embed_tokens.weight.qs");
+    CHECK(lmb_glm_tensor(&t, &v) != 0,
+          "sidecar silently changed an admitted float source into a quantized container");
+}

--- a/tests/c/test_planner_glm53.h
+++ b/tests/c/test_planner_glm53.h
@@ -1,0 +1,27 @@
+static void glm53_contract_test(void) {
+    LmbModelShape m = {.layers=4, .hidden=128, .vocab=128, .memory_contract=1,
+        .sizing_verified=1, .max_context=128, .session_fixed_bytes=65536,
+        .session_token_bytes=512, .boundary_width=256};
+    LmbRangeCost one=lmb_estimate_segment(&m,0,1,64,2);
+    LmbRangeCost all=lmb_estimate_segment(&m,0,4,64,2);
+    CHECK(one.ok && all.ok && one.state_bytes==all.state_bytes &&
+          one.state_bytes==(65536u+64u*512u)*2u,
+          "GLM5.3's engine-wide state was incorrectly divided by range length");
+    m.session_token_bytes=UINT64_MAX;
+    CHECK(!lmb_estimate_segment(&m,0,1,64,2).ok, "engine-wide session overflow admitted");
+    m.session_token_bytes=512;
+    LmbGlm53Inventory v={.model=&m,.h=128};
+    LmbPlanTensor t={.elements=128,.bytes=512,.rank=1,.shape={128}};
+    snprintf(t.dtype,sizeof t.dtype,"F32");
+    snprintf(t.name,sizeof t.name,"model.language_model.norm.weight");
+    CHECK(!lmb_glm53_tensor(&t,&v) && v.prefix==2 && m.edge_resident_bytes==1024,
+          "GLM5.3 text wrapper or conservative Edge norm bound failed");
+    CHECK(lmb_glm53_tensor(&t,&v)!=0,"GLM5.3 duplicated final norm accepted");
+    snprintf(t.name,sizeof t.name,"model.embed_tokens.weight");
+    CHECK(lmb_glm53_tensor(&t,&v)!=0,"mixed GLM5.3 namespaces accepted");
+    snprintf(t.name,sizeof t.name,"model.visual.patch_embed.proj.weight");
+    CHECK(lmb_glm53_tensor(&t,&v)!=0,"unbudgeted replicated vision tower accepted");
+    snprintf(t.name,sizeof t.name,"lm_head.weight");
+    snprintf(t.dtype,sizeof t.dtype,"U8");
+    CHECK(lmb_glm53_tensor(&t,&v)!=0,"unverified GLM5.3 packed format admitted");
+}

--- a/tests/c/test_planner_inkling.h
+++ b/tests/c/test_planner_inkling.h
@@ -1,0 +1,102 @@
+/* Metadata-only fixtures test admission arithmetic, not model numerics.
+ * Real float/int4 inference and split oracles are separate integration gates. */
+static void plan_tensor_write(const char *path, const char *json, uint64_t payload) {
+    FILE *f = fopen(path, "wb");
+    CHECK(f != NULL, "cannot create tensor fixture");
+    if (!f) return;
+    uint64_t n = strlen(json);
+    unsigned char prefix[8];
+    for (unsigned i = 0; i < 8; i++) prefix[i] = (unsigned char)(n >> (8 * i));
+    CHECK(fwrite(prefix, 1, 8, f) == 8 && fwrite(json, 1, n, f) == n,
+          "cannot write tensor header");
+    if (payload) {
+        CHECK(!fseeko(f, (off_t)(payload - 1), SEEK_CUR) && fputc(0, f) != EOF,
+              "cannot size sparse tensor payload");
+    }
+    fclose(f);
+}
+
+static int plan_tensor_count(const LmbPlanTensor *t, void *data) {
+    unsigned *count = data;
+    CHECK(t->elements == 2 && t->bytes == 8 && !strcmp(t->dtype, "F32"),
+          "tensor inventory changed shape or storage width");
+    (*count)++;
+    return 0;
+}
+
+static void tensor_header_test(void) {
+    char dir[] = "/tmp/lmb-tensor-plan-XXXXXX", path[256];
+    CHECK(mkdtemp(dir) != NULL, "cannot create tensor directory");
+    snprintf(path, sizeof path, "%s/model.safetensors", dir);
+    const char *valid = "{\"w\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}}";
+    plan_tensor_write(path, valid, 8);
+    unsigned count = 0;
+    CHECK(!lmb_plan_tensors(dir, plan_tensor_count, &count) && count == 1,
+          "valid tensor header rejected");
+    uint64_t budget = 2;
+    CHECK(lmb_plan_tensor_file(path, &budget, plan_tensor_count, &count) != 0,
+          "header byte budget was ignored");
+    const char *invalid[] = {
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,9]}}",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[3],\"data_offsets\":[0,8]}}",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[18446744073709551615,4],\"data_offsets\":[0,8]}}",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[2.0],\"data_offsets\":[0,8]}}",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[8,0]}}",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}]",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]},}",
+        "{\"w\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}} extra",
+        "{\"w\":{\"dtype\":\"F64\",\"shape\":[1],\"data_offsets\":[0,8]}}",
+        "{\"__metadata__\":{\"format\":\"pt\"}}"
+    };
+    for (size_t i = 0; i < sizeof invalid / sizeof *invalid; i++) {
+        plan_tensor_write(path, invalid[i], 8);
+        CHECK(lmb_plan_tensors(dir, plan_tensor_count, &count) != 0,
+              "invalid tensor header %zu accepted", i);
+    }
+    plan_tensor_write(path, valid, 7);
+    CHECK(lmb_plan_tensors(dir, plan_tensor_count, &count) != 0,
+          "truncated checkpoint accepted");
+    unlink(path); rmdir(dir);
+}
+
+static void inkling_contract_test(void) {
+    tensor_header_test();
+    LmbModelShape m = { .layers = 2, .hidden = 4, .vocab = 8 };
+    LmbInklingInventory v = { .model = &m, .hidden = 4, .inter = 2, .experts = 2 };
+    LmbPlanTensor t = { .elements = 32, .bytes = 64 };
+    snprintf(t.name, sizeof t.name, "model.embed_tokens.weight");
+    snprintf(t.dtype, sizeof t.dtype, "BF16");
+    CHECK(!lmb_inkling_tensor(&t, &v) && m.edge_resident_bytes == 64,
+          "BF16 Edge boundary was expanded despite native retention");
+    CHECK(lmb_inkling_tensor(&t, &v) != 0, "duplicate boundary accepted");
+    snprintf(t.name, sizeof t.name, "lm_head.weight");
+    snprintf(t.dtype, sizeof t.dtype, "F16");
+    CHECK(!lmb_inkling_tensor(&t, &v) && m.edge_resident_bytes == 192,
+          "F16 Edge boundary did not reserve native float32 expansion");
+    snprintf(t.name, sizeof t.name, "model.layers.0.mlp.experts.gate_up_proj");
+    snprintf(t.dtype, sizeof t.dtype, "U8"); t.elements = t.bytes = 16;
+    CHECK(!lmb_inkling_tensor(&t, &v) && m.memory[0].resident_bytes == 16 &&
+          v.encoding[0][0] == 4, "Inkling packed int4 was not retained at its real size");
+    snprintf(t.name, sizeof t.name, "model.layers.1.mlp.experts.gate_up_proj");
+    t.bytes = 15;
+    CHECK(lmb_inkling_tensor(&t, &v) != 0, "invalid packed expert length accepted");
+    snprintf(t.name, sizeof t.name, "model.layers.0.mlp.experts.gate_up_proj.qs");
+    snprintf(t.dtype, sizeof t.dtype, "F32"); t.elements = 7; t.bytes = 28;
+    CHECK(lmb_inkling_tensor(&t, &v) != 0, "missing expert scale row accepted");
+
+    m.sizing_verified = m.memory_contract = 1; m.max_context = 128;
+    m.memory[0].state_fixed_bytes = 96; m.memory[0].state_token_bytes = 32;
+    m.memory[0].state_context_limit = 8;
+    m.memory[1].state_fixed_bytes = 64; m.memory[1].state_token_bytes = 16;
+    LmbRangeCost a = lmb_estimate_segment(&m, 0, 2, 16, 1);
+    LmbRangeCost b = lmb_estimate_segment(&m, 0, 2, 32, 1);
+    CHECK(a.ok && b.ok && a.state_bytes == 96 + 32 * 8 + 64 + 16 * 16 &&
+          b.state_bytes - a.state_bytes == 16 * 16,
+          "sliding KV grew beyond its ring or full KV failed to grow");
+    CHECK(lmb_estimate_segment(&m, 0, 2, 32, 3).state_bytes == b.state_bytes * 3,
+          "Inkling session state was shared between clients");
+    CHECK(!m.disk_streaming && a.working_set_bytes == a.resident_bytes,
+          "unverified Inkling disk support was advertised");
+    CHECK(!lmb_estimate_segment(&m, 0, 2, 129, 1).ok,
+          "Inkling context admission ceiling ignored");
+}

--- a/tests/c/test_planner_kimi.h
+++ b/tests/c/test_planner_kimi.h
@@ -1,0 +1,41 @@
+static void kimi_contract_test(void) {
+    LmbModelShape m = { .layers = 2, .hidden = 32, .vocab = 8 };
+    uint8_t experts_seen[4] = {0};
+    LmbKimiInventory v = { .model = &m, .expert_seen = experts_seen,
+        .first = 1, .latent = 32, .inter = 32, .experts = 2 };
+    LmbPlanTensor t = { .bytes = 512, .elements = 512, .rank = 2, .shape = {32, 16} };
+    snprintf(t.dtype, sizeof t.dtype, "U8");
+    snprintf(t.name, sizeof t.name, "model.layers.1.block_sparse_moe.experts.0.w1.weight_packed");
+    CHECK(!lmb_kimi_tensor(&t, &v) && m.memory[1].resident_bytes == 512 && experts_seen[2] == 1,
+          "native MXFP4 payload did not retain its packed size");
+    CHECK(lmb_kimi_tensor(&t, &v) != 0, "duplicate Kimi expert tensor accepted");
+    snprintf(t.name, sizeof t.name, "model.layers.1.block_sparse_moe.experts.0.w1.weight_scale");
+    t.bytes = t.elements = 31;
+    CHECK(lmb_kimi_tensor(&t, &v) != 0, "short e8m0 scales accepted");
+    t.bytes = t.elements = 32;
+    CHECK(!lmb_kimi_tensor(&t, &v) && experts_seen[2] == 3,
+          "valid MXFP4 exponent scales rejected");
+    snprintf(t.name, sizeof t.name, "model.layers.0.block_sparse_moe.experts.0.w1.weight_packed");
+    t.bytes = t.elements = 512;
+    CHECK(lmb_kimi_tensor(&t, &v) != 0, "expert bank accepted on a dense layer");
+    snprintf(t.name, sizeof t.name, "model.layers.1.block_sparse_moe.experts.2.w1.weight_packed");
+    CHECK(lmb_kimi_tensor(&t, &v) != 0, "expert ID beyond the configured bank accepted");
+    snprintf(t.name, sizeof t.name, "language_model.model.embed_tokens.weight");
+    snprintf(t.dtype, sizeof t.dtype, "F32"); t.elements = 256; t.bytes = 1024;
+    CHECK(lmb_kimi_tensor(&t, &v) != 0, "mixed text namespaces were accepted");
+    uint8_t ids[3] = {0};
+    CHECK(!lmb_plan_indices("{\"layers\":[1,3]}", "layers", ids, 3, 1) && ids[0] && !ids[1] && ids[2],
+          "Kimi's one-based KDA layer list was shifted");
+    CHECK(lmb_plan_indices("{\"layers\":[0]}", "layers", ids, 3, 1) != 0 &&
+          lmb_plan_indices("{\"layers\":[4]}", "layers", ids, 3, 1) != 0,
+          "out-of-range KDA layer accepted");
+    m.memory_contract = m.sizing_verified = 1; m.max_context = 128;
+    m.boundary_width = 96; m.edge_scratch_fixed_bytes = 4096;
+    LmbRangeCost edge = lmb_estimate_edge(&m, 64, 2);
+    CHECK(edge.ok && edge.state_bytes == 64u * 96 * 4 * 2,
+          "AttnRes boundary state was budgeted as ordinary hidden state");
+    CHECK(edge.scratch_bytes == 4096 + 8 * 16, "Edge load workspace disappeared");
+    m.boundary_width = 0;
+    CHECK(lmb_estimate_edge(&m, 64, 2).state_bytes == 64u * 32 * 4 * 2,
+          "ordinary adapter's default boundary width changed");
+}

--- a/tests/c/test_planner_olmoe.h
+++ b/tests/c/test_planner_olmoe.h
@@ -1,0 +1,25 @@
+static void olmoe_contract_test(void) {
+    LmbModelShape m={.layers=2,.hidden=64,.vocab=256,.experts=8};
+    uint8_t seen[16]={0};
+    LmbOlmoeInventory v={.m=&m,.inter=128,.experts=seen};
+    LmbPlanTensor t={.rank=2,.shape={64,64},.elements=4096,.bytes=8192};
+    snprintf(t.dtype,sizeof t.dtype,"BF16");
+    snprintf(t.name,sizeof t.name,"model.layers.0.self_attn.q_proj.weight");
+    CHECK(!lmb_olmoe_tensor(&t,&v) && m.memory[0].resident_bytes==16384,
+          "OLMoE BF16 dense source not expanded to native f32");
+    CHECK(lmb_olmoe_tensor(&t,&v)!=0,"duplicate OLMoE dense tensor admitted");
+    snprintf(t.name,sizeof t.name,"model.layers.1.self_attn.q_proj.weight");
+    t.shape[0]=32;t.shape[1]=128;
+    CHECK(lmb_olmoe_tensor(&t,&v)!=0,"OLMoE same-numel wrong matrix shape admitted");
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.0.gate_proj.weight");
+    CHECK(lmb_olmoe_tensor(&t,&v)!=0,"unconverted OLMoE expert admitted");
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.0.merged_weight");
+    snprintf(t.dtype,sizeof t.dtype,"U8");t.elements=t.bytes=3*128*64;
+    CHECK(!lmb_olmoe_tensor(&t,&v),"merged OLMoE int8 expert rejected");
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.1.merged_weight");
+    t.bytes--;
+    CHECK(lmb_olmoe_tensor(&t,&v)!=0,"truncated OLMoE expert admitted");
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.0.qs");
+    snprintf(t.dtype,sizeof t.dtype,"F32");t.elements=320;t.bytes=1280;
+    CHECK(!lmb_olmoe_tensor(&t,&v) && seen[0]==3,"OLMoE row scales not validated");
+}

--- a/tests/c/test_planner_qwen36.h
+++ b/tests/c/test_planner_qwen36.h
@@ -1,0 +1,80 @@
+/* Check the resident contract without loading weights or importing Colibri. */
+static void qwen36_contract_test(void) {
+    char dir[] = "/tmp/lmb-qwen-plan-XXXXXX", path[256];
+    CHECK(mkdtemp(dir) != NULL, "cannot create Qwen contract fixture");
+    snprintf(path, sizeof path, "%s/config.json", dir);
+    FILE *f = fopen(path, "w");
+    CHECK(f != NULL, "cannot create Qwen config");
+    if (!f) return;
+    fputs("{\"model_type\":\"qwen3_5_moe_text\",\"hidden_size\":64,"
+          "\"num_hidden_layers\":2,\"vocab_size\":320}", f);
+    fclose(f);
+    LmbModelShape m;
+    CHECK(!lmb_shape_from_config(dir, &m) && !m.sizing_verified,
+          "Qwen without converted metadata was enabled");
+    snprintf(path, sizeof path, "%s/qwen36_meta.json", dir);
+    for (int grouped = 0; grouped < 2; grouped++) {
+        f = fopen(path, "w");
+        CHECK(f != NULL, "cannot create Qwen metadata");
+        if (!f) break;
+        fprintf(f, "{\"hidden\":64,\"n_layers\":2,\"num_experts\":8,\"topk\":2,"
+          "\"moe_inter\":32,\"shared_inter\":32,\"q_heads\":4,\"kv_heads\":2,"
+          "\"head_dim\":16,\"q_head_dim\":32,\"k_head_dim\":16,\"v_head_dim\":16,"
+          "\"o_in\":64,\"expert_gs\":%u,\"dn_vheads\":8,\"dn_kheads\":4,"
+          "\"dn_kdim\":8,\"dn_vdim\":8,\"dn_convk\":4,\"dn_conv_dim\":128,"
+          "\"layer_types\":[\"linear_attention\",\"full_attention\"],\"ebits\":%u}",
+          grouped ? 16 : 0, grouped ? 4 : 8);
+        fclose(f);
+        CHECK(!lmb_shape_from_config(dir, &m) && m.sizing_verified && m.memory_contract == 1,
+              "valid Qwen metadata did not produce a memory contract");
+        uint64_t scales = grouped ? 2u * 32 * 4 + 64 * 2 : 2u * 32 + 64;
+        uint64_t common = 3u * 64 + 8u * 64 + 8 + 3u * 64 * 32 + 2u * 16;
+        uint64_t attention = 4u * 32 * 64 + 2u * 32 * 64 + 64u * 64;
+        CHECK(m.memory[1].resident_bytes == (3u * 64 * 32 + scales * 4) * 8 +
+              (common + attention) * 4,
+              "Qwen CPU cache did not include unpacked int8 and all group scales");
+        LmbRangeCost linear = lmb_estimate_segment(&m, 0, 1, 64, 1);
+        LmbRangeCost full = lmb_estimate_segment(&m, 1, 2, 64, 1);
+        LmbRangeCost all = lmb_estimate_segment(&m, 0, 2, 64, 1);
+        CHECK(linear.ok && full.ok && all.ok, "Qwen ranges could not be estimated");
+        CHECK(linear.state_bytes == (8u * 8 * 8 + 128u * 3) * 4,
+              "DeltaNet recurrent and convolution state mismatch");
+        CHECK(full.state_bytes == 2u * 16 * 64 * 8, "attention KV size mismatch");
+        CHECK(all.state_bytes == linear.state_bytes + full.state_bytes,
+              "hybrid state did not sum by actual layer kind");
+        CHECK(lmb_estimate_segment(&m, 0, 1, 128, 1).state_bytes == linear.state_bytes,
+              "context incorrectly expanded fixed recurrent state");
+        CHECK(lmb_estimate_segment(&m, 1, 2, 128, 1).state_bytes == full.state_bytes * 2,
+              "context did not expand attention KV state");
+        CHECK(lmb_estimate_segment(&m, 0, 2, 64, 3).state_bytes == all.state_bytes * 3,
+              "sessions did not receive separate state");
+        CHECK(linear.resident_bytes + full.resident_bytes == all.resident_bytes + m.segment_fixed_bytes,
+              "split lost or double-counted its per-process structures");
+        CHECK(!m.disk_streaming && all.working_set_bytes == all.resident_bytes,
+              "a resident-only contract advertised unverified disk execution");
+        CHECK(!lmb_estimate_segment(&m, 0, 2, 262145, 1).ok &&
+              !lmb_estimate_edge(&m, 262145, 1).ok,
+              "context beyond the adapter limit was accepted");
+        CHECK(lmb_estimate_edge(&m, 64, 1).resident_bytes == (2u * 320 * 64 + 64) * 4,
+              "Edge did not reserve its float32 boundaries");
+        m.memory[1].state_token_bytes = UINT64_MAX;
+        CHECK(!lmb_estimate_segment(&m, 0, 2, 64, 1).ok,
+              "invalid explicit layer state wrapped into a valid budget");
+    }
+    uint32_t n = 0;
+    CHECK(!lmb_plan_u32("{\"x\":4}", "x", 1, 8, &n) && n == 4,
+          "strict metadata integer reader rejected a valid value");
+    const char *invalid[] = {"{\"x\":-1}", "{\"x\":04}", "{\"x\":4.5}",
+        "{\"x\":4e1}", "{\"x\":4294967296}", "{\"x\":\"4\"}",
+        "{\"x\":18446744073709551616000}"};
+    for (size_t i = 0; i < sizeof invalid / sizeof *invalid; i++)
+        CHECK(lmb_plan_u32(invalid[i], "x", 1, 8, &n) != 0,
+              "invalid metadata number accepted: %s", invalid[i]);
+    f = fopen(path, "w");
+    if (f) { fputs("{}", f); fclose(f); }
+    CHECK(!lmb_shape_from_config(dir, &m) && !m.sizing_verified,
+          "incomplete Qwen metadata enabled an estimate");
+    unlink(path);
+    snprintf(path, sizeof path, "%s/config.json", dir);
+    unlink(path); rmdir(dir);
+}

--- a/tests/c/test_planner_qwen36.h
+++ b/tests/c/test_planner_qwen36.h
@@ -1,4 +1,5 @@
-/* Check the resident contract without loading weights or importing Colibri. */
+/* Check metadata arithmetic separately from the production header guard.
+ * Real converted payloads and missing-tensor refusals run in integration. */
 static void qwen36_contract_test(void) {
     char dir[] = "/tmp/lmb-qwen-plan-XXXXXX", path[256];
     CHECK(mkdtemp(dir) != NULL, "cannot create Qwen contract fixture");
@@ -25,8 +26,32 @@ static void qwen36_contract_test(void) {
           "\"layer_types\":[\"linear_attention\",\"full_attention\"],\"ebits\":%u}",
           grouped ? 16 : 0, grouped ? 4 : 8);
         fclose(f);
-        CHECK(!lmb_shape_from_config(dir, &m) && m.sizing_verified && m.memory_contract == 1,
-              "valid Qwen metadata did not produce a memory contract");
+        CHECK(!lmb_shape_from_config(dir, &m) && !m.sizing_verified,
+              "Qwen metadata without actual tensor coverage was admitted");
+        LmbQwen36Inventory inventory;
+        CHECK(!lmb_qwen36_metadata(dir,&m,&inventory) && m.memory_contract==1,
+              "valid Qwen metadata did not produce base memory arithmetic");
+        m.sizing_verified=1; /* arithmetic-only fixture, not product admission */
+        uint8_t seen[16]={0}; inventory.experts=seen;
+        LmbPlanTensor tensor={.elements=6144,.bytes=6144,.rank=1,.shape={6144}};
+        snprintf(tensor.name,sizeof tensor.name,"model.layers.0.mlp.experts.0.merged_weight");
+        snprintf(tensor.dtype,sizeof tensor.dtype,"I8");
+        CHECK(!lmb_q36_tensor(&tensor,&inventory),"valid merged Qwen int8 header rejected");
+        CHECK(lmb_q36_tensor(&tensor,&inventory)!=0,"duplicate Qwen expert admitted");
+        snprintf(tensor.name,sizeof tensor.name,"model.layers.0.mlp.experts.1.merged_weight");
+        snprintf(tensor.dtype,sizeof tensor.dtype,"U8");
+        tensor.bytes=tensor.elements=tensor.shape[0]=3072;
+        CHECK(!lmb_q36_tensor(&tensor,&inventory),"actual packed Qwen int4 header rejected");
+        snprintf(tensor.name,sizeof tensor.name,"model.layers.0.mlp.experts.2.merged_weight");
+        tensor.bytes=tensor.elements=tensor.shape[0]=3071;
+        CHECK(lmb_q36_tensor(&tensor,&inventory)!=0,"short Qwen expert admitted");
+        snprintf(tensor.name,sizeof tensor.name,"model.layers.0.mlp.experts.0.qs");
+        snprintf(tensor.dtype,sizeof tensor.dtype,"F32");
+        tensor.elements=inventory.scale_elements; tensor.bytes=tensor.elements*4;
+        CHECK(!lmb_q36_tensor(&tensor,&inventory),"valid grouped Qwen scales rejected");
+        snprintf(tensor.name,sizeof tensor.name,"model.layers.0.mlp.experts.1.qs");
+        tensor.elements--;
+        CHECK(lmb_q36_tensor(&tensor,&inventory)!=0,"Qwen group count mismatch admitted");
         uint64_t scales = grouped ? 2u * 32 * 4 + 64 * 2 : 2u * 32 + 64;
         uint64_t common = 3u * 64 + 8u * 64 + 8 + 3u * 64 * 32 + 2u * 16;
         uint64_t attention = 4u * 32 * 64 + 2u * 32 * 64 + 64u * 64;

--- a/tests/c/test_planner_qwen38.h
+++ b/tests/c/test_planner_qwen38.h
@@ -22,6 +22,26 @@ static void qwen38_contract_test(void) {
     snprintf(t.name,sizeof t.name,"model.layers.0.ple.norm_key.weight");
     snprintf(t.dtype,sizeof t.dtype,"I64");
     CHECK(lmb_q38_tensor(&t,&v)!=0,"metadata accepted as Qwen3.8 floating weight");
+    uint16_t expert_seen[4]={0};
+    v.e=1; v.inter=136; v.experts=expert_seen;
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.0.gate_proj.weight");
+    snprintf(t.dtype,sizeof t.dtype,"F8_E4M3");
+    t.rank=2; t.shape[0]=136; t.shape[1]=32; t.elements=136*32; t.bytes=t.elements;
+    CHECK(!lmb_q38_tensor(&t,&v) && expert_seen[0]==33 && v.kinds[0]==8,
+          "native FP8 expert was not tracked separately from float weights");
+    CHECK(m.memory[0].resident_bytes==136*32*4,"FP8 opt-out expansion not budgeted");
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.0.gate_proj.weight_scale_inv");
+    snprintf(t.dtype,sizeof t.dtype,"F32");
+    t.shape[0]=1; t.shape[1]=2; t.elements=2; t.bytes=8;
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"transposed partial FP8 block scales admitted");
+    t.shape[0]=2; t.shape[1]=1;
+    CHECK(!lmb_q38_tensor(&t,&v) && expert_seen[0]==289 && v.kinds[0]==8,
+          "FP8 scale sidecar changed the arithmetic class");
+    CHECK(m.memory[0].resident_bytes==136*32*4+16,"shared and per-slot scales not both budgeted");
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"duplicate FP8 sidecar admitted");
+    snprintf(t.name,sizeof t.name,"model.layers.0.mlp.experts.0.up_proj.weight");
+    snprintf(t.dtype,sizeof t.dtype,"F8_E8M0");
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"scale-only FP8 type admitted as an expert weight");
     m.memory[0].state_fixed_bytes=4096;
     m.memory[1].state_token_bytes=144;
     LmbRangeCost dn=lmb_estimate_segment(&m,0,1,64,2), qsa=lmb_estimate_segment(&m,1,2,64,2);

--- a/tests/c/test_planner_qwen38.h
+++ b/tests/c/test_planner_qwen38.h
@@ -1,0 +1,49 @@
+static int q38_metadata_visit(const LmbPlanTensor *t, void *opaque) {
+    unsigned *visited=opaque;
+    CHECK(!strcmp(t->dtype,"I64") && t->elements==2 &&
+          t->meta_i64[0]==UINT64_C(0x0102030405060708) && t->meta_i64[1]==UINT64_MAX,
+          "bounded metadata reader changed signed bits or byte order");
+    (*visited)++;
+    return 0;
+}
+static void qwen38_contract_test(void) {
+    LmbModelShape m={.layers=4,.hidden=32,.vocab=256,.memory_contract=1,
+        .sizing_verified=1,.max_context=128,.boundary_width=128};
+    LmbQwen38Inventory v={.m=&m,.h=32,.hc=4,.rank=8,.ple=0,.pd=32,.pc=4,.nh=4,.nd=8,.parts=2};
+    LmbPlanTensor t={.rank=1,.elements=128,.shape={128},.bytes=512};
+    snprintf(t.dtype,sizeof t.dtype,"F32");
+    snprintf(t.name,sizeof t.name,"model.hyper_connection_mixer.hc_norm.weight");
+    CHECK(!lmb_q38_tensor(&t,&v) && m.edge_resident_bytes==512,"Qwen3.8 hyper-width norm not sized");
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"duplicate Qwen3.8 Edge tensor admitted");
+    snprintf(t.name,sizeof t.name,"model.language_model.embed_tokens.weight");
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"mixed Qwen3.8 namespaces admitted");
+    snprintf(t.name,sizeof t.name,"model.layers.1.ple.norm_key.weight");
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"PLE loaded outside its owning range");
+    snprintf(t.name,sizeof t.name,"model.layers.0.ple.norm_key.weight");
+    snprintf(t.dtype,sizeof t.dtype,"I64");
+    CHECK(lmb_q38_tensor(&t,&v)!=0,"metadata accepted as Qwen3.8 floating weight");
+    m.memory[0].state_fixed_bytes=4096;
+    m.memory[1].state_token_bytes=144;
+    LmbRangeCost dn=lmb_estimate_segment(&m,0,1,64,2), qsa=lmb_estimate_segment(&m,1,2,64,2);
+    CHECK(dn.ok && qsa.ok && dn.state_bytes==8192 && qsa.state_bytes==18432,
+          "Qwen3.8 recurrent state and context state conflated");
+    char path[]="/tmp/lumabri-i64-metadata-XXXXXX";
+    int fd=mkstemp(path);
+    CHECK(fd>=0,"metadata test could not create isolated file");
+    if(fd<0) return;
+    FILE *f=fdopen(fd,"wb");
+    const char *header="{\"offsets\":{\"dtype\":\"I64\",\"shape\":[2],\"data_offsets\":[0,16]}}";
+    unsigned char prefix[8], data[16]={8,7,6,5,4,3,2,1,255,255,255,255,255,255,255,255};
+    for(unsigned i=0;i<8;i++) prefix[i]=(unsigned char)((uint64_t)strlen(header)>>(8*i));
+    fwrite(prefix,1,8,f); fwrite(header,1,strlen(header),f); fwrite(data,1,sizeof data,f); fclose(f);
+    unsigned visited=0; uint64_t budget=4096;
+    CHECK(!lmb_plan_tensor_file(path,&budget,q38_metadata_visit,&visited) && visited==1,
+          "valid small I64 metadata rejected");
+    budget=strlen(header)+15;
+    CHECK(lmb_plan_tensor_file(path,&budget,q38_metadata_visit,&visited)!=0,
+          "I64 payload escaped shared metadata budget");
+    CHECK(!truncate(path,8+(off_t)strlen(header)+15),"truncate metadata fixture failed");
+    budget=4096;
+    CHECK(lmb_plan_tensor_file(path,&budget,q38_metadata_visit,&visited)!=0,"truncated I64 metadata admitted");
+    unlink(path);
+}

--- a/tests/c/test_planner_v4.h
+++ b/tests/c/test_planner_v4.h
@@ -1,0 +1,33 @@
+static void v4_contract_test(void) {
+    LmbModelShape m={.layers=3,.hidden=128,.vocab=128,.experts=4,.experts_per_tok=2};
+    LmbV4Expert experts[12]={0};
+    LmbV4Inventory v={.m=&m,.h=128,.heads=4,.hd=32,.qr=128,.og=1,.orr=128,
+        .inter=128,.hc=2,.ih=2,.id=32,.window=8,.topk=2,.hash=1,.expert=experts};
+    v.ratios[1]=4;v.ratios[2]=8;
+    for(unsigned layer=0;layer<3;layer++) {
+        LmbV4Spec specs[48];unsigned n=lmb_v4_specs(&v,layer,specs);
+        CHECK(n<48,"V4 required tensor plan exceeds its bounded spec array");
+        for(unsigned i=0;i<n;i++) {
+            LmbPlanTensor t={.rank=specs[i].cols ? 2 : 1,.shape={specs[i].rows,specs[i].cols}};
+            t.elements=specs[i].rows*(specs[i].cols ? specs[i].cols : 1);
+            unsigned width=!strcmp(specs[i].dtype,"F32") ? 4 : !strcmp(specs[i].dtype,"BF16") ? 2 :
+                !strcmp(specs[i].dtype,"I64") ? 8 : 1;
+            t.bytes=t.elements*width;
+            snprintf(t.dtype,sizeof t.dtype,"%s",specs[i].dtype);
+            snprintf(t.name,sizeof t.name,"layers.%u.%.79s",layer,specs[i].name);
+            uint64_t before=m.memory[layer].resident_bytes;
+            CHECK(!lmb_v4_tensor(&t,&v),"valid native V4 tensor rejected: %s",t.name);
+            CHECK(m.memory[layer].resident_bytes-before==t.elements*
+                (!strcmp(t.dtype,"F8_E8M0") ? 4u : width),"V4 dense scales not expanded");
+            CHECK(lmb_v4_tensor(&t,&v)!=0,"duplicate V4 tensor admitted");
+        }
+    }
+    LmbPlanTensor t={.rank=2,.shape={128,64},.elements=8192,.bytes=8192,.file_id=1};
+    snprintf(t.name,sizeof t.name,"layers.0.ffn.experts.0.w1.weight");
+    snprintf(t.dtype,sizeof t.dtype,"I8");
+    CHECK(!lmb_v4_tensor(&t,&v),"native V4 packed expert rejected");
+    snprintf(t.name,sizeof t.name,"layers.0.ffn.experts.0.w2.weight");t.file_id=2;
+    CHECK(lmb_v4_tensor(&t,&v)!=0,"V4 expert spanning different shards admitted");
+    t.file_id=1;snprintf(t.dtype,sizeof t.dtype,"U8");
+    CHECK(lmb_v4_tensor(&t,&v)!=0,"V4 incompatible packed expert dtype admitted");
+}

--- a/tests/c/test_segment_stream.c
+++ b/tests/c/test_segment_stream.c
@@ -1,0 +1,58 @@
+/* Exercise the real streaming state machine with deterministic decoder
+ * boundary failures. No model arithmetic is mocked by the separate oracles. */
+#define main segment_program_main
+#define coli_edge_detokenize stream_fixture_detokenize
+#include "../../segment_chat.c"
+#undef main
+#undef coli_edge_detokenize
+
+static int fixture;
+int stream_fixture_detokenize(ColiEdgeEngine *engine,const int32_t *tokens,size_t n,
+                              char *out,size_t cap,size_t *bytes,char *error,size_t error_size) {
+    (void)engine;(void)tokens;
+    const char *text="";
+    if(fixture==0) { /* an adapter reports incomplete UTF-8 as an error */
+        if(n==2) {snprintf(error,error_size,"incomplete byte prefix");return -1;}
+        text=n==1 ? "A" : n==3 ? "A\xc3\xa9" : "A\xc3\xa9!";
+    } else if(fixture==1) { /* another replaces every incomplete suffix */
+        text=n<4 ? "A\xef\xbf\xbd" : "A\xe2\x82\xac!";
+    } else if(fixture==2) {
+        snprintf(error,error_size,"permanent decoder failure");return -1;
+    } else text=n==1 ? "A" : n==2 ? "A!" : "B!";
+    *bytes=strlen(text);
+    if(out) {if(cap<=*bytes)return -1;memcpy(out,text,*bytes+1);}
+    return 0;
+}
+typedef struct {char text[128];size_t n;} StreamCapture;
+static int capture(void *opaque,GenerationEventKind kind,size_t current,size_t total,
+                    const void *text,size_t n) {
+    (void)current;(void)total;
+    StreamCapture *c=opaque;
+    if(kind!=GEN_EVENT_DATA || n>=sizeof c->text-c->n) return -1;
+    memcpy(c->text+c->n,text,n);c->n+=n;c->text[c->n]=0;return 0;
+}
+int main(void) {
+    for(fixture=0;fixture<4;fixture++) {
+        int32_t tokens[4]={1,2,3,4};char error[128]="",*previous=NULL;
+        size_t bytes=0,emitted=0;StreamCapture c={0};int rc=0;
+        unsigned count=fixture==3 ? 3 : 4;
+        for(unsigned n=1;n<=count;n++) {
+            rc=generation_stream_prefix(NULL,tokens,n,-1,0,capture,&c,&previous,&bytes,&emitted,error,sizeof error);
+            if(rc) break;
+        }
+        if(fixture==3) {
+            if(!rc || strcmp(c.text,"A")) {free(previous);return 1;}
+        } else {
+            if(rc) {free(previous);return 2;}
+            rc=generation_stream_prefix(NULL,tokens,4,-1,1,capture,&c,&previous,&bytes,&emitted,error,sizeof error);
+            if(fixture==2) {
+                if(!rc || c.n) {free(previous);return 3;}
+            } else if(rc || strcmp(c.text,fixture==0 ? "A\xc3\xa9!" : "A\xe2\x82\xac!")) {
+                free(previous);return 4;
+            }
+        }
+        free(previous);
+    }
+    puts("SEGMENT STREAM: PASS (deferred UTF-8, final validation, immutable emitted prefix)");
+    return 0;
+}

--- a/tests/integration/catalog_test.sh
+++ b/tests/integration/catalog_test.sh
@@ -26,10 +26,10 @@ cat >"$T/models/tiny/config.json" <<'EOF'
  "intermediate_size":128,"num_experts":8,"num_experts_per_tok":2,
  "num_attention_heads":4,"num_key_value_heads":4,"vocab_size":256}
 EOF
-# A config is metadata, not a checkpoint. These files stand in for actual
-# model containers; a separate case below proves config-only is refused.
+# The historical V4 formula is still under audit. OLMoE now requires a
+# validated tensor inventory, not an arbitrary model.bin placeholder.
 truncate -s 4096 "$T/models/huge/model.bin"
-truncate -s 4096 "$T/models/tiny/model.bin"
+python3 tests/integration/prepare_olmoe_headers.py "$T/models/tiny"
 
 out=$(./lumabri models --models-dir "$T/models" 2>&1) || fail "the catalogue exited non-zero"
 echo "$out" | sed 's/^/    /'

--- a/tests/integration/catalog_test.sh
+++ b/tests/integration/catalog_test.sh
@@ -16,19 +16,18 @@ fail() { echo "CATALOG TEST: FAIL — $*" >&2; exit 1; }
 # A model far larger than any laptop, and one that fits anywhere.
 mkdir -p "$T/models/huge" "$T/models/tiny"
 cat >"$T/models/huge/config.json" <<'EOF'
-{"model_type":"deepseek_v4","num_hidden_layers":43,"hidden_size":4096,
- "intermediate_size":11264,"moe_intermediate_size":1408,"n_routed_experts":256,
- "num_experts_per_tok":6,"num_attention_heads":32,"num_key_value_heads":8,
- "vocab_size":129280}
+{"model_type":"olmoe","num_hidden_layers":32,"hidden_size":4096,
+ "intermediate_size":4096,"num_experts":128,
+ "num_experts_per_tok":6,"num_attention_heads":32,"num_key_value_heads":32,
+ "vocab_size":32768}
 EOF
 cat >"$T/models/tiny/config.json" <<'EOF'
 {"model_type":"olmoe","num_hidden_layers":4,"hidden_size":64,
  "intermediate_size":128,"num_experts":8,"num_experts_per_tok":2,
  "num_attention_heads":4,"num_key_value_heads":4,"vocab_size":256}
 EOF
-# The historical V4 formula is still under audit. OLMoE now requires a
-# validated tensor inventory, not an arbitrary model.bin placeholder.
-truncate -s 4096 "$T/models/huge/model.bin"
+# Sparse header-only files, never a numerical oracle or arbitrary placeholder.
+python3 tests/integration/prepare_olmoe_headers.py "$T/models/huge"
 python3 tests/integration/prepare_olmoe_headers.py "$T/models/tiny"
 
 out=$(./lumabri models --models-dir "$T/models" 2>&1) || fail "the catalogue exited non-zero"

--- a/tests/integration/catalog_test.sh
+++ b/tests/integration/catalog_test.sh
@@ -68,7 +68,9 @@ if echo "$out" | grep -qE "[0-9]+([.,][0-9]+)? *tok/s"; then
     fail "a tok/s figure appeared for a plan nobody has measured"
 fi
 
-json=$(./lumabri models --models-dir "$T/models" --json)
+# The catalogue must not put its complete per-layer maps on the stack.
+# This caught a real regression when explicit hybrid memory contracts grew.
+json=$(ulimit -s 512; ./lumabri models --models-dir "$T/models" --json)
 python3 - "$json" <<'PY' || fail "the versioned JSON snapshot is invalid"
 import json, sys
 doc = json.loads(sys.argv[1])

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -1,6 +1,6 @@
 """Real encrypted tracker, two donor TUIs, Segment engines and hosted chat.
 
-Requires an actual converted small OLMoE checkpoint (not a mock engine).
+Requires one actual small planner-supported checkpoint (not a mock engine).
 This loopback integration gate is not a physical LAN or native-platform test.
 """
 import argparse

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -212,7 +212,8 @@ def main():
         until(lambda: chat.has("Tab completes commands"), message="slash completion did not execute help")
         chat.send("hi\n")
         until(lambda: chat.has("tok/s") or chat.has("prompt plus output exceeds context") or
-              chat.has("logits are unavailable for sampling") or chat.p.poll() is not None, seconds=120,
+              chat.has("logits are unavailable for sampling") or chat.has("Segment generation failed") or
+              chat.has("invalid token count") or chat.p.poll() is not None, seconds=120,
               message="real model did not finish a response")
         assert chat.has("tok/s"), "engine failed during generation"
         assert "hosted stream · no local checkpoint" in chat.text

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -27,6 +27,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--models-dir", required=True)
     parser.add_argument("--donor-ram-gb", type=float, default=0.5)
+    parser.add_argument("--context", type=int, default=128,
+                        help="approved context, including the actual family chat template")
+    parser.add_argument("--expect-greedy", action="store_true")
     parser.add_argument("--expect-no-fit", action="store_true",
                         help="verify insufficient-memory admission, without starting engines")
     parser.add_argument("--kill-donor", action="store_true",
@@ -100,7 +103,7 @@ def main():
         return any((tmp / name).rglob("cache"))
 
     base = ["./lumabri", "models", "--models-dir", str(Path(args.models_dir).resolve()),
-            "--tracker", addr, "--context", "128", "--max-new", "8"]
+            "--tracker", addr, "--context", str(args.context), "--max-new", "8"]
 
     try:
         with open(tmp / "tracker.log", "wb") as log:
@@ -194,6 +197,8 @@ def main():
         until(lambda: chat.has("receives the text") or chat.p.poll() is not None, seconds=180,
               message="accepted plan did not reach real hosted chat")
         assert chat.p.poll() is None, "accepted plan failed; inspect donor engine logs"
+        if args.expect_greedy:
+            assert chat.has("greedy decoding"), "greedy-only capability was not shown to the client"
         until(lambda: chat.has("/experts shows tracker activity."),
               message="the accepted compute allocation is missing from chat")
         assert "Approved Segment plan: 2 compute donors" in chat.text
@@ -206,7 +211,8 @@ def main():
         chat.send("\t\n")
         until(lambda: chat.has("Tab completes commands"), message="slash completion did not execute help")
         chat.send("hi\n")
-        until(lambda: chat.has("tok/s") or chat.p.poll() is not None, seconds=120,
+        until(lambda: chat.has("tok/s") or chat.has("prompt plus output exceeds context") or
+              chat.has("logits are unavailable for sampling") or chat.p.poll() is not None, seconds=120,
               message="real model did not finish a response")
         assert chat.has("tok/s"), "engine failed during generation"
         assert "hosted stream · no local checkpoint" in chat.text

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -26,6 +26,9 @@ ROOT = Path(__file__).resolve().parents[2]
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--models-dir", required=True)
+    parser.add_argument("--donor-ram-gb", type=float, default=0.5)
+    parser.add_argument("--expect-no-fit", action="store_true",
+                        help="verify insufficient-memory admission, without starting engines")
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
@@ -43,7 +46,7 @@ def main():
         settings = home / ".lumabri" / "home.conf"
         if not settings.exists():
             settings.parent.mkdir(exist_ok=True)
-            settings.write_text(f"tracker={addr}\ntoken=household-test\nmodels={Path(args.models_dir).resolve()}\nram=0.5\n")
+            settings.write_text(f"tracker={addr}\ntoken=household-test\nmodels={Path(args.models_dir).resolve()}\nram={args.donor_ram_gb}\n")
             settings.chmod(0o600)
         return {**os.environ, "HOME": str(home), "LUMABRI_ENCRYPT": "1",
                 "LUMABRI_PEER_KEY": str(home / "peer.key"),
@@ -121,7 +124,7 @@ def main():
             unreachable = closed_port.getsockname()[1]
         with open(tmp / "offline-worker.log", "wb") as log:
             offline_worker = subprocess.Popen(["./lumabri", "worker", "--join", addr,
-                "--name", "offline-test-donor", "--ram-gb", "0.5", "--disk", str(tmp),
+                "--name", "offline-test-donor", "--ram-gb", str(args.donor_ram_gb), "--disk", str(tmp),
                 "--control-address", f"127.0.0.1:{unreachable}"], cwd=ROOT,
                 env=env("offline-worker"), stdout=log, stderr=subprocess.STDOUT)
         children.append(offline_worker)
@@ -131,7 +134,8 @@ def main():
         time.sleep(.5)
         offline.send("\r\r")
         until(lambda: offline.p.poll() is not None, message="unreachable donor did not fail preflight")
-        assert offline.p.returncode != 0 and offline.has("Cannot reach offline-test-donor")
+        failure = "No complete resident plan fits" if args.expect_no_fit else "Cannot reach offline-test-donor"
+        assert offline.p.returncode != 0 and offline.has(failure)
         assert not list((tmp / "offline-request").rglob("home-source-*.log")), "indexed before reachability check"
         offline_worker.terminate(); offline_worker.wait(timeout=5)
 
@@ -155,6 +159,16 @@ def main():
         until(lambda: reject.has("Nothing is selected automatically"))
         reject.send("\x1b[B\r\x1b[B\r\t")
         time.sleep(.5)
+        if args.expect_no_fit:
+            reject.send("\r")
+            until(lambda: reject.has("model plan") and reject.has("sizing available"),
+                  message="no valid sizing result in model detail")
+            assert reject.has("Plan: not runnable"), "undersized donors were admitted"
+            assert not a.has("Waiting for your approval") and not b.has("Waiting for your approval")
+            assert not engines_started("donor-a") and not engines_started("donor-b")
+            assert not list((tmp / "reject").rglob("home-source-*.log"))
+            print("HOME ADMISSION: PASS (native memory floor; no offers or engines)", flush=True)
+            return
         reject.send("\r\r")
         until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"),
               seconds=60, message="offers never reached both donor TUIs")

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -38,9 +38,14 @@ def main():
     tmp = Path(tempfile.mkdtemp(prefix="lumabri-home-flow-"))
     children, terminals = [], []
     print(f"Household test logs: {tmp}", flush=True)
-    with socket.socket() as probe:
-        probe.bind(("127.0.0.1", 0))
-        port = probe.getsockname()[1]
+    # Reserve and pass the actual listener, exactly as the household launcher
+    # does. Closing a port probe before exec races other ephemeral sockets
+    # (observed on the second native macOS run: EADDRINUSE).
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(64)
+    port = listener.getsockname()[1]
+    unreachable_socket = None
     addr = f"127.0.0.1:{port}"
 
     def env(name):
@@ -107,24 +112,31 @@ def main():
 
     try:
         with open(tmp / "tracker.log", "wb") as log:
+            tracker_env = {**env("tracker"), "LUMABRI_HOME_LISTEN_FD": str(listener.fileno())}
             tracker = subprocess.Popen(["./tracker", "--port", str(port), "--token", "household-test",
                 "--peer-bindings", str(tmp / "bindings")], cwd=ROOT,
-                env=env("tracker"), stdout=log, stderr=subprocess.STDOUT)
+                env=tracker_env, pass_fds=(listener.fileno(),), stdout=log, stderr=subprocess.STDOUT)
+        listener.close()
         children.append(tracker)
 
         def listening():
+            if tracker.poll() is not None:
+                raise AssertionError("tracker exited before readiness: " +
+                                     (tmp / "tracker.log").read_text(errors="replace"))
             try:
                 with socket.create_connection(("127.0.0.1", port), timeout=.2):
                     return True
             except OSError:
                 return False
-        until(listening)
+        until(listening, message="reserved tracker listener did not become reachable")
 
         # A signed inventory advert does not prove the donor port is reachable.
         # Fail before indexing or sending an allocation, with a useful reason.
-        with socket.socket() as closed_port:
-            closed_port.bind(("127.0.0.1", 0))
-            unreachable = closed_port.getsockname()[1]
+        # Bound but not listening: the negative case stays unreachable without
+        # allowing another process to acquire the address during this test.
+        unreachable_socket = socket.socket()
+        unreachable_socket.bind(("127.0.0.1", 0))
+        unreachable = unreachable_socket.getsockname()[1]
         with open(tmp / "offline-worker.log", "wb") as log:
             offline_worker = subprocess.Popen(["./lumabri", "worker", "--join", addr,
                 "--name", "offline-test-donor", "--ram-gb", str(args.donor_ram_gb), "--disk", str(tmp),
@@ -285,6 +297,9 @@ def main():
             print(f"\n{log.relative_to(tmp)}:\n{log.read_text(errors='replace')[-12000:]}", file=sys.stderr)
         raise
     finally:
+        listener.close()
+        if unreachable_socket is not None:
+            unreachable_socket.close()
         for p in reversed(children):
             if p.poll() is None:
                 p.send_signal(signal.SIGTERM)

--- a/tests/integration/hosted_chat_test.sh
+++ b/tests/integration/hosted_chat_test.sh
@@ -131,12 +131,13 @@ cat >"$T/qwen36.c" <<'EOF'
 #include <string.h>
 int main(void) {
     setvbuf(stdout, NULL, _IONBF, 0);
-    fputs("\1\1READY\1\1\nSTAT 0 0 0 0\n", stdout);
+    fputs("\nLUMABRI_SAMPLING GREEDY\n\1\1READY\1\1\nSTAT 0 0 0 0\n", stdout);
     char line[512];
     while (fgets(line, sizeof line, stdin)) {
         char id[64]; unsigned slot, max_new; size_t bytes; float t, p;
         if (sscanf(line, "SUBMIT %63s %u %zu %u %f %f",
                    id, &slot, &bytes, &max_new, &t, &p) != 6) continue;
+        if (t != 0.0f) return 3; /* client must consume the actual capability */
         char *payload = malloc(bytes + 2);
         if (!payload || fread(payload, 1, bytes + 1, stdin) != bytes + 1)
             return 1;
@@ -161,7 +162,7 @@ for _ in $(seq 1 200); do
 done
 grep -q "host ready" "$T/real-host.log" || fail "the real host did not start"
 
-( sleep 3; printf '/quit\n' ) | timeout 20 ./lumabri chat \
+( printf 'hi\n'; sleep 3; printf '/quit\n' ) | timeout 20 ./lumabri chat \
     --host "127.0.0.1:$REAL_PORT" --plain >"$T/held.log" 2>&1 & held=$!
 sleep .5
 started=$(date +%s)
@@ -172,5 +173,10 @@ grep -qi "busy (0 sessions free)" "$T/real-busy.log" ||
     fail "the real host did not refuse its second client with BUSY"
 (( elapsed < 3 )) || fail "BUSY was queued for $elapsed seconds instead of immediate"
 wait "$held" || true
+
+grep -q "greedy decoding" "$T/held.log" ||
+    fail "greedy-only capability did not reach the client"
+grep -q "hello" "$T/held.log" ||
+    fail "client requested sampling from a greedy-only engine"
 
 echo "HOSTED CHAT TEST: PASS (zero checkpoint bytes, authenticated encrypted stream, real BUSY)"

--- a/tests/integration/lan_inventory_test.py
+++ b/tests/integration/lan_inventory_test.py
@@ -50,9 +50,9 @@ def main():
         (models / "config.json").write_text(json.dumps({
             "model_type": "olmoe", "num_hidden_layers": 4, "hidden_size": 64,
             "intermediate_size": 128, "num_experts": 8, "num_experts_per_tok": 2,
-            "num_attention_heads": 4, "vocab_size": 256}))
-        with open(models / "model.bin", "wb") as f:
-            f.truncate(4096)  # container-presence fixture, no inference claimed
+            "num_attention_heads": 4, "num_key_value_heads": 4, "vocab_size": 256}))
+        subprocess.run([sys.executable, str(ROOT / "tests/integration/prepare_olmoe_headers.py"),
+                        str(models)], check=True)  # header-only, not an inference fixture
         base = ["./lumabri", "models", "--models-dir", str(models.parent), "--tracker", addr]
 
         def snapshot(identity="observer", success=True):

--- a/tests/integration/model_family_test.sh
+++ b/tests/integration/model_family_test.sh
@@ -71,6 +71,14 @@ expected = set(sys.argv[1].split())
 registry = runpy.run_path(sys.argv[2])
 official = {f.id: set(f.model_types) for f in registry["FAMILIES"]}
 bad = []
+planner = open("planner_adapters/registry.h", encoding="utf-8").read()
+planner = planner.split("LMB_MEMORY_CONTRACTS[] = {", 1)[1].split("\n};", 1)[0]
+memory_ids = re.findall(r'\{\s*"([^"]+)"\s*,', planner)
+if len(memory_ids) != len(set(memory_ids)):
+    bad.append("duplicate planner memory contracts")
+if set(memory_ids) != expected:
+    bad.append("planner contracts differ from Colibri: missing=%s extra=%s" %
+               (sorted(expected - set(memory_ids)), sorted(set(memory_ids) - expected)))
 if set(table) - expected:
     bad.append("LMB_FAMILIES names adapters Colibri does not expose: %s"
                % " ".join(sorted(set(table) - expected)))

--- a/tests/integration/planner_tensor_contract_test.py
+++ b/tests/integration/planner_tensor_contract_test.py
@@ -17,7 +17,7 @@ import tempfile
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", type=Path, required=True)
-    parser.add_argument("--family", choices=("olmoe", "inkling", "kimi", "glm", "glm53", "qwen38"), required=True)
+    parser.add_argument("--family", choices=("deepseek_v4", "olmoe", "inkling", "kimi", "glm", "glm53", "qwen38"), required=True)
     parser.add_argument("--probe", type=Path, default=Path("./segment_budget_probe"))
     args = parser.parse_args()
     probe = args.probe.resolve()
@@ -34,8 +34,7 @@ def main():
                     continue
                 assert name not in original, f"duplicate source tensor {name}"
                 begin, end = tensor["data_offsets"]
-                if tensor["dtype"] == "I64":
-                    assert end - begin <= 512
+                if tensor["dtype"] == "I64" and end - begin <= 512:
                     f.seek(8 + length + begin)
                     metadata[name] = f.read(end - begin)
                 tensor["data_offsets"] = [payload + begin, payload + end]
@@ -64,6 +63,7 @@ def main():
 
         check(original, True, "baseline header-only inventory")
         suffix = {
+            "deepseek_v4": ".ffn.experts.0.w1.scale",
             "olmoe": ".mlp.experts.0.qs",
             "inkling": ".mlp.experts.gate_up_proj.qs",
             "kimi": ".block_sparse_moe.experts.0.w1.weight_scale",
@@ -73,12 +73,13 @@ def main():
         }[args.family]
         # Upstream generators describe their actual dense/sparse layout in
         # config; do not hard-code the first sparse layer into this test.
-        expert_key = next((name for name in original if name.startswith("model.")
-                           and name.endswith(suffix)), None)
+        expert_key = next((name for name in original if name.endswith(suffix)), None)
         assert expert_key is not None, f"fixture lacks the expected expert format: {suffix}"
         norm = "model.language_model.norm.weight" if "model.language_model.norm.weight" in original else "model.norm.weight"
         if args.family == "qwen38":
             norm = "model.hyper_connection_mixer.hc_norm.weight"
+        if args.family == "deepseek_v4":
+            norm = "norm.weight"
         for key in (norm, expert_key):
             changed = copy.deepcopy(original)
             assert key in changed, f"fixture changed: missing {key}"
@@ -94,6 +95,16 @@ def main():
             changed = copy.deepcopy(original)
             del changed["model.layers.0.self_attn.indexer.wk.weight"]
             check(changed, False, "partial DSA bank with wq still present")
+        if args.family == "deepseek_v4":
+            changed = copy.deepcopy(original)
+            changed[expert_key]["data_offsets"] = [n + 1 for n in changed[expert_key]["data_offsets"]]
+            check(changed, False, "non-contiguous native expert scale bank")
+            changed = copy.deepcopy(original)
+            changed[expert_key]["dtype"] = "U8"
+            check(changed, False, "wrong native expert scale format")
+            changed = copy.deepcopy(original)
+            del changed["layers.0.ffn.gate.tid2eid"]
+            check(changed, False, "missing token hash router")
         if args.family == "qwen38":
             key = next(name for name in metadata if name.endswith("ngram_heads_offsets"))
             check(original, False, "negative PLE offset", {key: b"\xff" * len(metadata[key])})

--- a/tests/integration/planner_tensor_contract_test.py
+++ b/tests/integration/planner_tensor_contract_test.py
@@ -17,7 +17,7 @@ import tempfile
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", type=Path, required=True)
-    parser.add_argument("--family", choices=("deepseek_v4", "olmoe", "inkling", "kimi", "glm", "glm53", "qwen38"), required=True)
+    parser.add_argument("--family", choices=("deepseek_v4", "olmoe", "inkling", "kimi", "glm", "glm53", "qwen36", "qwen38"), required=True)
     parser.add_argument("--probe", type=Path, default=Path("./segment_budget_probe"))
     args = parser.parse_args()
     probe = args.probe.resolve()
@@ -46,6 +46,8 @@ def main():
     with tempfile.TemporaryDirectory(prefix="lumabri-contract-headers-") as tmp:
         root = Path(tmp)
         shutil.copyfile(args.model / "config.json", root / "config.json")
+        if args.family == "qwen36":
+            shutil.copyfile(args.model / "qwen36_meta.json", root / "qwen36_meta.json")
 
         def check(header, accepted, label, override=None):
             raw = json.dumps(header, separators=(",", ":")).encode()
@@ -70,6 +72,7 @@ def main():
             "glm": ".mlp.experts.0.gate_proj.weight",
             "glm53": ".mlp.experts.0.gate_proj.weight",
             "qwen38": ".mlp.experts.0.gate_proj.weight",
+            "qwen36": ".mlp.experts.0.qs",
         }[args.family]
         # Upstream generators describe their actual dense/sparse layout in
         # config; do not hard-code the first sparse layer into this test.
@@ -95,6 +98,19 @@ def main():
             changed = copy.deepcopy(original)
             del changed["model.layers.0.self_attn.indexer.wk.weight"]
             check(changed, False, "partial DSA bank with wq still present")
+        if args.family == "qwen36":
+            changed = copy.deepcopy(original)
+            weight_key = expert_key[:-2] + "merged_weight"
+            del changed[weight_key]
+            check(changed, False, "missing native merged expert")
+            changed = copy.deepcopy(original)
+            changed[weight_key]["dtype"] = "F8_E4M3"
+            check(changed, False, "wrong one-byte expert encoding")
+            changed = copy.deepcopy(original)
+            key = "model.layers.0.linear_attn.in_proj_qkv.weight"
+            assert key in changed
+            del changed[key]
+            check(changed, False, "missing DeltaNet projection")
         if args.family == "deepseek_v4":
             changed = copy.deepcopy(original)
             changed[expert_key]["data_offsets"] = [n + 1 for n in changed[expert_key]["data_offsets"]]

--- a/tests/integration/planner_tensor_contract_test.py
+++ b/tests/integration/planner_tensor_contract_test.py
@@ -17,7 +17,7 @@ import tempfile
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", type=Path, required=True)
-    parser.add_argument("--family", choices=("inkling", "kimi", "glm", "glm53"), required=True)
+    parser.add_argument("--family", choices=("inkling", "kimi", "glm", "glm53", "qwen38"), required=True)
     parser.add_argument("--probe", type=Path, default=Path("./segment_budget_probe"))
     args = parser.parse_args()
     probe = args.probe.resolve()
@@ -27,6 +27,13 @@ def main():
         length, = struct.unpack("<Q", f.read(8))
         assert length <= 8 * 1024 * 1024
         original = json.loads(f.read(length))
+        metadata = {}
+        for name, tensor in original.items():
+            if name != "__metadata__" and tensor["dtype"] == "I64":
+                begin, end = tensor["data_offsets"]
+                assert end - begin <= 512
+                f.seek(8 + length + begin)
+                metadata[name] = f.read(end - begin)
     payload = files[0].stat().st_size - 8 - length
     config = json.loads((args.model / "config.json").read_text())
     layers = config.get("text_config", config)["num_hidden_layers"]
@@ -35,12 +42,16 @@ def main():
         root = Path(tmp)
         shutil.copyfile(args.model / "config.json", root / "config.json")
 
-        def check(header, accepted, label):
+        def check(header, accepted, label, override=None):
             raw = json.dumps(header, separators=(",", ":")).encode()
             with (root / "model.safetensors").open("wb") as f:
                 f.write(struct.pack("<Q", len(raw)))
                 f.write(raw)
                 f.truncate(8 + len(raw) + payload)
+                for name, data in metadata.items():
+                    if name in header:
+                        f.seek(8 + len(raw) + header[name]["data_offsets"][0])
+                        f.write((override or {}).get(name, data))
             result = subprocess.run([str(probe), str(root), "0", str(layers), "128", "1"],
                                     capture_output=True, text=True, timeout=10)
             assert (result.returncode == 0) == accepted, (label, result.returncode, result.stderr)
@@ -51,6 +62,7 @@ def main():
             "kimi": ".block_sparse_moe.experts.0.w1.weight_scale",
             "glm": ".mlp.experts.0.gate_proj.weight",
             "glm53": ".mlp.experts.0.gate_proj.weight",
+            "qwen38": ".mlp.experts.0.gate_proj.weight",
         }[args.family]
         # Upstream generators describe their actual dense/sparse layout in
         # config; do not hard-code the first sparse layer into this test.
@@ -58,6 +70,8 @@ def main():
                            and name.endswith(suffix)), None)
         assert expert_key is not None, f"fixture lacks the expected expert format: {suffix}"
         norm = "model.language_model.norm.weight" if "model.language_model.norm.weight" in original else "model.norm.weight"
+        if args.family == "qwen38":
+            norm = "model.hyper_connection_mixer.hc_norm.weight"
         for key in (norm, expert_key):
             changed = copy.deepcopy(original)
             assert key in changed, f"fixture changed: missing {key}"
@@ -73,6 +87,14 @@ def main():
             changed = copy.deepcopy(original)
             del changed["model.layers.0.self_attn.indexer.wk.weight"]
             check(changed, False, "partial DSA bank with wq still present")
+        if args.family == "qwen38":
+            key = next(name for name in metadata if name.endswith("ngram_heads_offsets"))
+            check(original, False, "negative PLE offset", {key: b"\xff" * len(metadata[key])})
+            key = next(name for name in metadata if name.endswith("ngram_heads_vocab_sizes"))
+            check(original, False, "zero PLE vocabulary", {key: b"\x00" * len(metadata[key])})
+            changed = copy.deepcopy(original)
+            del changed[key]
+            check(changed, False, "missing PLE head metadata")
     print(f"PLANNER TENSOR CONTRACT ({args.family}): PASS")
 
 

--- a/tests/integration/planner_tensor_contract_test.py
+++ b/tests/integration/planner_tensor_contract_test.py
@@ -17,24 +17,30 @@ import tempfile
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", type=Path, required=True)
-    parser.add_argument("--family", choices=("inkling", "kimi", "glm", "glm53", "qwen38"), required=True)
+    parser.add_argument("--family", choices=("olmoe", "inkling", "kimi", "glm", "glm53", "qwen38"), required=True)
     parser.add_argument("--probe", type=Path, default=Path("./segment_budget_probe"))
     args = parser.parse_args()
     probe = args.probe.resolve()
-    files = list(args.model.glob("*.safetensors"))
-    assert len(files) == 1, "this small-fixture test requires one shard"
-    with files[0].open("rb") as f:
-        length, = struct.unpack("<Q", f.read(8))
-        assert length <= 8 * 1024 * 1024
-        original = json.loads(f.read(length))
-        metadata = {}
-        for name, tensor in original.items():
-            if name != "__metadata__" and tensor["dtype"] == "I64":
+    files = sorted(args.model.glob("*.safetensors"))
+    assert files, "fixture has no safetensors shards"
+    original, metadata, payload = {}, {}, 0
+    for path in files:
+        with path.open("rb") as f:
+            length, = struct.unpack("<Q", f.read(8))
+            assert length <= 8 * 1024 * 1024
+            shard = json.loads(f.read(length))
+            for name, tensor in shard.items():
+                if name == "__metadata__":
+                    continue
+                assert name not in original, f"duplicate source tensor {name}"
                 begin, end = tensor["data_offsets"]
-                assert end - begin <= 512
-                f.seek(8 + length + begin)
-                metadata[name] = f.read(end - begin)
-    payload = files[0].stat().st_size - 8 - length
+                if tensor["dtype"] == "I64":
+                    assert end - begin <= 512
+                    f.seek(8 + length + begin)
+                    metadata[name] = f.read(end - begin)
+                tensor["data_offsets"] = [payload + begin, payload + end]
+                original[name] = tensor
+            payload += path.stat().st_size - 8 - length
     config = json.loads((args.model / "config.json").read_text())
     layers = config.get("text_config", config)["num_hidden_layers"]
 
@@ -58,6 +64,7 @@ def main():
 
         check(original, True, "baseline header-only inventory")
         suffix = {
+            "olmoe": ".mlp.experts.0.qs",
             "inkling": ".mlp.experts.gate_up_proj.qs",
             "kimi": ".block_sparse_moe.experts.0.w1.weight_scale",
             "glm": ".mlp.experts.0.gate_proj.weight",

--- a/tests/integration/planner_tensor_contract_test.py
+++ b/tests/integration/planner_tensor_contract_test.py
@@ -106,6 +106,17 @@ def main():
             del changed["layers.0.ffn.gate.tid2eid"]
             check(changed, False, "missing token hash router")
         if args.family == "qwen38":
+            scale_key = expert_key + "_scale_inv"
+            if scale_key in original:
+                changed = copy.deepcopy(original)
+                del changed[scale_key]
+                check(changed, False, "FP8 expert without block scales")
+                changed = copy.deepcopy(original)
+                changed[scale_key]["shape"].reverse()
+                check(changed, False, "transposed partial-block scale geometry")
+                changed = copy.deepcopy(original)
+                changed[scale_key]["dtype"] = "I64"
+                check(changed, False, "non-floating FP8 scales")
             key = next(name for name in metadata if name.endswith("ngram_heads_offsets"))
             check(original, False, "negative PLE offset", {key: b"\xff" * len(metadata[key])})
             key = next(name for name in metadata if name.endswith("ngram_heads_vocab_sizes"))

--- a/tests/integration/planner_tensor_contract_test.py
+++ b/tests/integration/planner_tensor_contract_test.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Reject damaged header-only fixtures before admission, without loading weights.
+
+The sparse files made here deliberately contain no valid model payload and must
+never be used for a numerical oracle. Real inference is tested separately.
+"""
+import argparse
+import copy
+import json
+from pathlib import Path
+import shutil
+import struct
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--family", choices=("inkling", "kimi", "glm", "glm53"), required=True)
+    parser.add_argument("--probe", type=Path, default=Path("./segment_budget_probe"))
+    args = parser.parse_args()
+    probe = args.probe.resolve()
+    files = list(args.model.glob("*.safetensors"))
+    assert len(files) == 1, "this small-fixture test requires one shard"
+    with files[0].open("rb") as f:
+        length, = struct.unpack("<Q", f.read(8))
+        assert length <= 8 * 1024 * 1024
+        original = json.loads(f.read(length))
+    payload = files[0].stat().st_size - 8 - length
+    config = json.loads((args.model / "config.json").read_text())
+    layers = config.get("text_config", config)["num_hidden_layers"]
+
+    with tempfile.TemporaryDirectory(prefix="lumabri-contract-headers-") as tmp:
+        root = Path(tmp)
+        shutil.copyfile(args.model / "config.json", root / "config.json")
+
+        def check(header, accepted, label):
+            raw = json.dumps(header, separators=(",", ":")).encode()
+            with (root / "model.safetensors").open("wb") as f:
+                f.write(struct.pack("<Q", len(raw)))
+                f.write(raw)
+                f.truncate(8 + len(raw) + payload)
+            result = subprocess.run([str(probe), str(root), "0", str(layers), "128", "1"],
+                                    capture_output=True, text=True, timeout=10)
+            assert (result.returncode == 0) == accepted, (label, result.returncode, result.stderr)
+
+        check(original, True, "baseline header-only inventory")
+        suffix = {
+            "inkling": ".mlp.experts.gate_up_proj.qs",
+            "kimi": ".block_sparse_moe.experts.0.w1.weight_scale",
+            "glm": ".mlp.experts.0.gate_proj.weight",
+            "glm53": ".mlp.experts.0.gate_proj.weight",
+        }[args.family]
+        # Upstream generators describe their actual dense/sparse layout in
+        # config; do not hard-code the first sparse layer into this test.
+        expert_key = next((name for name in original if name.startswith("model.")
+                           and name.endswith(suffix)), None)
+        assert expert_key is not None, f"fixture lacks the expected expert format: {suffix}"
+        norm = "model.language_model.norm.weight" if "model.language_model.norm.weight" in original else "model.norm.weight"
+        for key in (norm, expert_key):
+            changed = copy.deepcopy(original)
+            assert key in changed, f"fixture changed: missing {key}"
+            del changed[key]
+            check(changed, False, f"missing {key}")
+        changed = copy.deepcopy(original)
+        changed[norm]["data_offsets"][1] = payload + 1
+        check(changed, False, "tensor outside payload")
+        changed = copy.deepcopy(original)
+        changed[norm]["shape"][-1] += 1
+        check(changed, False, "wrong tensor geometry")
+        if args.family == "glm":
+            changed = copy.deepcopy(original)
+            del changed["model.layers.0.self_attn.indexer.wk.weight"]
+            check(changed, False, "partial DSA bank with wq still present")
+    print(f"PLANNER TENSOR CONTRACT ({args.family}): PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/prepare_glm53_fixture.py
+++ b/tests/integration/prepare_glm53_fixture.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Generate a native GLM5.3 fixture and normalize its oracle field names only."""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def normalize_reference(model):
+    original = json.loads((model / "ref.json").read_text())
+    # Token values are produced by upstream Transformers, never by Lumabri.
+    oracle = {"prompt_ids": original["prompt_ids"],
+              "full_ids": original["prompt_ids"] + original["greedy_new_ids"]}
+    (model / "edge_ref.json").write_text(json.dumps(oracle, indent=2) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    engine, out = args.engine.resolve(), args.out.resolve()
+    if out.exists():
+        parser.error("--out must be new; existing checkpoints are never overwritten")
+    subprocess.run([sys.executable, str(engine / "tools/make_glm53_tiny.py"),
+                    "--output", str(out)], check=True,
+                   env=dict(os.environ, OMP_NUM_THREADS="2", MKL_NUM_THREADS="2"))
+    normalize_reference(out)
+    subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
+                    str(out), "--vocab-size", "128"], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/prepare_glm_fixture.py
+++ b/tests/integration/prepare_glm_fixture.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Run the pinned upstream GLM oracle generator in a new isolated directory."""
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    engine, out = args.engine.resolve(), args.out.resolve()
+    if out.exists():
+        parser.error("--out must be new; existing checkpoints are never overwritten")
+    out.mkdir(parents=True)
+    env = dict(os.environ, OMP_NUM_THREADS="2", MKL_NUM_THREADS="2")
+    subprocess.run([sys.executable, str(engine / "tools/make_glm_oracle.py")],
+                   cwd=out, env=env, check=True)
+    subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
+                    str(out / "glm_tiny"), "--vocab-size", "256"], env=env, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/prepare_inkling_fixture.py
+++ b/tests/integration/prepare_inkling_fixture.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Build an isolated synthetic Inkling fixture with the pinned engine's tag.
+
+Transformers exports `inkling_text`; the pinned Colibri registry accepts
+`inkling`/`inkling_mm_model`. Only this synthetic fixture is retagged. Runtime
+model identification remains exact and does not guess aliases for user models.
+No Colibri source or user checkpoint is modified.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    engine = args.engine.resolve()
+    out = args.out.resolve()
+    if out.exists():
+        parser.error("--out must be a new directory; existing fixtures are never overwritten")
+    out.mkdir(parents=True)
+    env = dict(os.environ, OMP_NUM_THREADS="2", MKL_NUM_THREADS="2")
+    source = out / "float" / "inkling-tiny"
+    subprocess.run([sys.executable, str(engine / "tools/make_tiny_inkling.py"),
+                    str(source)], check=True, env=env)
+    config_path = source / "config.json"
+    config = json.loads(config_path.read_text())
+    if config["model_type"] != "inkling_text":
+        raise RuntimeError("upstream fixture changed; review its registry mapping")
+    config["model_type"] = "inkling"
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
+                    str(source), "--vocab-size", "256"], check=True, env=env)
+    subprocess.run([sys.executable, str(engine / "tools/convert_inkling_int4.py"),
+                    "--indir", str(source), "--outdir", str(out / "int4" / "inkling-tiny"),
+                    "--xbits", "4"], check=True, env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/prepare_inkling_fixture.py
+++ b/tests/integration/prepare_inkling_fixture.py
@@ -12,6 +12,33 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import struct
+
+
+def verify_int4(model):
+    """A successful converter exit is not evidence of quantization."""
+    config = json.loads((model / "config.json").read_text())
+    headers = {}
+    for shard in model.glob("*.safetensors"):
+        with shard.open("rb") as f:
+            size, = struct.unpack("<Q", f.read(8))
+            headers.update(json.loads(f.read(size)))
+    experts = config["n_routed_experts"]
+    hidden, inter = config["hidden_size"], config["moe_intermediate_size"]
+    sparse = 0
+    for layer, kind in enumerate(config["mlp_layer_types"]):
+        if kind != "sparse":
+            continue
+        sparse += 1
+        for suffix, rows, cols in (("gate_up_proj", 2 * inter, hidden),
+                                   ("down_proj", hidden, inter)):
+            key = f"model.layers.{layer}.mlp.experts.{suffix}"
+            tensor, scale = headers[key], headers[key + ".qs"]
+            assert tensor["dtype"] == "U8", f"not packed int4: {key}"
+            assert tensor["data_offsets"][1] - tensor["data_offsets"][0] == experts * rows * cols // 2
+            assert scale["dtype"] == "F32"
+            assert scale["data_offsets"][1] - scale["data_offsets"][0] == experts * rows * 4
+    assert sparse > 0, "fixture must exercise routed experts"
 
 
 def main():
@@ -36,9 +63,17 @@ def main():
     config_path.write_text(json.dumps(config, indent=2) + "\n")
     subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
                     str(source), "--vocab-size", "256"], check=True, env=env)
+    # This converter quantizes original TML names, not HF expert names. Its
+    # upstream e2e fixture helper reverses the mapping before conversion.
+    converted = out / "converted"
     subprocess.run([sys.executable, str(engine / "tools/convert_inkling_int4.py"),
-                    "--indir", str(source), "--outdir", str(out / "int4" / "inkling-tiny"),
-                    "--xbits", "4"], check=True, env=env)
+                    "--selftest-e2e", str(source), str(converted)], check=True, env=env)
+    packed = out / "int4" / "inkling-tiny"
+    packed.parent.mkdir()
+    Path(str(converted) + "-i4").rename(packed)
+    verify_int4(packed)
+    subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
+                    str(packed), "--vocab-size", "256"], check=True, env=env)
 
 
 if __name__ == "__main__":

--- a/tests/integration/prepare_olmoe_headers.py
+++ b/tests/integration/prepare_olmoe_headers.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Write a sparse HEADER-ONLY OLMoE fixture. Not usable for inference/oracles."""
+import argparse
+import json
+from pathlib import Path
+import struct
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    args = parser.parse_args()
+    config = json.loads((args.root / "config.json").read_text())
+    h, inter, experts, vocab = (config[k] for k in
+        ("hidden_size", "intermediate_size", "num_experts", "vocab_size"))
+    header, size = {}, 0
+
+    def tensor(name, shape, dtype="F32"):
+        nonlocal size
+        count = 1
+        for n in shape:
+            count *= n
+        end = size + count * (4 if dtype == "F32" else 1)
+        header[name] = dict(dtype=dtype, shape=shape, data_offsets=[size, end])
+        size = end
+
+    tensor("model.embed_tokens.weight", [vocab, h])
+    tensor("lm_head.weight", [vocab, h])
+    tensor("model.norm.weight", [h])
+    for layer in range(config["num_hidden_layers"]):
+        prefix = f"model.layers.{layer}."
+        for suffix in ("input_layernorm.weight", "post_attention_layernorm.weight",
+                       "self_attn.q_norm.weight", "self_attn.k_norm.weight"):
+            tensor(prefix + suffix, [h])
+        for proj in "qkvo":
+            tensor(prefix + f"self_attn.{proj}_proj.weight", [h, h])
+        tensor(prefix + "mlp.gate.weight", [experts, h])
+        for expert in range(experts):
+            ep = prefix + f"mlp.experts.{expert}."
+            tensor(ep + "merged_weight", [3 * inter * h], "I8")
+            tensor(ep + "qs", [2 * inter + h])
+    raw = json.dumps(header, separators=(",", ":")).encode()
+    path = args.root / "model.safetensors"
+    with path.open("xb") as f:
+        f.write(struct.pack("<Q", len(raw)))
+        f.write(raw)
+        f.truncate(8 + len(raw) + size)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/prepare_qwen38_fixture.py
+++ b/tests/integration/prepare_qwen38_fixture.py
@@ -7,16 +7,54 @@ original Transformers model, never from Lumabri or an edited Colibri runtime.
 import argparse
 import importlib.util
 import json
+import math
 from pathlib import Path
 import subprocess
 import sys
 import tempfile
 
 
+def quantize_experts(model, torch):
+    """Real block E4M3 payloads, with an independent dequantized HF oracle.
+
+    Power-of-two scales keep every reconstructed E4M3 value exactly
+    representable in BF16. The reference therefore sees the actual quantized
+    weights, not the original unquantized model or C-generated predictions.
+    """
+    payload = {}
+    for layer_id, layer in enumerate(model.model.layers):
+        experts = layer.mlp.experts
+        intermediate = model.config.moe_intermediate_size
+        for expert in range(model.config.num_experts):
+            matrices = (experts.gate_up_proj[expert, :intermediate],
+                        experts.gate_up_proj[expert, intermediate:], experts.down_proj[expert])
+            for projection, matrix in zip(("gate_proj", "up_proj", "down_proj"), matrices):
+                rows, cols = matrix.shape
+                raw = torch.empty((rows, cols), dtype=torch.float8_e4m3fn)
+                scales = torch.empty(((rows + 127) // 128, (cols + 127) // 128), dtype=torch.float32)
+                with torch.no_grad():
+                    for row in range(0, rows, 128):
+                        for col in range(0, cols, 128):
+                            block = matrix[row:row + 128, col:col + 128].float()
+                            maximum = block.abs().max().item()
+                            scale = 2.0 ** math.ceil(math.log2(maximum / 448.0)) if maximum else 1.0
+                            packed = (block / scale).to(torch.float8_e4m3fn)
+                            reconstructed = packed.float() * scale
+                            assert torch.equal(reconstructed, reconstructed.bfloat16().float())
+                            raw[row:row + 128, col:col + 128] = packed
+                            scales[row // 128, col // 128] = scale
+                            matrix[row:row + 128, col:col + 128].copy_(reconstructed)
+                name = f"model.layers.{layer_id}.mlp.experts.{expert}.{projection}.weight"
+                payload[name] = raw.contiguous()
+                payload[name + "_scale_inv"] = scales
+    return payload
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--engine", type=Path, required=True)
     parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--fp8-experts", action="store_true")
     args = parser.parse_args()
     out, engine = args.out.resolve(), args.engine.resolve()
     if out.exists():
@@ -32,11 +70,25 @@ def main():
         config = Config.from_pretrained(tmp)
     config.vocab_size = 256
     config.max_position_embeddings = 2048
+    if args.fp8_experts:
+        # Exercise partial 128x128 blocks, not only a one-element scale bank.
+        config.hidden_size = 128
+        config.moe_intermediate_size = 136
     torch.manual_seed(upstream.SEED)
     model = Model(config).to(dtype=torch.bfloat16).eval()
+    packed = quantize_experts(model, torch) if args.fp8_experts else None
     out.mkdir(parents=True)
     model.save_pretrained(str(out), safe_serialization=True)
+    if packed:
+        from safetensors.torch import load_file, save_file
+        files = list(out.glob("*.safetensors"))
+        assert len(files) == 1, "synthetic fixture unexpectedly became sharded"
+        tensors = load_file(files[0])
+        assert all(name in tensors for name in packed if not name.endswith("_scale_inv"))
+        tensors.update(packed)
+        save_file(tensors, files[0], metadata={"format": "pt"})
     reference = upstream._reference(model, [1, 3, 4, 5, 6], 8)
+    reference["expert_encoding"] = "E4M3 128x128 blocks, BF16-exact dequantized HF oracle" if packed else "BF16"
     (out / "ref.json").write_text(json.dumps(reference, indent=2) + "\n")
     subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
                     str(out), "--vocab-size", "256"], check=True)

--- a/tests/integration/prepare_qwen38_fixture.py
+++ b/tests/integration/prepare_qwen38_fixture.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Generate an upstream Qwen4-Exp fixture with a byte-sized chat vocabulary.
+
+Only synthetic fixture dimensions change. Weights and oracle come from the
+original Transformers model, never from Lumabri or an edited Colibri runtime.
+"""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args()
+    out, engine = args.out.resolve(), args.engine.resolve()
+    if out.exists():
+        parser.error("--out must be new; existing checkpoints are never overwritten")
+    spec = importlib.util.spec_from_file_location("upstream_q38_fixture", engine / "tools/make_qwen38_tiny.py")
+    upstream = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(upstream)
+    torch = upstream.torch
+    torch.set_num_threads(2)
+    _, Model, Config = upstream._classes()
+    with tempfile.TemporaryDirectory(prefix="lumabri-q38-template-") as tmp:
+        upstream.build(Path(tmp), emit_ref=False)
+        config = Config.from_pretrained(tmp)
+    config.vocab_size = 256
+    config.max_position_embeddings = 2048
+    torch.manual_seed(upstream.SEED)
+    model = Model(config).to(dtype=torch.bfloat16).eval()
+    out.mkdir(parents=True)
+    model.save_pretrained(str(out), safe_serialization=True)
+    reference = upstream._reference(model, [1, 3, 4, 5, 6], 8)
+    (out / "ref.json").write_text(json.dumps(reference, indent=2) + "\n")
+    subprocess.run([sys.executable, str(engine / "tools/make_edge_tiny_tokenizer.py"),
+                    str(out), "--vocab-size", "256"], check=True)
+    print("Qwen3.8 synthetic checkpoint and independent oracle:", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/prepare_v4_oracles.py
+++ b/tests/integration/prepare_v4_oracles.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Normalize upstream independent V4 references; never generate tokens in C."""
+import argparse
+import json
+from pathlib import Path
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("model", type=Path)
+    args = p.parse_args()
+    ref = json.loads((args.model / "ref.json").read_text())
+    assert ref["source"] == "transformers"
+    for name, case in ref["cases"].items():
+        assert name in ("short", "compressed", "long")
+        prompt, full = case["prompt_ids"], case["greedy_full_ids"]
+        assert full[:len(prompt)] == prompt and len(full) > len(prompt)
+        (args.model / f"edge_ref_{name}.json").write_text(json.dumps(
+            dict(prompt_ids=prompt, full_ids=full), indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/segment_direct_test.sh
+++ b/tests/integration/segment_direct_test.sh
@@ -167,6 +167,8 @@ def line():
         raise RuntimeError("Segment gateway closed unexpectedly")
     return value
 
+if line() != b"\n" or line() != b"LUMABRI_SAMPLING LOGITS\n":
+    raise RuntimeError("missing OLMoE sampling capability")
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("Segment gateway did not become ready")
 

--- a/tests/integration/segment_failover_test.sh
+++ b/tests/integration/segment_failover_test.sh
@@ -97,6 +97,8 @@ def line():
         raise RuntimeError("Segment gateway closed:\n"+
                            p.stderr.read().decode("utf-8", "replace"))
     return value
+if line() != b"\n" or line() != b"LUMABRI_SAMPLING LOGITS\n":
+    raise RuntimeError("missing OLMoE sampling capability")
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("gateway not ready")
 def turn(rid, prompt, kill_after_accept=None):

--- a/tests/integration/segment_relay_test.sh
+++ b/tests/integration/segment_relay_test.sh
@@ -75,6 +75,19 @@ output=$(env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
 grep -q 'relay-left.*transport=2' <<<"$output"
 grep -q 'relay-right.*transport=2' <<<"$output"
 
+# A LAN-only measurement must fail closed on this deliberately relay-only
+# chain. A successful response would mean the policy was silently ignored.
+if env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/direct-client.key" \
+    LUMABRI_KNOWN_HOSTS="$TMP/direct-known" \
+    "$SEGMENT_CHAT_BIN" --direct-only --engine olmoe --model-dir "$OLMOE_EDGE_MODEL" \
+    --model tiny-relay --tracker 127.0.0.1:7968 \
+    --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
+    --prompt-ids "$prompt_ids" --tokens 3 --context 64 --max-rows 16 \
+    >"$TMP/direct-only.log" 2>&1; then
+    echo "direct-only silently used a relay" >&2; exit 1
+fi
+grep -q 'direct-only policy forbids' "$TMP/direct-only.log"
+
 # Persistent mode forces a real checkpoint through the relay after generation.
 serve=$(printf 'SUBMIT 1 0 2 2 0.7 0.95\nhi\n' | \
     env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client2.key" \

--- a/tests/integration/segment_split_test.sh
+++ b/tests/integration/segment_split_test.sh
@@ -58,8 +58,8 @@ trap cleanup EXIT
 [[ -f "$MODEL_DIR/config.json" ]] ||
     { echo "SEGMENT SPLIT TEST: SKIP (no $MODEL_DIR)"; exit 0; }
 
-LAYERS=$(python3 -c "import json;print(json.load(open('$MODEL_DIR/config.json'))['num_hidden_layers'])")
-MTYPE=$(python3 -c "import json;print(json.load(open('$MODEL_DIR/config.json')).get('model_type',''))")
+LAYERS=$(python3 -c 'import json,sys; c=json.load(open(sys.argv[1])); print(c.get("text_config",c)["num_hidden_layers"])' "$MODEL_DIR/config.json")
+MTYPE=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("model_type",""))' "$MODEL_DIR/config.json")
 [[ "$LAYERS" -ge 2 ]] || { echo "SEGMENT SPLIT TEST: SKIP ($MODEL_DIR has $LAYERS layers)"; exit 0; }
 
 wait_port() {

--- a/tests/integration/segment_split_test.sh
+++ b/tests/integration/segment_split_test.sh
@@ -72,7 +72,9 @@ wait_port() {
 
 prompt=$(python3 - "$MODEL_DIR" <<'PY'
 import json,sys,os
-p=os.path.join(sys.argv[1],'ref.json')
+p=os.environ.get('SPLIT_REFERENCE') or os.path.join(sys.argv[1],'ref.json')
+if os.environ.get('SPLIT_REFERENCE') and not os.path.isfile(p):
+    raise RuntimeError('explicit split reference does not exist: '+p)
 print(','.join(map(str,json.load(open(p,encoding='utf-8'))['prompt_ids']))
       if os.path.exists(p) else '1,2,3,4')
 PY

--- a/tests/integration/segment_split_test.sh
+++ b/tests/integration/segment_split_test.sh
@@ -127,12 +127,13 @@ stop_phase() {
 run_chat() {                 # $1 = threads, $2 = log name
     local threads=$1 log=$2 t0 t1
     t0=$(date +%s.%N)
-    OMP_NUM_THREADS="$threads" ./segment_chat --engine "$ENGINE_ID" \
+    OMP_NUM_THREADS="$threads" LUMABRI_PEER_KEY="$TMP/client.key" \
+        LUMABRI_KNOWN_HOSTS="$TMP/client.hosts" ./segment_chat --engine "$ENGINE_ID" \
         --model-dir "$MODEL_DIR" --model "$MODEL_NAME" \
         --tracker "127.0.0.1:$TRACKER" \
         --model-root "$model_root" --tokenizer-root "$tokenizer_root" \
         --prompt-ids "$prompt" --tokens "$TOKENS" --context "$CONTEXT" \
-        --max-rows 16 --retry-first-run --json \
+        --max-rows 16 --retry-first-run --direct-only --json \
         >"$TMP/$log.json" 2>"$TMP/$log.log"
     t1=$(date +%s.%N)
     python3 - "$TMP/$log.json" "$t0" "$t1" <<'PY'
@@ -201,12 +202,8 @@ echo "  C  2 nodes, $THREADS_TOTAL+$THREADS_TOTAL threads   ${full_s}s"
 [[ "$full_ids" == "$oracle" ]] || {
     echo "SEGMENT SPLIT TEST: FAIL — the tokens changed with all cores" >&2; exit 1; }
 
-# Relay must never have been used: these nodes advertise direct addresses.
-if grep -qi "relay" "$TMP"/split-*.log "$TMP"/whole-*.log 2>/dev/null; then
-    echo "SEGMENT SPLIT TEST: FAIL — a run used the tracker relay; the numbers" \
-         "would measure the tunnel, not the split" >&2
-    exit 1
-fi
+# --direct-only forbids every relay request, including recovery and CLOSE.
+# Searching log text for "relay" is not evidence of which transport ran.
 
 # Timings are only reported when the machine could plausibly produce them.
 #

--- a/tests/integration/tui_test.sh
+++ b/tests/integration/tui_test.sh
@@ -16,18 +16,18 @@ fail() { echo "TUI TEST: FAIL — $*" >&2; exit 1; }
 
 mkdir -p "$T/models/huge" "$T/models/small"
 cat >"$T/models/huge/config.json" <<'EOF'
-{"model_type":"deepseek_v4","num_hidden_layers":43,"hidden_size":4096,
- "intermediate_size":11264,"moe_intermediate_size":1408,"n_routed_experts":256,
- "num_experts_per_tok":6,"num_attention_heads":32,"num_key_value_heads":8,
- "vocab_size":129280}
+{"model_type":"olmoe","num_hidden_layers":32,"hidden_size":4096,
+ "intermediate_size":4096,"num_experts":128,
+ "num_experts_per_tok":6,"num_attention_heads":32,"num_key_value_heads":32,
+ "vocab_size":32768}
 EOF
 cat >"$T/models/small/config.json" <<'EOF'
 {"model_type":"olmoe","num_hidden_layers":4,"hidden_size":64,
  "intermediate_size":128,"num_experts":8,"num_experts_per_tok":2,
  "num_attention_heads":4,"num_key_value_heads":4,"vocab_size":256}
 EOF
-truncate -s 4096 "$T/models/huge/model.bin"
-truncate -s 4096 "$T/models/small/model.bin"
+python3 tests/integration/prepare_olmoe_headers.py "$T/models/huge"
+python3 tests/integration/prepare_olmoe_headers.py "$T/models/small"
 
 snap() { ./lumabri models --models-dir "$T/models" --snapshot "$@" 2>&1; }
 


### PR DESCRIPTION
## Scope — roadmap gate 2 remains open

This PR implements missing CPU memory contracts for converted Qwen3.6,
Inkling, float-dense/MXFP4 Kimi, float-source GLM, text-only float-source
GLM5.3 and BF16/float/block-FP8-expert Qwen3.8, and replaces the historical OLMoE/V4 formulas
with explicit native-format inspections. It does not count the earlier budget PRs as
completion of gate 2. Additional encodings and full-size validation remain open.
Colibri source is unchanged. No GPU backend or disk mode is enabled.

### Implementation

- Bounded safetensors header inventory; no model initialization for planning.
- Adapter-specific retained weights, fixed recurrent state, context-dependent
  KV, actual hyper-connection boundary width and loading/prefill workspace.
- Qwen int4 experts expand to int8; Inkling int4 stays packed; Kimi retains
  MXFP4 with exponent scales and native slot padding. These are different costs.
- Qwen3.6 requires actual tensor coverage as well as converted metadata:
  complete Edge, per-layer attention/DeltaNet/shared tensors and merged expert
  weights/scales. On-disk payload size detects int4, not the ebits label.
- Qwen3.8 FP8 experts require complete 128x128 block scales. Conservative
  budgets cover native FP8 and optional f32 expansion, including scale-bank
  coexistence with per-slot scales.
- GLM includes DSA completeness checks and native miss slabs. GLM5.3 reserves
  whole-model session state on every range, matching its native initializer.
- Kimi includes its native 3.7 GB policy floor. No overcommit override.
- Missing, duplicated, truncated and unsupported tensor banks reject admission.
- OLMoE requires merged int8 experts with row scales and full-MHA geometry;
  BF16/F16 dense tensors are budgeted after their native f32 expansion.
- V4 validates native dense FP8 and expert FP4 geometry, per-expert two-bank
  contiguity in one shard, token hash router tables, mHC and compressed-state
  memory. Dense exponent scales expand to f32; expert scales stay encoded.
  Conservative workspace and row-read Edge source-cache allowances do not
  claim warm/pinned residency or enable disk execution.
- Stateless Edge context=0 means caller-selected, bounded by protocol and the
  selected Segment capabilities; fixes GLM5.3 household startup.
- Catalogue snapshots use the heap rather than overflowing macOS refresh stacks.
- `segment_chat --direct-only` forbids relay; split tests handle text_config.
- A single memory-contract registry is checked against Colibri, not two
  hand-maintained adapter counts.
- Qwen3.8 includes hyper-connection boundaries, DeltaNet/QSA state and bounded
  I64 PLE metadata validation. Its row-read table gets a full source-cache
  allowance; fit does not claim that pages are already warm or pinned.
- Actual greedy-only Edge capability is propagated before READY and through
  the Hosted greeting. Client displays it and sends temperature zero, without
  model-name exceptions. Older clients reject that extended greeting: upgrade
  host/client together. Explicit stochastic CLI requests still fail if unsupported.
- Streaming defers incomplete decoder prefixes, never emits half a UTF-8
  scalar or an unstable trailing replacement, and still requires final decode
  success. Permanent errors and changes to emitted text remain failures.

### Evidence and corrections

- OLMoE: real merged checkpoints, header-corruption rejection, one/two-node
  TCP token equality and complete household approval/generation/lost-donor cleanup.
- V4: independent short/compressed/long oracles (8/4/4 new tokens) match on
  one/two ranges and fresh sessions; direct TCP split equality and complete
  household flow with lost-donor cleanup pass locally. The mathematical
  fixture's special-token tokenizer is preserved; the chat test uses a separate
  byte-tokenizer copy of the same weights. Empty tokenization is now actionable.
- Qwen: independent int8 oracle (3 tokens); real int8/int4 household flows;
  grouped-int4 whole/split equivalence and lost-donor cleanup.
- Inkling: independent float oracle (24 tokens); real packed-int4 whole/split
  equivalence and household approval/execution/lost-donor cleanup.
- **Fixture correction:** earlier Inkling "int4" tests actually retained float
  tensors: the upstream converter quantizes TML names, not HF names. Those runs
  are not packed-format evidence. The corrected generator uses the upstream
  reverse mapping and asserts U8 payload/F32 row-scale sizes for every expert.
  Correctly packed local tests now pass.
- Kimi: independent MXFP4 oracle (8 tokens), whole/split equality, household
  execution with a sufficient budget, and no-fit refusal before offers/loading.
- **Native CI finding:** standard macOS ARM runners cannot meet Kimi's native
  floor for two ranges. They now test correct refusal; Intel runs execution.
  Sufficient-memory native ARM Kimi execution is still unverified, not waived.
- GLM: independent float oracle (20 tokens), household exact/default CPU
  profiles, whole/split equality and lost-donor cleanup.
- GLM5.3: independent oracle (4 tokens), household exact/default CPU profiles,
  whole/split equality and lost-donor cleanup.
- Qwen3.8: independent greedy oracle (8 tokens) on one/two ranges, fresh-session
  repetition, direct TCP split equality, and full TUI flow with two executing
  donors and killed-donor cleanup. Tested both upstream 64-token math fixture
  and a separately generated 256-token chat fixture. The chat fixture uses a
  512-token context to include the real family template.
- Qwen3.8 FP8: real E4M3 quantization with partial blocks; independent
  Transformers reference on exactly reconstructed weights. Native FP8 and
  expanded-f32 paths pass one/two-range oracles. Direct TCP split and complete
  TUI approval/generation/lost-donor cleanup pass locally.
- Decoder boundary regression covers deferred UTF-8, final failure and
  immutable emitted prefixes; Hosted regression proves capability propagation,
  temperature zero, no client checkpoint and BUSY.
- Header-corruption tests reject missing expert/scales/norms and invalid
  offsets/geometry for Inkling, Kimi, GLM, GLM5.3 and Qwen3.8, including negative
  PLE offsets and invalid head vocabularies.
- Planner/cluster/memory/calibration unit tests and planner ASan/UBSan pass
  locally; full regression is repeated for the updated head.
- Commit 7011dab passed all eight CI jobs, including the applicable native
  Intel/ARM macOS flows with/without OpenMP. The newer Qwen3.8 head adds that
  family to CI as well; its exact-head results must be checked separately.
- Subsequent CI failures exposed an omitted streaming source change, older
  protocol-test readers, placeholder checkpoint fixtures, and a missing build
  dependency for the probe. These were fixed, not skipped. Commit 84fd936
  passed the complete local regression and all eight CI jobs, including native
  V4 on Intel/ARM with/without OpenMP. FP8/Qwen3.6 follow-ups must pass their
  own exact-head checks before merging.

Tiny models prove plumbing/conformance, not large-model peak memory or speed.
Timings on the loaded development machine are withheld. The physical LAN test
and the other roadmap gates remain required. GLM quantized containers and
GLM5.3 packed/vision/pool=1 paths remain unverified and fail closed.

Merge policy: draft until scoped work is ready; normal merge only, never squash;
all checks must pass on the exact reviewed head. Not a production-complete claim.
