### PR TITLE
delivery: test native household candidates outside the source layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
         run: make test-home-network CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
       - name: Native workspace navigation and terminal restoration
         run: python3 tests/integration/workspace_navigation_test.py
+      - name: Native candidate packaging contracts
+        run: |
+          python3 tests/integration/package_household_test.py
+          python3 tests/integration/preload_path_test.py
   linux:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
@@ -275,10 +279,28 @@ jobs:
           name: tiny-v4-checkpoint
           path: lumabri/build/v4-chat/deepseek-v4-tiny/*
           retention-days: 3
+      - name: Assemble and test the Linux candidate outside the checkout layout
+        working-directory: lumabri
+        run: |
+          python3 tests/integration/package_household_test.py
+          python3 tools/package_household.py --colibri-root ../colibri --output 'build/native candidate'
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
+          python3 tools/package_household.py --verify 'build/native candidate'
+          tar -czf build/lumabri-linux-candidate.tar.gz -C 'build/native candidate' .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: household-candidate-linux
+          path: lumabri/build/lumabri-linux-candidate.tar.gz
+          retention-days: 7
   macos-household:
     # Real native CPU engines + signed CAS + approvals + streaming. Loopback
     # coverage does not replace the macOS 12.6 / physical household LAN test.
     needs: linux
+    env:
+      # A native macOS 15 test is not a macOS 12 test, but do not ship a binary
+      # whose load commands already forbid the user's macOS 12.6 machine.
+      MACOSX_DEPLOYMENT_TARGET: '12.0'
     strategy:
       fail-fast: false
       matrix:
@@ -387,6 +409,21 @@ jobs:
       - name: Native V4 request and execution
         working-directory: lumabri
         run: python3 tests/integration/home_flow_test.py --models-dir build/v4-home-models --donor-ram-gb 1.0
+      - name: Assemble and test a system-libraries-only native macOS candidate
+        if: matrix.openmp == 'disabled'
+        working-directory: lumabri
+        run: |
+          python3 tools/package_household.py --colibri-root ../colibri --output 'build/native candidate'
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
+          python3 tools/package_household.py --verify 'build/native candidate'
+          tar -czf build/lumabri-macos-candidate.tar.gz -C 'build/native candidate' .
+      - uses: actions/upload-artifact@v4
+        if: matrix.openmp == 'disabled'
+        with:
+          name: household-candidate-${{ matrix.runner }}
+          path: lumabri/build/lumabri-macos-candidate.tar.gz
+          retention-days: 7
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ PLANNER_ADAPTER_DEPS = $(wildcard planner_adapters/*.h)
 lumabri test_chat_ui test_planner test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
 lumabri test_chat_ui: lumabri_runtime_identity.h lumabri_checkpoint_identity.h lumabri_calibration_store.h lumabri_calibration.h
 lumabri test_chat_ui: src/planner/lumabri_catalogue_advice.h
+lumabri test_chat_ui: src/runtime/lumabri_preload.h
 lumabri segment_chat test_chat_ui: lumabri_metrics.h
 
 lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
@@ -762,6 +763,8 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	$(MAKE) test-ready-pipe
 	$(MAKE) test-home-network
 	python3 ./tests/integration/chat_ui_test.py
+	python3 ./tests/integration/package_household_test.py
+	python3 ./tests/integration/preload_path_test.py
 	python3 tests/ui_text_test.py
 	python3 tests/integration/workspace_navigation_test.py
 	python3 ./tests/integration/lan_inventory_test.py
@@ -799,6 +802,15 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 # and the shim in PREFIX/lib/lumabri. Phase-2 binaries are installed when
 # they have been built (make phase2 ENGINE=...).
 PREFIX ?= /usr/local
+
+# Deliberately small, complete household install. Unlike the historical
+# optional loop below, a missing Segment service is a build/install failure.
+install-household: household swarm_probe
+	install -d "$(DESTDIR)$(PREFIX)/bin" "$(DESTDIR)$(PREFIX)/lib/lumabri"
+	install -m 755 lumabri tracker maintainer swarm_probe segment_node segment_chat "$(DESTDIR)$(PREFIX)/bin/"
+	install -m 644 $(SHIM_LIB) tools/setup-household-firewall.ps1 "$(DESTDIR)$(PREFIX)/lib/lumabri/"
+
+.PHONY: install-household
 
 install: all
 	install -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/lib/lumabri

--- a/deploy/household-launcher.sh
+++ b/deploy/household-launcher.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# This file also ships as Lumabri.command in the native macOS candidate.
+# Keep the terminal attached: approval and chat are interactive.
+bundle_dir=$(CDPATH= cd -P "$(dirname "$0")" && pwd) || exit 1
+exec "$bundle_dir/bin/lumabri" "$@"

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -159,4 +159,10 @@ not a completed gate.
    disk working sets remain pending. See `HOUSEHOLD_WEIGHT_CACHE.md`.
 6. Pending: upstream-only GPU capability integration, CPU otherwise.
 7. Pending: concurrent sessions and actual replay after failure.
-8. Pending: native releases, platform validation and dependency-backed cleanup.
+8. Native candidate assembly now has an explicit binary allowlist, retained
+   upstream notices, exact file hashes and dependency reports. The installed
+   `bin`/`lib` layout is exercised by the same two-donor approval, generation,
+   cache/calibration and lost-donor tests. macOS candidates use system libraries
+   only (no OpenMP). Native Windows, older/clean-machine compatibility,
+   physical LAN acceptance and dependency-backed repository cleanup remain
+   pending. Candidate artifacts are not a completed release gate.

--- a/docs/NATIVE_CANDIDATES.md
+++ b/docs/NATIVE_CANDIDATES.md
@@ -1,0 +1,75 @@
+# Try a native household candidate
+
+This is a test candidate, not certification that the complete roadmap is done.
+It contains the C workspace, tracker, checkpoint source, Segment services,
+diagnostic probe and weight loader. It contains **no model weights or keys**.
+
+Keep the whole folder together. On macOS, open `Lumabri.command`; on Linux,
+run `./start-lumabri` from a terminal. The launcher opens the normal TUI.
+Python, pip and the Colibri source checkout are not needed to run the folder.
+
+1. On one computer, use `/create`. On the others, use `/join`, check the
+   displayed identity and enter that household's key.
+2. On helpers, open **Share resources** and keep it open. They do not allocate
+   model memory until their owner accepts a particular request.
+3. On the chatting computer, set the source model folder in `/settings`,
+   open **Your computers** and select the helpers you want to use.
+4. Choose a supported, fitting model and request its plan. Accept on each
+   selected helper. Chat starts after the complete approved chain is ready.
+
+The source checkpoint is still required on the requesting computer. A synthetic
+Tiny fixture tests transport and execution; its random text and speed do not
+represent a trained large model. An unmeasured model has no numerical speed.
+The latest measured speed is historical, not a guarantee for the next turn.
+
+## Platform limits
+
+- The manifest names the actual native build OS and architecture. An Intel
+  archive is not an Apple Silicon archive. macOS CI runs do not prove macOS
+  12.6 compatibility; test that machine before claiming it supported.
+  CI targets macOS 12.0, and packaging checks the minimum OS recorded in
+  every Mach-O binary. This necessary compatibility check is not a substitute
+  for running the candidate on macOS 12.6.
+- macOS candidates intentionally use the no-OpenMP build, with only system
+  libraries. This avoids requiring Homebrew on every helper but runs one
+  engine thread. It is not the performance release. A Mac downloaded archive
+  can require approval in macOS security settings; it is not notarized.
+  Spaces in the install folder are tested; colons in macOS library paths are
+  rejected because the loader treats them as a library-list separator.
+- Linux records its dynamic library dependencies in `manifest.json`; it is
+  not a universal static binary. Use the recorded compatible OS/runtime.
+  Windows/WSL runs this Linux candidate. Native Windows inference is not
+  included and is not certified by the firewall helper.
+- Neither a GPU detector nor a manifest entry proves accelerated execution.
+  These candidates use the verified CPU path. Each participating machine
+  must permit the household's fixed LAN ports in its own firewall.
+- One household chat plan at a time. Losing a participating donor stops the
+  current chat and releases resources; automatic household replay is pending.
+
+## Building and testing a candidate
+
+Build Colibri from the pinned checkout used by CI, without editing it. Build
+`make household swarm_probe ENGINE=/path/to/colibri/c`. For a macOS candidate,
+pass `OMP_FLAGS= OMP_LIBS=` to that build.
+
+Then assemble a **new** directory:
+
+```sh
+python3 tools/package_household.py --colibri-root /path/to/colibri --output /tmp/lumabri-candidate
+python3 tests/integration/home_flow_test.py --runtime-dir /tmp/lumabri-candidate/bin --models-dir /path/to/tiny-model-parent --repeat-cached --expect-metrics --expect-calibration
+python3 tools/package_household.py --verify /tmp/lumabri-candidate
+```
+
+The test uses fresh isolated homes, real encrypted services, two approvals,
+two actual Segment ranges, streaming, cache reuse and invalidation of timings.
+It does not use binaries from the source directory. Keep its logs together
+with the candidate manifest. Run the lost-donor test separately with
+`--kill-donor`. CI uploads candidates only after their installed-layout tests
+succeed; physical two-computer LAN validation remains a separate release gate.
+The post-test hash check rejects missing, changed or extra files and symlinks.
+It checks consistency with the manifest, not the trustworthiness of a download
+or a cryptographic release signature.
+
+`make install-household PREFIX=/your/prefix` is the strict install target:
+all required services must build, not just the TUI. The older general install
+target remains available for existing Expert/public-network deployments.

--- a/docs/REPOSITORY.md
+++ b/docs/REPOSITORY.md
@@ -19,7 +19,8 @@ ready for household use. The public README documents the tested TUI path.
 | `src/planner/` | Model-independent catalogue advice; no UI rendering or weight loading |
 | `lumabri_machine.*`, scheduler and governor headers | Hardware inventory, resource budgets and admission |
 | `expert_engines/`, `engine_patches/`, Expert bridge files | Optional Expert/Hybrid and upstream compatibility |
-| `deploy/`, root deployment/release documents | Existing deployment and release tooling |
+| `deploy/`, root deployment/release documents | Existing deployment tooling and the minimal household launcher |
+| `tools/package_household.py` | Allowlisted native candidate assembly; never copies models or credentials |
 | `build/`, local executables, `__pycache__/`, tiny fixtures | Generated/ignored artifacts, not production source files |
 
 The root Makefile remains the supported build entry point. Test executable

--- a/lumabri.c
+++ b/lumabri.c
@@ -66,6 +66,7 @@
 #include "lumabri_segment_discovery.h"
 #include "lumabri_sign.h"
 #include "lumabri_secure.h"
+#include "src/runtime/lumabri_preload.h"
 #include "lumabri_inventory.h"
 #include "lumabri_home.h"
 #include "lumabri_runtime_identity.h"
@@ -2919,7 +2920,7 @@ static int engine_spawn(const char *engine, const char *shim, const char *tracke
         if (local_dir) {
             setenv("SNAP", local_dir, 1);
         } else {
-            setenv(LMB_PRELOAD_ENV, shim, 1);
+            if (lmb_preload_file(shim)) { perror("Cannot load household weight loader"); _exit(125); }
             setenv("LUMABRI_VROOT", vroot, 1);
             setenv("LUMABRI_CACHE", cache, 1);
             setenv("LUMABRI_CAS", cas, 0);       /* shared across model mirrors */
