### PR TITLE
household: reuse verified weights between approved chats (gate 5, in progress)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
           cp -a ../colibri/c/olmoe_tiny_merged build/home-flow-models/olmoe-tiny
           make segment_budget_probe
           python3 tests/integration/planner_tensor_contract_test.py --family olmoe --model build/home-flow-models/olmoe-tiny
-          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
+          make swarm_probe
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
       - name: Same greedy tokens with one and two real Segment ranges
         working-directory: lumabri
@@ -317,7 +318,8 @@ jobs:
         run: |
           test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
-          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models
+          make swarm_probe
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
       - uses: actions/download-artifact@v4
         with:

--- a/docs/HOUSEHOLD_WEIGHT_CACHE.md
+++ b/docs/HOUSEHOLD_WEIGHT_CACHE.md
@@ -1,0 +1,56 @@
+# Reusing household weights
+
+An approved household plan keeps verified model data for the next request.
+The default donor storage layout is:
+
+```text
+~/.lumabri/home/
+  mirrors/<adapter-id>/cache/           reusable working mirror and block maps
+  cas/<hash-prefix>/<chunk-hash>        reusable content chunks
+  weights.lock                         one active owner of mutable mirrors
+```
+
+`--disk` places the same layout below its `lumabri-home` directory. A new
+request still requires explicit approval. Edge and Segment processes are
+restarted with fresh session state; these caches contain weights, not text
+history or KV snapshots. Releasing a plan frees its RAM and both allocation
+locks, but retains verified model files.
+
+The adapter selects a working mirror, not a trusted identity. Protocol model
+roots include the session routing name and therefore change between requests.
+The existing loader still validates the accepted signed root, current
+inventory and content hashes. A new identity resets the mirror's maps;
+its blocks can then be rebuilt
+from the local CAS without downloading matching weights again. Neither an
+adapter name nor a cached filename can authorize old bytes for a new model.
+Different homes
+pointing at one cache directory cannot run competing mutable mirrors: the
+second allocation fails promptly rather than waiting behind the first.
+
+This is not zero network traffic. Discovery, authentication, manifests and
+direct configuration reads still use the network. It is also not a disk
+execution mode: the resident memory checks remain unchanged.
+
+## Verification
+
+```sh
+make household swarm_probe
+python3 tests/integration/home_flow_test.py --models-dir /path/to/one-fixture-parent --repeat-cached
+```
+
+The test executes two separately approved plans on two real Segment
+processes. It checks the same persistent cache paths and content chunks,
+the source's published byte/read counters, generation in the second plan,
+and release of RAM/cache locks. The repeated synthetic OLMoE request must
+leave only the two direct `config.json` reads at the source. Native macOS CI
+runs the same test; loopback is not a physical LAN certification.
+
+## Still outside this change
+
+- Importing old per-request caches: existing directories are left untouched.
+- Automatic eviction, a total disk-cache quota and cache-aware free-space admission.
+- Remote checkpoint selection, authorized acquisition and model-license handling.
+- A verified smaller disk working set, concurrent sessions and KV replay.
+
+The requester still supplies a local checkpoint. Gate 5 is not complete just
+because verified weight blocks are reused.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -68,7 +68,7 @@ not a completed gate.
 
 1. PR #152 merged: approved layer-allocation view, named execution evidence,
    two-donor checks; physical two-computer oracle and timings still required.
-2. In progress: Qwen3.6 has an explicit CPU resident contract (float32 dense
+2. PR #155 merged initial contracts; gate 2 remains open. Qwen3.6 has an explicit CPU resident contract (float32 dense
    and Edge, int8 expert slots even for packed int4 files, grouped scales,
    per-layer attention/DeltaNet state). Real synthetic int8 and grouped-int4
    fixtures exercise approval, two compute donors, generation and cleanup.
@@ -142,7 +142,11 @@ not a completed gate.
    Measured-cost placement remains pending; this does not enable disk mode or
    certify additional model families.
 4. Pending: connected, persisted lightweight calibration and advice.
