### PR TITLE
metrics: collect real Segment chat timings (roadmap gate 4, in progress)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
           for native in 0 1; do
             Q38_NATIVE_FP8=$native OMP_NUM_THREADS=2 build/qwen38-greedy-oracle qwen38 build/qwen38-fp8-contract/qwen38-tiny build/qwen38-fp8-contract/qwen38-tiny/ref.json
           done
-          python3 tests/integration/home_flow_test.py --models-dir build/qwen38-fp8-contract --context 512 --expect-greedy --kill-donor
+          python3 tests/integration/home_flow_test.py --models-dir build/qwen38-fp8-contract --context 512 --expect-greedy --expect-metrics --kill-donor
           SPLIT_MODEL_DIR=build/qwen38-fp8-contract/qwen38-tiny SPLIT_ENGINE=qwen38 SPLIT_MODEL=qwen38-fp8 SPLIT_ROUNDS=1 SPLIT_THREADS=2 SPLIT_TOKENS=8 PORT=11040 bash tests/integration/segment_split_test.sh
       - uses: actions/upload-artifact@v4
         with:
@@ -373,7 +373,7 @@ jobs:
           path: lumabri/build/qwen38-fp8-home-models/qwen38-tiny
       - name: Native Qwen3.8 FP8 request and execution
         working-directory: lumabri
-        run: python3 tests/integration/home_flow_test.py --models-dir build/qwen38-fp8-home-models --context 512 --expect-greedy
+        run: python3 tests/integration/home_flow_test.py --models-dir build/qwen38-fp8-home-models --context 512 --expect-greedy --expect-metrics
       - uses: actions/download-artifact@v4
         with:
           name: tiny-v4-checkpoint

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ endif
 # regressions would make this gate depend on whichever checkout ENGINE names.
 check-warnings:
 	$(MAKE) -B all test_relay_exec test_swarm_fed test_key_rotation \
