### PR TITLE
catalogue: resource-based advice for selected resident plans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           ./test_planner
           ./test_cluster
           ./test_calibration
+          make test_catalogue_advice CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          ./test_catalogue_advice
           ./test_inventory
           make test-runtime-probe CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           python3 tests/integration/native_shim_test.py

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ PLANNER_ADAPTER_DEPS = $(wildcard planner_adapters/*.h)
 # consumer when one changes, including when a new contract is introduced.
 lumabri test_chat_ui test_planner test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
 lumabri test_chat_ui: lumabri_runtime_identity.h lumabri_checkpoint_identity.h lumabri_calibration_store.h lumabri_calibration.h
+lumabri test_chat_ui: src/planner/lumabri_catalogue_advice.h
 lumabri segment_chat test_chat_ui: lumabri_metrics.h
 
 lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
@@ -458,6 +459,9 @@ test_memory_budget: tests/c/test_memory_budget.c lumabri_memory_budget.h lumabri
 test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_calibration_store.h lumabri_runtime_identity.h lumabri_checkpoint_identity.h lumabri_checkpoint_inventory.h lumabri_planner.h $(SECURE_DEPS)
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_calibration.c -o $@
 
+test_catalogue_advice: tests/c/test_catalogue_advice.c src/planner/lumabri_catalogue_advice.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_catalogue_advice.c -o $@
+
 test_metrics: tests/c/test_metrics.c lumabri_metrics.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_metrics.c -o $@
 
@@ -722,7 +726,7 @@ test-segment-discovery: tracker test_segment_discovery
 	bash ./tests/integration/segment_discovery_test.sh
 
 test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget \
-		test_inventory test_home test_chat_ui test_calibration test_metrics \
+		test_inventory test_home test_chat_ui test_calibration test_catalogue_advice test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
 		test_scheduler test_run_gate
@@ -768,6 +772,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_cluster
 	./test_memory_budget
 	./test_calibration
+	./test_catalogue_advice
 	./test_metrics
 	./test_nat_adopt
 	bash ./tests/integration/rtt_refresh_test.sh
@@ -811,7 +816,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so liblumabri.dylib test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
-	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_metrics test_inventory test_home test_chat_ui segment_budget_probe \
+	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_catalogue_advice test_metrics test_inventory test_home test_chat_ui segment_budget_probe \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/docs/CATALOGUE_ADVICE.md
+++ b/docs/CATALOGUE_ADVICE.md
@@ -1,0 +1,25 @@
+# Catalogue advice
+
+The catalogue compares only verified, resident plans that fit the computers
+you selected and have a usable checkpoint source. Nothing is selected or
+downloaded automatically. Participating donors still approve the allocation.
+
+- **Lowest RAM reservation**: the smallest sum of the planned process budgets,
+  including the Edge host. This is reserved capacity, not predicted RSS.
+- **Largest resident checkpoint**: the largest checkpoint by bytes among the
+  admitted plans. More bytes do not imply better answers.
+- **Fastest last run**: the highest observed decode rate among at least two
+  plans with current, matching measurement records. Different prompts, model
+  tokenizers and machine load make this an observation, not a controlled
+  quality/speed benchmark or a promise about your next conversation.
+
+The compact row displays one applicable label, prioritizing observed speed,
+then lowest RAM, then checkpoint size. With fewer than two eligible choices
+there is no comparative advice. Unknown speeds are never invented. Selecting
+different computers clears advice immediately while the planner refreshes.
+
+The TUI and JSON use the same computed snapshot; model families are not
+hard-coded in the advisor. No host, donor or model is selected on your behalf.
+
+Run `make test_catalogue_advice && ./test_catalogue_advice` for the independent
+selection, invalid-input, unknown-speed and stable tie-break tests.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -143,12 +143,15 @@ not a completed gate.
    certify additional model families.
 4. PR #157 merged: versioned measurements collected during ordinary Segment chat,
    separating prefill, decode traversals and first visible text. No extra model
-   run is required. PR #159 connects completed household turns to private
+   run is required. PR #159 merged: completed household turns connect to private
    content/runtime-bound records and catalogue lookup. Context, selected
    computers and donor restarts invalidate old speeds; the last observed
    workload is shown separately from the configured context limit. Placement
-   cost calibration and catalogue advice remain pending; this is not the
-   entire gate 4. See `CALIBRATION_RECORDS.md` for its exact contract.
+   cost calibration remains pending. The catalogue advice follow-up highlights
+   lowest RAM reservation, largest resident checkpoint and fastest observed
+   run among eligible plans; it does not rank answer quality or invent speed
+   before a first measurement. See `CALIBRATION_RECORDS.md` and
+   `CATALOGUE_ADVICE.md` for the exact contracts.
 5. PR #158 merged: reusable adapter-scoped working mirrors and shared verified
    CAS chunks, with separate approval and fresh engine sessions on reuse.
    Cache-directory allocation is exclusive even across different homes.

--- a/docs/REPOSITORY.md
+++ b/docs/REPOSITORY.md
@@ -16,6 +16,7 @@ ready for household use. The public README documents the tested TUI path.
 | `segment_*.c`, `lumabri_segment*`, `segment_colibri.h` | Segment workers, Edge chat, discovery and Colibri integration |
 | `tracker.c`, `maintainer.c`, `lumashim.c` | Discovery/control, checkpoint distribution and block mirror |
 | `lumabri_planner.h`, `lumabri_cluster.h`, `lumabri_calibration.h` | Model sizing, placement and calibration records |
+| `src/planner/` | Model-independent catalogue advice; no UI rendering or weight loading |
 | `lumabri_machine.*`, scheduler and governor headers | Hardware inventory, resource budgets and admission |
 | `expert_engines/`, `engine_patches/`, Expert bridge files | Optional Expert/Hybrid and upstream compatibility |
 | `deploy/`, root deployment/release documents | Existing deployment and release tooling |

--- a/lumabri.c
+++ b/lumabri.c
@@ -5160,6 +5160,29 @@ static int catalog_calibration_key(const LmbTuiState *st, const LmbTuiModel *m,
     return edge ? 0 : -1;
 }
 
+static void catalog_advice_refresh(LmbTuiState *st) {
+    LmbAdviceCandidate candidates[LMB_TUI_MAX_MODELS] = {0};
+    uint32_t advice[LMB_TUI_MAX_MODELS];
+    for (int i = 0; i < st->nmodels; i++) {
+        const LmbTuiModel *m = &st->models[i];
+        LmbAdviceCandidate *c = &candidates[i];
+        c->eligible = st->inventory_ok && m->planned && m->shape.sizing_verified &&
+            m->weights_present && m->checkpoint_inventory_ok &&
+            m->plan.state == LMB_PLAN_RESIDENT && m->plan.nslices;
+        for (uint32_t j = 0; c->eligible && j < m->plan.nslices; j++) {
+            uint32_t node = m->plan.slices[j].node;
+            if (node >= st->nnodes || !lmb_tui_node_enabled(st, node)) c->eligible = 0;
+            c->reserved_bytes = lmb_budget_add(c->reserved_bytes, m->plan.slices[j].bytes_resident);
+        }
+        c->checkpoint_bytes = m->checkpoint_bytes;
+        if (m->has_calibration && m->calibration_key_valid && lmb_cal_valid(&m->calibration) &&
+            lmb_cal_matches(&m->calibration.key, &m->calibration_key))
+            c->measured_tok_s = m->calibration.decode_tok_s;
+    }
+    lmb_catalogue_advice(candidates, (size_t)st->nmodels, advice);
+    for (int i = 0; i < st->nmodels; i++) st->models[i].advice_flags = advice[i];
+}
+
 static int catalog_state_refresh(LmbTuiState *st, void *unused) {
     (void)unused;
     /* Per-layer contracts make each entry larger. Do not place the entire
@@ -5218,6 +5241,7 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
         }
         st->nmodels++;
     }
+    catalog_advice_refresh(st);
     free(found);
     return 0;
 }
@@ -5329,6 +5353,7 @@ static void catalog_json(const LmbTuiState *st) {
             if (current) printf("%.6f", model->calibration.decode_tok_s); else fputs("null", stdout);
             fputc('}', stdout);
         }
+        fputs(",\"advice\":", stdout); json_string(stdout, lmb_advice_text(model->advice_flags));
         fputc('}', stdout);
     }
     fputs("]}\n", stdout);

--- a/src/planner/lumabri_catalogue_advice.h
+++ b/src/planner/lumabri_catalogue_advice.h
@@ -1,0 +1,52 @@
+/* Resource advice, not model-quality rankings or synthetic speed estimates.
+ * The producer must admit a candidate only after validating its actual plan. */
+#ifndef LUMABRI_CATALOGUE_ADVICE_H
+#define LUMABRI_CATALOGUE_ADVICE_H
+#include <stdint.h>
+#include <stddef.h>
+#include <math.h>
+
+enum {
+    LMB_ADVICE_LOWEST_RAM = 1u,
+    LMB_ADVICE_LARGEST_CHECKPOINT = 2u,
+    LMB_ADVICE_FASTEST_OBSERVED = 4u
+};
+typedef struct {
+    int eligible;               /* verified resident plan on selected donors */
+    uint64_t reserved_bytes;    /* aggregate process reservation, including Edge */
+    uint64_t checkpoint_bytes;
+    double measured_tok_s;      /* zero unless its current exact key matches */
+} LmbAdviceCandidate;
+
+static inline void lmb_catalogue_advice(const LmbAdviceCandidate *c, size_t n,
+                                      uint32_t *flags) {
+    if (!flags) return;
+    for (size_t i = 0; i < n; i++) flags[i] = 0;
+    if (!c) return;
+    size_t least = n, largest = n, fastest = n, admitted = 0, measured = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (!c[i].eligible || !c[i].reserved_bytes || !c[i].checkpoint_bytes ||
+            c[i].reserved_bytes == UINT64_MAX || c[i].checkpoint_bytes == UINT64_MAX) continue;
+        admitted++;
+        if (least == n || c[i].reserved_bytes < c[least].reserved_bytes) least = i;
+        if (largest == n || c[i].checkpoint_bytes > c[largest].checkpoint_bytes) largest = i;
+        if (isfinite(c[i].measured_tok_s) && c[i].measured_tok_s > 0) {
+            measured++;
+            if (fastest == n || c[i].measured_tok_s > c[fastest].measured_tok_s) fastest = i;
+        }
+    }
+    /* With only one option there is no meaningful comparative advice. */
+    if (admitted > 1) {
+        flags[least] |= LMB_ADVICE_LOWEST_RAM;
+        flags[largest] |= LMB_ADVICE_LARGEST_CHECKPOINT;
+    }
+    if (measured > 1) flags[fastest] |= LMB_ADVICE_FASTEST_OBSERVED;
+}
+
+static inline const char *lmb_advice_text(uint32_t flags) {
+    if (flags & LMB_ADVICE_FASTEST_OBSERVED) return "fastest last run";
+    if (flags & LMB_ADVICE_LOWEST_RAM) return "lowest RAM reservation";
+    if (flags & LMB_ADVICE_LARGEST_CHECKPOINT) return "largest resident checkpoint";
+    return "";
+}
+#endif

