### PR TITLE
feat(storage): inspect and clear unused household weights from the TUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,11 @@ jobs:
           python-version: "3.12"
       - name: Build the C workspace with Apple Clang
         run: |
-          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration test_inventory CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration test_inventory test_weight_cache CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
           ./test_memory_budget
+          ./test_weight_cache
+          python3 tests/integration/storage_ui_test.py
           ./test_planner
           ./test_cluster
           ./test_calibration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           make segment_budget_probe
           python3 tests/integration/planner_tensor_contract_test.py --family olmoe --model build/home-flow-models/olmoe-tiny
           make swarm_probe
-          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --clear-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --expect-unused-donor
       - name: Same greedy tokens with one and two real Segment ranges
@@ -287,7 +287,7 @@ jobs:
         run: |
           python3 tests/integration/package_household_test.py
           python3 tools/package_household.py --colibri-root ../colibri --output 'build/native candidate'
-          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --clear-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
           python3 tools/package_household.py --verify 'build/native candidate'
           tar -czf build/lumabri-linux-candidate.tar.gz -C 'build/native candidate' .
@@ -348,7 +348,7 @@ jobs:
           test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           make swarm_probe
-          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
+          python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --repeat-cached --clear-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --kill-donor
           python3 tests/integration/home_flow_test.py --models-dir build/home-flow-models --expect-unused-donor
       - uses: actions/download-artifact@v4
@@ -418,7 +418,7 @@ jobs:
         working-directory: lumabri
         run: |
           python3 tools/package_household.py --colibri-root ../colibri --output 'build/native candidate'
-          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --clear-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
           python3 tools/package_household.py --verify 'build/native candidate'
           tar -czf build/lumabri-macos-candidate.tar.gz -C 'build/native candidate' .

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ endif
 
 all: tracker maintainer $(SHIM_LIB) test_shim swarm_probe lumabri
 
+lumabri test_chat_ui: src/runtime/lumabri_weight_cache.h
+
+test_weight_cache: tests/c/test_weight_cache.c src/runtime/lumabri_weight_cache.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_weight_cache.c -o $@
+
 # Native household runtime (Colibri sources are a build-time dependency).
 household: tracker maintainer $(SHIM_LIB) lumabri segment_node segment_chat
 
@@ -52,7 +57,7 @@ check-warnings:
 		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget test_calibration test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
-		test_scheduler test_run_gate test_inventory test_home test_chat_ui \
+		test_scheduler test_run_gate test_inventory test_home test_chat_ui test_weight_cache \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -726,7 +731,7 @@ test-adapters: tracker segment_node segment_chat
 test-segment-discovery: tracker test_segment_discovery
 	bash ./tests/integration/segment_discovery_test.sh
 
-test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget \
+test: all test_weight_cache test_key_rotation test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget \
 		test_inventory test_home test_chat_ui test_calibration test_catalogue_advice test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
@@ -767,6 +772,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	python3 ./tests/integration/preload_path_test.py
 	python3 tests/ui_text_test.py
 	python3 tests/integration/workspace_navigation_test.py
+	python3 tests/integration/storage_ui_test.py
 	python3 ./tests/integration/lan_inventory_test.py
 	python3 tests/integration/household_network_test.py
 	bash ./tests/integration/hosted_chat_test.sh
@@ -774,6 +780,7 @@ test: all test_key_rotation test_hedge test_local_fallback test_nat_adopt test_v
 	./test_planner
 	./test_cluster
 	./test_memory_budget
+	./test_weight_cache
 	./test_calibration
 	./test_catalogue_advice
 	./test_metrics
@@ -828,7 +835,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so liblumabri.dylib test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
-	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_catalogue_advice test_metrics test_inventory test_home test_chat_ui segment_budget_probe \
+	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_catalogue_advice test_metrics test_inventory test_home test_chat_ui test_weight_cache segment_budget_probe \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/docs/HOUSEHOLD_WEIGHT_CACHE.md
+++ b/docs/HOUSEHOLD_WEIGHT_CACHE.md
@@ -33,6 +33,39 @@ execution mode: the resident memory checks remain unchanged.
 
 ## Verification
 
+### Inspecting and clearing storage in the TUI
+
+Open the workspace command list with `/` and select `/storage`. This view
+counts allocated file blocks, not sparse files' apparent lengths, below the
+current user's default `~/.lumabri/home/cas` and `mirrors` directories.
+Hardlinked entries can be counted more than once, so the value is approximate.
+It does not include source model folders, legacy caches, custom `--disk`
+locations, logs or other applications' storage.
+
+Clearing requires a second, explicit confirmation; the default is to keep
+the weights. A plan holding the shared weight lease prevents clearing, even
+if it starts after the overview was displayed. The lease inode is retained.
+The operation validates both cache trees before deleting any entries, rejects
+cross-filesystem trees and special files, and never follows symlinks. Leaf
+links are removed without deleting their targets. Original checkpoint folders,
+keys, settings, conversations and engine logs are not cleanup targets.
+
+Scanning and clearing show progress and accept Escape between filesystem
+operations. Cancellation during inspection deletes nothing; cancellation or
+an I/O error during clearing can leave a partially cleared cache. Removed
+weights are permanently deleted, not moved to Trash, and must be fetched
+again. Clearing Linux files does not itself compact a WSL virtual disk.
+
+This is manual cache management, not a maximum growth quota or automatic
+eviction. The conservative admission reserve remains in force.
+
+`test_weight_cache` covers lease exclusion, sparse accounting, symlinks and
+hardlinks, unsafe-tree refusal, cancellation and lease release. The real PTY
+test `tests/integration/storage_ui_test.py` checks the storage action, busy
+refusal, the non-destructive default, confirmed cleanup and terminal restoration.
+
+### Reuse between approved sessions
+
 ```sh
 make household swarm_probe
 python3 tests/integration/home_flow_test.py --models-dir /path/to/one-fixture-parent --repeat-cached

--- a/docs/HOUSEHOLD_WEIGHT_CACHE.md
+++ b/docs/HOUSEHOLD_WEIGHT_CACHE.md
@@ -68,7 +68,7 @@ refusal, the non-destructive default, confirmed cleanup and terminal restoration
 
 ```sh
 make household swarm_probe
