### PR TITLE
planner: recover feasible household allocations without weakening memory guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           make swarm_probe
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --expect-unused-donor
       - name: Same greedy tokens with one and two real Segment ranges
         working-directory: lumabri
         run: |
@@ -347,6 +348,7 @@ jobs:
           make swarm_probe
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --expect-unused-donor
       - uses: actions/download-artifact@v4
         with:
           name: tiny-qwen36-checkpoint

--- a/docs/HOUSEHOLD_PLACEMENT.md
+++ b/docs/HOUSEHOLD_PLACEMENT.md
@@ -1,0 +1,49 @@
+# Resident household placement
+
+The catalogue and request path use the same resident-plan search. A successful
+existing proportional plan is retained, including its node order and ranges.
+This avoids gratuitously changing a working plan or its calibration identity.
+
+When the proportional assignment fails the actual process budgets, the planner
+tries each selected computer as Edge owner and assigns it a nonempty prefix.
+The remaining computers are tried in descending and ascending RAM order, with
+stable inventory-order ties. Each receives the largest contiguous range that
+fits the shared resident reservation. Computers unable to hold even one layer
+are skipped. The full candidate must pass the same validator used before
+launch: complete coverage, one interval per participant, exactly one Edge
+owner with a Segment interval, and no per-computer over-allocation.
+
+This fixes two false refusals: rounding that leaves Edge without a layer, and
+small donors that cannot pay the fixed process floor even though another
+selected computer has room for the model. Selection permits participation;
+it does not force every selected computer into the chain. Only actual plan
+participants are contacted during reachability preflight and receive offers.
+Every participant still explicitly approves its allocation before execution.
+
+The search is bounded and deterministic, not exhaustive and not a latency or
+throughput optimizer. A failed search means no resident plan was found, not a
+proof that every possible partition is impossible. It does not add computers
+outside the user's selection, combine CPU RAM with VRAM, weaken the memory
+guard, enable disk execution, or support multiple simultaneous sessions.
+
+The binary search relies on the current adapters' nonnegative per-layer
+resident/state costs and fixed scratch: extending a range cannot reduce its
+reservation. Future contracts must preserve that property or provide another
+search. Overflow never counts as a fit. Transfer metadata is recomputed for
+the chosen fallback and remains an adapter estimate, not measured wire bytes.
+No generation speed is inferred from this search.
+
+## Checks
+
+- `test_memory_budget`: legacy-plan stability, fixed-floor refusal and
+  recovery, more donors than layers, source/context/session/overflow guards,
+  and 500 deterministic heterogeneous budgets checked against launch costs.
+- `home_flow_test.py --expect-unused-donor`: two selected donor TUIs, one below
+  the process floor; only the fitting donor gets a request, approves, executes
+  a real model, streams a response and releases its locks. The other donor
+  receives no allocation and starts no engine.
+- The existing two-donor approval, rejection, cache/calibration and node-loss
+  tests continue to exercise unchanged successful plans.
+
+These are loopback checks. Physical LAN timings and measured-cost placement
+remain separate release gates.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -139,6 +139,12 @@ not a completed gate.
    recheck before offers. Edge and Segment budgets are separately MiB-aligned.
    Follow-up: checked tensor/state arithmetic and aggregate budgets reject
    overflow instead of wrapping into apparently small allocations.
+   Household placement now retains successful proportional plans and searches
+   alternative resident assignments when fixed process floors or an empty Edge
+   interval invalidate that split. Only planned participants receive offers;
+   every alternative is checked against the unchanged launch reservations.
+   This bounded search is not an exhaustive feasibility or speed solver.
+   See `HOUSEHOLD_PLACEMENT.md`.
    Measured-cost placement remains pending; this does not enable disk mode or
    certify additional model families.
 4. PR #157 merged: versioned measurements collected during ordinary Segment chat,

--- a/lumabri.c
+++ b/lumabri.c
@@ -5223,12 +5223,13 @@ static int catalog_state_refresh(LmbTuiState *st, void *unused) {
             selected[nselected] = st->nodes[j];
             mapping[nselected++] = j;
         }