--- a/src/ui/lumabri_tui.c
+++ b/src/ui/lumabri_tui.c
@@ -231,6 +231,7 @@ static void draw_models(const LmbTuiState *st, Size sz, int sel, int top) {
                      m->plan.nslices, m->plan.nslices == 1 ? "" : "s",
                      computers, computers == 1 ? "" : "s");
         }
+        if (m->advice_flags) snprintf(detail, sizeof detail, "%s", lmb_advice_text(m->advice_flags));
         speed_text(m, speed, sizeof speed);
         printf("%s", idx == sel ? c(INV) : "");
         printf("%s", idx == sel ? "▸" : " ");
@@ -405,6 +406,10 @@ static void draw_detail(const LmbTuiState *st, Size sz, int sel) {
     speed_text(m, speed, sizeof speed);
     at(row++, 1);
     printf("  %sSPEED%s   %s", c(DIM), c(OFF), speed);
+    if (m->advice_flags) {
+        at(row++, 1);
+        printf("  Advice: %s (not an answer-quality ranking)", lmb_advice_text(m->advice_flags));
+    }
     if (!m->has_calibration) {
         at(row++, 1);
         printf("  %sa number appears here after a calibration on these "
@@ -493,6 +498,8 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
         ui_printf(11, 5, UI_MUTED, "%s · %u layers · %u context · %u session(s)",
                   m->shape.model_type, m->shape.layers, st->context, st->sessions);
         ui_printf(13, 5, UI_TEXT, "Plan: %s    Speed: %s", state_word(m), speed);
+        if (m->advice_flags)
+            ui_printf(15, 5, UI_SAND, "Resource advice: %s (not an answer-quality ranking)", lmb_advice_text(m->advice_flags));
         if (m->has_calibration && m->calibration_key_valid &&
             lmb_cal_matches(&m->calibration.key, &m->calibration_key))
             ui_printf(14, 5, UI_MUTED, "Last turn: %u prompt / %u generated tokens. Longer chats or other load may be slower.",
@@ -537,7 +544,9 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
         }
         for (int i = top; i < st->nmodels && i < top + rows; i++) {
             char speed[96], description[256]; speed_text(&st->models[i], speed, sizeof speed);
-            snprintf(description, sizeof description, "%s · %s · %u layers", state_word(&st->models[i]), speed, st->models[i].shape.layers);
+            const char *advice = lmb_advice_text(st->models[i].advice_flags);
+            snprintf(description, sizeof description, "%s · %s · %u layers%s%s", state_word(&st->models[i]), speed,
+                st->models[i].shape.layers, *advice ? " · " : "", advice);
             ui_item(10 + (i - top) * 3, i == sel, st->models[i].name, description);
         }
         ui_text(ui_h - 6, 5, UI_MUTED, "A plan before a download. Speed appears only with a matching calibration.");

--- a/src/ui/lumabri_tui.h
+++ b/src/ui/lumabri_tui.h
@@ -16,6 +16,7 @@
 #include "lumabri_cluster.h"
 #include "lumabri_calibration.h"
 #include "lumabri_machine.h"
+#include "src/planner/lumabri_catalogue_advice.h"
 
 #define LMB_TUI_MAX_MODELS 64
 
@@ -33,6 +34,7 @@ typedef struct {
     char content_id[65];
     LmbCalKey calibration_key;      /* exact current conditions */
     int calibration_key_valid;
+    uint32_t advice_flags;
 } LmbTuiModel;
 
 typedef struct LmbTuiState {
@@ -65,6 +67,7 @@ static inline void lmb_tui_invalidate_plans(LmbTuiState *st) {
     for (int i = 0; i < st->nmodels; i++) {
         st->models[i].planned = 0;
         st->models[i].calibration_key_valid = 0;
+        st->models[i].advice_flags = 0;
     }
 }
 

--- a/tests/c/test_catalogue_advice.c
+++ b/tests/c/test_catalogue_advice.c
@@ -1,0 +1,32 @@
+#include "src/planner/lumabri_catalogue_advice.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    LmbAdviceCandidate c[] = {{1, 20, 10, 3}, {1, 40, 30, 7}, {0, 1, 100, 999}};
+    uint32_t f[3];
+    lmb_catalogue_advice(c, 3, f);
+    assert(f[0] == LMB_ADVICE_LOWEST_RAM);
+    assert(f[1] == (LMB_ADVICE_LARGEST_CHECKPOINT | LMB_ADVICE_FASTEST_OBSERVED));
+    assert(!f[2]); /* Unrunnable/unsupported entries never win advice. */
+    c[1].measured_tok_s = 0; /* changed plan or no measurement */
+    lmb_catalogue_advice(c, 3, f);
+    assert(!(f[0] & LMB_ADVICE_FASTEST_OBSERVED) && !(f[1] & LMB_ADVICE_FASTEST_OBSERVED));
+    c[1].measured_tok_s = NAN; lmb_catalogue_advice(c, 3, f);
+    assert(!(f[1] & LMB_ADVICE_FASTEST_OBSERVED));
+    c[1].measured_tok_s = INFINITY; lmb_catalogue_advice(c, 3, f);
+    assert(!(f[1] & LMB_ADVICE_FASTEST_OBSERVED));
+    c[1].reserved_bytes = UINT64_MAX; lmb_catalogue_advice(c, 3, f);
+    assert(!f[0] && !f[1] && !f[2]);
+    c[1] = c[0]; lmb_catalogue_advice(c, 3, f);
+    assert(f[0] == 7 && !f[1]); /* stable first-in-catalogue tie-break */
+    c[0].eligible = c[1].eligible = 0; lmb_catalogue_advice(c, 3, f);
+    assert(!f[0] && !f[1] && !f[2]);
+    f[0] = 7; lmb_catalogue_advice(NULL, 3, f); assert(!f[0]);
+    lmb_catalogue_advice(NULL, 0, NULL);
+    assert(!strcmp(lmb_advice_text(0), ""));
+    assert(!strcmp(lmb_advice_text(LMB_ADVICE_LOWEST_RAM), "lowest RAM reservation"));
+    puts("CATALOGUE ADVICE: PASS (admitted plans only; no invented speeds or quality rankings)");
+    return 0;
+}

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -80,8 +80,10 @@ int main(int argc, char **argv) {
     static LmbTuiState selection;
     selection.nmodels = 1;
     selection.models[0].planned = selection.models[0].calibration_key_valid = 1;
+    selection.models[0].advice_flags = LMB_ADVICE_FASTEST_OBSERVED;
     lmb_tui_invalidate_plans(&selection);
     assert(!selection.models[0].planned && !selection.models[0].calibration_key_valid);
+    assert(!selection.models[0].advice_flags);
     selection.nnodes = 3;
     for (int i = 0; i < 3; i++) {
         snprintf(selection.identities[i], sizeof selection.identities[i], "peer-%d", i);
@@ -91,6 +93,28 @@ int main(int argc, char **argv) {
     strcpy(selection.selected_nodes[0], selection.identities[1]);
     assert(lmb_tui_node_enabled(&selection, 1));
     assert(!lmb_tui_node_enabled(&selection, 0) && !lmb_tui_node_enabled(&selection, 2));
+    selection.nmodels = 2; selection.inventory_ok = 1;
+    for (int i = 0; i < 2; i++) {
+        LmbTuiModel *m = &selection.models[i];
+        snprintf(m->name, sizeof m->name, "advice-fixture-%d", i);
+        m->shape.layers = 1; m->plan.edge_node = 1; m->plan.slices[0].layer_end = 1;
+        m->planned = m->shape.sizing_verified = m->weights_present = m->checkpoint_inventory_ok = 1;
+        m->plan.state = LMB_PLAN_RESIDENT; m->plan.nslices = 1; m->plan.slices[0].node = 1;
+        m->plan.slices[0].bytes_resident = 20u * (i + 1); m->checkpoint_bytes = 10u * (i + 1);
+    }
+    catalog_advice_refresh(&selection);
+    assert(selection.models[0].advice_flags == LMB_ADVICE_LOWEST_RAM);
+    assert(selection.models[1].advice_flags == LMB_ADVICE_LARGEST_CHECKPOINT);
+    if (argc > 1 && !strcmp(argv[1], "advice")) {
+        catalog_json(&selection);
+        return lmb_tui_run(&selection, 1, "");
+    }
+    selection.models[1].shape.sizing_verified = 0;
+    catalog_advice_refresh(&selection);
+    assert(!selection.models[0].advice_flags && !selection.models[1].advice_flags);
+    selection.models[1].shape.sizing_verified = 1; selection.selected_nodes[0][0] = 0;
+    catalog_advice_refresh(&selection);
+    assert(!selection.models[0].advice_flags && !selection.models[1].advice_flags);
     if (argc > 1 && !strcmp(argv[1], "editor")) {
         char line[128];
         printf("USER-PREVIOUS\nASSISTANT-PREVIOUS\n\n│ › "); fflush(stdout);

--- a/tests/integration/chat_ui_test.py
+++ b/tests/integration/chat_ui_test.py
@@ -5,6 +5,7 @@ scroll regions and scrollback. No model, network or Python UI dependency.
 """
 import codecs
 import fcntl
+import json
 import os
 from pathlib import Path
 import pty
@@ -23,6 +24,14 @@ assert "layers [0,2)" in plan and "layers [2,4)" in plan
 assert "This chat process runs no model layers" in plan
 assert "No approved household plan" in plan
 assert "\x1b" not in plan, "a peer name injected terminal controls"
+
+advice = subprocess.check_output(["./test_chat_ui", "advice"], cwd=ROOT, text=True)
+document, screen_text = advice.split("\n", 1)
+models = json.loads(document)["models"]
+assert models[0]["advice"] == "lowest RAM reservation"
+assert models[1]["advice"] == "largest resident checkpoint"
+assert "lowest RAM reservation" in screen_text and "largest resident checkpoint" in screen_text
+assert "tok/s" not in screen_text, "resource advice invented a speed"
 
 
 class Screen:


### PR DESCRIPTION
## Catalogue advice on top of merged calibration PR #159

- Model-independent resource advisor lives in `src/planner/`, not model-specific UI branches.
- Consider only verified resident plans with source weights and explicitly selected donors.
- Highlight lowest aggregate RAM reservation (including Edge), largest fitting checkpoint by bytes, and fastest last observed run among at least two current measured plans.
- Unverified, non-fitting and unselected plans cannot win. Unknown or stale speed is never invented; ties follow catalogue order.
- Clear advice immediately when selection changes. No donor/model selection, download, allocation or execution is triggered by advice.
- TUI and JSON consume the same typed snapshot. Detail copy explicitly distinguishes resource advice from answer quality; different prompts/tokenizers/load limit historical speed comparisons.

## Verification

- `make test_catalogue_advice && ./test_catalogue_advice`: candidate exclusion, finite/unknown speed, overflow sentinel, empty input and deterministic ties.
- `python3 tests/integration/chat_ui_test.py`: actual producer -> JSON and rendered catalogue, plus no numerical speed without a record, selection invalidation, normal editor/streaming tests.
- `python3 tests/ui_text_test.py`: English application copy.
- Native macOS workspace CI runs the new unit test; ordinary Linux test suite includes it.

This does not rank model answer quality or promise the next turn's throughput. It does not implement measured per-stage placement, model acquisition, household multi-session recovery, native Windows inference or physical-LAN certification. Colibri remains unchanged. Merge only after exact-head green checks, with a normal merge, never squash.