-python3 tests/integration/home_flow_test.py --models-dir /path/to/one-fixture-parent --repeat-cached
+python3 tests/integration/home_flow_test.py --models-dir /path/to/one-fixture-parent --repeat-cached --clear-cached
 ```
 
 The test executes two separately approved plans on two real Segment
@@ -77,6 +77,12 @@ the source's published byte/read counters, generation in the second plan,
 and release of RAM/cache locks. The repeated synthetic OLMoE request must
 leave only the two direct `config.json` reads at the source. Native macOS CI
 runs the same test; loopback is not a physical LAN certification.
+
+With `--clear-cached`, the test then opens each donor's real workspace storage
+view, explicitly clears its released weight cache and starts a third approved
+plan. The source must serve weights again, both caches must be rebuilt and
+generation and lease release must succeed. The same check runs against the
+installed native candidate layout.
 
 ## Still outside this change
 

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -161,6 +161,10 @@ not a completed gate.
 5. PR #158 merged: reusable adapter-scoped working mirrors and shared verified
    CAS chunks, with separate approval and fresh engine sessions on reuse.
    Cache-directory allocation is exclusive even across different homes.
+   Workspace `/storage` adds allocated-block inspection and explicitly confirmed
+   clearing of unused default household caches. Clearing shares the runtime
+   lease, preserves source folders/settings, refuses unsafe trees and supports
+   cooperative cancellation. It is not a total cache quota or automatic eviction.
    Model acquisition, cache-aware disk admission/eviction and verified smaller
    disk working sets remain pending. See `HOUSEHOLD_WEIGHT_CACHE.md`.
 6. Pending: upstream-only GPU capability integration, CPU otherwise.

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -209,17 +209,9 @@ typedef struct {
  * Their RAM leases are separate files, so also serialize mutable mirrors by
  * cache directory. Fail immediately instead of blocking a second accepted
  * plan behind the first model's lifetime-long shared mirror lock. */
+#include "src/runtime/lumabri_weight_cache.h"
 static int home_weight_lease(const char *base) {
-    char path[1200];
-    if (checked_printf(path, sizeof path, "%s/weights.lock", base)) return -1;
-    int fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0600);
-    if (fd < 0) return -1;
-    struct stat st;
-    if (fstat(fd, &st) || !S_ISREG(st.st_mode) || st.st_nlink != 1 ||
-        flock(fd, LOCK_EX | LOCK_NB)) {
-        close(fd); return -1;
-    }
-    return fd;
+    return lmb_weight_cache_lock(base);
 }
 
 static void home_donor_release(HomeDonor *d, LmbHomePhase why, const char *reason) {

--- a/lumashim.c
+++ b/lumashim.c
@@ -1888,9 +1888,9 @@ static int ensure_block(RFile *f, uint32_t blk) {
      * sends people to look at their network for hours. The bytes arrived; it
      * is the mirror that failed. */
     if (!ok && werr == ENOSPC)
-        fprintf(stderr, "[lumabri] DISCO PIENO scrivendo il mirror in %s — "
-                        "il peer aveva i byte, non c'e' spazio per tenerli "
-                        "(blocco %u di %s)\n", g.data_dir, blk, f->rel);
+        fprintf(stderr, "[lumabri] Disk full while writing the mirror in %s: "
+                        "the peer delivered the bytes, but there is no space to keep them "
+                        "(block %u of %s)\n", g.data_dir, blk, f->rel);
     else if (!ok && werr)
         fprintf(stderr, "[lumabri] mirror write failed (%s): block %u of %s\n",
                 strerror(werr), blk, f->rel);

--- a/src/runtime/lumabri_weight_cache.h
+++ b/src/runtime/lumabri_weight_cache.h
@@ -1,0 +1,163 @@
+/* Household-owned weight trees only. Never traverse symlinks or clear a
+ * cache while an approved plan holds its exclusive weight lease. */
+#ifndef LUMABRI_WEIGHT_CACHE_H
+#define LUMABRI_WEIGHT_CACHE_H
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+typedef struct {
+    uint64_t allocated_bytes, logical_bytes, files;
+    uint32_t entries;
+} LmbWeightCacheUsage;
+
+/* Called between filesystem operations, never while inside one. A nonzero
+ * result cancels cooperatively; clearing may then be partially complete. */
+typedef int (*LmbWeightCacheProgress)(void *, const LmbWeightCacheUsage *, int);
+
+static int lmb_weight_cache_progress(LmbWeightCacheProgress progress, void *arg,
+                                    const LmbWeightCacheUsage *usage, int erase) {
+    if (progress && progress(arg, usage, erase)) { errno = ECANCELED; return -1; }
+    return 0;
+}
+
+static int lmb_weight_cache_lock_at(int base) {
+    int fd = openat(base, "weights.lock", O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW, 0600);
+    if (fd < 0) return -1;
+    struct stat st;
+    if (fstat(fd, &st)) goto fail;
+    if (!S_ISREG(st.st_mode) || st.st_nlink != 1) { errno = EINVAL; goto fail; }
+    if (st.st_uid != geteuid()) { errno = EPERM; goto fail; }
+    if (flock(fd, LOCK_EX | LOCK_NB)) goto fail;
+    return fd;
+fail: {
+    int saved = errno; close(fd); errno = saved; return -1;
+}
+}
+
+static int lmb_weight_cache_lock(const char *path) {
+    if (!path || !*path) { errno = EINVAL; return -1; }
+    int base = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (base < 0) return -1;
+    int fd = lmb_weight_cache_lock_at(base), saved = errno;
+    close(base); errno = saved; return fd;
+}
+
+/* Relative descriptor traversal keeps links inside weight trees from naming
+ * source checkpoints or unrelated files. Cross-device trees are refused.
+ * Bounds apply to both inspection and deletion; a full inspection precedes
+ * the destructive pass. Failure can still leave a partially cleared cache
+ * (e.g. an I/O error), which callers must report rather than claim success. */
+static int lmb_weight_cache_walk(int fd, dev_t device, unsigned depth,
+                                 int erase, LmbWeightCacheUsage *usage,
+                                 LmbWeightCacheProgress progress, void *arg) {
+    if (depth > 32) { errno = ELOOP; return -1; }
+    if (lmb_weight_cache_progress(progress, arg, usage, erase)) return -1;
+    int copy = openat(fd, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (copy < 0) return -1;
+    DIR *dir = fdopendir(copy);
+    if (!dir) { int saved = errno; close(copy); errno = saved; return -1; }
+    int bad = 0, saved = 0;
+    struct dirent *entry;
+    for (;;) {
+        errno = 0; entry = readdir(dir);
+        if (!entry) { if (errno) bad = 1; break; }
+        const char *name = entry->d_name;
+        if (!strcmp(name, ".") || !strcmp(name, "..")) continue;
+        if (++usage->entries > 10000000) { errno = E2BIG; bad = 1; break; }
+        if (!(usage->entries % 64) &&
+            lmb_weight_cache_progress(progress, arg, usage, erase)) { bad = 1; break; }
+        struct stat st;
+        if (fstatat(fd, name, &st, AT_SYMLINK_NOFOLLOW)) { bad = 1; break; }
+        if (st.st_dev != device || st.st_uid != geteuid() ||
+            (!S_ISREG(st.st_mode) && !S_ISDIR(st.st_mode) && !S_ISLNK(st.st_mode))) {
+            errno = EPERM; bad = 1; break;
+        }
+        if (st.st_blocks < 0 || st.st_size < 0 ||
+            (uint64_t)st.st_blocks > UINT64_MAX / 512 ||
+            UINT64_MAX - usage->allocated_bytes < (uint64_t)st.st_blocks * 512 ||
+            UINT64_MAX - usage->logical_bytes < (uint64_t)st.st_size) {
+            errno = EOVERFLOW; bad = 1; break;
+        }
+        usage->allocated_bytes += (uint64_t)st.st_blocks * 512;
+        usage->logical_bytes += (uint64_t)st.st_size;
+        if (!S_ISDIR(st.st_mode)) usage->files++;
+        if (S_ISDIR(st.st_mode)) {
+            int child = openat(fd, name, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+            struct stat opened;
+            if (child < 0) { bad = 1; break; }
+            if (fstat(child, &opened) || opened.st_dev != st.st_dev || opened.st_ino != st.st_ino) {
+                close(child); errno = EAGAIN; bad = 1; break;
+            }
+            bad = lmb_weight_cache_walk(child, device, depth + 1, erase, usage, progress, arg);
+            saved = errno; close(child); errno = saved;
+            if (bad) break;
+        }
+        if (erase && unlinkat(fd, name, S_ISDIR(st.st_mode) ? AT_REMOVEDIR : 0)) {
+            bad = 1; break;
+        }
+    }
+    saved = errno; closedir(dir); errno = saved;
+    return bad ? -1 : 0;
+}
+
+static int lmb_weight_cache_trees(int base, int erase, LmbWeightCacheUsage *usage,
+                                LmbWeightCacheProgress progress, void *arg) {
+    static const char *names[] = {"cas", "mirrors"};
+    struct stat st;
+    if (fstat(base, &st) || st.st_uid != geteuid()) { errno = EPERM; return -1; }
+    for (unsigned i = 0; i < sizeof names / sizeof *names; i++) {
+        int tree = openat(base, names[i], O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+        if (tree < 0) { if (errno == ENOENT) continue; return -1; }
+        struct stat root;
+        int bad = fstat(tree, &root) || root.st_dev != st.st_dev || root.st_uid != geteuid();
+        if (bad) errno = EPERM;
+        else bad = lmb_weight_cache_walk(tree, st.st_dev, 0, erase, usage, progress, arg);
+        int saved = errno; close(tree); errno = saved;
+        if (bad) return -1;
+        /* Keep the two stable roots: the loader can safely reuse them. */
+    }
+    return 0;
+}
+
+static int lmb_weight_cache_inspect_progress(const char *path, LmbWeightCacheUsage *usage,
+                                           LmbWeightCacheProgress progress, void *arg) {
+    if (!path || !*path || !usage) { errno = EINVAL; return -1; }
+    memset(usage, 0, sizeof *usage);
+    int base = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (base < 0) return errno == ENOENT ? 0 : -1;
+    int rc = lmb_weight_cache_trees(base, 0, usage, progress, arg), saved = errno;
+    close(base); errno = saved;
+    return rc;
+}
+
+static int lmb_weight_cache_clear_progress(const char *path,
+                                         LmbWeightCacheProgress progress, void *arg) {
+    if (!path || !*path) { errno = EINVAL; return -1; }
+    int base = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (base < 0) return errno == ENOENT ? 0 : -1;
+    int lease = lmb_weight_cache_lock_at(base);
+    if (lease < 0) {
+        int saved = errno; close(base); errno = saved;
+        return saved == EWOULDBLOCK || saved == EAGAIN ? -2 : -1;
+    }
+    LmbWeightCacheUsage before = {0}, removed = {0};
+    int rc = lmb_weight_cache_trees(base, 0, &before, progress, arg);
+    if (!rc) rc = lmb_weight_cache_trees(base, 1, &removed, progress, arg);
+    int saved = errno; close(lease); close(base); errno = saved;
+    return rc;
+}
+
+static inline int lmb_weight_cache_inspect(const char *path, LmbWeightCacheUsage *usage) {
+    return lmb_weight_cache_inspect_progress(path, usage, NULL, NULL);
+}
+
+static inline int lmb_weight_cache_clear(const char *path) {
+    return lmb_weight_cache_clear_progress(path, NULL, NULL);
+}
+#endif

--- a/src/ui/lumabri_home_ui.h
+++ b/src/ui/lumabri_home_ui.h
@@ -281,6 +281,108 @@ static void home_network_setup(char *notice, size_t cap) {
     }
 }
 
+typedef struct {
+    double painted;
+    int clearing;
+} HomeStorageProgress;
+
+static int home_storage_progress(void *arg, const LmbWeightCacheUsage *usage, int erase) {
+    HomeStorageProgress *p = arg;
+    int key = home_key();
+    if (key == 3) g_stopping = 1;
+    if (g_stopping || key == 27) return 1;
+    double now = nowd();
+    if (p->painted && now - p->painted < .1) return 0;
+    p->painted = now;
+    ui_begin("storage");
+    ui_text(5, 5, UI_TEXT, erase ? "Clearing unused household weights..." :
+        p->clearing ? "Checking both cache trees before clearing..." :
+        "Inspecting household weight caches...");
+    ui_printf(8, 5, UI_MUTED, "%llu files visited   %.2f GiB allocated blocks counted",
+        (unsigned long long)usage->files, usage->allocated_bytes / 1073741824.0);
+    ui_text(11, 5, UI_MUTED, "Cancellation is checked between filesystem operations.");
+    ui_footer(p->clearing ? "If clearing has started, removed weights are not restored." :
+              "Inspection does not remove any weights.", "Esc cancel   Ctrl-C exit");
+    ui_present();
+    return 0;
+}
+
+static void home_storage_screen(void) {
+    char base[1200], message[200] = "";
+    if (checked_printf(base, sizeof base, "%s/.lumabri/home",
+                       getenv("HOME") ? getenv("HOME") : ".")) return;
+    LmbWeightCacheUsage usage = {0};
+    int refresh = 1, bad = 0, busy = 0, confirm = 0, choice = 0;
+    HomeTerminal term; home_terminal_begin(&term);
+    while (!g_stopping) {
+        if (refresh) {
+            HomeStorageProgress progress = {0};
+            bad = lmb_weight_cache_inspect_progress(base, &usage, home_storage_progress, &progress);
+            if (bad && errno == ECANCELED) break;
+            int lease = home_weight_lease(base);
+            busy = lease < 0 && (errno == EWOULDBLOCK || errno == EAGAIN);
+            if (lease >= 0) close(lease);
+            refresh = 0;
+        }
+        ui_begin("storage");
+        ui_text(5, 5, UI_TEXT, confirm ? "Clear unused household weights?" : "Household weight storage");
+        ui_printf(7, 5, UI_MUTED, "%.110s", base);
+        if (bad) ui_text(9, 5, UI_SAND, "Cannot safely inspect this cache. Nothing has been removed.");
+        else ui_printf(9, 5, UI_TEXT, "Approx. allocated: %.2f GiB   Files: %llu",
+            usage.allocated_bytes / 1073741824.0, (unsigned long long)usage.files);
+        ui_text(11, 5, busy ? UI_SAND : UI_MUTED, busy ?
+            "Weights are in use. Clearing is blocked until the plan releases them." :
+            "Only household cas/ and mirrors/ are included; no source model folders.");
+        ui_text(13, 5, UI_MUTED, "Keys, settings, conversations and engine logs are kept.");
+        ui_text(14, 5, UI_MUTED, "Cleared weights must be fetched again. This does not compact a WSL disk.");
+        if (confirm) {
+            ui_item(17, choice == 0, "Keep cached weights", "Return without deleting anything.");
+            ui_item(20, choice == 1, "Clear unused weights", "Permanent removal; no move to Trash.");
+        } else {
+            ui_item(17, choice == 0, "Refresh storage", "Recount allocated file blocks; hardlinked entries may be counted twice.");
+            ui_item(20, choice == 1, "Clear unused weights", "Review and confirm first; active caches cannot be cleared.");
+            ui_item(23, choice == 2, "Back to workspace", "Keep all cached weights.");
+        }
+        ui_footer(message[0] ? message : "This view covers this user's default household cache only.",
+                  "↑ ↓ move   Enter select   Esc back   Ctrl-C exit");
+        int compact = ui_h < 28 || ui_w < 60;
+        if (compact) {
+            ui_begin("storage");
+            ui_text(5, 4, UI_SAND, "Resize the terminal to at least 60 × 28.");
+            ui_text(7, 4, UI_MUTED, "Esc returns without clearing weights.");
+        }
+        ui_present();
+        int key = home_key(), choices = confirm ? 2 : 3;
+        if (key == 3 || key == 27) { if (confirm && key == 27) { confirm = 0; choice = 0; } else break; }
+        if (key == 1001) choice = (choice + choices - 1) % choices;
+        if (key == 1002) choice = (choice + 1) % choices;
+        if (!compact && (key == '\r' || key == '\n')) {
+            if (confirm) {
+                if (choice == 1) {
+                    HomeStorageProgress progress = { .clearing = 1 };
+                    int rc = lmb_weight_cache_clear_progress(base, home_storage_progress, &progress);
+                    int cancelled = rc == -1 && errno == ECANCELED;
+                    snprintf(message, sizeof message, "%s", !rc ?
+                        "Household weights cleared. Source checkpoints and settings were preserved." :
+                        rc == -2 ?
+                        "A plan is using this cache. No cleanup was started." :
+                        cancelled ?
+                        "Cleanup cancelled. Already removed weights are not restored; remaining weights are kept." :
+                        "Cleanup could not finish. Some weights may remain; refresh or check permissions.");
+                    refresh = 1;
+                }
+                confirm = 0; choice = 0;
+            } else if (choice == 0) refresh = 1;
+            else if (choice == 2) break;
+            else if (busy || bad) snprintf(message, sizeof message,
+                "Cleanup is unavailable while the cache is active or cannot be inspected safely.");
+            else { confirm = 1; choice = 0; }
+        }
+        (void)poll(NULL, 0, 100);
+    }
+    home_terminal_end(&term);
+}
+
 static int cmd_home(void) {
     if (!isatty(0) || home_private_network()) return 1;
     HomeSettings s; home_settings_load(&s);
@@ -308,11 +410,12 @@ static int cmd_home(void) {
             static const char *titles[] = {"Start a conversation", "Explore models", "Your computers", "Share resources"};
             static const char *help[] = {"Choose a model and ask your selected donors.", "Memory needs, plans and measured speed.",
                 "See resources. Choose who participates.", "Review a request before anything is loaded."};
-            static const char *commands[] = {"/create", "/join", "/settings", "/quit", "/network"};
+            static const char *commands[] = {"/create", "/join", "/settings", "/quit", "/network", "/storage"};
             static const char *command_help[] = {"Create or show this household", "Find your household on the LAN and pair with its key",
-                "Model folder and maximum RAM to share", "Close Lumabri", "Set up trusted LAN access once (Windows/WSL)"};
+                "Model folder and maximum RAM to share", "Close Lumabri", "Set up trusted LAN access once (Windows/WSL)",
+                "Inspect and clear unused household weight caches"};
             ui_text(top, 5, UI_TEXT, actions ? "Workspace actions" : "What would you like to do?");
-            for (int i = 0; i < (actions ? 5 : 4); i++) ui_item(top + 2 + i * 3, selected == i,
+            for (int i = 0; i < (actions ? 6 : 4); i++) ui_item(top + 2 + i * 3, selected == i,
                 actions ? commands[i] : titles[i], actions ? command_help[i] : help[i]);
             ui_footer(notice[0] ? notice : s.tracker[0] ? s.tracker : "Create or join a household with / actions.",
                       "↑ ↓ move   Enter select   / actions   Esc back   Ctrl-C exit");
@@ -326,11 +429,11 @@ static int cmd_home(void) {
             if (key == 3 || (key == 27 && !actions)) break;
             if (key == 27) { actions = 0; selected = 0; }
             if (key == '/') { actions = !actions; selected = 0; }
-            int choices = actions ? 5 : 4;
+            int choices = actions ? 6 : 4;
             if (key == 1001) selected = (selected + choices - 1) % choices;
             if (key == 1002) selected = (selected + 1) % choices;
             if ((key == '\r' || key == '\n') && ui_h >= 28 && ui_w >= 60) {
-                key = actions ? "njsqf"[selected] : "ccpd"[selected];
+                key = actions ? "njsqfk"[selected] : "ccpd"[selected];
                 actions = 0; selected = 0; break;
             }
             (void)poll(NULL, 0, 100);
@@ -338,7 +441,9 @@ static int cmd_home(void) {
         home_terminal_end(&term);
         if (key == 'q' || key == 3 || key == 27 || g_stopping) break;
         notice[0] = 0;
-        if (key == 'f') {
+        if (key == 'k') {
+            home_storage_screen();
+        } else if (key == 'f') {
             home_network_setup(notice, sizeof notice);
         } else if (key == 'j') {
             if (tracker_child > 0) {

--- a/tests/c/test_weight_cache.c
+++ b/tests/c/test_weight_cache.c
@@ -1,0 +1,102 @@
+#define _POSIX_C_SOURCE 200809L
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "src/runtime/lumabri_weight_cache.h"
+
+static void file_at(int base, const char *name) {
+    int fd = openat(base, name, O_CREAT | O_EXCL | O_WRONLY, 0600);
+    assert(fd >= 0 && write(fd, "keep", 4) == 4 && !close(fd));
+}
+
+static int cancel_inspection(void *arg, const LmbWeightCacheUsage *usage, int erase) {
+    (void)arg; (void)usage; assert(!erase); return 1;
+}
+
+static int cancel_clearing(void *arg, const LmbWeightCacheUsage *usage, int erase) {
+    int *calls = arg;
+    (*calls)++;
+    return erase && usage->entries >= 64;
+}
+
+int main(void) {
+    char path[] = "/tmp/lumabri-weight-cache-XXXXXX";
+    assert(mkdtemp(path));
+    int base = open(path, O_DIRECTORY | O_RDONLY);
+    assert(base >= 0);
+    assert(!mkdirat(base, "cas", 0700));
+    assert(!mkdirat(base, "mirrors", 0700));
+    assert(!mkdirat(base, "mirrors/olmoe", 0700));
+    file_at(base, "settings"); file_at(base, "engines.log");
+    file_at(base, "source.safetensors");
+    file_at(base, "cas/chunk"); file_at(base, "mirrors/olmoe/config.json");
+    int sparse = openat(base, "mirrors/olmoe/sparse", O_CREAT | O_EXCL | O_WRONLY, 0600);
+    assert(sparse >= 0 && !ftruncate(sparse, 1u << 24) && !close(sparse));
+    /* Neither leaf links nor hardlinks grant ownership of their targets. */
+    assert(!symlinkat("../source.safetensors", base, "cas/link"));
+    assert(!linkat(base, "source.safetensors", base, "cas/hardlink", 0));
+    LmbWeightCacheUsage usage;
+    assert(!lmb_weight_cache_inspect(path, &usage));
+    assert(usage.files == 5 && usage.logical_bytes >= (1u << 24));
+    assert(usage.allocated_bytes < usage.logical_bytes);
+    int lease = lmb_weight_cache_lock(path);
+    assert(lease >= 0 && (fcntl(lease, F_GETFD) & FD_CLOEXEC));
+    assert(lmb_weight_cache_lock(path) < 0);
+    assert(lmb_weight_cache_clear(path) == -2);
+    assert(!faccessat(base, "cas/chunk", F_OK, 0));
+    close(lease);
+
+    /* Preflight checks BOTH roots before deleting anything. */
+    assert(!renameat(base, "mirrors", base, "saved"));
+    assert(!symlinkat("saved", base, "mirrors"));
+    assert(lmb_weight_cache_clear(path) == -1);
+    assert(!faccessat(base, "cas/chunk", F_OK, 0));
+    assert(!unlinkat(base, "mirrors", 0) && !renameat(base, "saved", base, "mirrors"));
+    assert(!mkfifoat(base, "mirrors/fifo", 0600));
+    assert(lmb_weight_cache_clear(path) == -1);
+    assert(!faccessat(base, "cas/chunk", F_OK, 0));
+    assert(!unlinkat(base, "mirrors/fifo", 0));
+
+    assert(lmb_weight_cache_inspect_progress(path, &usage, cancel_inspection, NULL) == -1);
+    assert(errno == ECANCELED && !usage.files);
+    assert(lmb_weight_cache_clear_progress(path, cancel_inspection, NULL) == -1);
+    assert(errno == ECANCELED && !faccessat(base, "cas/chunk", F_OK, 0));
+    lease = lmb_weight_cache_lock(path); assert(lease >= 0); close(lease);
+    for (unsigned i = 0; i < 130; i++) {
+        char name[64]; snprintf(name, sizeof name, "cas/extra-%u", i); file_at(base, name);
+    }
+    int calls = 0;
+    assert(lmb_weight_cache_clear_progress(path, cancel_clearing, &calls) == -1);
+    assert(errno == ECANCELED && calls > 1);
+    assert(!lmb_weight_cache_inspect(path, &usage) && usage.files > 0 && usage.files < 135);
+    lease = lmb_weight_cache_lock(path); assert(lease >= 0); close(lease);
+
+    assert(!lmb_weight_cache_clear(path));
+    assert(!lmb_weight_cache_inspect(path, &usage) && !usage.files && !usage.allocated_bytes);
+    assert(!faccessat(base, "settings", F_OK, 0));
+    assert(!faccessat(base, "engines.log", F_OK, 0));
+    assert(!faccessat(base, "source.safetensors", F_OK, 0));
+    assert(!faccessat(base, "weights.lock", F_OK, 0));
+    int source = openat(base, "source.safetensors", O_RDONLY); char text[4];
+    assert(source >= 0 && read(source, text, 4) == 4 && !memcmp(text, "keep", 4));
+    close(source);
+    assert(!lmb_weight_cache_clear(path));
+    assert(!unlinkat(base, "weights.lock", 0));
+    assert(!symlinkat("settings", base, "weights.lock"));
+    assert(lmb_weight_cache_clear(path) < 0);
+    assert(!unlinkat(base, "weights.lock", 0));
+    assert(!linkat(base, "settings", base, "weights.lock", 0));
+    errno = EAGAIN;
+    assert(lmb_weight_cache_clear(path) == -1 && errno == EINVAL);
+    assert(!unlinkat(base, "weights.lock", 0));
+    assert(!unlinkat(base, "settings", 0)); assert(!unlinkat(base, "engines.log", 0));
+    assert(!unlinkat(base, "source.safetensors", 0));
+    assert(!unlinkat(base, "cas", AT_REMOVEDIR)); assert(!unlinkat(base, "mirrors", AT_REMOVEDIR));
+    close(base); assert(!rmdir(path));
+    assert(!lmb_weight_cache_inspect(path, &usage) && !usage.files);
+    assert(!lmb_weight_cache_clear(path) && access(path, F_OK));
+    assert(lmb_weight_cache_clear(NULL) < 0);
+    assert(lmb_weight_cache_inspect(path, NULL) < 0);
+    puts("WEIGHT CACHE: PASS (exclusive lease, scoped removal, links, sparse accounting, preflight, cancellation)");
+    return 0;
+}

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -446,10 +446,14 @@ def main():
                 a.send("\x1b[A\r"); b.send("\x1b[A\r")
                 until(lambda: repeat.has("receives the text") or repeat.p.poll() is not None, seconds=180)
                 assert repeat.p.poll() is None, "cache reuse/refetch plan failed to start"
+                # A returning user's catalogue can already contain a measured
+                # tok/s value. Only this new turn's Hosted footer proves that
+                # generation finished; old catalogue output is not a response.
+                repeat.text = ""
                 repeat.send("hi\n")
-                until(lambda: repeat.has("tok/s") or repeat.has("generated tokens") or repeat.p.poll() is not None,
+                until(lambda: (repeat.has("hosted stream") and repeat.has("no local checkpoint")) or repeat.p.poll() is not None,
                       seconds=120, message="model did not finish a response after cache reuse/refetch")
-                assert repeat.p.poll() is None and "no local checkpoint" in repeat.text
+                assert repeat.p.poll() is None and (repeat.has("tok/s") or repeat.has("generated tokens"))
                 stats = source_stats(repeat)
                 if cleared:
                     assert stats["bytes_served"] > metadata_bytes, stats

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -35,6 +35,8 @@ def main():
     parser.add_argument("--expect-greedy", action="store_true")
     parser.add_argument("--repeat-cached", action="store_true",
                         help="run a separately approved second plan; verify shared weight reuse and source byte counters")
+    parser.add_argument("--clear-cached", action="store_true",
+                        help="after reuse, clear weights from the donor workspace and verify an approved cold restart")
     parser.add_argument("--expect-metrics", action="store_true",
                         help="require versioned generation timings through Hosted into the TUI")
     parser.add_argument("--expect-calibration", action="store_true",
@@ -46,6 +48,8 @@ def main():
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
+    if args.clear_cached and not args.repeat_cached:
+        parser.error("--clear-cached requires --repeat-cached")
     if args.expect_unused_donor and (args.repeat_cached or args.expect_no_fit or
                                     args.kill_donor or args.expect_calibration):
         parser.error("--expect-unused-donor is a separate single-session admission test")
@@ -401,41 +405,68 @@ def main():
             print("HOME CALIBRATION: PASS (real timing saved, catalogue reopened; context, selection and donor restart invalidate speed)", flush=True)
         if args.repeat_cached:
             before = cached_weights()
-            a.text = b.text = ""
-            repeat = Terminal("chatter-repeat", base)
-            until(lambda: repeat.has("3 computers"))
-            repeat.send("\t")
-            until(lambda: repeat.has("Nothing is selected automatically"))
-            repeat.send("\x1b[B\r\x1b[B\r\t")
-            time.sleep(.5)
-            repeat.send("\r\r")
-            until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"), seconds=60)
-            # Cached weights do not confer permission to execute again.
-            assert not repeat.has("receives the text")
-            a.send("\x1b[A\r"); b.send("\x1b[A\r")
-            until(lambda: repeat.has("receives the text") or repeat.p.poll() is not None, seconds=180)
-            assert repeat.p.poll() is None, "cached plan failed to start"
-            repeat.send("hi\n")
-            until(lambda: repeat.has("tok/s") or repeat.has("generated tokens") or repeat.p.poll() is not None,
-                  seconds=120, message="cached model did not finish a response")
-            assert repeat.p.poll() is None and "no local checkpoint" in repeat.text
-            warm = source_stats(repeat)
             # The requester and host each inspect config.json directly to
             # select the engine. These metadata reads still cross the wire;
             # do not misreport a warm weight cache as zero network traffic.
             configs = list(Path(args.models_dir).glob("*/config.json"))
             assert len(configs) == 1, "cache counter gate requires one fixture model"
             metadata_bytes = 2 * configs[0].stat().st_size
-            assert warm["reads"] == 2 and warm["bytes_served"] == metadata_bytes, (cold_bytes, warm)
             assert cold_bytes > metadata_bytes
-            assert cached_weights() == before, "the same checkpoint duplicated its persistent weight cache"
-            repeat.send("/quit\n")
-            until(lambda: repeat.p.poll() is not None)
-            assert repeat.p.returncode == 0
-            until(lambda: a.has("Released") and b.has("Released"))
-            until(leases_released)
-            assert not list((tmp / "chatter-repeat").rglob("*.safetensors"))
-            print(f"HOME CACHE: PASS (new approval, same checkpoint cache, source bytes {cold_bytes} -> {warm['bytes_served']}, two config reads remain)", flush=True)
+            for cleared in ([False, True] if args.clear_cached else [False]):
+                if cleared:
+                    for donor in ("donor-a", "donor-b"):
+                        storage = Terminal("storage-" + donor, ["./lumabri"], donor)
+                        until(lambda: storage.has("What would you like to do?"))
+                        storage.send("/")
+                        until(lambda: storage.has("/storage"))
+                        storage.send("\x1b[A\r")
+                        until(lambda: storage.has("Household weight storage"))
+                        storage.send("\x1b[B\r")
+                        until(lambda: storage.has("Clear unused household weights?"))
+                        storage.send("\x1b[B\r")
+                        until(lambda: storage.has("Household weights cleared"))
+                        for tree in ("cas", "mirrors"):
+                            assert not list((tmp / donor / ".lumabri/home" / tree).iterdir())
+                        storage.text = ""; storage.send("\x1b")
+                        until(lambda: storage.has("What would you like to do?"))
+                        storage.send("\x1b")
+                        until(lambda: storage.p.poll() is not None)
+                        assert storage.p.returncode == 0
+                a.text = b.text = ""
+                repeat = Terminal("chatter-refetch" if cleared else "chatter-repeat", base, "chatter-repeat")
+                until(lambda: repeat.has("3 computers"))
+                repeat.send("\t")
+                until(lambda: repeat.has("Nothing is selected automatically"))
+                repeat.send("\x1b[B\r\x1b[B\r\t")
+                time.sleep(.5)
+                repeat.send("\r\r")
+                until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"), seconds=60)
+                # Cached weights do not confer permission to execute again.
+                assert not repeat.has("receives the text")
+                a.send("\x1b[A\r"); b.send("\x1b[A\r")
+                until(lambda: repeat.has("receives the text") or repeat.p.poll() is not None, seconds=180)
+                assert repeat.p.poll() is None, "cache reuse/refetch plan failed to start"
+                repeat.send("hi\n")
+                until(lambda: repeat.has("tok/s") or repeat.has("generated tokens") or repeat.p.poll() is not None,
+                      seconds=120, message="model did not finish a response after cache reuse/refetch")
+                assert repeat.p.poll() is None and "no local checkpoint" in repeat.text
+                stats = source_stats(repeat)
+                if cleared:
+                    assert stats["bytes_served"] > metadata_bytes, stats
+                    assert cached_weights(), "cleared cache was not rebuilt"
+                else:
+                    assert stats["reads"] == 2 and stats["bytes_served"] == metadata_bytes, (cold_bytes, stats)
+                    assert cached_weights() == before, "the same checkpoint duplicated its persistent weight cache"
+                repeat.send("/quit\n")
+                until(lambda: repeat.p.poll() is not None)
+                assert repeat.p.returncode == 0
+                until(lambda: a.has("Released") and b.has("Released"))
+                until(leases_released)
+                assert not list((tmp / "chatter-repeat").rglob("*.safetensors"))
+                if cleared:
+                    print("HOME STORAGE: PASS (TUI cleanup, renewed approval, weight refetch, real generation, released leases)", flush=True)
+                else:
+                    print(f"HOME CACHE: PASS (new approval, same checkpoint cache, source bytes {cold_bytes} -> {stats['bytes_served']}, two config reads remain)", flush=True)
         def no_owned_processes():
             rows = subprocess.check_output(["ps", "-axo", "pgid=,stat="], text=True)
             return not any(int(row.split()[0]) in owned_groups and not row.split()[1].startswith("Z")

--- a/tests/integration/storage_ui_test.py
+++ b/tests/integration/storage_ui_test.py
@@ -35,7 +35,7 @@ with tempfile.TemporaryDirectory(prefix="lumabri-storage-ui-") as temp:
                            stdin=slave, stdout=slave, stderr=slave)
     output = bytearray()
 
-    def wait_for(text):
+    def until(predicate):
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline:
             while select.select([master], [], [], .02)[0]:
@@ -46,10 +46,13 @@ with tempfile.TemporaryDirectory(prefix="lumabri-storage-ui-") as temp:
                 if not data:
                     break
                 output.extend(data)
-            if text.encode() in output:
+            if predicate():
                 return
             time.sleep(.02)
         raise AssertionError(output.decode(errors="replace")[-4000:])
+
+    def wait_for(text):
+        until(lambda: text.encode() in output)
 
     def send(keys):
         output.clear()
@@ -73,7 +76,10 @@ with tempfile.TemporaryDirectory(prefix="lumabri-storage-ui-") as temp:
         assert source.read_bytes() == b"original model" and log.read_bytes() == b"keep log"
         assert (cache / "weights.lock").exists(), "cleanup removed the lease inode"
         send(b"\x1b"); wait_for("What would you like to do?")
-        send(b"\x1b"); app.wait(timeout=10)
+        # Keep consuming terminal output while waiting for exit. Darwin PTYs
+        # have a smaller output queue; blocking in wait() can strand the app
+        # in its final repaint before it reads Escape or restores termios.
+        send(b"\x1b"); until(lambda: app.poll() is not None)
         assert app.returncode == 0
         after = termios.tcgetattr(slave)
         mask = termios.ICANON | termios.ECHO
@@ -82,7 +88,11 @@ with tempfile.TemporaryDirectory(prefix="lumabri-storage-ui-") as temp:
         lease.close()
         if app.poll() is None:
             app.terminate()
-        app.wait(timeout=10)
+            try:
+                until(lambda: app.poll() is not None)
+            except AssertionError:
+                app.kill()
+        app.wait(timeout=5)
         os.close(master); os.close(slave)
 
 print("STORAGE UI: PASS (busy refusal, safe default, confirmed cleanup, sources/logs preserved, terminal restored)")

--- a/tests/integration/storage_ui_test.py
+++ b/tests/integration/storage_ui_test.py
@@ -1,0 +1,88 @@
+"""The real workspace storage action: approval, busy refusal and scoped clearing."""
+import fcntl
+import os
+from pathlib import Path
+import pty
+import select
+import struct
+import subprocess
+import tempfile
+import termios
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+
+with tempfile.TemporaryDirectory(prefix="lumabri-storage-ui-") as temp:
+    home = Path(temp)
+    cache = home / ".lumabri/home"
+    chunk = cache / "cas/aa/chunk"
+    mirror = cache / "mirrors/olmoe/cache/model.bin"
+    for file in (chunk, mirror):
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_bytes(b"cached weights")
+    source = home / "source-model.bin"
+    source.write_bytes(b"original model")
+    log = cache / "engines.log"
+    log.write_bytes(b"keep log")
+    lease = open(cache / "weights.lock", "w")
+    fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    master, slave = pty.openpty()
+    before = termios.tcgetattr(slave)
+    fcntl.ioctl(slave, termios.TIOCSWINSZ, struct.pack("HHHH", 38, 120, 0, 0))
+    env = {**os.environ, "HOME": temp, "LUMABRI_ENCRYPT": "1",
+           "LUMABRI_PEER_KEY": str(home / "peer.key")}
+    app = subprocess.Popen([str(ROOT / "lumabri")], cwd=ROOT, env=env,
+                           stdin=slave, stdout=slave, stderr=slave)
+    output = bytearray()
+
+    def wait_for(text):
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            while select.select([master], [], [], .02)[0]:
+                try:
+                    data = os.read(master, 65536)
+                except OSError:
+                    break
+                if not data:
+                    break
+                output.extend(data)
+            if text.encode() in output:
+                return
+            time.sleep(.02)
+        raise AssertionError(output.decode(errors="replace")[-4000:])
+
+    def send(keys):
+        output.clear()
+        os.write(master, keys)
+
+    try:
+        wait_for("What would you like to do?")
+        send(b"/"); wait_for("/storage")
+        send(b"\x1b[A\r"); wait_for("Household weight storage")
+        wait_for("Weights are in use")
+        send(b"\x1b[B\r"); wait_for("Cleanup is unavailable")
+        assert chunk.exists() and mirror.exists()
+        fcntl.flock(lease, fcntl.LOCK_UN)
+        send(b"\x1b[A\r"); wait_for("Only household cas/ and mirrors/")
+        send(b"\x1b[B\r"); wait_for("Clear unused household weights?")
+        send(b"\r"); wait_for("Household weight storage")
+        assert chunk.exists() and mirror.exists(), "default confirmation deleted weights"
+        send(b"\x1b[B\r"); wait_for("Clear unused household weights?")
+        send(b"\x1b[B\r"); wait_for("Household weights cleared")
+        assert not chunk.exists() and not mirror.exists()
+        assert source.read_bytes() == b"original model" and log.read_bytes() == b"keep log"
+        assert (cache / "weights.lock").exists(), "cleanup removed the lease inode"
+        send(b"\x1b"); wait_for("What would you like to do?")
+        send(b"\x1b"); app.wait(timeout=10)
+        assert app.returncode == 0
+        after = termios.tcgetattr(slave)
+        mask = termios.ICANON | termios.ECHO
+        assert (before[3] & mask) == (after[3] & mask)
+    finally:
+        lease.close()
+        if app.poll() is None:
+            app.terminate()
+        app.wait(timeout=10)
+        os.close(master); os.close(slave)
+
+print("STORAGE UI: PASS (busy refusal, safe default, confirmed cleanup, sources/logs preserved, terminal restored)")


### PR DESCRIPTION
## Scope
Adds the workspace /storage action with allocated-block accounting and explicitly confirmed clearing of unused default household CAS/mirror trees. Runtime and cleanup share one exclusive lease. Source model folders, settings, logs and lock inode are preserved. Symlinks are not traversed, unsafe trees fail closed, and inspection/clearing support cooperative cancellation.

## Verification
- Warning-clean C build.
- Unit tests plus AddressSanitizer/UndefinedBehaviorSanitizer/LeakSanitizer passed.
- Real PTY storage approval, busy refusal, safe default, cleanup and terminal restoration passed.
- Workspace navigation and English UI copy passed.
- Two-donor real Segment household flow, persisted calibration and repeated cache use passed; source data 1131952 -> 1638 bytes on repeated fixture.
- Added Linux and native Intel/ARM macOS CI coverage.

## Explicit limits
This does not close the entire models/storage roadmap gate: no automatic eviction, hard growth quota, remote model acquisition or disk execution is introduced. The view covers default household caches only. Physical LAN and native Windows release acceptance remain separate.

Merge only after all eight checks pass on the reviewed head; normal merge, no squash.