@@ -3027,7 +3028,7 @@ static int segment_engine_spawn(const char *engine, const char *shim,
     if (pid == 0) {
         dup2(in_pipe[0], 0); dup2(out_pipe[1], 1); dup2(err_pipe[1], 2);
         close(in_pipe[1]); close(out_pipe[0]); close(err_pipe[0]);
-        setenv(LMB_PRELOAD_ENV, shim, 1);
+        if (lmb_preload_file(shim)) { perror("Cannot load household weight loader"); _exit(125); }
         setenv("LUMABRI_VROOT", vroot, 1);
         setenv("LUMABRI_CACHE", cache, 1);
         setenv("LUMABRI_CAS", cas, 0);

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -123,7 +123,14 @@ static pid_t home_spawn(char *const argv[], char *const envv[], const char *log,
         dup2(nullfd, 0); dup2(logfd, 1); dup2(logfd, 2);
         if (nullfd > 2) close(nullfd);
         if (logfd > 2) close(logfd);
-        for (int i = 0; envv && envv[i]; i++) putenv(envv[i]);
+        for (int i = 0; envv && envv[i]; i++) {
+            const size_t preload_prefix = sizeof(LMB_PRELOAD_ENV "=") - 1;
+            if (!strncmp(envv[i], LMB_PRELOAD_ENV "=", preload_prefix)) {
+                if (lmb_preload_file(envv[i] + preload_prefix)) {
+                    perror("Cannot load household weight loader"); _exit(125);
+                }
+            } else if (putenv(envv[i])) _exit(125);
+        }
         if (listener >= 0) {
             char descriptor[32];
             if (fcntl(listener, F_SETFD, 0)) _exit(125);

--- a/src/runtime/lumabri_preload.h
+++ b/src/runtime/lumabri_preload.h
@@ -1,0 +1,42 @@
+/* A single application-owned preload library, not an arbitrary preload list.
+ * Call only in the forked child immediately before exec. */
+#ifndef LUMABRI_PRELOAD_H
+#define LUMABRI_PRELOAD_H
+#include "lumabri_platform.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static inline int lmb_preload_file(const char *path) {
+    if (!path) { errno = EINVAL; return -1; }
+#ifdef __linux__
+    /* ld.so splits LD_PRELOAD on whitespace and colons before opening files.
+     * Quoting a path cannot fix that. An inherited read-only descriptor gives
+     * the loader an unambiguous, stable path even in a spaced install folder.
+     * Keep this one descriptor for the engine lifetime, including child execs;
+     * process exit releases it. The original shim is still used for hashing.
+     */
+    if (strpbrk(path, " :\t\r\n\v\f")) {
+        int fd = open(path, O_RDONLY | O_NOFOLLOW);
+        if (fd < 0) return -1;
+        struct stat st;
+        if (fstat(fd, &st) || !S_ISREG(st.st_mode)) {
+            close(fd); errno = EINVAL; return -1;
+        }
+        char reference[64];
+        snprintf(reference, sizeof reference, "/proc/self/fd/%d", fd);
+        if (setenv(LMB_PRELOAD_ENV, reference, 1)) { close(fd); return -1; }
+        return 0;
+    }
+#elif defined(__APPLE__)
+    /* Spaces are literal in DYLD_INSERT_LIBRARIES, but colons delimit entries.
+     * Refuse that unsupported install path instead of silently skipping CAS. */
+    if (strchr(path, ':')) { errno = EINVAL; return -1; }
+#endif
+    return setenv(LMB_PRELOAD_ENV, path, 1);
+}
+#endif

--- a/tests/c/preload_path_fixture.c
+++ b/tests/c/preload_path_fixture.c
@@ -1,0 +1,20 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+#if defined(TEST_PRELOAD_LIBRARY)
+__attribute__((constructor)) static void loaded(void) {
+    setenv("LMB_PRELOAD_PATH_TEST", "loaded", 1);
+}
+#elif defined(TEST_PRELOAD_LAUNCHER)
+#include "src/runtime/lumabri_preload.h"
+int main(int argc, char **argv) {
+    if (argc != 3 || lmb_preload_file(argv[1])) return 2;
+    execl(argv[2], argv[2], (char *)NULL);
+    return 3;
+}
+#else
+int main(void) {
+    const char *value = getenv("LMB_PRELOAD_PATH_TEST");
+    return !value || strcmp(value, "loaded");
+}
+#endif

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -24,7 +24,10 @@ ROOT = Path(__file__).resolve().parents[2]
 
 
 def main():
+    global ROOT
     parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime-dir", type=Path, default=ROOT,
+                        help="directory containing the installed household binaries; no source tree fallback")
     parser.add_argument("--models-dir", required=True)
     parser.add_argument("--donor-ram-gb", type=float, default=0.5)
     parser.add_argument("--context", type=int, default=128,
@@ -41,6 +44,10 @@ def main():
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
+    ROOT = args.runtime_dir.resolve(strict=True)
+    for binary in ("lumabri", "tracker", "maintainer", "segment_node", "segment_chat"):
+        if not (ROOT / binary).is_file() or not os.access(ROOT / binary, os.X_OK):
+            parser.error(f"missing executable in runtime directory: {binary}")
     if args.repeat_cached and (args.kill_donor or args.expect_no_fit):
         parser.error("--repeat-cached requires a normal completed first session")
     if args.expect_calibration and (args.kill_donor or args.expect_no_fit):

--- a/tests/integration/package_household_test.py
+++ b/tests/integration/package_household_test.py
@@ -1,0 +1,144 @@
+"""Packaging contracts; real installed inference is a separate native CI gate."""
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("package_household", ROOT / "tools/package_household.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class PackageTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="lumabri-package-test-")
+        self.root = Path(self.temporary.name)
+        self.runtime = self.root / "runtime"
+        self.runtime.mkdir()
+        for name in (*module.BINARIES, "liblumabri.so", "liblumabri.dylib"):
+            path = self.runtime / name
+            path.write_bytes(b"test packaging bytes, not a model runtime\n")
+            path.chmod(0o755)
+        (self.runtime / "private.key").write_text("must never ship")
+        (self.runtime / "weights.safetensors").write_text("must never ship")
+        self.colibri = self.root / "colibri"
+        self.colibri.mkdir()
+        (self.colibri / "LICENSE").write_text("test upstream licence")
+        (self.colibri / "THIRD_PARTY_NOTICES.md").write_text("test upstream notices")
+        self.output = self.root / "candidate with spaces"
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def build(self, system="Linux"):
+        with patch.object(module.platform, "system", return_value=system), \
+                patch.object(module, "dependencies", return_value="test dependencies"), \
+                patch.object(module, "macos_minimum", return_value=(12, 0, 0)), \
+                patch.object(module, "revision", return_value={"commit": "a" * 40, "tracked_changes": False}):
+            return module.package(self.runtime, self.colibri, self.output)
+
+    def test_exact_allowlist_manifest_and_modes(self):
+        result = self.build()
+        self.assertEqual(json.loads((self.output / "manifest.json").read_text()), result)
+        self.assertEqual(module.verify(self.output), result)
+        names = {str(p.relative_to(self.output)) for p in self.output.rglob("*") if p.is_file()}
+        self.assertEqual(names, set(result["files"]) | {"manifest.json"})
+        self.assertEqual(set(p.name for p in (self.output / "bin").iterdir()), set(module.BINARIES))
+        self.assertNotIn("private.key", " ".join(names))
+        self.assertNotIn("weights.safetensors", " ".join(names))
+        for name, info in result["files"].items():
+            path = self.output / name
+            self.assertEqual(hashlib.sha256(path.read_bytes()).hexdigest(), info["sha256"])
+            self.assertEqual(path.stat().st_size, info["bytes"])
+            self.assertEqual(path.stat().st_mode & 0o777, int(info["mode"], 8))
+
+    def test_existing_output_is_never_overwritten(self):
+        self.build()
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            self.build()
+
+    def test_verify_rejects_mutation_extra_file_and_symlink(self):
+        self.build()
+        binary = self.output / "bin/lumabri"
+        original = binary.read_bytes()
+        binary.write_bytes(b"changed")
+        with self.assertRaisesRegex(ValueError, "file changed"):
+            module.verify(self.output)
+        binary.write_bytes(original)
+        extra = self.output / "private.key"
+        extra.write_text("must never ship")
+        with self.assertRaisesRegex(ValueError, "extra files"):
+            module.verify(self.output)
+        extra.unlink()
+        binary.unlink()
+        binary.symlink_to(self.runtime / "lumabri")
+        with self.assertRaisesRegex(ValueError, "symlink"):
+            module.verify(self.output)
+
+    def test_incomplete_runtime_does_not_create_output(self):
+        (self.runtime / "segment_chat").unlink()
+        with self.assertRaises(FileNotFoundError):
+            self.build()
+        self.assertFalse(self.output.exists())
+
+    def test_symlink_runtime_or_destination_is_rejected(self):
+        target = self.runtime / "segment_chat"
+        target.unlink()
+        target.symlink_to(self.runtime / "segment_node")
+        with self.assertRaisesRegex(ValueError, "not a regular"):
+            self.build()
+        self.assertFalse(self.output.exists())
+        self.output.symlink_to(self.root / "absent")
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            self.build()
+
+    def test_macos_launcher_and_upstream_notices(self):
+        result = self.build("Darwin")
+        self.assertIn("Lumabri.command", result["files"])
+        self.assertIn("lib/lumabri/liblumabri.dylib", result["files"])
+        self.assertEqual((self.output / "licenses/Colibri-THIRD_PARTY_NOTICES.md").read_text(), "test upstream notices")
+
+    def test_windows_is_not_silently_linux(self):
+        with self.assertRaisesRegex(ValueError, "Windows household packaging is not implemented"):
+            self.build("Windows")
+
+    def test_non_system_macos_dependency_refused(self):
+        bad = "segment_node:\n\t/opt/homebrew/opt/libomp/lib/libomp.dylib (compatibility version 5.0.0)\n"
+        with patch.object(module.subprocess, "check_output", return_value=bad):
+            with self.assertRaisesRegex(ValueError, "non-system macOS dependency"):
+                module.dependencies(self.runtime / "segment_node", "Darwin")
+        good = "liblumabri.dylib:\n\tliblumabri.dylib (compatibility version 0.0.0)\n\t/usr/lib/libSystem.B.dylib (compatibility version 1.0.0)\n"
+        with patch.object(module.subprocess, "check_output", return_value=good):
+            self.assertEqual(module.dependencies(self.runtime / "liblumabri.dylib", "Darwin"), good)
+
+    def test_missing_linux_library_refused(self):
+        with patch.object(module.subprocess, "check_output", return_value="libgomp.so.1 => not found\n"):
+            with self.assertRaisesRegex(ValueError, "unresolved runtime dependency"):
+                module.dependencies(self.runtime / "segment_node", "Linux")
+
+    def test_macos_minimum_comes_from_load_commands(self):
+        report = "cmd LC_BUILD_VERSION\nplatform 1\nminos 12.0\nsdk 15.0\ncmd LC_SOURCE_VERSION\nversion 99.0\n"
+        with patch.object(module.subprocess, "check_output", return_value=report):
+            self.assertEqual(module.macos_minimum(self.runtime / "segment_node"), (12, 0, 0))
+        with patch.object(module.subprocess, "check_output", return_value="cmd LC_VERSION_MIN_MACOSX\nversion 10.15\nsdk 15.0\n"):
+            self.assertEqual(module.macos_minimum(self.runtime / "segment_node"), (10, 15, 0))
+        with patch.object(module.subprocess, "check_output", return_value="cmd LC_SOURCE_VERSION\nversion 99.0\n"):
+            with self.assertRaisesRegex(ValueError, "no macOS deployment"):
+                module.macos_minimum(self.runtime / "segment_node")
+
+    def test_candidate_cannot_exceed_requested_macos_target(self):
+        with patch.dict(os.environ, {"MACOSX_DEPLOYMENT_TARGET": "11.0"}):
+            with self.assertRaisesRegex(ValueError, "above the requested target"):
+                self.build("Darwin")
+        self.assertFalse(self.output.exists())
+        with patch.dict(os.environ, {"MACOSX_DEPLOYMENT_TARGET": "12.0"}):
+            self.assertEqual(self.build("Darwin")["minimum_macos"], "12.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/preload_path_test.py
+++ b/tests/integration/preload_path_test.py
@@ -1,0 +1,32 @@
+"""Native loader proof: the tested helper execs a real separately built binary."""
+import os
+from pathlib import Path
+import platform
+import shlex
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+source = ROOT / "tests/c/preload_path_fixture.c"
+cc = shlex.split(os.environ.get("CC", "cc"))
+with tempfile.TemporaryDirectory(prefix="lumabri-preload-test-") as temporary:
+    root = Path(temporary)
+    folder = root / ("install with spaces:and colon" if platform.system() == "Linux" else "install with spaces")
+    folder.mkdir()
+    library = folder / ("libtest.dylib" if platform.system() == "Darwin" else "libtest.so")
+    launcher, probe = root / "launcher", folder / "probe"
+    common = cc + ["-O2", "-Wall", "-Wextra", "-Werror", "-I", str(ROOT), str(source)]
+    subprocess.run(common + ["-DTEST_PRELOAD_LIBRARY", "-dynamiclib" if platform.system() == "Darwin" else "-shared",
+                             "-fPIC", "-o", str(library)], check=True)
+    subprocess.run(common + ["-DTEST_PRELOAD_LAUNCHER", "-o", str(launcher)], check=True)
+    subprocess.run(common + ["-o", str(probe)], check=True)
+    environment = {k: v for k, v in os.environ.items()
+                   if k not in ("LD_PRELOAD", "DYLD_INSERT_LIBRARIES", "LMB_PRELOAD_PATH_TEST")}
+    assert subprocess.run([str(probe)], env=environment).returncode != 0, "probe must require the actual constructor"
+    if platform.system() == "Linux":
+        old = subprocess.run([str(probe)], env={**environment, "LD_PRELOAD": str(library)},
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        assert old.returncode != 0, "regression fixture must expose the old unescaped preload failure"
+    subprocess.run([str(launcher), str(library), str(probe)], check=True, env=environment)
+    assert subprocess.run([str(launcher), str(folder / "missing library"), str(probe)], env=environment).returncode != 0
+print("PRELOAD PATH: PASS (native constructor loaded through a spaced install path)")

--- a/tools/package_household.py
+++ b/tools/package_household.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Assemble a native test candidate, never a cross-platform support claim.
+
+Python is build tooling only. The delivered UI/runtime remain C; the launcher
+uses the system shell. No checkpoint, key, cache or developer binary is swept
+into the package. Build each platform natively, then test this exact directory.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import platform
+import shutil
+import stat
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+BINARIES = ("lumabri", "tracker", "maintainer", "segment_node", "segment_chat", "swarm_probe")
+
+
+def regular(path, executable=False):
+    info = path.lstat()
+    if not stat.S_ISREG(info.st_mode) or (executable and not os.access(path, os.X_OK)):
+        raise ValueError(f"not a regular {'executable' if executable else 'file'}: {path}")
+    return path
+
+
+def revision(root):
+    commit = subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
+    dirty = bool(subprocess.check_output(
+        ["git", "-C", str(root), "status", "--porcelain", "--untracked-files=no"], text=True).strip())
+    return {"commit": commit, "tracked_changes": dirty}
+
+
+def checksum(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def dependencies(binary, system):
+    # Inspection happens only on our just-built native binaries. Do not invoke
+    # ldd on downloads supplied by third parties.
+    command = ["otool", "-L", str(binary)] if system == "Darwin" else ["ldd", str(binary)]
+    report = subprocess.check_output(command, text=True, stderr=subprocess.STDOUT)
+    if "not found" in report:
+        raise ValueError(f"unresolved runtime dependency: {binary}\n{report}")
+    if system == "Darwin":
+        for line in report.splitlines()[1:]:
+            name = line.strip().split(" (", 1)[0]
+            # A dylib's first entry is its own install name, not a dependency.
+            if binary.suffix == ".dylib" and name in (binary.name, str(binary)):
+                continue
+            if not name.startswith(("/usr/lib/", "/System/Library/")):
+                raise ValueError(f"non-system macOS dependency {name}; build the candidate with OMP_FLAGS= OMP_LIBS=")
+    return report
+
+
+def version_tuple(text):
+    value = tuple(int(part) for part in text.split("."))
+    if not 1 <= len(value) <= 3 or any(part < 0 for part in value):
+        raise ValueError(f"invalid OS version: {text}")
+    return value + (0,) * (3 - len(value))
+
+
+def macos_minimum(binary):
+    report = subprocess.check_output(["otool", "-l", str(binary)], text=True)
+    command, versions = "", []
+    for line in report.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[0] == "cmd":
+            command = fields[1]
+        if len(fields) == 2 and ((command == "LC_BUILD_VERSION" and fields[0] == "minos") or
+                                 (command == "LC_VERSION_MIN_MACOSX" and fields[0] == "version")):
+            versions.append(version_tuple(fields[1]))
+    if not versions:
+        raise ValueError(f"no macOS deployment version in {binary}")
+    return max(versions)
+
+
+def package(runtime, colibri, output, repository=ROOT):
+    system = platform.system()
+    if system not in ("Linux", "Darwin"):
+        raise ValueError("native Windows household packaging is not implemented; WSL is a Linux build")
+    runtime, colibri, repository = runtime.resolve(strict=True), colibri.resolve(strict=True), repository.resolve(strict=True)
+    # Reject existing paths (including dangling symlinks); never overwrite an
+    # installation or reuse a directory containing another build's binaries.
+    if output.exists() or output.is_symlink():
+        raise ValueError(f"output already exists: {output}")
+    shim = "liblumabri.dylib" if system == "Darwin" else "liblumabri.so"
+    files = [(regular(runtime / name, True), f"bin/{name}", 0o755) for name in BINARIES]
+    files += [(regular(runtime / shim), f"lib/lumabri/{shim}", 0o644),
+              (regular(repository / "tools/setup-household-firewall.ps1"), "lib/lumabri/setup-household-firewall.ps1", 0o644),
+              (regular(repository / "LICENSE"), "licenses/Lumabri-LICENSE", 0o644),
+              (regular(colibri / "LICENSE"), "licenses/Colibri-LICENSE", 0o644),
+              (regular(repository / "docs/NATIVE_CANDIDATES.md"), "START_HERE.md", 0o644),
+              (regular(repository / "deploy/household-launcher.sh"),
+               "Lumabri.command" if system == "Darwin" else "start-lumabri", 0o755)]
+    # Keep the upstream notices with the exact checkout used by this build.
+    for name in ("NOTICE", "THIRD_PARTY_NOTICES.md"):
+        if (colibri / name).exists():
+            files.append((regular(colibri / name), f"licenses/Colibri-{name}", 0o644))
+    report = {name: dependencies(runtime / name, system) for name in (*BINARIES, shim)}
+    minimum_macos = None
+    if system == "Darwin":
+        required = max(macos_minimum(runtime / name) for name in (*BINARIES, shim))
+        minimum_macos = ".".join(str(part) for part in required)
+        target = os.environ.get("MACOSX_DEPLOYMENT_TARGET")
+        if target and required > version_tuple(target):
+            raise ValueError(f"a binary requires macOS {minimum_macos}, above the requested target {target}")
+    manifest = {"schema": "LMB-NATIVE-CANDIDATE-1", "status": "requires-native-and-physical-acceptance",
+                "system": system, "architecture": platform.machine(), "build_os": platform.platform(),
+                "minimum_macos": minimum_macos,
+                "lumabri": revision(repository), "colibri_checkout": revision(colibri),
+                "dependencies": report, "files": {}}
+    # No model-runtime provenance is inferred from a directory name: retain
+    # hashes of the actual shipped bytes as well as source checkout metadata.
+    output.mkdir(mode=0o755)
+    for source, relative, mode in files:
+        target = output / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+        target.chmod(mode)
+        manifest["files"][relative] = {"sha256": checksum(target),
+                                      "bytes": target.stat().st_size, "mode": oct(mode)}
+    (output / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return manifest
+
+
+def verify(directory):
+    """Consistency check, not a signature or independent trust attestation."""
+    directory = directory.resolve(strict=True)
+    manifest_path = regular(directory / "manifest.json")
+    if manifest_path.stat().st_size > 128 * 1024:
+        raise ValueError("oversized candidate manifest")
+    manifest = json.loads(manifest_path.read_text())
+    if not isinstance(manifest, dict) or manifest.get("schema") != "LMB-NATIVE-CANDIDATE-1":
+        raise ValueError("unknown candidate manifest")
+    files = manifest.get("files")
+    if not isinstance(files, dict) or not 1 <= len(files) <= 32:
+        raise ValueError("invalid manifest file list")
+    actual = set()
+    # Inspect entries before resolving declared paths; a symlinked directory
+    # must not make the verifier read outside the candidate.
+    for index, path in enumerate(directory.rglob("*")):
+        if index >= 64 or path.is_symlink():
+            raise ValueError("unexpected entry or symlink in candidate")
+        if path.is_file():
+            actual.add(str(path.relative_to(directory)))
+        elif not path.is_dir():
+            raise ValueError("non-regular entry in candidate")
+    if actual != set(files) | {"manifest.json"}:
+        raise ValueError("candidate has missing or extra files")
+    for name, expected in files.items():
+        relative = PurePosixPath(name)
+        if relative.is_absolute() or ".." in relative.parts or str(relative) != name:
+            raise ValueError("unsafe manifest path")
+        path = regular(directory / name)
+        if (not isinstance(expected, dict) or expected.get("sha256") != checksum(path) or
+                expected.get("bytes") != path.stat().st_size or
+                expected.get("mode") != oct(path.stat().st_mode & 0o777)):
+            raise ValueError(f"candidate file changed: {name}")
+    return manifest
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime-dir", type=Path, default=ROOT)
+    parser.add_argument("--colibri-root", type=Path,
+                        help="read-only source checkout used for the native build, including LICENSE")
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--output", type=Path, help="new, empty destination (must not exist)")
+    action.add_argument("--verify", type=Path, help="check exact file hashes and contents after native tests")
+    args = parser.parse_args()
+    if args.output and not args.colibri_root:
+        parser.error("--output requires --colibri-root")
+    try:
+        if args.verify:
+            verify(args.verify)
+            print("Native candidate contents and hashes: PASS")
+            return 0
+        manifest = package(args.runtime_dir, args.colibri_root, args.output)
+    except (OSError, ValueError, subprocess.SubprocessError) as error:
+        print(f"Household candidate was not completed: {error}", file=sys.stderr)
+        return 1
+    print(f"Native {manifest['system']} {manifest['architecture']} candidate: {args.output}")
+    print("Run the household acceptance flow from its bin directory before distributing it.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Native household delivery on top of merged #160

This is a tested CPU candidate path, not a declaration that all eight roadmap gates are complete.

- Strict `install-household` target builds and installs every required service; no optional Segment binary loop.
- Allowlisted candidate assembly: six C executables, platform shim, network helper, launcher, instructions and retained Colibri/Lumabri licenses/notices. No models, cache, keys, tests or legacy Expert binaries are swept into it.
- Manifest records actual shipped file hashes/modes, dependency inspection and checkout metadata. Verification after native tests rejects mutation or extra files. It is not a release signature.
- macOS candidates use the no-OpenMP, system-libraries-only variant. Native household CI targets macOS 12.0, and packaging inspects actual Mach-O minimum-OS load commands. macOS 12.6 still needs a physical test; no notarization or native Windows inference is claimed.
- The real two-donor approval/generation/cache/calibration/restart/lost-donor harness accepts a runtime directory, with no source-tree binary fallback. Native Linux and macOS CI test the packaged `bin`/`lib` layout before uploading candidate archives.
- Spaced install paths are exercised. Linux's single owned preload library uses an inherited read-only descriptor when loader-list separators occur in its path. A real native constructor/exec regression proves the old string form fails and the new form loads the library. macOS spaces are tested; unsupported colons fail explicitly.

## Local evidence

- Full actual household path from the ordinary installed directory: consent, two executing ranges, generation, cached second approval, recorded/stale calibration and donor restart pass (`/tmp/lumabri-home-flow-vksbm8pg`); separate killed-donor cleanup passes (`/tmp/lumabri-home-flow-fawgntba`).
- Same complete path from `build/native candidate/bin`, including spaces: pass (`/tmp/lumabri-home-flow-izwdw53q`), plus killed-donor cleanup (`/tmp/lumabri-home-flow-2x7ql3op`).
- Packaging contract tests, native preload constructor/exec regression, chat editor/transcript tests, English-copy checks and `git diff --check` pass.
- Upstream Colibri is unmodified; local engine archive is the already verified pinned CPU build. Native platform CI builds each candidate itself.

Remaining gates include measured placement, model acquisition/disk working sets, household concurrent sessions/replay, native Windows inference and physical/large-model validation. Merge only the exact green reviewed head using a normal merge, never squash.
