### PR TITLE
calibration: real household timings and stale-safe catalogue records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,12 @@ jobs:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
         run: |
-          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
           ./test_memory_budget
           ./test_planner
           ./test_cluster
+          ./test_calibration
           make test-runtime-probe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           python3 tests/integration/native_shim_test.py
           python3 tests/integration/household_network_test.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
         run: |
-          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration test_inventory CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
           ./test_memory_budget
           ./test_planner
           ./test_cluster
           ./test_calibration
+          ./test_inventory
           make test-runtime-probe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           python3 tests/integration/native_shim_test.py
           python3 tests/integration/household_network_test.py
@@ -133,7 +134,7 @@ jobs:
           make segment_budget_probe
           python3 tests/integration/planner_tensor_contract_test.py --family olmoe --model build/home-flow-models/olmoe-tiny
           make swarm_probe
-          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
       - name: Same greedy tokens with one and two real Segment ranges
         working-directory: lumabri
@@ -320,7 +321,7 @@ jobs:
           test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           make swarm_probe
-          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
       - uses: actions/download-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -454,7 +454,7 @@ test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h l
 test_memory_budget: tests/c/test_memory_budget.c lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h lumabri_cluster.h lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_memory_budget.c -o $@
 
-test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_planner.h
+test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_calibration_store.h lumabri_planner.h $(SECURE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_calibration.c -o $@
 
 test_metrics: tests/c/test_metrics.c lumabri_metrics.h

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ PLANNER_ADAPTER_DEPS = $(wildcard planner_adapters/*.h)
 # Adapter contracts are included transitively by the planner. Rebuild every
 # consumer when one changes, including when a new contract is introduced.
 lumabri test_chat_ui test_planner test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
+lumabri test_chat_ui: lumabri_runtime_identity.h lumabri_checkpoint_identity.h lumabri_calibration_store.h lumabri_calibration.h
 lumabri segment_chat test_chat_ui: lumabri_metrics.h
 
 lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
@@ -454,7 +455,7 @@ test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h l
 test_memory_budget: tests/c/test_memory_budget.c lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h lumabri_cluster.h lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_memory_budget.c -o $@
 
-test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_calibration_store.h lumabri_planner.h $(SECURE_DEPS)
+test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_calibration_store.h lumabri_runtime_identity.h lumabri_checkpoint_identity.h lumabri_checkpoint_inventory.h lumabri_planner.h $(SECURE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_calibration.c -o $@
 
 test_metrics: tests/c/test_metrics.c lumabri_metrics.h

--- a/docs/CALIBRATION_RECORDS.md
+++ b/docs/CALIBRATION_RECORDS.md
@@ -1,14 +1,54 @@
-# Calibration records — integration in progress
+# Speeds from real household chats
 
-`lumabri_calibration_store.h` supplies a private, bounded record format for
-exact-key measurements. It is not yet a producer of catalogue speeds. The
-remaining integration must obtain the actual participating runtime identities,
-bind the checkpoint content independently of the request routing name, and
-connect completed generation measurements to lookup/invalidation in the TUI.
-Until that is done, the catalogue continues to say **not calibrated**.
+There is no extra model download, synthetic prompt or long benchmark. A
+completed household Segment turn supplies prefill and decode timing. Once it
+has at least two generated tokens and complete execution identities, Lumabri
+saves the latest observation in `~/.lumabri/calibrations/` on the requesting
+computer. Reopening the catalogue and selecting the same donors can show
+`12.50 tok/s (last)`. This example is illustrative, not a performance claim.
 
-The format stores the conditions and numerical measurements, not prompts,
-replies, tokens or credentials. Records contain at most 32 nodes and 32 KiB.
+The detail view includes the observed prompt and output token counts. This is
+historical evidence for that plan, not a guarantee for a different prompt,
+longer conversation, changing network conditions or other machine load. The
+configured context limit is part of the key; the actual prompt length is
+recorded separately. One-token replies, legacy timing frames and incomplete
+numeric/runtime metadata cannot create a speed record.
+
+## When a number disappears
+
+Checkpoint content, adapter/numeric ABI, executable binaries, donor identity,
+hardware, addresses, threads, ordered layer ranges, Edge placement, execution
+mode, context limit and session count are bound to the observation. Changing
+the selected computers immediately invalidates the displayed plan while a
+background refresh runs. A mismatching record says **stale** and exposes no
+numerical speed. A missing or unreadable record says **not calibrated**.
+
+Each Share resources instance creates a new runtime epoch. Stopping and
+restarting it invalidates previous observations even if its binaries have not
+changed. This conservatively avoids reusing a result from a different launch
+environment. Restart sharing after updating runtimes or dynamic libraries;
+this is not live attestation of arbitrary library changes or a dishonest host.
+GPU discovery never substitutes for an actual execution backend.
+
+The runtime fingerprint hashes the installed Lumabri, Segment node, Segment
+chat and shim binaries. Unchanged hashes are cached after stat checks. Model
+content is identified from the source's existing hash sidecars, without
+reading weight payloads again. Before recording, that content is checked
+against the signed routing root of the approved session. Per-request routing
+names therefore do not prevent reuse of the same checkpoint's observations.
+Missing or stale sidecars withhold the measurement; they do not weaken the
+signed model checks or prevent an otherwise valid chat.
+
+Upgrade the tracker, requester and donors together: machine inventory is now
+version 3. The Hosted greeting has optional numeric ABI metadata. Old
+inventory versions are rejected explicitly rather than treated as a complete
+calibration identity. An older host without metadata can still serve chat,
+but cannot produce these records.
+
+## Storage and limits
+
+The format stores conditions, numerical measurements and token counts, not
+prompts, replies, token IDs or credentials. Records contain at most 32 nodes and 32 KiB.
 Integers and binary64 values have an explicit little-endian representation;
 C structure padding, locale and host endianness are not part of the format.
 
@@ -19,11 +59,34 @@ Truncated, malformed, non-finite and checksum-invalid records are rejected,
 as are unsafe names, symlinks, FIFOs, hardlinked files and non-private paths.
 The checksum detects corruption; it does not attest a remote host's work.
 
-Keys require all identity and execution fields. Empty keys, unterminated
+Keys require all identity and execution fields; commit provenance is optional
+but exact binary identities are required. Empty keys, unterminated
 strings, unknown thread counts and empty ranges cannot establish a match.
 Changing any matched condition makes a previous speed stale. The producer
-must still verify where each field came from: passing structural validation
-does not make invented build IDs or a partial key authoritative.
+verifies where each field came from: structural validation alone would not
+make invented build IDs or a partial key authoritative.
+
+The C TUI and JSON export consume the same owned snapshot. JSON returns
+`calibration: null` when absent, and `decode_tok_s: null` when stale. This
+feature does not yet provide a calibrated cost model for placement or a
+quality ranking across model families.
+
+## Verification
 
 Run `make test_calibration && ./test_calibration`. Native macOS workspace CI
 runs the same record and key tests; Linux also runs them in the ordinary suite.
+`make test_inventory` additionally validates runtime identity fields. Chat UI
+tests cover numeric readiness metadata and immediate selection invalidation.
+
+With a real small checkpoint, run:
+
+```sh
+python3 tests/integration/home_flow_test.py --models-dir /path/to/model-parent \
+  --expect-metrics --expect-calibration --repeat-cached
+```
+
+This starts an isolated tracker and two donor TUIs, requires approval,
+generates a real reply, reopens the catalogue and invalidates the speed after
+context, selection and donor-runtime changes. It also verifies cached weights
+still require new approval. Linux and native macOS CI run this loopback gate;
+it is not a physical LAN throughput measurement.

--- a/docs/CALIBRATION_RECORDS.md
+++ b/docs/CALIBRATION_RECORDS.md
@@ -1,0 +1,29 @@
+# Calibration records — integration in progress
+
+`lumabri_calibration_store.h` supplies a private, bounded record format for
+exact-key measurements. It is not yet a producer of catalogue speeds. The
+remaining integration must obtain the actual participating runtime identities,
+bind the checkpoint content independently of the request routing name, and
+connect completed generation measurements to lookup/invalidation in the TUI.
+Until that is done, the catalogue continues to say **not calibrated**.
+
+The format stores the conditions and numerical measurements, not prompts,
+replies, tokens or credentials. Records contain at most 32 nodes and 32 KiB.
+Integers and binary64 values have an explicit little-endian representation;
+C structure padding, locale and host endianness are not part of the format.
+
+Each private directory holds one latest record per checkpoint. A temporary
+file is written and synced before atomic replacement. A failed load clears
+the output rather than leaving an earlier record available by accident.
+Truncated, malformed, non-finite and checksum-invalid records are rejected,
+as are unsafe names, symlinks, FIFOs, hardlinked files and non-private paths.
+The checksum detects corruption; it does not attest a remote host's work.
+
+Keys require all identity and execution fields. Empty keys, unterminated
+strings, unknown thread counts and empty ranges cannot establish a match.
+Changing any matched condition makes a previous speed stale. The producer
+must still verify where each field came from: passing structural validation
+does not make invented build IDs or a partial key authoritative.
+
+Run `make test_calibration && ./test_calibration`. Native macOS workspace CI
+runs the same record and key tests; Linux also runs them in the ordinary suite.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -143,9 +143,13 @@ not a completed gate.
    certify additional model families.
 4. PR #157 merged: versioned measurements collected during ordinary Segment chat,
    separating prefill, decode traversals and first visible text. No extra model
-   run is required. Persisted exact-key calibration, stale-data handling and
-   catalogue advice remain pending; timing collection alone does not close gate 4.
-5. In progress: reusable adapter-scoped working mirrors and shared verified
+   run is required. PR #159 connects completed household turns to private
+   content/runtime-bound records and catalogue lookup. Context, selected
+   computers and donor restarts invalidate old speeds; the last observed
+   workload is shown separately from the configured context limit. Placement
+   cost calibration and catalogue advice remain pending; this is not the
+   entire gate 4. See `CALIBRATION_RECORDS.md` for its exact contract.
+5. PR #158 merged: reusable adapter-scoped working mirrors and shared verified
    CAS chunks, with separate approval and fresh engine sessions on reuse.
    Cache-directory allocation is exclusive even across different homes.
    Model acquisition, cache-aware disk admission/eviction and verified smaller

--- a/lumabri.c
+++ b/lumabri.c
@@ -68,6 +68,15 @@
 #include "lumabri_secure.h"
 #include "lumabri_inventory.h"
 #include "lumabri_home.h"
+#include "lumabri_runtime_identity.h"
+#include "lumabri_runtime_probe.h"
+#include "lumabri_checkpoint_identity.h"
+#include "lumabri_calibration_store.h"
+
+/* Borrowed by the synchronous household chat only. Ordinary/legacy hosts
+ * cannot create an entry without an approved plan and actual numeric metadata. */
+static LmbCalibration *g_recording_calibration;
+static const char *g_calibration_directory;
 
 /* ---- terminal ----------------------------------------------------------- */
 
@@ -2403,6 +2412,8 @@ typedef struct {
     int segment;
     int greedy_only; /* actual Edge capability, not a model-name assumption */
     EngineTransport transport;
+    uint32_t numeric_abi;
+    char numeric_class[97];
 } Engine;
 
 static int artifact_is(const char *value, const char *name) {
@@ -2470,6 +2481,7 @@ static char *read_until_prompt(int fd) {
  * Returns 0, or -1 if the child died first. */
 static int engine_wait_ready(Engine *e) {
     e->greedy_only = 0;
+    e->numeric_abi = 0; e->numeric_class[0] = 0;
     size_t cap = 8192, len = 0;
     char *buf = malloc(cap);
     if (!buf) return -1;
@@ -2486,6 +2498,15 @@ static int engine_wait_ready(Engine *e) {
         buf[len] = 0;
         if (memmem(buf, len, FRAME_READY, strlen(FRAME_READY))) {
             e->greedy_only = strstr(buf, "\nLUMABRI_SAMPLING GREEDY\n") != NULL;
+            const char *numeric = strstr(buf, "\nLUMABRI_NUMERIC ");
+            if (numeric) {
+                unsigned abi = 0; char value[97] = ""; int consumed = 0;
+                if (sscanf(numeric, "\nLUMABRI_NUMERIC %u %96[^\n]%n", &abi, value, &consumed) == 2 && abi &&
+                    consumed > 0 && numeric[consumed] == '\n' &&
+                    lmb_cal_text(value, sizeof value)) {
+                    e->numeric_abi = abi; snprintf(e->numeric_class, sizeof e->numeric_class, "%s", value);
+                }
+            }
             e->proto = PROTO_FRAMED; free(buf); return 0;
         }
         if ((len >= 3 && !memcmp(buf + len - 3, "\n> ", 3)) ||
@@ -3227,7 +3248,12 @@ static int host_greet(int fd, const HostState *h, int busy) {
     lmb_buf_u32(&b, 2);       /* SUBMIT/DATA/DONE, independent of model family */
     /* Optional capability word after codec. Older clients reject the extra
      * field rather than silently request unsupported stochastic sampling. */
-    if (h->engine->greedy_only) lmb_buf_u32(&b, 1);
+    if (h->engine->greedy_only || h->engine->numeric_abi) lmb_buf_u32(&b, (uint32_t)h->engine->greedy_only);
+    if (h->engine->numeric_abi) {
+        lmb_buf_u32(&b, 0x314d554e); /* NUM1, optional measured runtime metadata */
+        lmb_buf_u32(&b, h->engine->numeric_abi);
+        lmb_buf_str(&b, h->engine->numeric_class);
+    }
     int rc = lmb_send(fd, LMB_HOST_HELLO_R, b.p, (uint32_t)b.len, NULL, 0);
     free(b.p);
     return rc;
@@ -3586,6 +3612,14 @@ static int host_connect(const char *addr, const char *model_type, const char *ex
         fprintf(stderr, "[lumabri] unsupported host sampling capabilities\n");
         lmb_msg_free(&m); lmb_close(fd); return -1;
     }
+    uint32_t numeric_tag = 0, numeric_abi = 0;
+    char numeric_class[97] = "";
+    if (c.off < c.len && (lmb_cur_u32(&c, &numeric_tag) || numeric_tag != 0x314d554e ||
+        lmb_cur_u32(&c, &numeric_abi) || !numeric_abi ||
+        lmb_inventory_string(&c, numeric_class, sizeof numeric_class) || !numeric_class[0])) {
+        fprintf(stderr, "[lumabri] unsupported host numeric metadata\n");
+        lmb_msg_free(&m); lmb_close(fd); return -1;
+    }
     if (c.off != c.len || m.pay_len) { lmb_msg_free(&m); lmb_close(fd); return -1; }
     lmb_msg_free(&m);
     if (model_type && model_type[0] && strcmp(model_type, mtype)) {
@@ -3624,6 +3658,8 @@ static int host_connect(const char *addr, const char *model_type, const char *ex
     e->to = e->from = pair[0];
     e->kind = kind_id;
     e->greedy_only = (int)sampling_flags;
+    e->numeric_abi = numeric_abi;
+    snprintf(e->numeric_class, sizeof e->numeric_class, "%s", numeric_class);
     e->proto = codec == 2 || kind_is_serve2(e->kind) ? PROTO_SERVE2 : PROTO_FRAMED;
     g_signal_engine_fd = (sig_atomic_t)pair[0];
 
@@ -4791,13 +4827,29 @@ static int cmd_chat(int argc, char **argv) {
         /* STAT <tokens> <tok/s> <cache hit%> <rss GB> */
         double tps = 0, hit = 0, rss = 0;
         int ntok = 0;
-        int nstat = sscanf(stat, "STAT %d %lf %lf %lf", &ntok, &tps, &hit, &rss);
+        unsigned prompt_count = 0;
+        int nstat = sscanf(stat, "STAT %d %lf %lf %lf %u", &ntok, &tps, &hit, &rss, &prompt_count);
         double dmb = g_eng.net_mb - m0;
         double end = nowd(), first = g_first_token_at;
         LmbGenerationMetrics metrics;
         int metric_status=lmb_metrics_parse(stat,&metrics);
         if(metric_status==0 && metrics.generated_tokens!=(uint32_t)ntok) metric_status=-1;
         if(metric_status==0) {
+            if (g_recording_calibration && g_calibration_directory && eng.numeric_abi &&
+                nstat >= 5 && prompt_count && lmb_metrics_decode_rate(&metrics) > 0) {
+                LmbCalibration record = *g_recording_calibration;
+                record.key.adapter_abi = eng.numeric_abi;
+                snprintf(record.key.numeric_class, sizeof record.key.numeric_class, "%s", eng.numeric_class);
+                record.decode_tok_s = lmb_metrics_decode_rate(&metrics);
+                record.ttft_seconds = first > r0 ? first - r0 : metrics.prefill_seconds;
+                record.measured_at = (double)time(NULL); record.samples = 1;
+                record.prompt_tokens = prompt_count; record.generated_tokens = metrics.generated_tokens;
+                if (!lmb_cal_store(g_calibration_directory, &record))
+                    *g_recording_calibration = record;
+                else fprintf(stderr, "[lumabri] Could not save this measurement; the reply is unaffected.\n");
+            }
+            if (g_recording_calibration && !eng.numeric_abi)
+                fprintf(stderr, "[calibration] No speed saved: the host did not supply its numeric ABI.\n");
             printf("%s  host prefill %.1fs · %u generated tokens",C_DIM,
                    metrics.prefill_seconds,metrics.generated_tokens);
             double rate=lmb_metrics_decode_rate(&metrics);
@@ -5017,6 +5069,7 @@ static void inventory_id_text(const uint8_t id[32], char out[65]) {
 static int catalog_inventory(LmbTuiState *st) {
     memset(st->nodes, 0, sizeof st->nodes);
     memset(st->identities, 0, sizeof st->identities);
+    memset(st->runtime_ids, 0, sizeof st->runtime_ids);
     memset(st->ages_ms, 0, sizeof st->ages_ms);
     catalog_self(&st->nodes[0], &st->profiles[0], st->disk[0] ? st->disk : ".");
     st->nnodes = 1;
@@ -5049,6 +5102,8 @@ static int catalog_inventory(LmbTuiState *st) {
         node->ram_budget_bytes = r->ram_budget_bytes;
         node->vram_budget_bytes = r->machine.vram_available_bytes;
         node->threads = r->machine.logical_cpus;
+        if (r->runtime_threads && node->threads > r->runtime_threads) node->threads = r->runtime_threads;
+        snprintf(st->runtime_ids[at], sizeof st->runtime_ids[at], "%s", r->runtime_id);
         /* Resource reporting is not executable Segment capability. No remote
          * card is promoted to a supported backend by an inventory advert. */
         node->gpu_backends = 0;
@@ -5058,6 +5113,51 @@ static int catalog_inventory(LmbTuiState *st) {
         inventory_id_text(r->identity, st->identities[at]);
     }
     return 0;
+}
+
+static int catalog_calibration_dir(char out[1200]) {
+    const char *home = getenv("HOME");
+    return !home || checked_printf(out, 1200, "%s/.lumabri/calibrations", home);
+}
+
+static void catalog_hardware_id(const LmbMachineProfile *p, const char *address, char out[65]) {
+    LmbSha sha; uint8_t digest[32]; lmb_sha_init(&sha);
+    const char *fields[] = {p->os, p->arch, p->cpu_model, p->isa, address};
+    for (unsigned i = 0; i < sizeof fields / sizeof *fields; i++)
+        lmb_sha_update(&sha, fields[i], strlen(fields[i]) + 1);
+    lmb_sha_le32(&sha, p->logical_cpus); lmb_sha_le32(&sha, p->physical_cores);
+    lmb_sha_le32(&sha, p->numa_nodes); lmb_sha_le64(&sha, p->ram_total_bytes);
+    lmb_sha_le32(&sha, p->gpu_count); lmb_sha_le64(&sha, p->vram_total_bytes);
+    lmb_sha_final(&sha, digest); lmb_hex(out, digest, sizeof digest);
+}
+
+static int catalog_calibration_key(const LmbTuiState *st, const LmbTuiModel *m,
+    uint32_t abi, const char *numeric, LmbCalKey *key) {
+    memset(key, 0, sizeof *key);
+    if (!m->planned || m->plan.state != LMB_PLAN_RESIDENT || !m->content_id[0] ||
+        !st->build_id[0] || !m->plan.nslices || m->plan.nslices > LMB_CAL_NODES_MAX) return -1;
+    snprintf(key->model_root, sizeof key->model_root, "%s", m->content_id);
+    snprintf(key->adapter, sizeof key->adapter, "%s", m->shape.segment_id);
+    snprintf(key->build_id, sizeof key->build_id, "%s", st->build_id);
+    snprintf(key->plan_kind, sizeof key->plan_kind, "segment");
+    snprintf(key->numeric_class, sizeof key->numeric_class, "%s", numeric ? numeric : "");
+    key->adapter_abi = abi; key->goal = m->plan.goal;
+    key->context = st->context; key->sessions = st->sessions; key->nodes = m->plan.nslices;
+    int edge = 0;
+    for (uint32_t i = 0; i < key->nodes; i++) {
+        const LmbSlice *slice = &m->plan.slices[i]; uint32_t n = slice->node;
+        if (n >= st->nnodes || !st->identities[n][0] || !st->runtime_ids[n][0]) return -1;
+        if (n == m->plan.edge_node) { key->edge_node = i; edge = 1; }
+        snprintf(key->node_id[i], sizeof key->node_id[i], "%s", st->identities[n]);
+        snprintf(key->node_build_id[i], sizeof key->node_build_id[i], "%s", st->runtime_ids[n]);
+        snprintf(key->node_backend[i], sizeof key->node_backend[i], "cpu");
+        catalog_hardware_id(&st->profiles[n], st->nodes[n].addr, key->node_hardware_id[i]);
+        key->layer_begin[i] = slice->layer_begin; key->layer_end[i] = slice->layer_end;
+        key->threads[i] = st->nodes[n].threads > 256 ? 256 : st->nodes[n].threads;
+    }
+    /* ABI/numeric may be unknown until the real Edge greeting. All other
+     * fields must already be bound; the writer validates the completed key. */
+    return edge ? 0 : -1;
 }
 
 static int catalog_state_refresh(LmbTuiState *st, void *unused) {
@@ -5073,6 +5173,12 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
     int n = catalog_scan(st->root, found, LMB_TUI_MAX_MODELS);
     st->nmodels = 0;
     (void)catalog_inventory(st);
+    static LmbBinaryDigest self_digest;
+    char bin_dir[1024], binary[1200], calibration_dir[1200]; uint8_t digest[32];
+    exe_dir(bin_dir, sizeof bin_dir); st->build_id[0] = 0;
+    if (!checked_printf(binary, sizeof binary, "%s/lumabri", bin_dir) &&
+        !lmb_binary_digest(binary, &self_digest, digest)) lmb_hex(st->build_id, digest, 32);
+    int have_cal_dir = !catalog_calibration_dir(calibration_dir);
     for (int i = 0; i < n; i++) {
         LmbTuiModel *m = &st->models[st->nmodels];
         memset(m, 0, sizeof *m);
@@ -5104,9 +5210,12 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
             for (uint32_t j = 0; j < m->plan.nslices; j++)
                 m->plan.slices[j].node = mapping[m->plan.slices[j].node];
         }
-        /* Runtime/checkpoint binding to the record store is not connected
-         * yet. Never manufacture a partial key in the renderer. */
-        m->calibration = NULL;
+        if (have_cal_dir && !lmb_checkpoint_identity(m->dir, m->content_id, NULL, NULL) &&
+            !lmb_cal_load(calibration_dir, m->content_id, &m->calibration)) {
+            m->has_calibration = 1;
+            m->calibration_key_valid = !catalog_calibration_key(st, m, m->calibration.key.adapter_abi,
+                m->calibration.key.numeric_class, &m->calibration_key) && lmb_cal_key_valid(&m->calibration_key);
+        }
         st->nmodels++;
     }
     free(found);
@@ -5140,9 +5249,12 @@ static void catalog_row(const LmbTuiModel *m) {
     /* The speed column is deliberately not a number. It becomes one when a
      * calibration exists for THIS model on THIS cluster with THIS plan, and
      * not one moment earlier. */
+    char speed[128] = "not calibrated";
+    if (m->has_calibration) lmb_cal_speed_text(&m->calibration,
+        m->calibration_key_valid ? &m->calibration_key : NULL, speed, sizeof speed);
     printf("  %s%-2s%s %-22s %-14s %-28s %s\n",
            mark[0] == 'x' ? C_RED : mark[0] == '!' ? C_CORAL : C_GRN,
-           mark, C_R, m->name, state, detail, "not calibrated");
+           mark, C_R, m->name, state, detail, speed);
 }
 
 static void json_string(FILE *out, const char *s) {
@@ -5205,8 +5317,19 @@ static void catalog_json(const LmbTuiState *st) {
                planned ? "true" : "false");
         json_string(stdout, planned ? lmb_plan_state_name(plan->state) :
                                      "cannot plan");
-        printf(",\"missing_bytes\":%llu,\"calibration\":null}",
+        printf(",\"missing_bytes\":%llu,\"calibration\":",
                (unsigned long long)(planned ? plan->missing_bytes : 0));
+        if (!model->has_calibration) fputs("null", stdout);
+        else {
+            int current = model->calibration_key_valid &&
+                lmb_cal_matches(&model->calibration.key, &model->calibration_key);
+            printf("{\"state\":\"%s\",\"measured_at\":%.0f,\"samples\":%u,\"prompt_tokens\":%u,\"generated_tokens\":%u,\"decode_tok_s\":",
+                current ? "measured" : "stale", model->calibration.measured_at, model->calibration.samples,
+                model->calibration.prompt_tokens, model->calibration.generated_tokens);
+            if (current) printf("%.6f", model->calibration.decode_tok_s); else fputs("null", stdout);
+            fputc('}', stdout);
+        }
+        fputc('}', stdout);
     }
     fputs("]}\n", stdout);
 }
@@ -5297,12 +5420,14 @@ static int cmd_models(int argc, char **argv) {
  * does not reserve RAM, launch engines or download checkpoint blocks. */
 static int cmd_worker(int argc, char **argv) {
     const char *tracker = NULL, *name = NULL, *disk = ".", *control = "";
+    const char *runtime_epoch = NULL;
     uint64_t limit = UINT64_MAX;
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "--join") && i + 1 < argc) tracker = argv[++i];
         else if (!strcmp(argv[i], "--name") && i + 1 < argc) name = argv[++i];
         else if (!strcmp(argv[i], "--disk") && i + 1 < argc) disk = argv[++i];
         else if (!strcmp(argv[i], "--control-address") && i + 1 < argc) control = argv[++i];
+        else if (!strcmp(argv[i], "--runtime-epoch") && i + 1 < argc) runtime_epoch = argv[++i];
         else if (!strcmp(argv[i], "--ram-gb") && i + 1 < argc) {
             char *end;
             double gb = strtod(argv[++i], &end);
@@ -5326,6 +5451,15 @@ static int cmd_worker(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
     LmbMachineProfile profile;
     if (lmb_machine_probe(&profile, disk, NULL)) return 1;
+    LmbRuntimeIdentityCache runtime_cache = {0};
+    char runtime_dir[1024], runtime_binary[1200], runtime_id[65] = "";
+    unsigned runtime_threads = 0;
+    if (runtime_epoch) {
+        exe_dir(runtime_dir, sizeof runtime_dir);
+        if (!control[0] || checked_printf(runtime_binary, sizeof runtime_binary, "%s/segment_node", runtime_dir) ||
+            lmb_runtime_thread_capacity(runtime_binary, &runtime_threads) ||
+            lmb_runtime_identity(runtime_dir, runtime_epoch, &runtime_cache, runtime_id)) return 1;
+    }
     printf("worker: reporting this computer to %s; waiting for a model plan\n", tracker);
     fflush(stdout);
     while (!g_stopping) {
@@ -5342,6 +5476,10 @@ static int cmd_worker(int argc, char **argv) {
             LmbMachineReport report = {0};
             memcpy(report.identity, pk, sizeof pk);
             snprintf(report.control_addr, sizeof report.control_addr, "%s", control);
+            if (runtime_epoch && !lmb_runtime_identity(runtime_dir, runtime_epoch, &runtime_cache, runtime_id)) {
+                snprintf(report.runtime_id, sizeof report.runtime_id, "%s", runtime_id);
+                report.runtime_threads = runtime_threads;
+            }
             lmb_machine_refresh_resources(&profile, disk);
             report.machine = profile;
             if (name) snprintf(report.machine.hostname, sizeof report.machine.hostname, "%s", name);

--- a/lumabri.c
+++ b/lumabri.c
@@ -5104,8 +5104,8 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
             for (uint32_t j = 0; j < m->plan.nslices; j++)
                 m->plan.slices[j].node = mapping[m->plan.slices[j].node];
         }
-        /* A calibration store is not implemented yet. Never manufacture a
-         * partial key in the renderer: no record means no speed. */
+        /* Runtime/checkpoint binding to the record store is not connected
+         * yet. Never manufacture a partial key in the renderer. */
         m->calibration = NULL;
         st->nmodels++;
     }

--- a/lumabri_calibration.h
+++ b/lumabri_calibration.h
@@ -19,6 +19,7 @@
 #define LUMABRI_CALIBRATION_H
 
 #include <stdint.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include "lumabri_planner.h"
@@ -29,14 +30,14 @@ typedef struct {
     char model_root[65];        /* the checkpoint's signed identity */
     char adapter[32];
     uint32_t adapter_abi;
-    char numeric_class[48];     /* what the nodes agreed to compute in */
+    char numeric_class[97];     /* Segment numeric class, including terminator */
     char commit_lumabri[41];
     char commit_colibri[41];
     char build_id[65];          /* compiler, flags, engine configuration */
     char plan_kind[16];         /* segment or expert */
     uint32_t goal;              /* LmbPlanGoal without including cluster.h */
     uint32_t nodes;
-    char node_id[LMB_CAL_NODES_MAX][64];
+    char node_id[LMB_CAL_NODES_MAX][65]; /* 32-byte identity in hex + NUL */
     char node_hardware_id[LMB_CAL_NODES_MAX][65];
     char node_build_id[LMB_CAL_NODES_MAX][65];
     char node_backend[LMB_CAL_NODES_MAX][16];
@@ -56,11 +57,45 @@ typedef struct {
     uint32_t samples;           /* how many runs the median came from */
 } LmbCalibration;
 
+/* Never compare unterminated fields or let two equally incomplete records
+ * establish a match. These checks also bound data loaded from disk. */
+static LMB_UNUSED int lmb_cal_text(const char *s, size_t cap) {
+    const char *end = memchr(s, 0, cap);
+    if (!end || end == s) return 0;
+    for (; s != end; s++) if ((unsigned char)*s < 32 || (unsigned char)*s > 126) return 0;
+    return 1;
+}
+
+static LMB_UNUSED int lmb_cal_key_valid(const LmbCalKey *k) {
+    if (!k || !k->nodes || k->nodes > LMB_CAL_NODES_MAX ||
+        !k->adapter_abi || !k->context || !k->sessions || k->goal > 1) return 0;
+#define CAL_TEXT(f) if (!lmb_cal_text(k->f, sizeof k->f)) return 0
+    CAL_TEXT(model_root); CAL_TEXT(adapter); CAL_TEXT(numeric_class);
+    CAL_TEXT(commit_lumabri); CAL_TEXT(commit_colibri); CAL_TEXT(build_id); CAL_TEXT(plan_kind);
+    if (strcmp(k->plan_kind, "segment") && strcmp(k->plan_kind, "expert")) return 0;
+    for (uint32_t i = 0; i < k->nodes; i++) {
+        CAL_TEXT(node_id[i]); CAL_TEXT(node_hardware_id[i]);
+        CAL_TEXT(node_build_id[i]); CAL_TEXT(node_backend[i]);
+        if (!k->threads[i] || k->layer_begin[i] >= k->layer_end[i] ||
+            k->from_disk[i] > 1) return 0;
+    }
+#undef CAL_TEXT
+    return 1;
+}
+
+static LMB_UNUSED int lmb_cal_valid(const LmbCalibration *c) {
+    return c && lmb_cal_key_valid(&c->key) && c->samples &&
+           isfinite(c->decode_tok_s) && c->decode_tok_s > 0 &&
+           isfinite(c->ttft_seconds) && c->ttft_seconds >= 0 &&
+           isfinite(c->measured_at) && c->measured_at > 0;
+}
+
 /* Everything in the key, in order, and nothing outside it. Deliberately not
  * a hash: a mismatch has to be able to say WHICH field moved, because "your
  * measurement is stale" without a reason is how people learn to ignore it. */
 static LMB_UNUSED const char *lmb_cal_mismatch(const LmbCalKey *a,
                                                const LmbCalKey *b) {
+    if (!lmb_cal_key_valid(a) || !lmb_cal_key_valid(b)) return "incomplete measurement conditions";
     if (strcmp(a->model_root, b->model_root))       return "the checkpoint";
     if (strcmp(a->adapter, b->adapter))             return "the adapter";
     if (a->adapter_abi != b->adapter_abi)           return "the adapter ABI";
@@ -107,6 +142,7 @@ static LMB_UNUSED void lmb_cal_speed_text(const LmbCalibration *have,
                                           const LmbCalKey *want,
                                           char *out, size_t cap) {
     if (!have) { snprintf(out, cap, "not calibrated"); return; }
+    if (!lmb_cal_valid(have)) { snprintf(out, cap, "invalid measurement — recalibrate"); return; }
     const char *moved = lmb_cal_mismatch(&have->key, want);
     if (moved) {
         snprintf(out, cap, "stale (%.20s changed) — recalibrate", moved);

--- a/lumabri_calibration.h
+++ b/lumabri_calibration.h
@@ -27,16 +27,17 @@
 #define LMB_CAL_NODES_MAX 32
 
 typedef struct {
-    char model_root[65];        /* the checkpoint's signed identity */
+    char model_root[65];        /* content identity, checked against the signed routing root */
     char adapter[32];
     uint32_t adapter_abi;
     char numeric_class[97];     /* Segment numeric class, including terminator */
-    char commit_lumabri[41];
+    char commit_lumabri[41];    /* optional provenance; exact binary IDs remain required */
     char commit_colibri[41];
     char build_id[65];          /* compiler, flags, engine configuration */
     char plan_kind[16];         /* segment or expert */
     uint32_t goal;              /* LmbPlanGoal without including cluster.h */
     uint32_t nodes;
+    uint32_t edge_node;         /* index in this key's ordered ranges */
     char node_id[LMB_CAL_NODES_MAX][65]; /* 32-byte identity in hex + NUL */
     char node_hardware_id[LMB_CAL_NODES_MAX][65];
     char node_build_id[LMB_CAL_NODES_MAX][65];
@@ -54,7 +55,9 @@ typedef struct {
     double decode_tok_s;
     double ttft_seconds;
     double measured_at;         /* wall clock, for the operator, not for matching */
-    uint32_t samples;           /* how many runs the median came from */
+    uint32_t samples;           /* completed turns represented by this record */
+    uint32_t prompt_tokens;     /* observed workload, not the configured context limit */
+    uint32_t generated_tokens;
 } LmbCalibration;
 
 /* Never compare unterminated fields or let two equally incomplete records
@@ -67,11 +70,15 @@ static LMB_UNUSED int lmb_cal_text(const char *s, size_t cap) {
 }
 
 static LMB_UNUSED int lmb_cal_key_valid(const LmbCalKey *k) {
-    if (!k || !k->nodes || k->nodes > LMB_CAL_NODES_MAX ||
+    if (!k || !k->nodes || k->nodes > LMB_CAL_NODES_MAX || k->edge_node >= k->nodes ||
         !k->adapter_abi || !k->context || !k->sessions || k->goal > 1) return 0;
 #define CAL_TEXT(f) if (!lmb_cal_text(k->f, sizeof k->f)) return 0
     CAL_TEXT(model_root); CAL_TEXT(adapter); CAL_TEXT(numeric_class);
-    CAL_TEXT(commit_lumabri); CAL_TEXT(commit_colibri); CAL_TEXT(build_id); CAL_TEXT(plan_kind);
+    if (!memchr(k->commit_lumabri, 0, sizeof k->commit_lumabri) ||
+        !memchr(k->commit_colibri, 0, sizeof k->commit_colibri)) return 0;
+    if (k->commit_lumabri[0]) { CAL_TEXT(commit_lumabri); }
+    if (k->commit_colibri[0]) { CAL_TEXT(commit_colibri); }
+    CAL_TEXT(build_id); CAL_TEXT(plan_kind);
     if (strcmp(k->plan_kind, "segment") && strcmp(k->plan_kind, "expert")) return 0;
     for (uint32_t i = 0; i < k->nodes; i++) {
         CAL_TEXT(node_id[i]); CAL_TEXT(node_hardware_id[i]);
@@ -85,6 +92,8 @@ static LMB_UNUSED int lmb_cal_key_valid(const LmbCalKey *k) {
 
 static LMB_UNUSED int lmb_cal_valid(const LmbCalibration *c) {
     return c && lmb_cal_key_valid(&c->key) && c->samples &&
+           c->prompt_tokens && c->prompt_tokens <= c->key.context &&
+           c->generated_tokens > 1 && c->generated_tokens <= 1048576 &&
            isfinite(c->decode_tok_s) && c->decode_tok_s > 0 &&
            isfinite(c->ttft_seconds) && c->ttft_seconds >= 0 &&
            isfinite(c->measured_at) && c->measured_at > 0;
@@ -108,6 +117,7 @@ static LMB_UNUSED const char *lmb_cal_mismatch(const LmbCalKey *a,
     if (a->context != b->context)                   return "the context length";
     if (a->sessions != b->sessions)                 return "the session count";
     if (a->nodes != b->nodes)                       return "the number of machines";
+    if (a->edge_node != b->edge_node)               return "the Edge host";
     if (a->nodes > LMB_CAL_NODES_MAX || b->nodes > LMB_CAL_NODES_MAX)
         return "an invalid machine count";
     for (uint32_t i = 0; i < a->nodes; i++) {
@@ -148,7 +158,7 @@ static LMB_UNUSED void lmb_cal_speed_text(const LmbCalibration *have,
         snprintf(out, cap, "stale (%.20s changed) — recalibrate", moved);
         return;
     }
-    snprintf(out, cap, "%.2f tok/s", have->decode_tok_s);
+    snprintf(out, cap, "%.2f tok/s (last)", have->decode_tok_s);
 }
 
 /* Compose the build id from what actually varies between two binaries of the

--- a/lumabri_calibration_store.h
+++ b/lumabri_calibration_store.h
@@ -24,10 +24,10 @@ static LMB_UNUSED int lmb_cal_get_double(LmbCur *c, double *value) {
 }
 static LMB_UNUSED int lmb_cal_get_text(LmbCur *c, char *out, size_t cap) {
     uint16_t n;
-    if (lmb_cur_u16(c, &n) || !n || n >= cap || c->off > c->len ||
+    if (lmb_cur_u16(c, &n) || n >= cap || c->off > c->len ||
         n > c->len - c->off || memchr(c->p + c->off, 0, n)) return -1;
     memcpy(out, c->p + c->off, n); out[n] = 0; c->off += n;
-    return lmb_cal_text(out, cap) ? 0 : -1;
+    return !n || lmb_cal_text(out, cap) ? 0 : -1;
 }
 
 static LMB_UNUSED int lmb_cal_encode(const LmbCalibration *r, LmbBuf *out) {
@@ -40,7 +40,7 @@ static LMB_UNUSED int lmb_cal_encode(const LmbCalibration *r, LmbBuf *out) {
     PUT(lmb_buf_bytes(&b, "LMB-CAL1", 8));
     STR(model_root); STR(adapter); U32(adapter_abi); STR(numeric_class);
     STR(commit_lumabri); STR(commit_colibri); STR(build_id); STR(plan_kind);
-    U32(goal); U32(nodes); U32(context); U32(sessions);
+    U32(goal); U32(nodes); U32(edge_node); U32(context); U32(sessions);
     for (uint32_t i = 0; i < k->nodes; i++) {
         STR(node_id[i]); STR(node_hardware_id[i]); STR(node_build_id[i]); STR(node_backend[i]);
         U32(layer_begin[i]); U32(layer_end[i]); U32(threads[i]); U32(from_disk[i]);
@@ -49,6 +49,8 @@ static LMB_UNUSED int lmb_cal_encode(const LmbCalibration *r, LmbBuf *out) {
     PUT(lmb_cal_put_double(&b, r->ttft_seconds));
     PUT(lmb_cal_put_double(&b, r->measured_at));
     PUT(lmb_buf_u32(&b, r->samples));
+    PUT(lmb_buf_u32(&b, r->prompt_tokens));
+    PUT(lmb_buf_u32(&b, r->generated_tokens));
     lmb_sha_init(&sha); lmb_sha_update(&sha, b.p, b.len); lmb_sha_final(&sha, digest);
     PUT(lmb_buf_bytes(&b, digest, sizeof digest));
     if (b.len > LMB_CAL_RECORD_MAX) goto bad;
@@ -74,7 +76,7 @@ static LMB_UNUSED int lmb_cal_decode(const void *data, size_t len, LmbCalibratio
 #define U32(f) GET(lmb_cur_u32(&c, &k->f))
     STR(model_root); STR(adapter); U32(adapter_abi); STR(numeric_class);
     STR(commit_lumabri); STR(commit_colibri); STR(build_id); STR(plan_kind);
-    U32(goal); U32(nodes); U32(context); U32(sessions);
+    U32(goal); U32(nodes); U32(edge_node); U32(context); U32(sessions);
     if (!k->nodes || k->nodes > LMB_CAL_NODES_MAX) return -1;
     for (uint32_t i = 0; i < k->nodes; i++) {
         STR(node_id[i]); STR(node_hardware_id[i]); STR(node_build_id[i]); STR(node_backend[i]);
@@ -87,6 +89,8 @@ static LMB_UNUSED int lmb_cal_decode(const void *data, size_t len, LmbCalibratio
     GET(lmb_cal_get_double(&c, &r.ttft_seconds));
     GET(lmb_cal_get_double(&c, &r.measured_at));
     GET(lmb_cur_u32(&c, &r.samples));
+    GET(lmb_cur_u32(&c, &r.prompt_tokens));
+    GET(lmb_cur_u32(&c, &r.generated_tokens));
     if (c.off != c.len || !lmb_cal_valid(&r)) return -1;
     *out = r; return 0;
 #undef GET

--- a/lumabri_calibration_store.h
+++ b/lumabri_calibration_store.h
@@ -1,0 +1,177 @@
+/* Private, bounded calibration records. The checksum detects torn/corrupt
+ * records, not dishonest hosts. No prompt, reply, token or credential is
+ * stored. Publication to the catalogue still requires an exact valid key. */
+#ifndef LUMABRI_CALIBRATION_STORE_H
+#define LUMABRI_CALIBRATION_STORE_H
+#include <float.h>
+#include <sys/stat.h>
+#include "lumabri_proto.h"
+#include "lumabri_sha.h"
+#include "lumabri_calibration.h"
+
+#define LMB_CAL_RECORD_MAX 32768u
+_Static_assert(sizeof(double) == 8 && DBL_MANT_DIG == 53 && DBL_MAX_EXP == 1024,
+               "calibration records require binary64 doubles");
+
+static LMB_UNUSED int lmb_cal_put_double(LmbBuf *b, double value) {
+    uint64_t bits; memcpy(&bits, &value, sizeof bits);
+    return lmb_buf_u64(b, bits);
+}
+static LMB_UNUSED int lmb_cal_get_double(LmbCur *c, double *value) {
+    uint64_t bits;
+    if (lmb_cur_u64(c, &bits)) return -1;
+    memcpy(value, &bits, sizeof bits); return 0;
+}
+static LMB_UNUSED int lmb_cal_get_text(LmbCur *c, char *out, size_t cap) {
+    uint16_t n;
+    if (lmb_cur_u16(c, &n) || !n || n >= cap || c->off > c->len ||
+        n > c->len - c->off || memchr(c->p + c->off, 0, n)) return -1;
+    memcpy(out, c->p + c->off, n); out[n] = 0; c->off += n;
+    return lmb_cal_text(out, cap) ? 0 : -1;
+}
+
+static LMB_UNUSED int lmb_cal_encode(const LmbCalibration *r, LmbBuf *out) {
+    if (!out || out->len || !lmb_cal_valid(r)) return -1;
+    const LmbCalKey *k = &r->key;
+    LmbBuf b = {0}; uint8_t digest[32]; LmbSha sha;
+#define PUT(call) do { if (call) goto bad; } while (0)
+#define STR(f) PUT(lmb_buf_str(&b, k->f))
+#define U32(f) PUT(lmb_buf_u32(&b, k->f))
+    PUT(lmb_buf_bytes(&b, "LMB-CAL1", 8));
+    STR(model_root); STR(adapter); U32(adapter_abi); STR(numeric_class);
+    STR(commit_lumabri); STR(commit_colibri); STR(build_id); STR(plan_kind);
+    U32(goal); U32(nodes); U32(context); U32(sessions);
+    for (uint32_t i = 0; i < k->nodes; i++) {
+        STR(node_id[i]); STR(node_hardware_id[i]); STR(node_build_id[i]); STR(node_backend[i]);
+        U32(layer_begin[i]); U32(layer_end[i]); U32(threads[i]); U32(from_disk[i]);
+    }
+    PUT(lmb_cal_put_double(&b, r->decode_tok_s));
+    PUT(lmb_cal_put_double(&b, r->ttft_seconds));
+    PUT(lmb_cal_put_double(&b, r->measured_at));
+    PUT(lmb_buf_u32(&b, r->samples));
+    lmb_sha_init(&sha); lmb_sha_update(&sha, b.p, b.len); lmb_sha_final(&sha, digest);
+    PUT(lmb_buf_bytes(&b, digest, sizeof digest));
+    if (b.len > LMB_CAL_RECORD_MAX) goto bad;
+    free(out->p); *out = b; return 0;
+bad:
+    free(b.p); return -1;
+#undef PUT
+#undef STR
+#undef U32
+}
+
+static LMB_UNUSED int lmb_cal_decode(const void *data, size_t len, LmbCalibration *out) {
+    if (!out) return -1;
+    memset(out, 0, sizeof *out);
+    if (!data || len < 40 || len > LMB_CAL_RECORD_MAX || memcmp(data, "LMB-CAL1", 8)) return -1;
+    uint8_t digest[32]; LmbSha sha;
+    lmb_sha_init(&sha); lmb_sha_update(&sha, data, len - 32); lmb_sha_final(&sha, digest);
+    if (memcmp(digest, (const uint8_t *)data + len - 32, 32)) return -1;
+    LmbCur c = {(const uint8_t *)data, len - 32, 8};
+    LmbCalibration r = {0}; LmbCalKey *k = &r.key;
+#define GET(call) do { if (call) return -1; } while (0)
+#define STR(f) GET(lmb_cal_get_text(&c, k->f, sizeof k->f))
+#define U32(f) GET(lmb_cur_u32(&c, &k->f))
+    STR(model_root); STR(adapter); U32(adapter_abi); STR(numeric_class);
+    STR(commit_lumabri); STR(commit_colibri); STR(build_id); STR(plan_kind);
+    U32(goal); U32(nodes); U32(context); U32(sessions);
+    if (!k->nodes || k->nodes > LMB_CAL_NODES_MAX) return -1;
+    for (uint32_t i = 0; i < k->nodes; i++) {
+        STR(node_id[i]); STR(node_hardware_id[i]); STR(node_build_id[i]); STR(node_backend[i]);
+        U32(layer_begin[i]); U32(layer_end[i]); U32(threads[i]);
+        uint32_t disk; GET(lmb_cur_u32(&c, &disk));
+        if (disk > 1) return -1;
+        k->from_disk[i] = (uint8_t)disk;
+    }
+    GET(lmb_cal_get_double(&c, &r.decode_tok_s));
+    GET(lmb_cal_get_double(&c, &r.ttft_seconds));
+    GET(lmb_cal_get_double(&c, &r.measured_at));
+    GET(lmb_cur_u32(&c, &r.samples));
+    if (c.off != c.len || !lmb_cal_valid(&r)) return -1;
+    *out = r; return 0;
+#undef GET
+#undef STR
+#undef U32
+}
+
+static LMB_UNUSED int lmb_cal_filename(const char *root, char out[69]) {
+    if (!root || strnlen(root, 65) != 64) return -1;
+    for (size_t i = 0; i < 64; i++)
+        if (!((root[i] >= '0' && root[i] <= '9') || (root[i] >= 'a' && root[i] <= 'f'))) return -1;
+    snprintf(out, 69, "%s.cal", root); return 0;
+}
+
+static LMB_UNUSED int lmb_cal_directory(const char *path, int create) {
+    if (!path || !*path) return -1;
+    if (create && mkdir(path, 0700) && errno != EEXIST) return -1;
+    int fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0) return -1;
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISDIR(st.st_mode) || st.st_uid != geteuid() || (st.st_mode & 077)) {
+        close(fd); return -1;
+    }
+    return fd;
+}
+
+/* One latest record per checkpoint. Atomic replacement never exposes a
+ * partial key. Multiple writers may replace each other's latest measurement,
+ * but cannot mix fields from different runs. Caller owns the private parent. */
+static LMB_UNUSED int lmb_cal_store(const char *directory, const LmbCalibration *r) {
+    char name[69], temp[96]; LmbBuf b = {0};
+    if (!r || lmb_cal_filename(r->key.model_root, name) || lmb_cal_encode(r, &b)) return -1;
+    int dir = lmb_cal_directory(directory, 1), fd = -1, rc = -1;
+    if (dir < 0) { free(b.p); return -1; }
+    for (unsigned i = 0; i < 128; i++) {
+        snprintf(temp, sizeof temp, ".record-%ld-%u.tmp", (long)getpid(), i);
+        fd = openat(dir, temp, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0600);
+        if (fd >= 0 || errno != EEXIST) break;
+    }
+    if (fd >= 0) {
+        size_t at = 0;
+        while (at < b.len) {
+            ssize_t n = write(fd, b.p + at, b.len - at);
+            if (n < 0 && errno == EINTR) continue;
+            if (n <= 0) break;
+            at += (size_t)n;
+        }
+        int ready = at == b.len && !fsync(fd);
+        if (close(fd)) ready = 0;
+        if (ready && !renameat(dir, temp, dir, name)) rc = fsync(dir) ? -1 : 0;
+        (void)unlinkat(dir, temp, 0);
+    }
+    close(dir); free(b.p); return rc;
+}
+
+/* Failure clears the caller's record: an earlier successful lookup may never
+ * survive a missing, malformed or inaccessible replacement as current data. */
+static LMB_UNUSED int lmb_cal_load(const char *directory, const char *root, LmbCalibration *out) {
+    if (!out) return -1;
+    memset(out, 0, sizeof *out);
+    char name[69];
+    if (lmb_cal_filename(root, name)) return -1;
+    int dir = lmb_cal_directory(directory, 0);
+    if (dir < 0) return -1;
+    int fd = openat(dir, name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+    close(dir);
+    if (fd < 0) return -1;
+    struct stat st; int rc = -1;
+    if (!fstat(fd, &st) && S_ISREG(st.st_mode) && st.st_uid == geteuid() && st.st_nlink == 1 &&
+        !(st.st_mode & 077) && st.st_size >= 40 && st.st_size <= LMB_CAL_RECORD_MAX) {
+        size_t len = (size_t)st.st_size, at = 0;
+        uint8_t *bytes = malloc(len);
+        if (bytes) {
+            while (at < len) {
+                ssize_t n = read(fd, bytes + at, len - at);
+                if (n < 0 && errno == EINTR) continue;
+                if (n <= 0) break;
+                at += (size_t)n;
+            }
+            uint8_t extra;
+            if (at == len && read(fd, &extra, 1) == 0) rc = lmb_cal_decode(bytes, len, out);
+            if (!rc && strcmp(out->key.model_root, root)) { memset(out, 0, sizeof *out); rc = -1; }
+            free(bytes);
+        }
+    }
+    close(fd); return rc;
+}
+#endif

--- a/lumabri_checkpoint_identity.h
+++ b/lumabri_checkpoint_identity.h
@@ -1,0 +1,87 @@
+/* Lightweight identity lookup from the maintainer's existing hash sidecars.
+ * No weight bytes are read here. Missing/stale sidecars mean unknown, never
+ * a guessed identity. Execution still checks the signed routing root. */
+#ifndef LUMABRI_CHECKPOINT_IDENTITY_H
+#define LUMABRI_CHECKPOINT_IDENTITY_H
+#include "lumabri_checkpoint_inventory.h"
+#include "lumabri_runtime_identity.h"
+
+typedef struct {
+    LmbModelItem items[LMB_CONTENT_MAX_FILES];
+    size_t count, hash_bytes;
+} LmbCheckpointHashes;
+
+static LMB_MAYBE_UNUSED int lmb_checkpoint_cached_hash(const char *root, const char *rel,
+    const struct stat *observed, void *arg) {
+    LmbCheckpointHashes *h = arg;
+    char path[1600];
+    int n = snprintf(path, sizeof path, "%s/%s", root, rel);
+    if (n < 0 || (size_t)n >= sizeof path || h->count >= LMB_CONTENT_MAX_FILES) return -1;
+    int weight = open(path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+    if (weight < 0) return -1;
+    struct stat before, after;
+    if (fstat(weight, &before) || !S_ISREG(before.st_mode) || before.st_size < 0 ||
+        !lmb_stat_same(observed, &before)) { close(weight); return -1; }
+    uint64_t chunks = ((uint64_t)before.st_size + (1u << 20) - 1) >> 20;
+    if (chunks > ((64u << 20) - h->hash_bytes) / 32) { close(weight); return -1; }
+    n = snprintf(path, sizeof path, "%s/.lumabri_hashes/%s.sha", root, rel);
+    if (n < 0 || (size_t)n >= sizeof path) { close(weight); return -1; }
+    int fd = open(path, O_RDONLY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
+    if (fd < 0) { close(weight); return -1; }
+    /* This is the local LSH1 sidecar written by maintainer.c, not a new wire
+     * format. All supported source platforms use its same fixed layout. */
+    struct {
+        uint32_t magic, version;
+        uint64_t size, mtime_ns, ctime_ns;
+        uint32_t nh, reserved;
+    } hdr;
+    _Static_assert(sizeof hdr == 40, "unexpected LSH1 sidecar layout");
+    struct stat sidecar;
+    int valid = !fstat(fd, &sidecar) && S_ISREG(sidecar.st_mode) &&
+        sidecar.st_size == (off_t)(sizeof hdr + chunks * 32);
+    size_t bytes = sizeof hdr + (size_t)chunks * 32, at = 0;
+    uint8_t *data = valid ? malloc(bytes) : NULL;
+    if (data) while (at < bytes) {
+        ssize_t got = read(fd, data + at, bytes - at);
+        if (got < 0 && errno == EINTR) continue;
+        if (got <= 0) break;
+        at += (size_t)got;
+    }
+    close(fd);
+    valid = data && at == bytes && !fstat(weight, &after) && lmb_stat_same(&before, &after);
+    close(weight);
+    if (!valid) { free(data); return -1; }
+    memcpy(&hdr, data, sizeof hdr);
+    if (hdr.magic != 0x3148534Cu || hdr.version != 1 || hdr.reserved ||
+        hdr.size != (uint64_t)before.st_size || hdr.nh != chunks ||
+        hdr.mtime_ns != lmb_stat_mtime_ns(&before) || hdr.ctime_ns != lmb_stat_ctime_ns(&before)) {
+        free(data); return -1;
+    }
+    char *name = strdup(rel);
+    uint8_t *hashes = malloc((size_t)chunks * 32 + 1);
+    if (!name || !hashes) { free(name); free(hashes); free(data); return -1; }
+    memcpy(hashes, data + sizeof hdr, (size_t)chunks * 32); free(data);
+    h->items[h->count++] = (LmbModelItem){name, hdr.size, hdr.nh, hashes};
+    h->hash_bytes += (size_t)chunks * 32;
+    return 0;
+}
+
+static LMB_MAYBE_UNUSED int lmb_checkpoint_identity(const char *directory, char content[65],
+    const char *routing_name, uint8_t routing_root[32]) {
+    if (!content) return -1;
+    content[0] = 0;
+    if (routing_root) memset(routing_root, 0, 32);
+    if (!directory || !*directory || (!!routing_name != !!routing_root)) return -1;
+    LmbCheckpointHashes *hashes = calloc(1, sizeof *hashes);
+    if (!hashes) return -1;
+    LmbCheckpointInventory inventory = {0}; uint8_t digest[32];
+    int bad = lmb_checkpoint_walk(directory, "", 0, &inventory, lmb_checkpoint_cached_hash, hashes) ||
+        !hashes->count || lmb_model_root("lumabri-calibration-content-v1", hashes->items, hashes->count, digest);
+    if (!bad && routing_name) bad = lmb_model_root(routing_name, hashes->items, hashes->count, routing_root);
+    if (!bad) for (unsigned i = 0; i < 32; i++) snprintf(content + 2 * i, 3, "%02x", digest[i]);
+    for (size_t i = 0; i < hashes->count; i++) {
+        free((void *)hashes->items[i].path); free((void *)hashes->items[i].hashes);
+    }
+    free(hashes); return bad ? -1 : 0;
+}
+#endif

--- a/lumabri_checkpoint_inventory.h
+++ b/lumabri_checkpoint_inventory.h
@@ -15,8 +15,10 @@ typedef struct {
     int has_weights;
 } LmbCheckpointInventory;
 
+typedef int (*LmbCheckpointVisitor)(const char *, const char *, const struct stat *, void *);
+
 static int lmb_checkpoint_walk(const char *root, const char *rel, unsigned depth,
-                                LmbCheckpointInventory *out) {
+                                LmbCheckpointInventory *out, LmbCheckpointVisitor visit, void *arg) {
     if (depth > 32) return -1;
     char directory[1024];
     int len = snprintf(directory, sizeof directory, "%s%s%s", root, *rel ? "/" : "", rel);
@@ -41,7 +43,7 @@ static int lmb_checkpoint_walk(const char *root, const char *rel, unsigned depth
         if (S_ISDIR(st.st_mode)) {
             /* Weight-file symlinks (HF caches) work; directory symlinks may
              * form cycles and are not accepted by this bounded preview. */
-            if (S_ISLNK(link.st_mode) || lmb_checkpoint_walk(root, child, depth + 1, out)) {
+            if (S_ISLNK(link.st_mode) || lmb_checkpoint_walk(root, child, depth + 1, out, visit, arg)) {
                 rc = -1; break;
             }
         } else if (S_ISREG(st.st_mode)) {
@@ -49,6 +51,7 @@ static int lmb_checkpoint_walk(const char *root, const char *rel, unsigned depth
                 UINT64_MAX - out->bytes < (uint64_t)st.st_size) { rc = -1; break; }
             out->files++;
             out->bytes += (uint64_t)st.st_size;
+            if (visit && visit(root, child, &st, arg)) { rc = -1; break; }
             const char *dot = strrchr(name, '.');
             if (st.st_size >= 4096 && dot && (!strcmp(dot, ".safetensors") ||
                 !strcmp(dot, ".bin") || !strcmp(dot, ".gguf") || !strcmp(dot, ".coli")))
@@ -59,10 +62,10 @@ static int lmb_checkpoint_walk(const char *root, const char *rel, unsigned depth
     return rc;
 }
 
-static int lmb_checkpoint_inventory(const char *root, LmbCheckpointInventory *out) {
+static inline int lmb_checkpoint_inventory(const char *root, LmbCheckpointInventory *out) {
     if (!out) return -1;
     memset(out, 0, sizeof *out);
-    if (!root || !*root || lmb_checkpoint_walk(root, "", 0, out)) {
+    if (!root || !*root || lmb_checkpoint_walk(root, "", 0, out, NULL, NULL)) {
         memset(out, 0, sizeof *out);
         return -1;
     }

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -194,6 +194,8 @@ typedef struct {
     pid_t segment, host;
     char bin_dir[1024], cache_base[1024], disk[512], ip[INET_ADDRSTRLEN];
     char log[1200];
+    char runtime_epoch[65], runtime_id[65];
+    LmbRuntimeIdentityCache runtime_cache;
 } HomeDonor;
 
 /* --disk can point two different homes at the same persistent weight cache.
@@ -237,6 +239,12 @@ static void home_donor_disconnect(HomeDonor *d, const char *reason) {
  * Session/KV state never goes into these weight caches. The shim still checks
  * current signed inventory, accepted root and each block hash on reuse. */
 static int home_donor_launch(HomeDonor *d, int edge) {
+    char current_runtime[65];
+    if (lmb_runtime_identity(d->bin_dir, d->runtime_epoch, &d->runtime_cache, current_runtime) ||
+        strcmp(current_runtime, d->runtime_id)) {
+        fprintf(stderr, "The installed runtime changed. Restart Share resources before accepting a new plan.\n");
+        return -1;
+    }
     const LmbHomeOffer *o = &d->transaction.offer;
     const LmbModelFamily *family = lmb_family_for(o->model_type);
     if (!family) return -1;
@@ -463,6 +471,9 @@ static int cmd_donor(int argc, char **argv) {
     if (checked_printf(service_path, sizeof service_path, "%s/segment_node", d.bin_dir) ||
         lmb_runtime_thread_capacity(service_path, &d.thread_capacity))
         return home_fail("Cannot query the installed Segment runtime. Rebuild the complete household runtime; no resources were shared.");
+    uint8_t epoch[32]; lmb_random(epoch, sizeof epoch); lmb_hex(d.runtime_epoch, epoch, sizeof epoch);
+    if (lmb_runtime_identity(d.bin_dir, d.runtime_epoch, &d.runtime_cache, d.runtime_id))
+        return home_fail("Cannot identify the installed household runtime. No resources were shared.");
     if (checked_printf(d.cache_base, sizeof d.cache_base, "%s/%s", disk ? disk :
                        (getenv("HOME") ? getenv("HOME") : "."), disk ? "lumabri-home" : ".lumabri/home") ||
         home_local_ip(tracker, d.ip))
@@ -491,7 +502,7 @@ static int cmd_donor(int argc, char **argv) {
     snprintf(report_log, sizeof report_log, "%s/inventory.log", d.cache_base);
     char *worker_argv[] = {own_bin, "worker", "--join", (char *)tracker,
         "--name", (char *)name, "--ram-gb", budget, "--disk", d.cache_base,
-        "--control-address", addr, NULL};
+        "--control-address", addr, "--runtime-epoch", d.runtime_epoch, NULL};
     pid_t reporter = home_spawn(worker_argv, NULL, report_log, NULL, -1);
     if (reporter <= 0) { close(listener); return home_fail("Cannot start the inventory reporter: %s.", strerror(errno)); }
     g_stopping = 0; install_chat_signal_handlers(); signal(SIGPIPE, SIG_IGN);
@@ -726,6 +737,9 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         (void)poll(NULL, 0, 200);
     }
     if (!found) goto done;
+    uint8_t indexed_root[32];
+    if (lmb_checkpoint_identity(m->dir, m->content_id, model, indexed_root) ||
+        memcmp(indexed_root, identity.root, sizeof indexed_root)) m->content_id[0] = 0;
     stage = "validating the indexed plan";
     if (lmb_home_plan_budgets(&m->shape, swarm.total_bytes, nodes, count,
                              st->context, &plan) || plan.state != LMB_PLAN_RESIDENT) {
@@ -852,7 +866,42 @@ static int home_request_chat(LmbTuiState *st, int selected) {
                                  "--role", "chat", "--max-new", token_limit, "--host-key", expected_host,
                                  "--tracker", st->tracker};
             g_execution_view = &execution;
+            LmbCalibration measurement = {0}; char measurement_dir[1200];
+            LmbTuiModel measured = *m;
+            measured.plan = plan;
+            measured.planned = 1; /* the actual revalidated plan, not an earlier UI snapshot */
+            measured.plan.edge_node = indices[plan.edge_node];
+            for (uint32_t j = 0; j < measured.plan.nslices; j++)
+                measured.plan.slices[j].node = indices[plan.slices[j].node];
+            int can_record = !catalog_calibration_dir(measurement_dir) &&
+                !catalog_calibration_key(st, &measured, 0, NULL, &measurement.key);
+            if (can_record) {
+                LmbMachineReport current[LMB_INVENTORY_MAX]; uint32_t current_count = 0;
+                can_record = !lmb_inventory_fetch(st->tracker, current, &current_count);
+                for (uint32_t j = 0; can_record && j < measurement.key.nodes; j++) {
+                    int matched = 0;
+                    for (uint32_t k = 0; k < current_count; k++) {
+                        char peer[65], hardware[65]; lmb_hex(peer, current[k].identity, 32);
+                        catalog_hardware_id(&current[k].machine, current[k].control_addr, hardware);
+                        if (!strcmp(peer, measurement.key.node_id[j]) &&
+                            !strcmp(hardware, measurement.key.node_hardware_id[j]) &&
+                            !strcmp(current[k].runtime_id, measurement.key.node_build_id[j])) matched = 1;
+                    }
+                    if (!matched) {
+                        fprintf(stderr, "[calibration] Donor %u no longer matches the approved runtime inventory.\n", j + 1);
+                        can_record = 0;
+                    }
+                }
+            }
+            g_recording_calibration = can_record ? &measurement : NULL;
+            g_calibration_directory = can_record ? measurement_dir : NULL;
+            if (!can_record)
+                fprintf(stderr, "[calibration] No speed will be saved: %s.\n",
+                        !m->content_id[0] ? "checkpoint content identity is unavailable" :
+                        !st->build_id[0] ? "client binary identity is unavailable" :
+                        "the approved plan's runtime identities are incomplete or changed");
             result = cmd_chat(14, chat_argv);
+            g_recording_calibration = NULL; g_calibration_directory = NULL;
             g_execution_view = NULL;
             atomic_store(&s.stop, 1); pthread_join(heartbeat, NULL);
             if (atomic_load(&s.failed)) result = -1;

--- a/lumabri_inventory.h
+++ b/lumabri_inventory.h
@@ -5,7 +5,7 @@
 #include "lumabri_proto.h"
 #include "lumabri_machine.h"
 
-#define LMB_INVENTORY_VERSION 2u
+#define LMB_INVENTORY_VERSION 3u
 #define LMB_INVENTORY_MAX 32u
 #define LMB_INVENTORY_TTL_MS 15000u
 #define LMB_INVENTORY_HEARTBEAT_MS 5000u
@@ -16,6 +16,8 @@ typedef struct {
     uint64_t ram_budget_bytes;
     uint32_t age_ms;
     char control_addr[64];      /* empty for an inventory-only worker */
+    char runtime_id[65];        /* executable hashes + active donor epoch; empty = unknown */
+    uint32_t runtime_threads;   /* queried installed engine, not detected CPU cores */
 } LmbMachineReport;
 
 /* Lengths and control characters are checked before any field reaches a
@@ -51,7 +53,8 @@ static LMB_MAYBE_UNUSED int lmb_inventory_pack(LmbBuf *b,
     INV_U64(vram_total_bytes); INV_U64(vram_available_bytes);
     INV_U64(disk_available_bytes); INV_U64(disk_read_bps);
 #undef INV_U64
-    return lmb_buf_u64(b, r->ram_budget_bytes) || lmb_buf_str(b, r->control_addr);
+    return lmb_buf_u64(b, r->ram_budget_bytes) || lmb_buf_str(b, r->control_addr) ||
+           lmb_buf_str(b, r->runtime_id) || lmb_buf_u32(b, r->runtime_threads);
 }
 
 static LMB_MAYBE_UNUSED int lmb_inventory_unpack(LmbCur *c,
@@ -76,7 +79,16 @@ static LMB_MAYBE_UNUSED int lmb_inventory_unpack(LmbCur *c,
     INV_U64(disk_available_bytes); INV_U64(disk_read_bps);
 #undef INV_U64
     if (lmb_cur_u64(c, &r->ram_budget_bytes) ||
-        lmb_inventory_string(c, r->control_addr, sizeof r->control_addr)) return -1;
+        lmb_inventory_string(c, r->control_addr, sizeof r->control_addr) ||
+        lmb_inventory_string(c, r->runtime_id, sizeof r->runtime_id) ||
+        lmb_cur_u32(c, &r->runtime_threads)) return -1;
+    if (r->runtime_threads > 256 || (!!r->runtime_threads != !!r->runtime_id[0])) return -1;
+    if (r->runtime_id[0]) {
+        if (strlen(r->runtime_id) != 64 || !r->control_addr[0]) return -1;
+        for (unsigned i = 0; i < 64; i++)
+            if (!((r->runtime_id[i] >= '0' && r->runtime_id[i] <= '9') ||
+                  (r->runtime_id[i] >= 'a' && r->runtime_id[i] <= 'f'))) return -1;
+    }
     uint8_t nonzero = 0;
     for (size_t i = 0; i < sizeof r->identity; i++) nonzero |= r->identity[i];
     if (!nonzero || !m->hostname[0] || !m->logical_cpus ||

--- a/lumabri_runtime_identity.h
+++ b/lumabri_runtime_identity.h
@@ -1,0 +1,89 @@
+/* A conservative identity for the currently running donor's launch context.
+ * A new donor epoch invalidates measurements even if the binaries are equal:
+ * inherited engine environment and dynamic-library state are not guessed.
+ * No model is opened. Unchanged executable hashes are reused after stat checks. */
+#ifndef LUMABRI_RUNTIME_IDENTITY_H
+#define LUMABRI_RUNTIME_IDENTITY_H
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "lumabri_platform.h"
+#include "lumabri_sha.h"
+
+static LMB_MAYBE_UNUSED uint64_t lmb_stat_mtime_ns(const struct stat *s) {
+#ifdef __APPLE__
+    return (uint64_t)s->st_mtimespec.tv_sec * 1000000000ull + (uint64_t)s->st_mtimespec.tv_nsec;
+#else
+    return (uint64_t)s->st_mtim.tv_sec * 1000000000ull + (uint64_t)s->st_mtim.tv_nsec;
+#endif
+}
+static LMB_MAYBE_UNUSED uint64_t lmb_stat_ctime_ns(const struct stat *s) {
+#ifdef __APPLE__
+    return (uint64_t)s->st_ctimespec.tv_sec * 1000000000ull + (uint64_t)s->st_ctimespec.tv_nsec;
+#else
+    return (uint64_t)s->st_ctim.tv_sec * 1000000000ull + (uint64_t)s->st_ctim.tv_nsec;
+#endif
+}
+static LMB_MAYBE_UNUSED int lmb_stat_same(const struct stat *a, const struct stat *b) {
+    return a->st_dev == b->st_dev && a->st_ino == b->st_ino && a->st_size == b->st_size &&
+           a->st_mode == b->st_mode && lmb_stat_mtime_ns(a) == lmb_stat_mtime_ns(b) &&
+           lmb_stat_ctime_ns(a) == lmb_stat_ctime_ns(b);
+}
+typedef struct { struct stat stat; uint8_t digest[32]; int valid; } LmbBinaryDigest;
+typedef struct { LmbBinaryDigest files[4]; } LmbRuntimeIdentityCache;
+
+static LMB_MAYBE_UNUSED int lmb_binary_digest(const char *path, LmbBinaryDigest *cache, uint8_t out[32]) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC | O_NONBLOCK);
+    if (fd < 0) return -1;
+    struct stat before, after;
+    if (fstat(fd, &before) || !S_ISREG(before.st_mode) || before.st_size <= 0 ||
+        (uint64_t)before.st_size > (UINT64_C(1) << 30)) { close(fd); return -1; }
+    if (cache->valid && lmb_stat_same(&cache->stat, &before)) {
+        memcpy(out, cache->digest, 32); close(fd); return 0;
+    }
+    uint8_t buf[65536], digest[32]; uint64_t total = 0; LmbSha sha;
+    lmb_sha_init(&sha);
+    while (total < (uint64_t)before.st_size) {
+        size_t want = (uint64_t)before.st_size - total > sizeof buf ? sizeof buf : (size_t)((uint64_t)before.st_size - total);
+        ssize_t n = read(fd, buf, want);
+        if (n < 0 && errno == EINTR) continue;
+        if (n <= 0) { close(fd); cache->valid = 0; return -1; }
+        lmb_sha_update(&sha, buf, (size_t)n); total += (uint64_t)n;
+    }
+    int stable = !fstat(fd, &after) && lmb_stat_same(&before, &after);
+    close(fd);
+    if (!stable) { cache->valid = 0; return -1; }
+    lmb_sha_final(&sha, digest); cache->stat = before;
+    memcpy(cache->digest, digest, 32); cache->valid = 1;
+    memcpy(out, digest, 32); return 0;
+}
+
+static LMB_MAYBE_UNUSED int lmb_runtime_identity(const char *bin_dir, const char *epoch,
+    LmbRuntimeIdentityCache *cache, char out[65]) {
+    out[0] = 0;
+    if (!bin_dir || !epoch || strnlen(epoch, 65) != 64 || !cache) return -1;
+    for (size_t i = 0; i < 64; i++)
+        if (!((epoch[i] >= '0' && epoch[i] <= '9') || (epoch[i] >= 'a' && epoch[i] <= 'f'))) return -1;
+    const char *names[] = {"lumabri", "segment_node", "segment_chat", LMB_SHIM_NAME};
+    LmbSha sha; lmb_sha_init(&sha);
+    lmb_sha_update(&sha, "lumabri-donor-runtime-v1", sizeof "lumabri-donor-runtime-v1");
+    lmb_sha_update(&sha, epoch, 64);
+    for (unsigned i = 0; i < 4; i++) {
+        char path[1200]; uint8_t digest[32];
+        int n = snprintf(path, sizeof path, "%s/%s", bin_dir, names[i]);
+        if (n < 0 || (size_t)n >= sizeof path) return -1;
+        if (i == 3 && access(path, R_OK)) {
+            n = snprintf(path, sizeof path, "%s/../lib/lumabri/%s", bin_dir, names[i]);
+            if (n < 0 || (size_t)n >= sizeof path) return -1;
+        }
+        if (lmb_binary_digest(path, &cache->files[i], digest)) return -1;
+        lmb_sha_update(&sha, names[i], strlen(names[i]) + 1);
+        lmb_sha_update(&sha, digest, 32);
+    }
+    uint8_t digest[32]; lmb_sha_final(&sha, digest);
+    for (unsigned i = 0; i < 32; i++) snprintf(out + 2 * i, 3, "%02x", digest[i]);
+    return 0;
+}
+#endif

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -1746,8 +1746,8 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
     /* Report capabilities before READY, so a pipe reader cannot consume
      * readiness first and lose a later capability line. Direct CLI requests
      * for unavailable stochastic sampling still fail explicitly. */
-    printf("\nLUMABRI_SAMPLING %s\n" SEGMENT_FRAME_READY "\nSTAT 0 0 0 0\n",
-           cap->flags & COLI_EDGE_CAP_LOGITS ? "LOGITS" : "GREEDY");
+    printf("\nLUMABRI_SAMPLING %s\nLUMABRI_NUMERIC %u %s\n" SEGMENT_FRAME_READY "\nSTAT 0 0 0 0\n",
+           cap->flags & COLI_EDGE_CAP_LOGITS ? "LOGITS" : "GREEDY", cap->abi_version, cap->numeric_class);
     fflush(stdout);
     LmbSampler sampler;
     lmb_sampler_init(&sampler, seed);

--- a/src/ui/lumabri_tui.c
+++ b/src/ui/lumabri_tui.c
@@ -142,12 +142,12 @@ static const char *state_word(const LmbTuiModel *m) {
 /* What the SPEED column says, and the rule it obeys: a number only when a
  * calibration exists for this exact plan. */
 static void speed_text(const LmbTuiModel *m, char *out, size_t cap) {
-    if (!m->calibration) { snprintf(out, cap, "not calibrated"); return; }
+    if (!m->has_calibration) { snprintf(out, cap, "not calibrated"); return; }
     if (!m->calibration_key_valid) {
         snprintf(out, cap, "stale (plan key unavailable)");
         return;
     }
-    lmb_cal_speed_text(m->calibration, &m->calibration_key, out, cap);
+    lmb_cal_speed_text(&m->calibration, &m->calibration_key, out, cap);
 }
 
 static void human_bytes(uint64_t b, char *out, size_t cap) {
@@ -405,7 +405,7 @@ static void draw_detail(const LmbTuiState *st, Size sz, int sel) {
     speed_text(m, speed, sizeof speed);
     at(row++, 1);
     printf("  %sSPEED%s   %s", c(DIM), c(OFF), speed);
-    if (!m->calibration) {
+    if (!m->has_calibration) {
         at(row++, 1);
         printf("  %sa number appears here after a calibration on these "
                "machines with this plan%s", c(DIM), c(OFF));
@@ -493,6 +493,10 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
         ui_printf(11, 5, UI_MUTED, "%s · %u layers · %u context · %u session(s)",
                   m->shape.model_type, m->shape.layers, st->context, st->sessions);
         ui_printf(13, 5, UI_TEXT, "Plan: %s    Speed: %s", state_word(m), speed);
+        if (m->has_calibration && m->calibration_key_valid &&
+            lmb_cal_matches(&m->calibration.key, &m->calibration_key))
+            ui_printf(14, 5, UI_MUTED, "Last turn: %u prompt / %u generated tokens. Longer chats or other load may be slower.",
+                m->calibration.prompt_tokens, m->calibration.generated_tokens);
         if (m->planned && m->plan.state != LMB_PLAN_UNRUNNABLE) {
             for (uint32_t i = 0; i < m->plan.nslices && 16 + (int)i * 2 < ui_h - 7; i++) {
                 const LmbSlice *s = &m->plan.slices[i];
@@ -625,8 +629,7 @@ int lmb_tui_run(LmbTuiState *st, int snapshot, const char *keys) {
             int selection_changed = memcmp(job.next->selected_nodes, st->selected_nodes,
                                              sizeof st->selected_nodes) != 0;
             memcpy(job.next->selected_nodes, st->selected_nodes, sizeof st->selected_nodes);
-            if (selection_changed)
-                for (int i = 0; i < job.next->nmodels; i++) job.next->models[i].planned = 0;
+            if (selection_changed) lmb_tui_invalidate_plans(job.next);
             char selected_dir[512] = "";
             if (!tab && sel < st->nmodels)
                 snprintf(selected_dir, sizeof selected_dir, "%s", st->models[sel].dir);
@@ -692,6 +695,7 @@ int lmb_tui_run(LmbTuiState *st, int snapshot, const char *keys) {
                         if (!st->selected_nodes[i][0]) {
                             memmove(st->selected_nodes[i], st->identities[sel], sizeof st->selected_nodes[i]); break;
                         }
+                lmb_tui_invalidate_plans(st);
                 refresh_start(&job, st);
             }
             break;

--- a/src/ui/lumabri_tui.h
+++ b/src/ui/lumabri_tui.h
@@ -28,7 +28,9 @@ typedef struct {
     int weights_present;
     uint64_t checkpoint_bytes;
     int checkpoint_inventory_ok;
-    const LmbCalibration *calibration;   /* NULL until something is measured */
+    LmbCalibration calibration;    /* owned by the snapshot, never a borrowed pointer */
+    int has_calibration;
+    char content_id[65];
     LmbCalKey calibration_key;      /* exact current conditions */
     int calibration_key_valid;
 } LmbTuiModel;
@@ -39,9 +41,11 @@ typedef struct LmbTuiState {
     LmbClusterNode nodes[LMB_CLUSTER_MAX_NODES];
     LmbMachineProfile profiles[LMB_CLUSTER_MAX_NODES];
     char identities[LMB_CLUSTER_MAX_NODES][65];
+    char runtime_ids[LMB_CLUSTER_MAX_NODES][65];
     uint32_t ages_ms[LMB_CLUSTER_MAX_NODES];
     uint32_t nnodes;
     int inventory_ok;
+    char build_id[65];
     int action_model;
     int initial_tab;
     char selected_nodes[LMB_CLUSTER_MAX_NODES][65];
@@ -54,6 +58,15 @@ typedef struct LmbTuiState {
 } LmbTuiState;
 
 enum { LMB_TUI_REQUEST_CHAT = 10 };
+
+/* Selection changes precede asynchronous planning. Never render a speed
+ * attached to the previous selection during that refresh window. */
+static inline void lmb_tui_invalidate_plans(LmbTuiState *st) {
+    for (int i = 0; i < st->nmodels; i++) {
+        st->models[i].planned = 0;
+        st->models[i].calibration_key_valid = 0;
+    }
+}
 
 static inline int lmb_tui_node_enabled(const LmbTuiState *st, uint32_t node) {
     if (node >= st->nnodes || !st->nodes[node].addr[0]) return 0;

--- a/tests/c/test_calibration.c
+++ b/tests/c/test_calibration.c
@@ -6,7 +6,7 @@
  * or a two-machine number for a four-machine plan, and be believed. */
 #include <stdio.h>
 #include <string.h>
-#include "lumabri_calibration.h"
+#include "lumabri_calibration_store.h"
 
 static int bad;
 #define CHECK(c, ...) do { if (!(c)) { fprintf(stderr, __VA_ARGS__); \
@@ -35,6 +35,59 @@ static LmbCalKey base(void) {
         k.from_disk[i] = 0;
     }
     return k;
+}
+
+static void record_tests(void) {
+    LmbCalibration r = { .key = base(), .decode_tok_s = 12.5,
+        .ttft_seconds = 1.25, .measured_at = 1234567, .samples = 3 }, got;
+    memset(r.key.model_root, 'a', 64); r.key.model_root[64] = 0;
+    LmbBuf encoded = {0};
+    CHECK(!lmb_cal_encode(&r, &encoded), "record encoding failed");
+    if (!encoded.p) return;
+    CHECK(!lmb_cal_decode(encoded.p, encoded.len, &got) && lmb_cal_matches(&r.key, &got.key) &&
+          r.decode_tok_s == got.decode_tok_s && r.ttft_seconds == got.ttft_seconds &&
+          r.measured_at == got.measured_at && r.samples == got.samples, "record round trip failed");
+    for (size_t i = 0; i < encoded.len; i++) {
+        got = r;
+        CHECK(lmb_cal_decode(encoded.p, i, &got) && !got.samples, "truncated record accepted at %zu", i);
+    }
+    encoded.p[12] ^= 1; got = r;
+    CHECK(lmb_cal_decode(encoded.p, encoded.len, &got) && !got.samples, "corrupt record accepted");
+    encoded.p[12] ^= 1;
+    char tmp[] = "/tmp/lumabri-cal-record-XXXXXX", directory[256], path[384], link_path[256];
+    char *created = mkdtemp(tmp);
+    CHECK(created != NULL, "cannot create private test directory");
+    if (!created) { free(encoded.p); return; }
+    snprintf(directory, sizeof directory, "%s/records", tmp);
+    snprintf(path, sizeof path, "%s/%s.cal", directory, r.key.model_root);
+    snprintf(link_path, sizeof link_path, "%s/link", tmp);
+    CHECK(!lmb_cal_store(directory, &r), "record store failed");
+    CHECK(!lmb_cal_load(directory, r.key.model_root, &got) && lmb_cal_matches(&r.key, &got.key), "record load failed");
+    r.decode_tok_s = 7.25;
+    CHECK(!lmb_cal_store(directory, &r) && !lmb_cal_load(directory, r.key.model_root, &got) &&
+          got.decode_tok_s == 7.25, "atomic replacement failed");
+    struct stat st;
+    CHECK(!stat(path, &st) && !(st.st_mode & 077), "record is not private");
+    CHECK(lmb_cal_load(directory, "../../elsewhere", &got) && !got.samples, "unsafe filename accepted");
+    CHECK(!symlink(directory, link_path), "cannot prepare directory symlink test");
+    CHECK(lmb_cal_load(link_path, r.key.model_root, &got) && !got.samples, "directory symlink accepted");
+    CHECK(!unlink(link_path), "cannot remove test directory symlink");
+    CHECK(!chmod(path, 0644), "cannot prepare exposed record test");
+    CHECK(lmb_cal_load(directory, r.key.model_root, &got) && !got.samples, "non-private record accepted");
+    CHECK(!unlink(path) && !symlink("missing", path), "cannot prepare record symlink test");
+    CHECK(lmb_cal_load(directory, r.key.model_root, &got) && !got.samples, "record symlink accepted");
+    CHECK(!unlink(path) && !mkfifo(path, 0600), "cannot prepare FIFO test");
+    CHECK(lmb_cal_load(directory, r.key.model_root, &got) && !got.samples, "FIFO accepted or blocked");
+    CHECK(!unlink(path), "cannot remove test FIFO");
+    CHECK(!lmb_cal_store(directory, &r), "cannot prepare truncated disk record");
+    char linked[384]; snprintf(linked, sizeof linked, "%s/linked", directory);
+    CHECK(!link(path, linked), "cannot prepare hardlink test");
+    CHECK(lmb_cal_load(directory, r.key.model_root, &got) && !got.samples, "hardlinked record accepted");
+    CHECK(!unlink(linked), "cannot remove test hardlink");
+    CHECK(!truncate(path, 20), "cannot truncate test record");
+    CHECK(lmb_cal_load(directory, r.key.model_root, &got) && !got.samples, "truncated disk record accepted");
+    CHECK(!unlink(path) && !rmdir(directory) && !rmdir(tmp), "test record cleanup failed");
+    free(encoded.p);
 }
 
 int main(void) {
@@ -82,7 +135,7 @@ int main(void) {
     /* What the screen actually prints, which is where this either helps or
      * misleads. */
     LmbCalibration have; memset(&have, 0, sizeof have);
-    have.key = base(); have.decode_tok_s = 12.5; have.samples = 3;
+    have.key = base(); have.decode_tok_s = 12.5; have.samples = 3; have.measured_at = 1;
     char text[128];
 
     lmb_cal_speed_text(NULL, &a, text, sizeof text);
@@ -118,6 +171,33 @@ int main(void) {
     LmbCalKey invalid = base(); invalid.nodes = LMB_CAL_NODES_MAX + 1;
     CHECK(!lmb_cal_matches(&invalid, &invalid),
           "an out-of-bounds machine count was accepted as a calibration key");
+
+    LmbCalKey empty = {0};
+    CHECK(!lmb_cal_matches(&empty, &empty), "two empty keys matched");
+    CHECK(!lmb_cal_matches(NULL, &a) && !lmb_cal_matches(&a, NULL), "null keys matched");
+    invalid = base(); memset(invalid.node_id[0], 'a', sizeof invalid.node_id[0]);
+    CHECK(!lmb_cal_matches(&invalid, &invalid), "unterminated identity matched");
+    invalid = base(); invalid.numeric_class[0] = '\033';
+    CHECK(!lmb_cal_matches(&invalid, &invalid), "terminal controls accepted");
+    invalid = base(); invalid.threads[0] = 0;
+    CHECK(!lmb_cal_key_valid(&invalid), "unknown thread count accepted");
+    invalid = base(); invalid.layer_end[0] = invalid.layer_begin[0];
+    CHECK(!lmb_cal_key_valid(&invalid), "empty range accepted");
+    invalid = base(); memset(invalid.node_id[0], 'a', 64); invalid.node_id[0][64] = 0;
+    memset(invalid.numeric_class, 'x', 96); invalid.numeric_class[96] = 0;
+    CHECK(lmb_cal_key_valid(&invalid), "full identity or numeric class did not fit");
+    const double invalid_rates[] = {0, -1, NAN, INFINITY};
+    for (size_t i = 0; i < sizeof invalid_rates / sizeof invalid_rates[0]; i++) {
+        have.decode_tok_s = invalid_rates[i];
+        lmb_cal_speed_text(&have, &a, text, sizeof text);
+        CHECK(strstr(text, "invalid") && !strstr(text, "tok/s"), "invalid speed printed: %s", text);
+    }
+    have.decode_tok_s = 12.5; have.samples = 0;
+    CHECK(!lmb_cal_valid(&have), "zero samples accepted");
+    have.samples = 1; have.measured_at = NAN;
+    CHECK(!lmb_cal_valid(&have), "invalid measurement date accepted");
+
+    record_tests();
 
     printf("CALIBRATION KEY: %s\n", bad ? "FAIL" : "PASS");
     return bad ? 1 : 0;

--- a/tests/c/test_calibration.c
+++ b/tests/c/test_calibration.c
@@ -54,6 +54,30 @@ static void record_tests(void) {
     encoded.p[12] ^= 1; got = r;
     CHECK(lmb_cal_decode(encoded.p, encoded.len, &got) && !got.samples, "corrupt record accepted");
     encoded.p[12] ^= 1;
+    /* Exercise parsing, not just the checksum: re-sign truncated payloads
+     * and malformed length/count fields so integrity does not hide bugs. */
+    uint8_t *candidate = malloc(encoded.len);
+    CHECK(candidate != NULL, "cannot allocate malformed record fixture");
+    if (candidate) {
+        for (size_t len = 40; len < encoded.len; len++) {
+            memcpy(candidate, encoded.p, len);
+            LmbSha sha; lmb_sha_init(&sha); lmb_sha_update(&sha, candidate, len - 32);
+            lmb_sha_final(&sha, candidate + len - 32);
+            got = r;
+            CHECK(lmb_cal_decode(candidate, len, &got) && !got.samples,
+                  "checksummed truncated payload accepted at %zu", len);
+        }
+        for (size_t i = 8; i < encoded.len - 32; i++) {
+            memcpy(candidate, encoded.p, encoded.len); candidate[i] ^= 0x80;
+            LmbSha sha; lmb_sha_init(&sha); lmb_sha_update(&sha, candidate, encoded.len - 32);
+            lmb_sha_final(&sha, candidate + encoded.len - 32);
+            got = r;
+            int result = lmb_cal_decode(candidate, encoded.len, &got);
+            CHECK(result ? !got.samples : lmb_cal_valid(&got),
+                  "mutated record returned invalid data at %zu", i);
+        }
+        free(candidate);
+    }
     char tmp[] = "/tmp/lumabri-cal-record-XXXXXX", directory[256], path[384], link_path[256];
     char *created = mkdtemp(tmp);
     CHECK(created != NULL, "cannot create private test directory");

--- a/tests/c/test_calibration.c
+++ b/tests/c/test_calibration.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "lumabri_calibration_store.h"
+#include "lumabri_checkpoint_identity.h"
 
 static int bad;
 #define CHECK(c, ...) do { if (!(c)) { fprintf(stderr, __VA_ARGS__); \
@@ -37,16 +38,63 @@ static LmbCalKey base(void) {
     return k;
 }
 
+static void identity_tests(void) {
+    char dir[] = "/tmp/lumabri-cal-identity-XXXXXX", path[512];
+    if (!mkdtemp(dir)) { CHECK(0, "cannot create identity fixture"); return; }
+    const char *binaries[] = {"lumabri", "segment_node", "segment_chat", LMB_SHIM_NAME};
+    for (unsigned i = 0; i < 4; i++) {
+        snprintf(path, sizeof path, "%s/%s", dir, binaries[i]);
+        FILE *f = fopen(path, "wb"); CHECK(f != NULL, "cannot create fake runtime binary");
+        if (f) { fputs("fixture", f); fclose(f); }
+    }
+    LmbRuntimeIdentityCache cache = {0}; char epoch[65], first[65], second[65];
+    memset(epoch, 'a', 64); epoch[64] = 0;
+    CHECK(!lmb_runtime_identity(dir, epoch, &cache, first), "runtime identity failed");
+    CHECK(!lmb_runtime_identity(dir, epoch, &cache, second) && !strcmp(first, second), "unchanged runtime identity moved");
+    epoch[0] = 'b';
+    CHECK(!lmb_runtime_identity(dir, epoch, &cache, second) && strcmp(first, second), "new donor epoch retained speed key");
+    epoch[0] = 'a'; snprintf(path, sizeof path, "%s/segment_node", dir);
+    FILE *f = fopen(path, "ab"); if (f) { fputs("updated", f); fclose(f); }
+    CHECK(!lmb_runtime_identity(dir, epoch, &cache, second) && strcmp(first, second), "changed binary retained speed key");
+    for (unsigned i = 0; i < 4; i++) {
+        snprintf(path, sizeof path, "%s/%s", dir, binaries[i]); CHECK(!unlink(path), "cannot remove fake runtime");
+    }
+    CHECK(lmb_runtime_identity(dir, epoch, &cache, second) && !second[0], "missing runtime retained identity");
+    snprintf(path, sizeof path, "%s/config.json", dir);
+    f = fopen(path, "wb"); if (f) { fputs("{}\n", f); fclose(f); }
+    CHECK(lmb_checkpoint_identity(dir, second, NULL, NULL) && !second[0], "uncached checkpoint was assigned an identity");
+    struct stat st; CHECK(!stat(path, &st), "cannot stat checkpoint fixture");
+    char side_dir[512], side[600]; snprintf(side_dir, sizeof side_dir, "%s/.lumabri_hashes", dir);
+    CHECK(!mkdir(side_dir, 0700), "cannot create sidecar directory");
+    snprintf(side, sizeof side, "%s/config.json.sha", side_dir);
+    struct { uint32_t magic, version; uint64_t size, mtime, ctime; uint32_t nh, reserved; }
+        hdr = {0x3148534Cu, 1, 3, lmb_stat_mtime_ns(&st), lmb_stat_ctime_ns(&st), 1, 0};
+    uint8_t hash[32], root1[32], root2[32], expected[32]; LmbSha sha;
+    lmb_sha_init(&sha); lmb_sha_update(&sha, "{}\n", 3); lmb_sha_final(&sha, hash);
+    f = fopen(side, "wb"); CHECK(f != NULL, "cannot create hash sidecar");
+    if (f) { CHECK(fwrite(&hdr, sizeof hdr, 1, f) == 1 && fwrite(hash, 32, 1, f) == 1, "cannot write hash sidecar"); fclose(f); }
+    CHECK(!lmb_checkpoint_identity(dir, first, "session-a", root1), "cached checkpoint identity failed");
+    CHECK(!lmb_checkpoint_identity(dir, second, "session-b", root2) && !strcmp(first, second) && memcmp(root1, root2, 32),
+          "content identity depends on the routing name");
+    LmbModelItem item = {"config.json", 3, 1, hash};
+    CHECK(!lmb_model_root("session-a", &item, 1, expected) && !memcmp(root1, expected, 32), "routing root differs from the source algorithm");
+    f = fopen(path, "ab"); if (f) { fputs("changed", f); fclose(f); }
+    CHECK(lmb_checkpoint_identity(dir, second, NULL, NULL) && !second[0], "stale sidecar remained current");
+    CHECK(!unlink(side) && !rmdir(side_dir) && !unlink(path) && !rmdir(dir), "identity fixture cleanup failed");
+}
+
 static void record_tests(void) {
     LmbCalibration r = { .key = base(), .decode_tok_s = 12.5,
-        .ttft_seconds = 1.25, .measured_at = 1234567, .samples = 3 }, got;
+        .ttft_seconds = 1.25, .measured_at = 1234567, .samples = 1,
+        .prompt_tokens = 24, .generated_tokens = 8 }, got;
     memset(r.key.model_root, 'a', 64); r.key.model_root[64] = 0;
     LmbBuf encoded = {0};
     CHECK(!lmb_cal_encode(&r, &encoded), "record encoding failed");
     if (!encoded.p) return;
     CHECK(!lmb_cal_decode(encoded.p, encoded.len, &got) && lmb_cal_matches(&r.key, &got.key) &&
           r.decode_tok_s == got.decode_tok_s && r.ttft_seconds == got.ttft_seconds &&
-          r.measured_at == got.measured_at && r.samples == got.samples, "record round trip failed");
+          r.measured_at == got.measured_at && r.samples == got.samples &&
+          r.prompt_tokens == got.prompt_tokens && r.generated_tokens == got.generated_tokens, "record round trip failed");
     for (size_t i = 0; i < encoded.len; i++) {
         got = r;
         CHECK(lmb_cal_decode(encoded.p, i, &got) && !got.samples, "truncated record accepted at %zu", i);
@@ -136,6 +184,7 @@ int main(void) {
     VARY("context",         v.context = 8192);
     VARY("sessions",        v.sessions = 4);
     VARY("machine count",   v.nodes = 1);
+    VARY("Edge host",       v.edge_node = 1);
     VARY("which machine",   snprintf(v.node_id[1], sizeof v.node_id[1], "elsewhere"));
     VARY("node hardware",   snprintf(v.node_hardware_id[1], sizeof v.node_hardware_id[1], "other"));
     VARY("node build",      snprintf(v.node_build_id[1], sizeof v.node_build_id[1], "other"));
@@ -160,6 +209,7 @@ int main(void) {
      * misleads. */
     LmbCalibration have; memset(&have, 0, sizeof have);
     have.key = base(); have.decode_tok_s = 12.5; have.samples = 3; have.measured_at = 1;
+    have.prompt_tokens = 24; have.generated_tokens = 8;
     char text[128];
 
     lmb_cal_speed_text(NULL, &a, text, sizeof text);
@@ -218,10 +268,18 @@ int main(void) {
     }
     have.decode_tok_s = 12.5; have.samples = 0;
     CHECK(!lmb_cal_valid(&have), "zero samples accepted");
-    have.samples = 1; have.measured_at = NAN;
+    have.samples = 1; have.prompt_tokens = have.key.context + 1;
+    CHECK(!lmb_cal_valid(&have), "prompt outside the approved context accepted");
+    have.prompt_tokens = 24; have.generated_tokens = 1;
+    CHECK(!lmb_cal_valid(&have), "a single token cannot measure decode speed");
+    have.generated_tokens = 8;
+    have.key.commit_lumabri[0] = have.key.commit_colibri[0] = 0;
+    CHECK(lmb_cal_valid(&have), "exact binary IDs require no invented commit provenance");
+    have.measured_at = NAN;
     CHECK(!lmb_cal_valid(&have), "invalid measurement date accepted");
 
     record_tests();
+    identity_tests();
 
     printf("CALIBRATION KEY: %s\n", bad ? "FAIL" : "PASS");
     return bad ? 1 : 0;

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,22 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    const char *boot[] = {
+        "\nLUMABRI_SAMPLING LOGITS\nLUMABRI_NUMERIC 2 cpu-test\n" FRAME_READY "\n",
+        "\nLUMABRI_SAMPLING GREEDY\nLUMABRI_NUMERIC 2 cpu-test\n" FRAME_READY "\n",
+        "\nLUMABRI_NUMERIC 0 cpu-test\n" FRAME_READY "\n",
+        "\n" FRAME_READY "\n",
+        "\nLUMABRI_NUMERIC 2 abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz\n" FRAME_READY "\n"
+    };
+    for (unsigned i = 0; i < sizeof boot / sizeof *boot; i++) {
+        int ready[2]; assert(!pipe(ready));
+        assert(write(ready[1], boot[i], strlen(boot[i])) == (ssize_t)strlen(boot[i]));
+        close(ready[1]); Engine engine = {.from = ready[0], .numeric_abi = 99};
+        assert(!engine_wait_ready(&engine)); close(ready[0]);
+        assert(engine.numeric_abi == (i < 2 ? 2u : 0u));
+        assert(engine.greedy_only == (i == 1));
+        assert(i < 2 ? !strcmp(engine.numeric_class, "cpu-test") : !engine.numeric_class[0]);
+    }
     const char *io_env = getenv("LUMABRI_IO_TIMEOUT_MS");
     char *saved_io = io_env ? strdup(io_env) : NULL;
     unsetenv("LUMABRI_IO_TIMEOUT_MS");
@@ -62,6 +78,10 @@ int main(int argc, char **argv) {
     g_slash_completion = 1;
     signal(SIGPIPE, SIG_IGN);
     static LmbTuiState selection;
+    selection.nmodels = 1;
+    selection.models[0].planned = selection.models[0].calibration_key_valid = 1;
+    lmb_tui_invalidate_plans(&selection);
+    assert(!selection.models[0].planned && !selection.models[0].calibration_key_valid);
     selection.nnodes = 3;
     for (int i = 0; i < 3; i++) {
         snprintf(selection.identities[i], sizeof selection.identities[i], "peer-%d", i);

--- a/tests/c/test_inventory.c
+++ b/tests/c/test_inventory.c
@@ -38,6 +38,30 @@ int main(int argc, char **argv) {
     assert(!lmb_inventory_pack(&b, &r));
     b.p[4 + 32 + 2] = 0; /* embedded NUL in the declared machine name */
     assert(decode(&b)); free(b.p);
+    /* V3 runtime identity must describe an actual, addressable donor. A
+     * partial or non-canonical identity cannot bind a speed measurement. */
+    r = fixture();
+    snprintf(r.control_addr, sizeof r.control_addr, "127.0.0.1:47301");
+    memset(r.runtime_id, 'a', 64); r.runtime_id[64] = 0;
+    r.runtime_threads = 2;
+    b = (LmbBuf){0}; assert(!lmb_inventory_pack(&b, &r)); assert(!decode(&b));
+    LmbCur cur = {b.p, b.len, 0}; LmbMachineReport got;
+    assert(!lmb_inventory_unpack(&cur, &got) && got.runtime_threads == 2 &&
+           !strcmp(got.runtime_id, r.runtime_id));
+    for (size_t i = 0; i < b.len; i++) {
+        LmbBuf cut = b; cut.len = i; assert(decode(&cut));
+    }
+    b.p[0] = 2; assert(decode(&b)); free(b.p);
+    for (unsigned i = 0; i < 5; i++) {
+        LmbMachineReport invalid = r;
+        if (i == 0) invalid.runtime_threads = 0;
+        if (i == 1) invalid.runtime_threads = 257;
+        if (i == 2) invalid.runtime_id[0] = 'G';
+        if (i == 3) invalid.runtime_id[63] = 0;
+        if (i == 4) invalid.control_addr[0] = 0;
+        b = (LmbBuf){0}; assert(!lmb_inventory_pack(&b, &invalid));
+        assert(decode(&b)); free(b.p);
+    }
     if (argc == 2) {
         assert(!lmb_secure_init());
         int fd = lmb_connect(argv[1]); assert(fd >= 0); assert(!lmb_auth(fd));

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -34,6 +34,8 @@ def main():
                         help="run a separately approved second plan; verify shared weight reuse and source byte counters")
     parser.add_argument("--expect-metrics", action="store_true",
                         help="require versioned generation timings through Hosted into the TUI")
+    parser.add_argument("--expect-calibration", action="store_true",
+                        help="require saved real timings, matching catalogue speed and changed-context invalidation")
     parser.add_argument("--expect-no-fit", action="store_true",
                         help="verify insufficient-memory admission, without starting engines")
     parser.add_argument("--kill-donor", action="store_true",
@@ -41,6 +43,8 @@ def main():
     args = parser.parse_args()
     if args.repeat_cached and (args.kill_donor or args.expect_no_fit):
         parser.error("--repeat-cached requires a normal completed first session")
+    if args.expect_calibration and (args.kill_donor or args.expect_no_fit):
+        parser.error("--expect-calibration requires a normally completed session")
     if args.repeat_cached and not (ROOT / "swarm_probe").is_file():
         parser.error("build swarm_probe before running --repeat-cached")
     tmp = Path(tempfile.mkdtemp(prefix="lumabri-home-flow-"))
@@ -80,12 +84,12 @@ def main():
                 "OMP_NUM_THREADS": "2", "COLI_NO_OMP_TUNE": "1", "PIN": "off"}
 
     class Terminal:
-        def __init__(self, name, argv):
+        def __init__(self, name, argv, environment_name=None):
             self.name, self.text = name, ""
             self.master, slave = pty.openpty()
             fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 35, 140, 0, 0))
             self.log = open(tmp / f"{name}.terminal.log", "wb")
-            self.p = subprocess.Popen(argv, cwd=ROOT, env=env(name),
+            self.p = subprocess.Popen(argv, cwd=ROOT, env=env(environment_name or name),
                                       stdin=slave, stdout=slave, stderr=slave)
             os.close(slave)
             terminals.append(self)
@@ -323,6 +327,37 @@ def main():
                             return False
             return True
         until(leases_released, message="a child retained a donor resource lease after closing chat")
+        if args.expect_calibration:
+            records = list((tmp / "chatter/.lumabri/calibrations").glob("*.cal"))
+            assert len(records) == 1, "completed real generation did not save a bound measurement"
+            assert records[0].stat().st_mode & 0o077 == 0, "calibration record is not private"
+            for condition in ("current", "context", "selection", "runtime"):
+                changed = condition != "current"
+                if condition == "runtime":
+                    a.text = ""; a.send("\x1b")
+                    until(lambda: a.has("your workspace"), message="donor did not stop sharing")
+                    a.send("\x1b")  # exit the workspace; this PTY has no foreground signal group
+                    until(lambda: a.p.poll() is not None, message="donor workspace did not close")
+                    a = Terminal("donor-a-restarted", ["./lumabri"], "donor-a")
+                    until(lambda: a.has("your workspace"))
+                    a.send("\x1b[B\x1b[B\x1b[B\r")
+                    until(lambda: a.has("Available"))
+                argv = base + (["--context", str(args.context * 2)] if condition == "context" else [])
+                view = Terminal("calibration-" + condition, argv, "chatter")
+                until(lambda: view.has("3 computers"))
+                view.send("\t")
+                until(lambda: view.has("Nothing is selected automatically"))
+                view.send("\x1b[B\r\t" if condition == "selection" else "\x1b[B\r\x1b[B\r\t")
+                until(lambda: view.has("A plan before a download."), message="catalogue did not reopen")
+                time.sleep(1); view.text = ""
+                until(lambda: view.has("stale") if changed else view.has("tok/s"), seconds=30,
+                      message=f"changed {condition} did not invalidate the speed" if changed else "matching plan did not recover its measured speed")
+                if changed:
+                    assert "tok/s" not in view.text, "stale catalogue retained a numerical speed"
+                view.send("q")
+                until(lambda: view.p.poll() is not None)
+                assert view.p.returncode == 0
+            print("HOME CALIBRATION: PASS (real timing saved, catalogue reopened; context, selection and donor restart invalidate speed)", flush=True)
         if args.repeat_cached:
             before = cached_weights()
             a.text = b.text = ""

--- a/tests/integration/segment_direct_test.sh
+++ b/tests/integration/segment_direct_test.sh
@@ -167,7 +167,7 @@ PY
         # executor's explicit reuse diagnostic.
         "${run_env[@]}" python3 - "$SEGMENT_CHAT_BIN" "$model_dir" "$model" \
             "$model_root" "$tokenizer_root" <<'PY'
-import subprocess, sys
+import re, subprocess, sys
 
 binary, model_dir, model, model_root, tokenizer_root = sys.argv[1:]
 process = subprocess.Popen([
@@ -185,6 +185,8 @@ def line():
 
 if line() != b"\n" or line() != b"LUMABRI_SAMPLING LOGITS\n":
     raise RuntimeError("missing OLMoE sampling capability")
+if not re.fullmatch(rb"LUMABRI_NUMERIC [1-9][0-9]* [\x20-\x7e]{1,96}\n", line()):
+    raise RuntimeError("missing or invalid numeric ABI metadata")
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("Segment gateway did not become ready")
 

--- a/tests/integration/segment_failover_test.sh
+++ b/tests/integration/segment_failover_test.sh
@@ -82,7 +82,7 @@ env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
     LUMABRI_SEGMENT_DISCOVERY_MS=60000 \
     python3 - "$DONOR_PID" "$SEGMENT_CHAT_BIN" "$OLMOE_EDGE_MODEL" \
         "$root" "$tok" "$TMP" <<'PY'
-import os, socket, subprocess, sys, time
+import os, re, socket, subprocess, sys, time
 donor, binary, model_dir, root, tok, tmp = sys.argv[1:]
 p = subprocess.Popen([
     binary, "--serve", "--engine", "olmoe",
@@ -99,6 +99,8 @@ def line():
     return value
 if line() != b"\n" or line() != b"LUMABRI_SAMPLING LOGITS\n":
     raise RuntimeError("missing OLMoE sampling capability")
+if not re.fullmatch(rb"LUMABRI_NUMERIC [1-9][0-9]* [\x20-\x7e]{1,96}\n", line()):
+    raise RuntimeError("missing or invalid numeric ABI metadata")
 if b"READY" not in line() or not line().startswith(b"STAT "):
     raise RuntimeError("gateway not ready")
 def turn(rid, prompt, kill_after_accept=None):


### PR DESCRIPTION
## Roadmap gate 4 — real chat measurements in the catalogue

This follow-up builds on the real generation timings merged in #157.

- Require complete, bounded keys: full 64-character node identities fit; numeric classes are not truncated; empty/unterminated keys do not match.
- Reject invalid/non-finite speeds, zero samples and invalid dates before rendering a measurement.
- Add a bounded, versioned, endian-independent private record store with atomic replacement and corruption detection. It stores timing and token counts, never prompts, replies, token IDs or credentials.
- Reject truncated/corrupt records, unsafe names, symlinks, hardlinks, FIFOs and non-private files/directories; failed lookups clear the output.
- Exercise the same record tests in native Intel/ARM macOS workspace CI.
- Bind stable checkpoint content to the approved signed routing root without rereading model payloads: reuse validated maintainer hash sidecars.
- Advertise actual runtime fingerprints and installed thread capacity in inventory V3. Exact binaries plus a fresh donor launch epoch prevent stale reuse across runtime/environment restarts. Upgrade the household together.
- Carry actual numeric ABI metadata through the Hosted greeting; legacy hosts still chat without creating calibrated records.
- Save only completed real generation measurements, then look up the record from the catalogue's owned C snapshots and JSON export.
- Show `tok/s (last)` with actual prompt/output counts; no prediction for unmeasured plans and no universal speed guarantee.
- Invalidate immediately on selection changes and on mismatched checkpoint, runtime, topology, context or other conditions.

## Verified locally

Unit tests for calibration, inventory, budgets and readiness metadata pass. AddressSanitizer and UndefinedBehaviorSanitizer pass outside the ptrace sandbox, including leak detection. Chat UI tests pass (slash completion, retained transcript, UTF-8, terminal restoration).

The two-donor real OLMoE Tiny flow verifies chat -> save -> reopen catalogue -> stale after context change, changed selection and restarted donor. The test also reuses weights under a separately approved new session. These are synthetic checkpoint / loopback checks, not physical LAN measurements or large-model performance claims.

## Not claimed by this PR

- Measured-cost placement, automatic warm probes and cross-model recommendations remain follow-ups. This is a connected implementation, but not all of gate 4 or the roadmap.
- A trusted household report is not remote execution attestation. Restart sharing after runtime/library updates; load and network changes can still alter future speed.
- No upstream Colibri modifications, GPU kernels, native Windows inference or physical household validation.

Review and all CI checks must pass on the final head before a normal merge (no squash).