-5. Pending: model acquisition, cache reuse and verified disk execution.
+5. In progress: reusable adapter-scoped working mirrors and shared verified
+   CAS chunks, with separate approval and fresh engine sessions on reuse.
+   Cache-directory allocation is exclusive even across different homes.
+   Model acquisition, cache-aware disk admission/eviction and verified smaller
+   disk working sets remain pending. See `HOUSEHOLD_WEIGHT_CACHE.md`.
 6. Pending: upstream-only GPU capability integration, CPU otherwise.
 7. Pending: concurrent sessions and actual replay after failure.
 8. Pending: native releases, platform validation and dependency-backed cleanup.

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -80,6 +80,13 @@ static int home_listen(int *port) {
     return lmb_home_listen_service(port);
 }
 
+static int home_control_io_ms(int fallback) {
+    /* Respect the existing operator/test timeout, but a partial control
+     * frame must not block the donor UI for the general five-minute default. */
+    int ms = lmb_env_int("LUMABRI_IO_TIMEOUT_MS", fallback, 100, 600000);
+    return ms > 10000 ? 10000 : ms;
+}
+
 /* Consumes listener, including on failure; other child descriptors stay CLOEXEC. */
 static pid_t home_spawn(char *const argv[], char *const envv[], const char *log, int *ready_fd, int listener) {
     int ready[2] = {-1, -1};
@@ -183,17 +190,35 @@ static int home_status_send(int fd, const LmbHomeTransaction *t, int segment_por
 typedef struct {
     LmbHomeTransaction transaction;
     unsigned thread_capacity;
-    int client, lease, segment_port, host_port, segment_ready, host_ready;
+    int client, lease, weight_lease, segment_port, host_port, segment_ready, host_ready;
     pid_t segment, host;
     char bin_dir[1024], cache_base[1024], disk[512], ip[INET_ADDRSTRLEN];
     char log[1200];
 } HomeDonor;
+
+/* --disk can point two different homes at the same persistent weight cache.
+ * Their RAM leases are separate files, so also serialize mutable mirrors by
+ * cache directory. Fail immediately instead of blocking a second accepted
+ * plan behind the first model's lifetime-long shared mirror lock. */
+static int home_weight_lease(const char *base) {
+    char path[1200];
+    if (checked_printf(path, sizeof path, "%s/weights.lock", base)) return -1;
+    int fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (fd < 0) return -1;
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode) || st.st_nlink != 1 ||
+        flock(fd, LOCK_EX | LOCK_NB)) {
+        close(fd); return -1;
+    }
+    return fd;
+}
 
 static void home_donor_release(HomeDonor *d, LmbHomePhase why, const char *reason) {
     home_stop_child(&d->host); home_stop_child(&d->segment);
     if (d->segment_ready >= 0) { close(d->segment_ready); d->segment_ready = -1; }
     if (d->host_ready >= 0) { close(d->host_ready); d->host_ready = -1; }
     if (d->lease >= 0) { close(d->lease); d->lease = -1; }
+    if (d->weight_lease >= 0) { close(d->weight_lease); d->weight_lease = -1; }
     d->host_port = d->segment_port = 0;
     lmb_home_released(&d->transaction, why, reason);
 }
@@ -203,8 +228,14 @@ static void home_donor_disconnect(HomeDonor *d, const char *reason) {
     if (d->client >= 0) { lmb_close(d->client); d->client = -1; }
 }
 