-        m->planned = st->inventory_ok && !lmb_plan_cluster_source(&m->shape, selected, nselected,
-                                       st->context, st->sessions,
-                                       LMB_GOAL_ONE_SESSION, household && found[i].has_weights, &m->plan);
-        if (m->planned && household && m->weights_present)
-            m->planned = m->checkpoint_inventory_ok && !lmb_home_plan_budgets(
-                &m->shape, m->checkpoint_bytes, selected, nselected, st->context, &m->plan);
+        if (household && m->weights_present)
+            m->planned = st->inventory_ok && m->checkpoint_inventory_ok &&
+                !lmb_home_plan_source(&m->shape, m->checkpoint_bytes, selected,
+                    nselected, st->context, st->sessions, LMB_GOAL_ONE_SESSION, 1, &m->plan);
+        else
+            m->planned = st->inventory_ok && !lmb_plan_cluster_source(&m->shape, selected,
+                nselected, st->context, st->sessions, LMB_GOAL_ONE_SESSION, 0, &m->plan);
         if (m->planned) {
             m->plan.edge_node = mapping[m->plan.edge_node];
             for (uint32_t j = 0; j < m->plan.nslices; j++)

--- a/lumabri_cluster.h
+++ b/lumabri_cluster.h
@@ -253,6 +253,113 @@ static LMB_UNUSED int lmb_home_plan_budgets(const LmbModelShape *shape,
     return 0;
 }
 
+/* A failed proportional split is not proof that the selected computers cannot
+ * hold the model. Fixed per-process floors and Edge can make that split fail
+ * even when another contiguous assignment fits. Preserve successful plans;
+ * otherwise try each Edge owner first, followed by descending/ascending RAM.
+ * This bounded greedy search is NOT an exhaustive solver or a speed optimizer.
+ * Only the selected nodes are candidates; an unused selection receives no
+ * offer. Edge must own at least one layer in the household protocol. */
+static LMB_UNUSED int lmb_home_plan_source(const LmbModelShape *shape,
+    uint64_t checkpoint_bytes, const LmbClusterNode *nodes, uint32_t count,
+    uint32_t context, uint32_t sessions, LmbPlanGoal goal,
+    int external_checkpoint, LmbClusterPlan *out) {
+    if (!out) return -1;
+    memset(out, 0, sizeof *out);
+    out->state = LMB_PLAN_UNRUNNABLE;
+    out->goal = goal; out->sessions = sessions;
+    if (!shape || !nodes || !checkpoint_bytes || !count ||
+        count > LMB_CLUSTER_MAX_NODES || sessions != 1) return -1;
+    LmbClusterPlan proportional;
+    int original = lmb_plan_cluster_source(shape, nodes, count, context,
+        sessions, goal, external_checkpoint, &proportional);
+    if (!original) original = lmb_home_plan_budgets(shape, checkpoint_bytes,
+        nodes, count, context, &proportional);
+    if (!original) {
+        *out = proportional;
+        if (out->state == LMB_PLAN_RESIDENT) return 0;
+    }
+    int available = external_checkpoint != 0;
+    for (uint32_t i = 0; i < count; i++) available |= nodes[i].has_checkpoint != 0;
+    if (!available || !shape->layers || !shape->sizing_verified) return -1;
+
+    for (uint32_t owner = 0; owner < count; owner++) {
+        for (int ascending = 0; ascending < 2; ascending++) {
+            uint32_t order[LMB_CLUSTER_MAX_NODES], used = 1;
+            order[0] = owner;
+            for (uint32_t i = 0; i < count; i++) if (i != owner) {
+                uint32_t pos = used++;
+                while (pos > 1 && (ascending ?
+                    nodes[order[pos - 1]].ram_budget_bytes > nodes[i].ram_budget_bytes :
+                    nodes[order[pos - 1]].ram_budget_bytes < nodes[i].ram_budget_bytes)) {
+                    order[pos] = order[pos - 1]; pos--;
+                }
+                order[pos] = i;
+            }
+            LmbClusterPlan candidate = {0};
+            candidate.goal = goal; candidate.sessions = 1;
+            candidate.edge_node = owner; candidate.data_available = 1;
+            uint32_t next = 0;
+            for (uint32_t j = 0; j < count && next < shape->layers; j++) {
+                uint32_t nd = order[j], lo = next, hi = shape->layers;
+                /* All current resident contracts have nonnegative layer
+                 * costs and fixed scratch. Their cost for [next,end) is
+                 * monotone; an overflow is not a fit. The final shared
+                 * validator independently checks every chosen reservation. */
+                while (lo < hi) {
+                    uint32_t mid = lo + (hi - lo) / 2 + (hi - lo) % 2;
+                    LmbHomeReservation r;
+                    int fits = !lmb_home_reservation(shape, checkpoint_bytes,
+                        next, mid, context, nd == owner, &r) &&
+                        r.total_bytes <= nodes[nd].ram_budget_bytes;
+                    if (fits) lo = mid; else hi = mid - 1;
+                }
+                if (lo == next) {
+                    if (nd == owner) break; /* Edge cannot be an empty slice. */
+                    continue;
+                }
+                LmbSlice *s = &candidate.slices[candidate.nslices++];
+                s->node = nd; s->layer_begin = next; s->layer_end = lo;
+                next = lo;
+            }
+            if (next != shape->layers || lmb_home_plan_budgets(shape,
+                checkpoint_bytes, nodes, count, context, &candidate) ||
+                candidate.state != LMB_PLAN_RESIDENT) continue;
+            /* Preparation metadata follows this candidate, not the rejected
+             * proportional plan. These are adapter weight estimates, not
+             * measured wire bytes or a generation speed. */
+            candidate.ready_known = 1;
+            for (uint32_t j = 0; j < candidate.nslices; j++) {
+                LmbSlice *s = &candidate.slices[j];
+                const LmbClusterNode *nd = &nodes[s->node];
+                if (nd->has_checkpoint) continue;
+                LmbRangeCost cost = lmb_estimate_segment(shape, s->layer_begin,
+                    s->layer_end, context, 1);
+                if (!cost.ok) return -1;
+                s->bytes_to_fetch = cost.resident_bytes;
+                if (s->node == owner) {
+                    LmbRangeCost edge = lmb_estimate_edge(shape, context, 1);
+                    if (!edge.ok) return -1;
+                    s->bytes_to_fetch = lmb_size_add(s->bytes_to_fetch, edge.resident_bytes);
+                }
+                candidate.fetch_bytes = lmb_size_add(candidate.fetch_bytes, s->bytes_to_fetch);
+                if (candidate.fetch_bytes == UINT64_MAX) return -1;
+                if (!s->bytes_to_fetch) continue;
+                if (!nd->lan_bps) candidate.ready_known = 0;
+                else {
+                    double seconds = (double)s->bytes_to_fetch / nd->lan_bps;
+                    if (seconds > candidate.ready_seconds) candidate.ready_seconds = seconds;
+                }
+            }
+            *out = candidate;
+            return 0;
+        }
+    }
+    /* Retain a valid unsuccessful proportional plan for deficit display.
+     * A failed search means "no plan found", never a feasibility proof. */
+    return original;
+}
+
 /* Would adding this machine help, and at what?
  *
  * Three different answers, and collapsing them is how a cluster tells

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -668,16 +668,16 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         count++;
     }
     LmbClusterPlan plan;
-    if (!count || lmb_plan_cluster_source(&m->shape, nodes, count, st->context, 1,
-                                   LMB_GOAL_ONE_SESSION, 1, &plan) ||
-        lmb_home_plan_budgets(&m->shape, m->checkpoint_bytes, nodes, count, st->context, &plan) ||
+    if (!count || lmb_home_plan_source(&m->shape, m->checkpoint_bytes, nodes, count,
+        st->context, 1, LMB_GOAL_ONE_SESSION, 1, &plan) ||
         plan.state != LMB_PLAN_RESIDENT) {
-        return home_fail("No complete resident plan fits the selected computers. Keep Share resources open and check their offered RAM.");
+        return home_fail("No complete resident plan found for the selected computers. Keep Share resources open and check their offered RAM.");
     }
     /* Discovery is not proof that inbound connections work. Authenticate the
-     * selected donors before indexing/starting a source, without any OFFER,
+     * planned donors before indexing/starting a source, without any OFFER,
      * reservation or engine launch. Recheck again when actually sending. */
-    for (uint32_t i = 0; i < count; i++) {
+    for (uint32_t j = 0; j < plan.nslices; j++) {
+        uint32_t i = plan.slices[j].node;
         uint8_t expected[32];
         if (lmb_unhex(expected, st->identities[indices[i]], 32))
             return home_fail("Invalid identity for %.64s. Refresh the computer list.", nodes[i].name);

--- a/tests/c/test_memory_budget.c
+++ b/tests/c/test_memory_budget.c
@@ -12,7 +12,101 @@ static void sized_file(const char *path, off_t size) {
     assert(!close(fd));
 }
 
+static void feasible_plans(void) {
+    const uint64_t mib = UINT64_C(1) << 20;
+    LmbModelShape m = {0};
+    strcpy(m.model_type, "olmoe");
+    m.layers = 4; m.hidden = 64; m.vocab = 128;
+    m.sizing_verified = m.memory_contract = 1; m.max_context = 4096;
+    m.edge_resident_bytes = 8 * mib;
+    for (uint32_t i = 0; i < m.layers; i++) m.memory[i].resident_bytes = 100 * mib;
+    LmbClusterNode nodes[LMB_CLUSTER_MAX_NODES] = {0};
+    nodes[0].ram_budget_bytes = 500 * mib;
+    nodes[1].ram_budget_bytes = 100 * mib;
+    LmbClusterPlan p, old;
+    assert(!lmb_plan_cluster_source(&m, nodes, 2, 128, 1, LMB_GOAL_ONE_SESSION, 1, &old));
+    assert(!lmb_home_plan_budgets(&m, 1, nodes, 2, 128, &old));
+    assert(old.state == LMB_PLAN_UNRUNNABLE);
+    assert(!lmb_home_plan_source(&m, 1, nodes, 2, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(p.state == LMB_PLAN_RESIDENT && p.nslices == 1 && p.edge_node == 0);
+    assert(p.slices[0].node == 0 && p.slices[0].layer_end == 4);
+    assert(p.fetch_bytes == 408 * mib && !p.ready_known);
+    nodes[0].lan_bps = mib;
+    assert(!lmb_home_plan_source(&m, 1, nodes, 2, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(p.ready_known && p.ready_seconds == 408);
+    nodes[0].has_checkpoint = 1;
+    assert(!lmb_home_plan_source(&m, 1, nodes, 2, 128, 1, LMB_GOAL_ONE_SESSION, 0, &p));
+    assert(!p.fetch_bytes && p.ready_known && !p.ready_seconds);
+    nodes[0].has_checkpoint = 0;
+
+    /* Successful legacy placements (and thus calibration keys) are stable. */
+    nodes[1].ram_budget_bytes = 500 * mib;
+    assert(!lmb_plan_cluster_source(&m, nodes, 2, 128, 1, LMB_GOAL_ONE_SESSION, 1, &old));
+    assert(!lmb_home_plan_budgets(&m, 1, nodes, 2, 128, &old));
+    assert(old.state == LMB_PLAN_RESIDENT && old.nslices == 2);
+    assert(!lmb_home_plan_source(&m, 1, nodes, 2, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(!memcmp(&p, &old, sizeof p));
+
+    /* More selected donors than layers used to strand Edge without a slice.
+     * Neither donor can hold both layers with Edge; two are genuinely needed. */
+    m.layers = 2;
+    for (uint32_t i = 0; i < LMB_CLUSTER_MAX_NODES; i++) nodes[i].ram_budget_bytes = 250 * mib;
+    assert(!lmb_plan_cluster_source(&m, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 1, &old));
+    assert(lmb_home_plan_budgets(&m, 1, nodes, 8, 128, &old));
+    assert(!lmb_home_plan_source(&m, 1, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(p.state == LMB_PLAN_RESIDENT && p.nslices == 2);
+    assert(p.edge_node == p.slices[0].node && p.slices[0].layer_end == 1);
+    assert(!lmb_home_plan_budgets(&m, 1, nodes, 8, 128, &p));
+
+    /* No sources, extra sessions, invalid context/geometry and overflow
+     * must never become approved plans through the alternative search. */
+    assert(lmb_home_plan_source(&m, 1, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 0, &p));
+    assert(lmb_home_plan_source(&m, 1, nodes, 8, 128, 2, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(lmb_home_plan_source(&m, 1, nodes, 8, 8192, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(lmb_home_plan_source(&m, 0, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(lmb_home_plan_source(NULL, 1, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    assert(lmb_home_plan_source(&m, 1, nodes, LMB_CLUSTER_MAX_NODES + 1,
+        128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    m.layers = 0;
+    assert(lmb_home_plan_source(&m, 1, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p));
+    m.layers = 4;
+    for (uint32_t i = 0; i < 8; i++) {
+        nodes[i].ram_budget_bytes = 100 * mib;
+        nodes[i].vram_budget_bytes = UINT64_C(100) << 30;
+    }
+    int rc = lmb_home_plan_source(&m, 1, nodes, 8, 128, 1, LMB_GOAL_ONE_SESSION, 1, &p);
+    assert(rc || p.state == LMB_PLAN_UNRUNNABLE); /* No RAM/VRAM pooling. */
+
+    /* Deterministic heterogeneous sweeps: every accepted interval is checked
+     * independently against the same budget launch will actually enforce. */
+    for (uint32_t trial = 0; trial < 500; trial++) {
+        uint32_t count = 1 + trial % 8;
+        m.layers = 1 + trial % 11;
+        for (uint32_t i = 0; i < m.layers; i++)
+            m.memory[i].resident_bytes = (10 + (trial * 7 + i * 53) % 200) * mib;
+        for (uint32_t i = 0; i < count; i++)
+            nodes[i].ram_budget_bytes = (40 + (trial * 47 + i * 71) % 700) * mib;
+        rc = lmb_home_plan_source(&m, 1234567, nodes, count, 128, 1,
+            LMB_GOAL_ONE_SESSION, 1, &p);
+        if (rc || p.state != LMB_PLAN_RESIDENT) continue;
+        uint32_t next = 0, edge = 0, seen = 0;
+        for (uint32_t i = 0; i < p.nslices; i++) {
+            const LmbSlice *s = &p.slices[i];
+            assert(s->node < count && !(seen & (1u << s->node)));
+            seen |= 1u << s->node;
+            assert(s->layer_begin == next && s->layer_end > next);
+            next = s->layer_end; edge += s->node == p.edge_node;
+            LmbHomeReservation r;
+            assert(!lmb_home_reservation(&m, 1234567, s->layer_begin,
+                s->layer_end, 128, s->node == p.edge_node, &r));
+            assert(r.total_bytes == s->bytes_resident && r.total_bytes <= nodes[s->node].ram_budget_bytes);
+        }
+        assert(next == m.layers && edge == 1);
+    }
+}
+
 int main(void) {
+    feasible_plans();
     LmbModelShape m = {0};
     strcpy(m.model_type, "olmoe");
     m.layers = 4; m.hidden = 64; m.intermediate = 32;

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -41,9 +41,14 @@ def main():
                         help="require saved real timings, matching catalogue speed and changed-context invalidation")
     parser.add_argument("--expect-no-fit", action="store_true",
                         help="verify insufficient-memory admission, without starting engines")
+    parser.add_argument("--expect-unused-donor", action="store_true",
+                        help="select a donor below the process floor; require a valid plan on the other donor only")
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
+    if args.expect_unused_donor and (args.repeat_cached or args.expect_no_fit or
+                                    args.kill_donor or args.expect_calibration):
+        parser.error("--expect-unused-donor is a separate single-session admission test")
     ROOT = args.runtime_dir.resolve(strict=True)
     for binary in ("lumabri", "tracker", "maintainer", "segment_node", "segment_chat"):
         if not (ROOT / binary).is_file() or not os.access(ROOT / binary, os.X_OK):
@@ -80,7 +85,8 @@ def main():
         settings = home / ".lumabri" / "home.conf"
         if not settings.exists():
             settings.parent.mkdir(exist_ok=True)
-            settings.write_text(f"tracker={addr}\ntoken=household-test\nmodels={Path(args.models_dir).resolve()}\nram={args.donor_ram_gb}\n")
+            ram = 0.1 if args.expect_unused_donor and name == "donor-b" else args.donor_ram_gb
+            settings.write_text(f"tracker={addr}\ntoken=household-test\nmodels={Path(args.models_dir).resolve()}\nram={ram}\n")
             settings.chmod(0o600)
         return {**os.environ, "HOME": str(home), "LUMABRI_ENCRYPT": "1",
                 "LUMABRI_HOME_PORT_BASE": str(service_base + 16 * service_slots.get(name, 0)),
@@ -201,7 +207,7 @@ def main():
         time.sleep(.5)
         offline.send("\r\r")
         until(lambda: offline.p.poll() is not None, message="unreachable donor did not fail preflight")
-        failure = "No complete resident plan fits" if args.expect_no_fit else "Cannot reach offline-test-donor"
+        failure = "No complete resident plan found" if args.expect_no_fit else "Cannot reach offline-test-donor"
         assert offline.p.returncode != 0 and offline.has(failure)
         assert not list((tmp / "offline-request").rglob("home-source-*.log")), "indexed before reachability check"
         offline_worker.terminate(); offline_worker.wait(timeout=5)
@@ -237,6 +243,34 @@ def main():
             print("HOME ADMISSION: PASS (native memory floor; no offers or engines)", flush=True)
             return
         reject.send("\r\r")
+        if args.expect_unused_donor:
+            until(lambda: a.has("Waiting for your approval"), seconds=60,
+                  message="feasible alternative did not reach its donor")
+            assert not b.has("Waiting for your approval"), "unused donor received an offer"
+            assert not engines_started("donor-a") and not engines_started("donor-b")
+            a.send("\x1b[A\r")
+            until(lambda: reject.has("/experts shows tracker activity.") or reject.p.poll() is not None,
+                  seconds=180, message="alternative plan did not reach hosted chat")
+            assert reject.p.poll() is None, "accepted alternative failed"
+            assert "Approved Segment plan: 1 compute donor" in reject.text
+            reject.send("hi\n")
+            until(lambda: reject.has("hosted stream · no local checkpoint") or reject.p.poll() is not None,
+                  seconds=120, message="alternative plan did not finish real generation")
+            assert reject.p.poll() is None
+            log = (tmp / "donor-a/.lumabri/home/engines.log").read_text(errors="replace")
+            commits = re.findall(r"\[segment-node [^\]\n]+ (\d+):(\d+)\] committed_runs=(\d+)", log)
+            assert any(int(begin) == 0 and int(end) > 0 and int(runs) > 0
+                       for begin, end, runs in commits), "no actual full-range execution"
+            assert not b.has("Waiting for your approval") and not engines_started("donor-b")
+            reject.send("/quit\n")
+            until(lambda: reject.p.poll() is not None, message="alternative quit blocked")
+            assert reject.p.returncode == 0
+            until(lambda: a.has("Released"), message="alternative donor lease leaked")
+            for lock in ("compute-donor.lock", "home/weights.lock"):
+                with open(tmp / "donor-a/.lumabri" / lock, "r") as lease:
+                    fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            print("HOME ALTERNATIVE PLAN: PASS (two selected, one used; real generation, no unused-donor offer, cleanup)", flush=True)
+            return
         until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"),
               seconds=60, message="offers never reached both donor TUIs")
         assert not engines_started("donor-a") and not engines_started("donor-b")


### PR DESCRIPTION
## Summary

Roadmap gate 3 follow-up, not a completed roadmap gate.

- Keep already-valid proportional placements unchanged.
- If process floors or an empty Edge interval invalidate that split, try bounded deterministic alternative contiguous assignments, checking the exact existing launch reservations.
- Use the same search in the catalogue and request path; only actual plan participants receive reachability checks and offers.
- Do not merge RAM and VRAM, weaken resident memory guards, enable disk mode, or claim measured-cost/optimal placement.

## Verification

- `test_memory_budget`, including 500 heterogeneous assignments checked independently against launch costs; ASan/UBSan/LSan and `-Werror` pass.
- Planner, cluster, catalogue advice, calibration, generation metrics, household transaction and inventory unit tests pass.
- Chat UI, English UI copy, 11 packaging contracts and actual spaced-path preload tests pass.
- Real encrypted TUI test: two selected donors, one below the process floor; fitting donor alone receives/approves a request, executes the model and releases locks. Unused donor receives no offer and starts no engine.
- Existing two-donor flow, decline/approval, actual execution ranges, persistent calibration invalidation, repeated cache use and killed-donor cleanup pass.
- New unused-donor case added to Linux and native Intel/ARM macOS household CI, with and without OpenMP.

These are local loopback/tiny-checkpoint checks. Physical LAN, large-model conformance, measured-cost placement and household multi-session/replay remain open. Normal merge only, after green checks on the reviewed head.