-		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget test_calibration \
+		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget test_calibration test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate test_inventory test_home test_chat_ui \
@@ -64,6 +64,7 @@ PLANNER_ADAPTER_DEPS = $(wildcard planner_adapters/*.h)
 # Adapter contracts are included transitively by the planner. Rebuild every
 # consumer when one changes, including when a new contract is introduced.
 lumabri test_chat_ui test_planner test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
+lumabri segment_chat test_chat_ui: lumabri_metrics.h
 
 lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
 		lumabri_inventory.h lumabri_home.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h \
@@ -456,6 +457,9 @@ test_memory_budget: tests/c/test_memory_budget.c lumabri_memory_budget.h lumabri
 test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_planner.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_calibration.c -o $@
 
+test_metrics: tests/c/test_metrics.c lumabri_metrics.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_metrics.c -o $@
+
 test_inventory: tests/c/test_inventory.c lumabri_inventory.h lumabri_machine.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_inventory.c -o $@
 
@@ -717,7 +721,7 @@ test-segment-discovery: tracker test_segment_discovery
 	bash ./tests/integration/segment_discovery_test.sh
 
 test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget \
-		test_inventory test_home test_chat_ui test_calibration \
+		test_inventory test_home test_chat_ui test_calibration test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -763,6 +767,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_cluster
 	./test_memory_budget
 	./test_calibration
+	./test_metrics
 	./test_nat_adopt
 	bash ./tests/integration/rtt_refresh_test.sh
 	./test_segment_v2
@@ -805,7 +810,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so liblumabri.dylib test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
-	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_inventory test_home test_chat_ui segment_budget_probe \
+	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_metrics test_inventory test_home test_chat_ui segment_budget_probe \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/docs/GENERATION_METRICS.md
+++ b/docs/GENERATION_METRICS.md
@@ -20,6 +20,9 @@ tail adds `PERF1 generated_tokens decode_steps prefill_seconds decode_seconds
 total_seconds`. Non-finite, negative, inconsistent, truncated or unknown-version
 observations do not produce a speed. Legacy engines without the extension keep
 the previous display; their client-side timing is not an exact calibration.
+`PERF_UNAVAILABLE` explicitly suppresses a speed when the engine could not
+validate its clocks. This never discards a successfully completed reply or KV
+history: measurement failure is not generation failure.
 
 `segment_chat --json` adds a `generation_metrics` object with `version: 1` and
 the same fields. Historical top-level `decode_tokens`/`decode_seconds` fields

--- a/docs/GENERATION_METRICS.md
+++ b/docs/GENERATION_METRICS.md
@@ -1,0 +1,32 @@
+# Generation observations, version 1
+
+Segment collects these observations during an ordinary completed chat turn.
+It does not run an extra inference, reload a checkpoint or start a benchmark.
+
+- `generated_tokens`: all selected output IDs, including a terminating EOS.
+- `prefill_seconds`: generation start through selection of the first token.
+- `decode_steps`: `generated_tokens - 1`; the first token came from prefill.
+- `decode_seconds`: first-token selection through last-token selection. This
+  includes intervening streaming/backpressure and recovery, if any, but excludes
+  final text formatting and cleanup after selection of the last token.
+- `total_seconds`: generation start through finalization.
+
+Decode rate is `decode_steps / decode_seconds`. A one-token reply has no decode
+rate. A client's first visible text can arrive later than first-token selection
+(transport, buffering, incomplete UTF-8); the TUI labels that time separately.
+
+The existing serve-codec `STAT` prefix remains readable by older clients. The
+tail adds `PERF1 generated_tokens decode_steps prefill_seconds decode_seconds
+total_seconds`. Non-finite, negative, inconsistent, truncated or unknown-version
+observations do not produce a speed. Legacy engines without the extension keep
+the previous display; their client-side timing is not an exact calibration.
+
+`segment_chat --json` adds a `generation_metrics` object with `version: 1` and
+the same fields. Historical top-level `decode_tokens`/`decode_seconds` fields
+remain for compatibility and retain their original convention; new consumers
+should use the versioned object.
+
+These are observations, not capacity promises. Persisting them against complete
+checkpoint/build/hardware/plan keys, invalidating stale records, and using them
+in the catalogue are separate unfinished parts of roadmap gate 4. The catalogue
+must continue to say **not calibrated** until those requirements are met.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -141,7 +141,10 @@ not a completed gate.
    overflow instead of wrapping into apparently small allocations.
    Measured-cost placement remains pending; this does not enable disk mode or
    certify additional model families.
-4. Pending: connected, persisted lightweight calibration and advice.
+4. In progress: versioned measurements collected during ordinary Segment chat,
+   separating prefill, decode traversals and first visible text. No extra model
+   run is required. Persisted exact-key calibration, stale-data handling and
+   catalogue advice remain pending; timing collection alone does not close gate 4.
 5. Pending: model acquisition, cache reuse and verified disk execution.
 6. Pending: upstream-only GPU capability integration, CPU otherwise.
 7. Pending: concurrent sessions and actual replay after failure.

--- a/lumabri.c
+++ b/lumabri.c
@@ -2665,6 +2665,7 @@ static int sr_take(SReader *s, size_t n, int emit, Cap *cap) {   /* copy/discard
 /* When the first token of the current reply arrived: everything before it
  * is prefill (the prompt crossing the layers), everything after is decode.
  * One number for both hid a 60 s prefill inside "0.2 tok/s". */
+#include "lumabri_metrics.h"
 static volatile double g_first_token_at;
 
 static int stream_serve2(Engine *e, char *statline, size_t scap, char **captured) {
@@ -4707,7 +4708,7 @@ static int cmd_chat(int argc, char **argv) {
         }
 
         double m0 = g_eng.net_mb, r0 = nowd();
-        char stat[128] = "";
+        char stat[512] = "";
 
         if (eng.proto == PROTO_SERVE2) {
             char *reply = NULL;
@@ -4793,7 +4794,19 @@ static int cmd_chat(int argc, char **argv) {
         int nstat = sscanf(stat, "STAT %d %lf %lf %lf", &ntok, &tps, &hit, &rss);
         double dmb = g_eng.net_mb - m0;
         double end = nowd(), first = g_first_token_at;
-        if (first > r0 && ntok > 0 && end > first) {
+        LmbGenerationMetrics metrics;
+        int metric_status=lmb_metrics_parse(stat,&metrics);
+        if(metric_status==0 && metrics.generated_tokens!=(uint32_t)ntok) metric_status=-1;
+        if(metric_status==0) {
+            printf("%s  host prefill %.1fs · %u generated tokens",C_DIM,
+                   metrics.prefill_seconds,metrics.generated_tokens);
+            double rate=lmb_metrics_decode_rate(&metrics);
+            if(rate>0) printf(" · decode %.2f tok/s",rate);
+            else printf(" · decode speed not measured");
+            if(first>r0) printf(" · first text %.1fs",first-r0);
+        } else if(metric_status<0) {
+            printf("%s  %.1fs · invalid timing report; speed unavailable",C_DIM,end-r0);
+        } else if (first > r0 && ntok > 0 && end > first) {
             /* prefill and decode are two different costs: the prompt crossing
              * every layer once, then one network round per layer per token */
             double decode_s = end - first;

--- a/lumabri.c
+++ b/lumabri.c
@@ -4805,7 +4805,7 @@ static int cmd_chat(int argc, char **argv) {
             else printf(" · decode speed not measured");
             if(first>r0) printf(" · first text %.1fs",first-r0);
         } else if(metric_status<0) {
-            printf("%s  %.1fs · invalid timing report; speed unavailable",C_DIM,end-r0);
+            printf("%s  %.1fs · timing unavailable; no speed recorded",C_DIM,end-r0);
         } else if (first > r0 && ntok > 0 && end > first) {
             /* prefill and decode are two different costs: the prompt crossing
              * every layer once, then one network round per layer per token */

--- a/lumabri_metrics.h
+++ b/lumabri_metrics.h
@@ -42,18 +42,21 @@ static inline int lmb_metrics_format(const LmbGenerationMetrics *m,char *out,siz
 /* 0 valid; 1 absent on a legacy engine; -1 malformed. Never interpret a
  * truncated/new-version observation as an exact historical calibration. */
 static inline int lmb_metrics_parse(const char *stat,LmbGenerationMetrics *out) {
+    if(!out) return -1;
     memset(out,0,sizeof *out);
+    if(!stat) return -1;
+    LmbGenerationMetrics parsed={0};
     const char *p=strstr(stat," PERF1 ");
     if(!p) return strstr(stat," PERF") ? -1 : 1;
     p+=7;
-    uint32_t *counts[]={&out->generated_tokens,&out->decode_steps};
+    uint32_t *counts[]={&parsed.generated_tokens,&parsed.decode_steps};
     for(unsigned i=0;i<2;i++) {
         if(*p<'0' || *p>'9') return -1;
         errno=0; char *end; unsigned long n=strtoul(p,&end,10);
         if(errno || n>1048576 || *end!=' ') return -1;
         *counts[i]=(uint32_t)n; p=end+1;
     }
-    double *times[]={&out->prefill_seconds,&out->decode_seconds,&out->total_seconds};
+    double *times[]={&parsed.prefill_seconds,&parsed.decode_seconds,&parsed.total_seconds};
     for(unsigned i=0;i<3;i++) {
         if(*p<'0' || *p>'9') return -1;
         errno=0; char *end; double value=strtod(p,&end);
@@ -63,7 +66,8 @@ static inline int lmb_metrics_parse(const char *stat,LmbGenerationMetrics *out) 
         else p=end;
     }
     while(*p==' ' || *p=='\r' || *p=='\n') p++;
-    if(*p || !lmb_metrics_valid(out)) {memset(out,0,sizeof *out);return -1;}
+    if(*p || !lmb_metrics_valid(&parsed)) return -1;
+    *out=parsed;
     return 0;
 }
 #endif

--- a/lumabri_metrics.h
+++ b/lumabri_metrics.h
@@ -1,0 +1,69 @@
+/* Versioned observations from one completed generation. No benchmark or
+ * calibration is implied by collecting timing from a real chat turn. */
+#ifndef LUMABRI_METRICS_H
+#define LUMABRI_METRICS_H
+#include <errno.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    uint32_t generated_tokens, decode_steps;
+    double prefill_seconds, decode_seconds, total_seconds;
+} LmbGenerationMetrics;
+
+static inline int lmb_metrics_valid(const LmbGenerationMetrics *m) {
+    return m && m->generated_tokens>0 && m->generated_tokens<=1048576 &&
+        m->decode_steps==m->generated_tokens-1 &&
+        isfinite(m->prefill_seconds) && m->prefill_seconds>=0 &&
+        isfinite(m->decode_seconds) && m->decode_seconds>=0 &&
+        isfinite(m->total_seconds) && m->total_seconds>=0 && m->total_seconds<=1e9 &&
+        (m->decode_steps || m->decode_seconds==0) &&
+        m->total_seconds+1e-6>=m->prefill_seconds+m->decode_seconds;
+}
+
+static inline double lmb_metrics_decode_rate(const LmbGenerationMetrics *m) {
+    /* The first token comes from prefill, not a decode traversal. A one-token
+     * reply cannot measure decode speed, even if selecting it took 1 us. */
+    double rate=lmb_metrics_valid(m) && m->decode_steps && m->decode_seconds>0
+        ? m->decode_steps/m->decode_seconds : 0;
+    return isfinite(rate) ? rate : 0;
+}
+
+static inline int lmb_metrics_format(const LmbGenerationMetrics *m,char *out,size_t cap) {
+    if(!lmb_metrics_valid(m)) return -1;
+    int n=snprintf(out,cap,"PERF1 %u %u %.9f %.9f %.9f",m->generated_tokens,
+        m->decode_steps,m->prefill_seconds,m->decode_seconds,m->total_seconds);
+    return n<0 || (size_t)n>=cap ? -1 : 0;
+}
+
+/* 0 valid; 1 absent on a legacy engine; -1 malformed. Never interpret a
+ * truncated/new-version observation as an exact historical calibration. */
+static inline int lmb_metrics_parse(const char *stat,LmbGenerationMetrics *out) {
+    memset(out,0,sizeof *out);
+    const char *p=strstr(stat," PERF1 ");
+    if(!p) return strstr(stat," PERF") ? -1 : 1;
+    p+=7;
+    uint32_t *counts[]={&out->generated_tokens,&out->decode_steps};
+    for(unsigned i=0;i<2;i++) {
+        if(*p<'0' || *p>'9') return -1;
+        errno=0; char *end; unsigned long n=strtoul(p,&end,10);
+        if(errno || n>1048576 || *end!=' ') return -1;
+        *counts[i]=(uint32_t)n; p=end+1;
+    }
+    double *times[]={&out->prefill_seconds,&out->decode_seconds,&out->total_seconds};
+    for(unsigned i=0;i<3;i++) {
+        if(*p<'0' || *p>'9') return -1;
+        errno=0; char *end; double value=strtod(p,&end);
+        if(errno || !isfinite(value) || value<0) return -1;
+        *times[i]=value;
+        if(i<2) {if(*end!=' ')return -1;p=end+1;}
+        else p=end;
+    }
+    while(*p==' ' || *p=='\r' || *p=='\n') p++;
+    if(*p || !lmb_metrics_valid(out)) {memset(out,0,sizeof *out);return -1;}
+    return 0;
+}
+#endif

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -45,6 +45,8 @@ typedef struct {
     size_t checkpoint_count;
 } SegmentConversation;
 
+#include "lumabri_metrics.h"
+
 typedef struct {
     char *text;
     size_t text_bytes;
@@ -53,6 +55,7 @@ typedef struct {
     size_t prompt_count;
     double elapsed_seconds;
     double decode_seconds;
+    LmbGenerationMetrics metrics;
 } GenerationResult;
 
 typedef enum {
@@ -1491,6 +1494,7 @@ static int segment_generate(ColiEdgeEngine *edge,
             goto cleanup;
         }
     } else if (coli_edge_select(edge, &select, error, error_size)) goto cleanup;
+    double first_selected_at=monotonic_seconds(), last_selected_at=first_selected_at;
     size_t generated_count = 1;
     if (event &&
         (generation_stream_prefix(edge, generated, generated_count,
@@ -1550,6 +1554,7 @@ static int segment_generate(ColiEdgeEngine *edge,
             }
         } else if (coli_edge_select(edge, &select, error, error_size))
             goto cleanup;
+        last_selected_at=monotonic_seconds();
         generated_count++;
         if (event &&
             (generation_stream_prefix(edge, generated, generated_count,
@@ -1626,8 +1631,13 @@ static int segment_generate(ColiEdgeEngine *edge,
     result->tokens = generated;
     result->token_count = generated_count;
     result->prompt_count = prompt_count;
-    result->elapsed_seconds = monotonic_seconds() - started;
-    result->decode_seconds = monotonic_seconds() - decode_started;
+    double finished_at=monotonic_seconds();
+    result->elapsed_seconds = finished_at - started;
+    result->decode_seconds = finished_at - decode_started; /* legacy JSON convention */
+    result->metrics=(LmbGenerationMetrics){
+        .generated_tokens=(uint32_t)generated_count,.decode_steps=(uint32_t)generated_count-1,
+        .prefill_seconds=first_selected_at-started,.decode_seconds=last_selected_at-first_selected_at,
+        .total_seconds=finished_at-started};
     generated = NULL;
     rc = 0;
 
@@ -1834,10 +1844,13 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
             fflush(stdout);
             continue;
         }
-        double rate = result.elapsed_seconds > 0.0
-            ? (double)result.token_count / result.elapsed_seconds : 0.0;
-        printf("DONE %u STAT %zu %.3f 0 0 %zu 0\n", request_id,
-               result.token_count, rate, result.prompt_count);
+        char metrics[192];
+        if(lmb_metrics_format(&result.metrics,metrics,sizeof metrics)) {
+            printf("ERROR %u Invalid generation timing\n",request_id);
+            fflush(stdout); generation_result_free(&result); continue;
+        }
+        printf("DONE %u STAT %zu %.3f 0 0 %zu 0 %s\n", request_id,
+               result.token_count, lmb_metrics_decode_rate(&result.metrics), result.prompt_count,metrics);
         fflush(stdout);
         generation_result_free(&result);
     }
@@ -2097,10 +2110,16 @@ int main(int argc, char **argv) {
             printf("%s%d", i ? "," : "", generated.tokens[i]);
         printf("],\"decode_tokens\":%zu,\"decode_seconds\":%.9f,"
                "\"prefill_decode_seconds\":%.9f,"
-               "\"bytes\":{\"segment\":%llu}}\n",
+               "\"bytes\":{\"segment\":%llu},"
+               "\"generation_metrics\":{\"version\":1,\"generated_tokens\":%u,"
+               "\"decode_steps\":%u,\"prefill_seconds\":%.9f,"
+               "\"decode_seconds\":%.9f,\"total_seconds\":%.9f}}\n",
                generated.token_count, generated.decode_seconds,
                generated.elapsed_seconds,
-               (unsigned long long)segment_wire_bytes);
+               (unsigned long long)segment_wire_bytes,
+               generated.metrics.generated_tokens,generated.metrics.decode_steps,
+               generated.metrics.prefill_seconds,generated.metrics.decode_seconds,
+               generated.metrics.total_seconds);
     }
     generation_result_free(&generated);
     lmb_seg_discovery_stop(discovery);

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1846,8 +1846,9 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
         }
         char metrics[192];
         if(lmb_metrics_format(&result.metrics,metrics,sizeof metrics)) {
-            printf("ERROR %u Invalid generation timing\n",request_id);
-            fflush(stdout); generation_result_free(&result); continue;
+            /* Observability must not discard a completed reply or its KV
+             * history merely because timing could not be validated. */
+            snprintf(metrics,sizeof metrics,"PERF_UNAVAILABLE");
         }
         printf("DONE %u STAT %zu %.3f 0 0 %zu 0 %s\n", request_id,
                result.token_count, lmb_metrics_decode_rate(&result.metrics), result.prompt_count,metrics);

--- a/tests/c/test_metrics.c
+++ b/tests/c/test_metrics.c
@@ -1,0 +1,28 @@
+#include "lumabri_metrics.h"
+#include <assert.h>
+
+int main(void) {
+    LmbGenerationMetrics m={.generated_tokens=9,.decode_steps=8,
+        .prefill_seconds=15,.decode_seconds=2,.total_seconds=17.2}, parsed;
+    assert(lmb_metrics_decode_rate(&m)==4);
+    char extension[192], stat[256];
+    assert(!lmb_metrics_format(&m,extension,sizeof extension));
+    snprintf(stat,sizeof stat,"STAT 9 4 0 0 20 0 %s\n",extension);
+    assert(!lmb_metrics_parse(stat,&parsed) && parsed.generated_tokens==9 &&
+           parsed.decode_steps==8 && lmb_metrics_decode_rate(&parsed)==4);
+    assert(lmb_metrics_parse("STAT 9 0.5 0 0",&parsed)==1);
+    const char *bad[]={" PERF2 9 8 15 2 17.2", " PERF1 -1 0 0 0 0",
+        " PERF1 4294967297 0 0 0 0", " PERF1 9 -8 15 2 17.2",
+        " PERF1 9 9 15 2 17.2", " PERF1 9 8 nan 2 17.2",
+        " PERF1 9 8 15 inf 17.2", " PERF1 9 8 15 -2 17.2",
+        " PERF1 9 8 15 2 16", " PERF1 9 8 15 2 17.2 trailing",
+        " PERF1 1 0 1 0.1 1.1", " PERF1 0 0 0 0 0", " PERF1 9 8 15 2"};
+    for(size_t i=0;i<sizeof bad/sizeof *bad;i++) assert(lmb_metrics_parse(bad[i],&parsed)==-1);
+    m=(LmbGenerationMetrics){.generated_tokens=1,.prefill_seconds=1,.total_seconds=1.1};
+    assert(lmb_metrics_valid(&m) && lmb_metrics_decode_rate(&m)==0);
+    assert(!lmb_metrics_format(&m,extension,sizeof extension));
+    assert(lmb_metrics_format(&m,extension,4)==-1);
+    m.decode_seconds=NAN; assert(!lmb_metrics_valid(&m));
+    puts("GENERATION METRICS: PASS (prefill separate, first token excluded, bounded wire format)");
+    return 0;
+}

--- a/tests/c/test_metrics.c
+++ b/tests/c/test_metrics.c
@@ -11,7 +11,7 @@ int main(void) {
     assert(!lmb_metrics_parse(stat,&parsed) && parsed.generated_tokens==9 &&
            parsed.decode_steps==8 && lmb_metrics_decode_rate(&parsed)==4);
     assert(lmb_metrics_parse("STAT 9 0.5 0 0",&parsed)==1);
-    const char *bad[]={" PERF2 9 8 15 2 17.2", " PERF1 -1 0 0 0 0",
+    const char *bad[]={" PERF_UNAVAILABLE", " PERF2 9 8 15 2 17.2", " PERF1 -1 0 0 0 0",
         " PERF1 4294967297 0 0 0 0", " PERF1 9 -8 15 2 17.2",
         " PERF1 9 9 15 2 17.2", " PERF1 9 8 nan 2 17.2",
         " PERF1 9 8 15 inf 17.2", " PERF1 9 8 15 -2 17.2",

--- a/tests/c/test_metrics.c
+++ b/tests/c/test_metrics.c
@@ -17,7 +17,14 @@ int main(void) {
         " PERF1 9 8 15 inf 17.2", " PERF1 9 8 15 -2 17.2",
         " PERF1 9 8 15 2 16", " PERF1 9 8 15 2 17.2 trailing",
         " PERF1 1 0 1 0.1 1.1", " PERF1 0 0 0 0 0", " PERF1 9 8 15 2"};
-    for(size_t i=0;i<sizeof bad/sizeof *bad;i++) assert(lmb_metrics_parse(bad[i],&parsed)==-1);
+    for(size_t i=0;i<sizeof bad/sizeof *bad;i++) {
+        parsed=m;
+        assert(lmb_metrics_parse(bad[i],&parsed)==-1);
+        assert(!parsed.generated_tokens && !parsed.decode_steps &&
+               !parsed.prefill_seconds && !parsed.decode_seconds && !parsed.total_seconds);
+    }
+    assert(lmb_metrics_parse(NULL,&parsed)==-1);
+    assert(lmb_metrics_parse("STAT 1 0 0 0",NULL)==-1);
     m=(LmbGenerationMetrics){.generated_tokens=1,.prefill_seconds=1,.total_seconds=1.1};
     assert(lmb_metrics_valid(&m) && lmb_metrics_decode_rate(&m)==0);
     assert(!lmb_metrics_format(&m,extension,sizeof extension));

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -30,6 +30,8 @@ def main():
     parser.add_argument("--context", type=int, default=128,
                         help="approved context, including the actual family chat template")
     parser.add_argument("--expect-greedy", action="store_true")
+    parser.add_argument("--expect-metrics", action="store_true",
+                        help="require versioned generation timings through Hosted into the TUI")
     parser.add_argument("--expect-no-fit", action="store_true",
                         help="verify insufficient-memory admission, without starting engines")
     parser.add_argument("--kill-donor", action="store_true",
@@ -228,6 +230,9 @@ def main():
               chat.has("invalid token count") or chat.p.poll() is not None, seconds=120,
               message="real model did not finish a response")
         assert chat.has("tok/s") or chat.has("generated tokens"), "engine failed during generation"
+        if args.expect_metrics:
+            assert chat.has("host prefill") and chat.has("generated tokens"), "versioned engine timings did not reach the TUI"
+            assert not chat.has("invalid timing report"), "inconsistent engine timings"
         assert "hosted stream · no local checkpoint" in chat.text
         executed_ranges = []
         for donor in ("donor-a", "donor-b"):

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -211,11 +211,11 @@ def main():
         chat.send("\t\n")
         until(lambda: chat.has("Tab completes commands"), message="slash completion did not execute help")
         chat.send("hi\n")
-        until(lambda: chat.has("tok/s") or chat.has("prompt plus output exceeds context") or
+        until(lambda: chat.has("tok/s") or chat.has("generated tokens") or chat.has("prompt plus output exceeds context") or
               chat.has("logits are unavailable for sampling") or chat.has("Segment generation failed") or
               chat.has("invalid token count") or chat.p.poll() is not None, seconds=120,
               message="real model did not finish a response")
-        assert chat.has("tok/s"), "engine failed during generation"
+        assert chat.has("tok/s") or chat.has("generated tokens"), "engine failed during generation"
         assert "hosted stream · no local checkpoint" in chat.text
         executed_ranges = []
         for donor in ("donor-a", "donor-b"):

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -232,7 +232,7 @@ def main():
         assert chat.has("tok/s") or chat.has("generated tokens"), "engine failed during generation"
         if args.expect_metrics:
             assert chat.has("host prefill") and chat.has("generated tokens"), "versioned engine timings did not reach the TUI"
-            assert not chat.has("invalid timing report"), "inconsistent engine timings"
+            assert not chat.has("timing unavailable"), "inconsistent engine timings"
         assert "hosted stream · no local checkpoint" in chat.text
         executed_ranges = []
         for donor in ("donor-a", "donor-b"):

--- a/tests/integration/hosted_chat_test.sh
+++ b/tests/integration/hosted_chat_test.sh
@@ -134,7 +134,7 @@ cat >"$T/qwen36.c" <<'EOF'
 int main(void) {
     setvbuf(stdout, NULL, _IONBF, 0);
     fputs("\nLUMABRI_SAMPLING GREEDY\n\1\1READY\1\1\nSTAT 0 0 0 0\n", stdout);
-    char line[512];
+    char line[512]; unsigned turns = 0;
     while (fgets(line, sizeof line, stdin)) {
         char id[64]; unsigned slot, max_new; size_t bytes; float t, p;
         if (sscanf(line, "SUBMIT %63s %u %zu %u %f %f",
@@ -145,8 +145,13 @@ int main(void) {
             return 1;
         payload[bytes] = 0;
         if (!strstr(payload, "<|im_start|>assistant\n<think>\n")) return 2;
+        if (turns && !strstr(payload, "hello")) return 4;
         free(payload);
-        printf("ACCEPT %s\nDATA %s 5\nhello\nDONE %s\n", id, id, id);
+        printf("ACCEPT %s\nDATA %s 5\nhello\nDONE %s", id, id, id);
+        if (!turns) fputs(" STAT 1 0 0 0 20 0 PERF_UNAVAILABLE", stdout);
+        else if (turns == 1) fputs(" STAT 1 0 0 0 20 0 PERF1 1 0 0.2 0 0.2", stdout);
+        /* Third turn deliberately remains a legacy engine response. */
+        fputc('\n', stdout); turns++;
     }
     return 0;
 }
@@ -164,7 +169,7 @@ for _ in $(seq 1 200); do
 done
 grep -q "host ready" "$T/real-host.log" || fail "the real host did not start"
 
-( printf 'hi\n'; sleep 3; printf '/quit\n' ) | timeout 20 ./lumabri chat \
+( printf 'hi\nagain\nlegacy\n'; sleep 3; printf '/quit\n' ) | timeout 20 ./lumabri chat \
     --host "127.0.0.1:$REAL_PORT" --plain >"$T/held.log" 2>&1 & held=$!
 sleep .5
 started=$(date +%s)
@@ -180,5 +185,9 @@ grep -q "greedy decoding" "$T/held.log" ||
     fail "greedy-only capability did not reach the client"
 grep -q "hello" "$T/held.log" ||
     fail "client requested sampling from a greedy-only engine"
+grep -q "timing unavailable; no speed recorded" "$T/held.log" ||
+    fail "an unavailable observation produced a speed"
+grep -q "decode speed not measured" "$T/held.log" ||
+    fail "a one-token reply manufactured a decode rate or lost its history"
 
 echo "HOSTED CHAT TEST: PASS (zero checkpoint bytes, authenticated encrypted stream, real BUSY)"

--- a/tests/integration/hosted_chat_test.sh
+++ b/tests/integration/hosted_chat_test.sh
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
             if (lmb_recv(fd, &stream) || stream.op != LMB_HOST_STREAM ||
                 !stream.pay_len) { lmb_msg_free(&stream); break; }
             lmb_msg_free(&stream);
-            const char *reply = "ACCEPT 0\nDATA 0 5\nhello\nDONE 0\n";
+            const char *reply = "ACCEPT 0\nDATA 0 5\nhello\nDONE 0 STAT 9 4 0 0 20 0 PERF1 9 8 15 2 17.2\n";
             if (lmb_send(fd, LMB_HOST_STREAM, NULL, 0,
                          reply, (uint32_t)strlen(reply))) break;
         }
@@ -104,6 +104,8 @@ grep -qi "not yet measured" "$T/client.log" ||
     fail "an unmeasured host did not say its speed is unknown"
 grep -q "hello" "$T/client.log" ||
     fail "the encrypted HOST_STREAM did not carry a generated reply"
+grep -q "host prefill 15.0s" "$T/client.log" || fail "host phase timing was lost"
+grep -q "decode 4.00 tok/s" "$T/client.log" || fail "decode rate included prefill or the first token"
 
 # Not one byte of model, mirror or CAS.
 (( after - before < 65536 )) ||

--- a/tests/integration/role_test.sh
+++ b/tests/integration/role_test.sh
@@ -13,10 +13,12 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-make -s lumabri tracker maintainer
+make -s lumabri tracker maintainer swarm_probe
 
 T=$(mktemp -d /tmp/lumabri-role.XXXXXX)
 export LUMABRI_PEER_BINDINGS="$T/peer-bindings"
+export HOME="$T/services-home"
+mkdir -p "$HOME"
 PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
@@ -32,7 +34,22 @@ for _ in $(seq 1 100); do
 done
 ./maintainer --root "$T/src" --port 7599 --tracker 127.0.0.1:7598 \
              --name origin --model-name fx > "$T/origin.log" 2>&1 & PIDS+=($!)
-sleep 1.5
+# A listening tracker does not imply the source has finished indexing and
+# registered. Fixed sleeps failed on a loaded validation host before the
+# role parser could run, falsely reporting that `disk` meant `chat`.
+ready=0
+for _ in $(seq 1 200); do
+    if ./swarm_probe --tracker 127.0.0.1:7598 --model fx > "$T/ready.json" 2> "$T/ready.err" &&
+       python3 -c 'import json,sys; rows=json.load(open(sys.argv[1]))["peers"]; sys.exit(not any(p["storage"]["files"] == 2 and p["storage"]["bytes_held"] >= 65536 for p in rows))' "$T/ready.json"; then
+        ready=1; break
+    fi
+    sleep .1
+done
+if [[ "$ready" != 1 ]]; then
+    echo "ROLE TEST: source did not become ready" >&2
+    cat "$T/tracker.log" "$T/origin.log" "$T/ready.err" >&2
+    exit 1
+fi
 
 # role → does it become a donor?
 try() {                       # try ROLE EXPECT_DONOR EXPECT_RC

--- a/tests/integration/security_test.sh
+++ b/tests/integration/security_test.sh
@@ -26,6 +26,18 @@ PIDS=()
 cleanup() { kill "${PIDS[@]}" 2>/dev/null || true; rm -rf "$T"; }
 trap cleanup EXIT
 
+wait_tracker() {
+    local port=$1
+    for _ in $(seq 1 200); do
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+            exec 3<&-; exec 3>&-; return 0
+        fi
+        sleep .05
+    done
+    echo "SECURITY TEST: tracker on $port did not become ready" >&2
+    return 1
+}
+
 CANARY="$T/precious.txt"
 echo "do not touch me" > "$CANARY"
 CANARY_SUM=$(sha256sum "$CANARY" | cut -d' ' -f1)
@@ -128,7 +140,7 @@ echo "   ✓ refused, and the file outside the mirror is untouched"
 
 echo "· 3) the real tracker refuses to carry such a name at all"
 ./tracker --port 7553 > "$T/tracker.log" 2>&1 & PIDS+=($!)
-sleep 0.4
+wait_tracker 7553
 cat > "$T/evil_reg.c" <<'EOF'
 #include "lumabri_proto.h"
 int main(int argc, char **argv) {
@@ -162,7 +174,7 @@ echo "   ✓ refused at the index, so it never reaches a client"
 echo "· 4) oversized control frames are rejected before their body is read"
 env LUMABRI_MAX_CONNECTIONS=2 LUMABRI_IO_TIMEOUT_MS=5000 \
     ./tracker --port 7554 > "$T/limits.log" 2>&1 & LIMIT_PID=$!; PIDS+=($LIMIT_PID)
-sleep 0.4
+wait_tracker 7554
 python3 - 7554 <<'PY'
 import socket, struct, sys
 port = int(sys.argv[1])
@@ -242,7 +254,7 @@ cc -O2 -w -I. "$T/authreg.c" -o "$T/authreg" -lpthread
 
 env LUMABRI_STALE_MS=100 LUMABRI_MAX_NAMES_PER_SOURCE=64 \
     ./tracker --port 7555 > "$T/reuse.log" 2>&1 & PIDS+=($!)
-sleep 0.3
+wait_tracker 7555
 for i in $(seq 0 63); do
     "$T/authreg" 127.0.0.1:7555 "gone-$i" "$T/jk-$i" || {
         echo "   authenticated peer $i was refused a slot in an empty table"; exit 1; }
@@ -254,7 +266,7 @@ echo "   ✓ stale slot recycled; the cap applies to live peers, not history"
 
 echo "· 7) one key cannot monopolise the table with many names"
 env LUMABRI_STALE_MS=600000 ./tracker --port 7556 > "$T/cap.log" 2>&1 & PIDS+=($!)
-sleep 0.3
+wait_tracker 7556
 ok=0
 for i in $(seq 1 8); do
     "$T/authreg" 127.0.0.1:7556 "mine-$i" "$T/onekey" && ok=$((ok+1))
@@ -267,7 +279,7 @@ echo "   ✓ 8 names held, the 9th refused; anonymous junk cannot exhaust the ta
 echo "· 8) one source address cannot bypass the cap with many identity keys"
 env LUMABRI_STALE_MS=600000 LUMABRI_MAX_NAMES_PER_SOURCE=8 \
     ./tracker --port 7557 > "$T/source-cap.log" 2>&1 & PIDS+=($!)
-sleep 0.3
+wait_tracker 7557
 ok=0
 for i in $(seq 1 8); do
     "$T/authreg" 127.0.0.1:7557 "source-$i" "$T/source-key-$i" && ok=$((ok+1))

--- a/tests/integration/segment_direct_test.sh
+++ b/tests/integration/segment_direct_test.sh
@@ -172,8 +172,8 @@ if line() != b"\n" or line() != b"LUMABRI_SAMPLING LOGITS\n":
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("Segment gateway did not become ready")
 
-def turn(request_id, prompt):
-    header = f"SUBMIT {request_id} 0 {len(prompt)} 1 0.7 0.95\n".encode()
+def turn(request_id, prompt, max_new=1):
+    header = f"SUBMIT {request_id} 0 {len(prompt)} {max_new} 0.7 0.95\n".encode()
     process.stdin.write(header + prompt + b"\n")
     process.stdin.flush()
     if line() != f"ACCEPT {request_id}\n".encode():
@@ -192,6 +192,18 @@ def turn(request_id, prompt):
                 raise RuntimeError("Segment DATA frame is truncated")
             seen_data = True
         elif frame.startswith(f"DONE {request_id} STAT ".encode()):
+            fields = frame.decode().split()
+            marker = fields.index("PERF1")
+            generated, steps = map(int, fields[marker+1:marker+3])
+            prefill, decode, total = map(float, fields[marker+3:])
+            assert generated == int(fields[3]) and 1 <= generated <= max_new
+            assert steps == generated - 1
+            assert all(0 <= seconds <= 1e9 for seconds in (prefill, decode, total))
+            assert total + 1e-6 >= prefill + decode
+            expected = steps / decode if steps and decode else 0
+            assert abs(float(fields[4]) - expected) < 0.001
+            if not steps:
+                assert decode == 0 and float(fields[4]) == 0
             break
         elif not frame.startswith(f"PROGRESS {request_id} ".encode()):
             raise RuntimeError("unexpected Segment frame: "+repr(frame))
@@ -199,7 +211,7 @@ def turn(request_id, prompt):
         raise RuntimeError("Segment response lacks streaming progress")
 
 turn(91, b"hi\n")
-turn(92, b"hi\nthere\n")
+turn(92, b"hi\nthere\n", max_new=4)
 process.stdin.close()
 if process.wait(timeout=15):
     raise RuntimeError("Segment gateway exited with an error")

--- a/tests/integration/segment_direct_test.sh
+++ b/tests/integration/segment_direct_test.sh
@@ -92,7 +92,7 @@ print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt
     case "$family" in
         glm) run_env+=(GLM_SEGMENT_EBITS=16 GLM_SEGMENT_DBITS=16) ;;
         inkling) run_env+=(INK_SEGMENT_BITS=0) ;;
-        kimi) run_env+=(COLI_RAM_OVERCOMMIT=1 K3_BITS=32 K3_MLA_BITS=32
+        kimi) run_env+=(K3_BITS=32 K3_MLA_BITS=32
                         K3_HEAD_BITS=32 K3_IDOT=0) ;;
     esac
 
@@ -137,13 +137,29 @@ print(",".join(map(str,prompt))+"|"+",".join(map(str,full[len(prompt):len(prompt
         >"$serve_output"
     if ! grep -aq $'\001\001READY\001\001' "$serve_output" ||
        ! grep -aq '^DATA 1 ' "$serve_output" ||
-       [[ $(grep -ac '^DATA 1 ' "$serve_output") -lt 2 ]] ||
+       ! grep -aq '^PROGRESS 1 DECODE 2 2$' "$serve_output" ||
        ! grep -aq '^DONE 1 STAT ' "$serve_output"; then
         cat "$serve_output"
         cat "$TMP/$family-left.log" "$TMP/$family-right.log"
         echo "SEGMENT DIRECT $family: incremental serve-codec gate failed" >&2
         exit 1
     fi
+    # A token is not necessarily a complete UTF-8 prefix. Two decode events
+    # may legitimately result in one DATA frame; the final text is still
+    # mandatory and the token-ID oracle above is independent of framing.
+    python3 - "$serve_output" <<'PY'
+import math, sys
+lines = open(sys.argv[1], "rb").read().splitlines()
+done = next(line for line in lines if line.startswith(b"DONE 1 STAT "))
+fields = done.decode("ascii").split()
+marker = fields.index("PERF1")
+generated, steps = map(int, fields[marker+1:marker+3])
+prefill, decode, total = map(float, fields[marker+3:])
+assert generated == int(fields[3]) == 2 and steps == 1
+assert all(math.isfinite(s) and 0 <= s <= 1e9 for s in (prefill, decode, total))
+assert decode > 0 and total + 1e-6 >= prefill + decode
+assert abs(float(fields[4]) - steps / decode) < 0.001
+PY
     if [[ "$family" == olmoe ]]; then
         # A second request must reuse the remote state established by the
         # first one. Keep generation to one token so the committed prefix is


### PR DESCRIPTION
## Roadmap gate 4: real measurements, in progress

Builds on merged PR #155. This PR does not declare catalogue calibration or the full roadmap complete.

### Implemented
- Collect timing during ordinary Segment generation, with no extra model run.
- Separate prefill (including first-token selection), subsequent decode traversals, and total generation time. A one-token reply does not claim decode speed.
- Carry versioned PERF1 observations through the existing Hosted protocol to the TUI. Keep legacy hosts compatible.
- Preserve completed responses and conversation history if timing is unavailable; telemetry failure must not become inference failure.
- Require real timing through the Qwen3.8 FP8 household flow in Linux and native macOS CI.

### Verification
- Timing validation/format/parser unit tests; legacy, malformed/unavailable and one-token cases.
- Hosted encrypted client/server tests, multi-turn history preservation, BUSY and zero client checkpoint download.
- Actual Qwen3.8 FP8 household approval, two ranges, generation and lost-donor cleanup, including `--expect-metrics`.

### Remaining in gate 4
Persist observations under complete checkpoint/runtime/hardware/topology/context keys, connect the catalogue and stale-data state, and add resource-based advice. No tok/s is yet manufactured for uncalibrated catalogue entries. Tiny fixture performance is not a large-model speed estimate.

Colibri is unchanged. No new GPU backend or disk mode is claimed. Preserve commit history when merging; no squash.