-/* The scope is immutable after acceptance. Both processes use a root-pinned
- * mirror, a dedicated cache namespace and the request's fixed context. */
+/* The scope is immutable after acceptance. The virtual path remains private
+ * to this request, while verified weights survive it: one working mirror per
+ * adapter and one content-addressed store per donor. The protocol model root
+ * includes the session's routing name, so it is NOT a stable cache key.
+ * A mirror's name grants no trust: the loader resets its maps on every
+ * signed-identity change, then restores matching blocks from the shared CAS.
+ * Session/KV state never goes into these weight caches. The shim still checks
+ * current signed inventory, accepted root and each block hash on reuse. */
 static int home_donor_launch(HomeDonor *d, int edge) {
     const LmbHomeOffer *o = &d->transaction.offer;
     const LmbModelFamily *family = lmb_family_for(o->model_type);
@@ -220,8 +251,8 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     if (checked_printf(shim, sizeof shim, "%s/" LMB_SHIM_NAME, d->bin_dir) ||
         checked_printf(binary, sizeof binary, "%s/%s", d->bin_dir, edge ? "lumabri" : "segment_node") ||
         checked_printf(vroot, sizeof vroot, "%s/%.16s/vroot", d->cache_base, id) ||
-        checked_printf(cache, sizeof cache, "%s/%.16s/cache", d->cache_base, id) ||
-        checked_printf(cas, sizeof cas, "%s/%.16s/cas", d->cache_base, id) ||
+        checked_printf(cache, sizeof cache, "%s/mirrors/%s/cache", d->cache_base, family->segment_id) ||
+        checked_printf(cas, sizeof cas, "%s/cas", d->cache_base) ||
         access(binary, X_OK)) return -1;
     if (access(shim, R_OK) &&
         (checked_printf(shim, sizeof shim, "%s/../lib/lumabri/" LMB_SHIM_NAME, d->bin_dir) ||
@@ -338,7 +369,7 @@ static void home_donor_screen(const HomeDonor *d, const char *name, uint64_t ram
 static int home_donor_offer(HomeDonor *d, int incoming, const char *tracker,
     uint64_t ram, uint64_t disk) {
     (void)fcntl(incoming, F_SETFD, FD_CLOEXEC);
-    lmb_set_io_timeout(incoming, 1000);
+    lmb_set_io_timeout(incoming, home_control_io_ms(1000));
     if (lmb_secure_server(incoming)) return -1;
     LmbMsg m = {0}; LmbHomeOffer offer;
     int rc = lmb_recv(incoming, &m);
@@ -415,7 +446,7 @@ static int cmd_donor(int argc, char **argv) {
     if (!tracker || !*tracker || strlen(tracker) >= 256 || !isatty(0) ||
         (name && (!*name || strlen(name) >= 64 || lmb_inventory_text(name))) || home_private_network())
         return 2;
-    HomeDonor d = {0}; d.client = d.lease = d.segment_ready = d.host_ready = -1;
+    HomeDonor d = {0}; d.client = d.lease = d.weight_lease = d.segment_ready = d.host_ready = -1;
     exe_dir(d.bin_dir, sizeof d.bin_dir);
     const char *services[] = {"segment_node", "segment_chat"};
     char service_path[1200];
@@ -507,11 +538,12 @@ static int cmd_donor(int argc, char **argv) {
                 char owner[256];
                 if (!lmb_governor_manual_paused() && d.transaction.offer.threads <= profile.logical_cpus)
                     d.lease = lmb_machine_compute_lease_acquire(d.transaction.offer.model, tracker, owner, sizeof owner);
+                if (d.lease >= 0) d.weight_lease = home_weight_lease(d.cache_base);
             }
-            if ((key == 'y' && d.lease < 0) ||
+            if ((key == 'y' && (d.lease < 0 || d.weight_lease < 0)) ||
                 lmb_home_decide(&d.transaction, key == 'y', free_ram,
                                 profile.disk_available_bytes, (uint64_t)(nowd() * 1000)))
-                home_donor_release(&d, LMB_HOME_FAILED, "Resources are no longer available or another plan owns this computer.");
+                home_donor_release(&d, LMB_HOME_FAILED, "Resources are unavailable or another plan owns this computer or weight cache.");
             if (d.client >= 0 && home_status_send(d.client, &d.transaction, 0, 0))
                 home_donor_disconnect(&d, "The requester disconnected.");
         }
@@ -631,14 +663,14 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         uint8_t expected[32];
         if (lmb_unhex(expected, st->identities[indices[i]], 32))
             return home_fail("Invalid identity for %.64s. Refresh the computer list.", nodes[i].name);
-        int fd = lmb_connect_ms_io(nodes[i].addr, 2000, 2000);
+        int fd = lmb_connect_ms_io(nodes[i].addr, 2000, home_control_io_ms(2000));
         if (fd < 0) return home_fail("Cannot reach %.64s at %.64s: %s. Check inbound permissions on that computer; no model was loaded.",
                                     nodes[i].name, nodes[i].addr, lmb_connect_why());
         int matched = lmb_secure_peer_matches(fd, expected);
         int authenticated = matched && !lmb_auth(fd);
         lmb_close(fd);
         if (!authenticated) return home_fail("Cannot authenticate %.64s at %.64s. %s No model was loaded.",
-            nodes[i].name, nodes[i].addr, matched ? "Check the household key." : "The donor identity changed; refresh the computer list.");
+            nodes[i].name, nodes[i].addr, matched ? "Check the household key and whether the donor is responding in time." : "The donor identity changed; refresh the computer list.");
     }
     HomeSession s = {0};
     for (uint32_t i = 0; i < LMB_CLUSTER_MAX_NODES; i++) s.fd[i] = -1;
@@ -741,7 +773,7 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         snprintf(s.addresses[s.count], sizeof s.addresses[0], "%s", nodes[n].addr);
         uint8_t recipient[32];
         if (lmb_unhex(recipient, st->identities[indices[n]], 32)) goto done;
-        int fd = lmb_connect_ms_io(nodes[n].addr, 1500, 1000);
+        int fd = lmb_connect_ms_io(nodes[n].addr, 1500, home_control_io_ms(1000));
         if (fd < 0) {
             home_fail("Cannot reach %.64s at %.64s while sending the request: %s.", nodes[n].name, nodes[n].addr, lmb_connect_why());
             goto done;

--- a/swarm_probe.c
+++ b/swarm_probe.c
@@ -1,4 +1,5 @@
 #include "lumabri_proto.h"
+#include "lumabri_secure.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -35,6 +36,7 @@ int main(int argc, char **argv) {
         return 2;
     }
 
+    if (lmb_secure_init()) return 1;
     LmbMsg message = {0};
     if (lmb_request(tracker, LMB_SWARM_DETAIL, NULL, 0, &message) ||
         message.op != LMB_SWARM_DETAIL_R || message.pay_len) {

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,31 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    const char *io_env = getenv("LUMABRI_IO_TIMEOUT_MS");
+    char *saved_io = io_env ? strdup(io_env) : NULL;
+    unsetenv("LUMABRI_IO_TIMEOUT_MS");
+    assert(home_control_io_ms(1000) == 1000);
+    setenv("LUMABRI_IO_TIMEOUT_MS", "5000", 1);
+    assert(home_control_io_ms(1000) == 5000);
+    setenv("LUMABRI_IO_TIMEOUT_MS", "300000", 1);
+    assert(home_control_io_ms(1000) == 10000);
+    setenv("LUMABRI_IO_TIMEOUT_MS", "invalid", 1);
+    assert(home_control_io_ms(1000) == 1000);
+    if (saved_io) { setenv("LUMABRI_IO_TIMEOUT_MS", saved_io, 1); free(saved_io); }
+    else unsetenv("LUMABRI_IO_TIMEOUT_MS");
+    char cache_dir[] = "/tmp/lumabri-weight-lease-XXXXXX", lock_path[160];
+    assert(mkdtemp(cache_dir));
+    snprintf(lock_path, sizeof lock_path, "%s/weights.lock", cache_dir);
+    int weight_lease = home_weight_lease(cache_dir);
+    assert(weight_lease >= 0 && home_weight_lease(cache_dir) < 0);
+    assert(fcntl(weight_lease, F_GETFD) & FD_CLOEXEC);
+    close(weight_lease);
+    weight_lease = home_weight_lease(cache_dir);
+    assert(weight_lease >= 0); close(weight_lease);
+    assert(!unlink(lock_path));
+    assert(!symlink("missing", lock_path));
+    assert(home_weight_lease(cache_dir) < 0);
+    assert(!unlink(lock_path) && !rmdir(cache_dir));
     LmbExecutionView execution = { .count = 2, .layers = 4 };
     for (uint32_t i = 0; i < 2; i++) {
         snprintf(execution.nodes[i].name, 64, "donor-%u", i);

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -30,11 +30,17 @@ def main():
     parser.add_argument("--context", type=int, default=128,
                         help="approved context, including the actual family chat template")
     parser.add_argument("--expect-greedy", action="store_true")
+    parser.add_argument("--repeat-cached", action="store_true",
+                        help="run a separately approved second plan; verify shared weight reuse and source byte counters")
     parser.add_argument("--expect-no-fit", action="store_true",
                         help="verify insufficient-memory admission, without starting engines")
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
+    if args.repeat_cached and (args.kill_donor or args.expect_no_fit):
+        parser.error("--repeat-cached requires a normal completed first session")
+    if args.repeat_cached and not (ROOT / "swarm_probe").is_file():
+        parser.error("build swarm_probe before running --repeat-cached")
     tmp = Path(tempfile.mkdtemp(prefix="lumabri-home-flow-"))
     children, terminals = [], []
     print(f"Household test logs: {tmp}", flush=True)
@@ -47,6 +53,13 @@ def main():
     port = listener.getsockname()[1]
     unreachable_socket = None
     addr = f"127.0.0.1:{port}"
+    # Each simulated computer has its own endpoint namespace, just as it
+    # would have its own IP on a physical LAN. Reusing one loopback endpoint
+    # for two different donor identities must (correctly) fail persistent
+    # TOFU authentication; do not erase known_hosts to make a repeat pass.
+    service_base = 12000 + (port % 200) * 160
+    service_slots = {"donor-a": 1, "donor-b": 2, "reject": 3,
+                     "chatter": 4, "chatter-repeat": 5}
 
     def env(name):
         home = tmp / name
@@ -57,6 +70,7 @@ def main():
             settings.write_text(f"tracker={addr}\ntoken=household-test\nmodels={Path(args.models_dir).resolve()}\nram={args.donor_ram_gb}\n")
             settings.chmod(0o600)
         return {**os.environ, "HOME": str(home), "LUMABRI_ENCRYPT": "1",
+                "LUMABRI_HOME_PORT_BASE": str(service_base + 16 * service_slots.get(name, 0)),
                 "LUMABRI_PEER_KEY": str(home / "peer.key"),
                 "LUMABRI_KNOWN_HOSTS": str(home / "known.hosts"),
                 "LUMABRI_TOKEN": "household-test", "LUMABRI_NO_DISK_PROBE": "1",
@@ -106,6 +120,31 @@ def main():
 
     def engines_started(name):
         return any((tmp / name).rglob("cache"))
+
+    def source_stats(chat):
+        # Source counters are published every ten seconds. Wait for a fresh
+        # heartbeat after generation; a startup counter of zero proves nothing.
+        model = re.search(r"home-[0-9a-f]{12}-[0-9a-f]{12}-[A-Za-z0-9_-]+", chat.text)
+        assert model, "chat did not identify its model session"
+        time.sleep(11)
+        p = subprocess.run(["./swarm_probe", "--tracker", addr, "--model", model.group()],
+                           cwd=ROOT, env=env("observer"), capture_output=True, text=True, timeout=15)
+        assert p.returncode == 0, p.stderr
+        sources = [row for row in json.loads(p.stdout)["peers"] if row["name"].startswith("home-source-")]
+        assert len(sources) == 1 and sources[0]["age_s"] <= 11, sources
+        return sources[0]["storage"]
+
+    def cached_weights():
+        result = {}
+        for name in ("donor-a", "donor-b"):
+            home = tmp / name / ".lumabri/home"
+            mirrors = list((home / "mirrors").glob("*/cache"))
+            assert len(mirrors) == 1 and re.fullmatch(r"[a-z0-9_]+", mirrors[0].parent.name), mirrors
+            chunks = {str(p.relative_to(home / "cas")): p.stat().st_ino
+                      for p in (home / "cas").glob("*/*") if re.fullmatch(r"[0-9a-f]{64}", p.name)}
+            assert chunks, f"{name} did not retain verified content chunks"
+            result[name] = (str(mirrors[0]), chunks)
+        return result
 
     base = ["./lumabri", "models", "--models-dir", str(Path(args.models_dir).resolve()),
             "--tracker", addr, "--context", str(args.context), "--max-new", "8"]
@@ -244,6 +283,9 @@ def main():
         chat.send("/experts\n")
         until(lambda: chat.has("executor activity"),
               message="hosted chat did not retain its household tracker for diagnostics")
+        if args.repeat_cached:
+            cold_bytes = source_stats(chat)["bytes_served"]
+            assert cold_bytes > 0, "cold run did not exercise the byte source"
         owned_groups = set()
         if args.kill_donor:
             rows = subprocess.check_output(["ps", "-axo", "pid=,ppid=,pgid="], text=True)
@@ -268,13 +310,51 @@ def main():
             until(lambda: a.has("Released") and b.has("Released"), message="donor leases were not released")
         def leases_released():
             for name in ("donor-a", "donor-b"):
-                with open(tmp / name / ".lumabri" / "compute-donor.lock", "r") as lease:
-                    try:
-                        fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                    except BlockingIOError:
-                        return False
+                for lock in ("compute-donor.lock", "home/weights.lock"):
+                    with open(tmp / name / ".lumabri" / lock, "r") as lease:
+                        try:
+                            fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        except BlockingIOError:
+                            return False
             return True
         until(leases_released, message="a child retained a donor resource lease after closing chat")
+        if args.repeat_cached:
+            before = cached_weights()
+            a.text = b.text = ""
+            repeat = Terminal("chatter-repeat", base)
+            until(lambda: repeat.has("3 computers"))
+            repeat.send("\t")
+            until(lambda: repeat.has("Nothing is selected automatically"))
+            repeat.send("\x1b[B\r\x1b[B\r\t")
+            time.sleep(.5)
+            repeat.send("\r\r")
+            until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"), seconds=60)
+            # Cached weights do not confer permission to execute again.
+            assert not repeat.has("receives the text")
+            a.send("\x1b[A\r"); b.send("\x1b[A\r")
+            until(lambda: repeat.has("receives the text") or repeat.p.poll() is not None, seconds=180)
+            assert repeat.p.poll() is None, "cached plan failed to start"
+            repeat.send("hi\n")
+            until(lambda: repeat.has("tok/s") or repeat.has("generated tokens") or repeat.p.poll() is not None,
+                  seconds=120, message="cached model did not finish a response")
+            assert repeat.p.poll() is None and "no local checkpoint" in repeat.text
+            warm = source_stats(repeat)
+            # The requester and host each inspect config.json directly to
+            # select the engine. These metadata reads still cross the wire;
+            # do not misreport a warm weight cache as zero network traffic.
+            configs = list(Path(args.models_dir).glob("*/config.json"))
+            assert len(configs) == 1, "cache counter gate requires one fixture model"
+            metadata_bytes = 2 * configs[0].stat().st_size
+            assert warm["reads"] == 2 and warm["bytes_served"] == metadata_bytes, (cold_bytes, warm)
+            assert cold_bytes > metadata_bytes
+            assert cached_weights() == before, "the same checkpoint duplicated its persistent weight cache"
+            repeat.send("/quit\n")
+            until(lambda: repeat.p.poll() is not None)
+            assert repeat.p.returncode == 0
+            until(lambda: a.has("Released") and b.has("Released"))
+            until(leases_released)
+            assert not list((tmp / "chatter-repeat").rglob("*.safetensors"))
+            print(f"HOME CACHE: PASS (new approval, same checkpoint cache, source bytes {cold_bytes} -> {warm['bytes_served']}, two config reads remain)", flush=True)
         def no_owned_processes():
             rows = subprocess.check_output(["ps", "-axo", "pgid=,stat="], text=True)
             return not any(int(row.split()[0]) in owned_groups and not row.split()[1].startswith("Z")


### PR DESCRIPTION
## Scope — roadmap gate 5, still in progress

Reuse verified household weights across separately approved sessions. Working mirrors are adapter-scoped; their namespace does not authorize bytes. The existing signed root/inventory and per-block verification remain authoritative. The protocol root includes the session routing name, so it is intentionally not used as a persistent cache directory name.

- Shared content-addressed chunks survive a completed plan; each request still starts fresh Edge/Segment state and needs all donors' approval.
- An exclusive cache-directory lease prevents two homes sharing `--disk` from competing for mutable mirrors. Both cache and RAM leases are released after owned engines stop.
- Secure `swarm_probe` can observe the encrypted household's source counters.
- Control I/O respects the existing explicit timeout, capped at ten seconds. Authentication/pinning are unchanged.
- Repeat-session integration runs in Linux and native macOS Intel/ARM CI. Simulated computers use distinct endpoint namespaces, retaining persistent TOFU identities.

## Local verification

- `test_chat_ui plan`: cache lease exclusivity, CLOEXEC, release/reacquire, symlink refusal and bounded timeout tests pass.
- Two real OLMoE Segment donors, TUI selection/rejection/approval, generation and cleanup pass.
- A second separately approved chat reuses the same mirrors and CAS inodes. Source bytes: **1,131,952 -> 1,638**, with only two `config.json` reads left. This is weight reuse, **not zero network traffic**.
- Repeated the combined flow after merging main/#157 with `--repeat-cached --expect-metrics`: pass.

## Not claimed

No physical LAN certification, full gate 5 completion, remote model acquisition, cache quota/eviction, disk working-set mode, concurrent sessions or automatic KV replay. Existing old per-request caches are left untouched. Colibri is unchanged.
