### PR TITLE
fix(home): isolate simultaneous plans and report occupied donors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
           python3 tools/package_household.py --colibri-root ../colibri --output 'build/native candidate'
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --expect-disjoint-plans --context 256
           python3 tools/package_household.py --verify 'build/native candidate'
           tar -czf build/lumabri-linux-candidate.tar.gz -C 'build/native candidate' .
       - uses: actions/upload-artifact@v4
@@ -418,6 +419,7 @@ jobs:
           python3 tools/package_household.py --colibri-root ../colibri --output 'build/native candidate'
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --expect-disjoint-plans --context 256
           python3 tools/package_household.py --verify 'build/native candidate'
           tar -czf build/lumabri-macos-candidate.tar.gz -C 'build/native candidate' .
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -66,11 +66,15 @@ offered RAM, detected hardware, placement and missing resources. **Not
 calibrated** means there is no matching speed measurement—not zero speed.
 A detected GPU is not a promise that this execution path uses it.
 
-The household path currently admits **one CPU, resident Segment plan** with
+Each participating computer currently admits **one CPU, resident Segment plan** with
 verified model sizing and source weights on the requesting computer. It
 distributes contiguous layer ranges, not isolated experts. Each donor keeps
 the state for its layers; the chosen chat host receives the conversation text.
 The chat connection itself does not mount or download a checkpoint.
+Separate donor groups can run independent chats at the same time, provided
+each group can hold its model. An occupied computer returns `BUSY`; it does
+not replace its existing request or chat. Sharing one donor between sessions
+and automatic recovery after a donor failure are not implemented yet.
 
 The donor queries its installed Segment runtime before sharing. A runtime
 built without OpenMP uses one execution thread; CPU core count is not a

--- a/docs/HOUSEHOLD_ADMISSION.md
+++ b/docs/HOUSEHOLD_ADMISSION.md
@@ -1,0 +1,48 @@
+# Household admission and independent chats
+
+Admission is currently exclusive per participating computer and weight-cache
+directory, not globally exclusive across the household. Two selected donor
+groups can serve two independent chats if each group can hold a complete
+resident plan. No computer is added without selection and owner approval.
+
+An authenticated offer for an occupied donor receives a rejected status with
+`BUSY` and its own request ID. The admitted transaction, connection, resource
+leases and engines are unchanged. This applies while the owner is deciding,
+while weights are being prepared, and during an active chat. An unrelated
+preflight or offer must not reset the owner's current Accept/Decline choice.
+
+The requester reads the initial allocation acknowledgement before sending
+heartbeats. A donor refusing an offer may close after sending its status;
+writing first could hide that queued reason behind a connection error.
+Malformed or missing acknowledgements stop preparation and release any
+allocations already obtained. An unapproved allocation never starts a model.
+
+## Executable gate
+
+```sh
+python3 tests/integration/home_flow_test.py \
+  --models-dir /path/to/tiny-model-parent --expect-disjoint-plans --context 256
+```
+
+The test uses an encrypted tracker, two actual donor TUIs and two separate
+Hosted/Segment sessions. It checks:
+
+- explicit rejection before approval and during an active allocation;
+- an owner's selected Accept action surviving another client's request;
+- both approved sessions and both sets of engine/cache leases coexisting;
+- both chats producing new generation results, not stale catalogue timings;
+- closing the first chat without releasing the second chat's resources;
+- another generation on the surviving chat, then complete lease cleanup;
+- real Segment execution on both donors and no checkpoint copy on the clients.
+
+The same gate runs against installed Linux and macOS candidates. Loopback
+tests do not certify physical LAN performance. A tiny checkpoint is a protocol
+fixture, not evidence of useful language quality or large-model throughput.
+
+## Not claimed
+
+There is no shared-donor multi-session engine scheduling, continuous batching,
+per-session speed guarantee, capacity certification or automatic replay after
+a participating donor fails. Those remain separate release gates. A donor's
+advertised RAM alone is not proof that it will admit another request; admission
+is checked again when the request reaches it.

--- a/docs/HOUSEHOLD_WEIGHT_CACHE.md
+++ b/docs/HOUSEHOLD_WEIGHT_CACHE.md
@@ -50,7 +50,8 @@ runs the same test; loopback is not a physical LAN certification.
 - Importing old per-request caches: existing directories are left untouched.
 - Automatic eviction, a total disk-cache quota and cache-aware free-space admission.
 - Remote checkpoint selection, authorized acquisition and model-license handling.
-- A verified smaller disk working set, concurrent sessions and KV replay.
+- A verified smaller disk working set, sessions sharing one donor/cache and KV replay.
+  Independent plans on disjoint donors hold separate cache leases and can coexist.
 
 The requester still supplies a local checkpoint. Gate 5 is not complete just
 because verified weight blocks are reused.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -164,7 +164,12 @@ not a completed gate.
    Model acquisition, cache-aware disk admission/eviction and verified smaller
    disk working sets remain pending. See `HOUSEHOLD_WEIGHT_CACHE.md`.
 6. Pending: upstream-only GPU capability integration, CPU otherwise.
-7. Pending: concurrent sessions and actual replay after failure.
+7. Two independent household chats on disjoint donors now have an end-to-end
+   gate: simultaneous generation, separate engines and leases, closing one
+   while continuing the other, and explicit `BUSY` for an overlapping request.
+   An unrelated request must not reset an owner's pending approval choice.
+   Shared-donor multi-session scheduling, 1/2/4/8 capacity measurements and
+   actual replay after failure remain pending. See `HOUSEHOLD_ADMISSION.md`.
 8. Native candidate assembly now has an explicit binary allowlist, retained
    upstream notices, exact file hashes and dependency reports. The installed
    `bin`/`lib` layout is exercised by the same two-donor approval, generation,

--- a/docs/NATIVE_CANDIDATES.md
+++ b/docs/NATIVE_CANDIDATES.md
@@ -43,7 +43,9 @@ The latest measured speed is historical, not a guarantee for the next turn.
 - Neither a GPU detector nor a manifest entry proves accelerated execution.
   These candidates use the verified CPU path. Each participating machine
   must permit the household's fixed LAN ports in its own firewall.
-- One household chat plan at a time. Losing a participating donor stops the
+- One household chat plan per participating computer and cache directory.
+  Disjoint donor groups can serve independent chats concurrently; this is
+  not multi-session inference on a shared donor. Losing a participating donor stops the
   current chat and releases resources; automatic household replay is pending.
 
 ## Building and testing a candidate

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -408,7 +408,16 @@ static int home_donor_offer(HomeDonor *d, int incoming, const char *tracker,
              !lmb_secure_peer_matches(incoming, offer.requester);
     }
     lmb_msg_free(&m);
-    if (!rc && d->client >= 0) rc = -1;
+    if (!rc && d->client >= 0) {
+        /* Reply against the NEW request ID without changing the admitted
+         * transaction, its leases, or its controller connection. An EOF is
+         * not a useful capacity signal to a second household chatter. */
+        LmbHomeTransaction busy = { .offer = offer, .phase = LMB_HOME_REJECTED };
+        snprintf(busy.reason, sizeof busy.reason,
+                 "BUSY: this computer already has an active household request.");
+        (void)home_status_send(incoming, &busy, 0, 0);
+        return -1; /* caller closes only this unadmitted connection */
+    }
     if (!rc) rc = lmb_home_offer_begin(&d->transaction, &offer, tracker,
                                        ram, disk, (uint64_t)(nowd() * 1000));
     if (rc) return -1;
@@ -528,7 +537,9 @@ static int cmd_donor(int argc, char **argv) {
         if (ready[0].revents & POLLIN) {
             int incoming = accept(listener, NULL, NULL);
             if (incoming >= 0) {
-                donor_choice = 1;
+                /* An unrelated preflight/offer must not reset the choice
+                 * the owner is making on an existing pending request. */
+                if (d.client < 0) donor_choice = 1;
                 lmb_machine_refresh_resources(&profile, d.cache_base);
                 uint64_t free_ram = profile.ram_available_bytes > reserve ? profile.ram_available_bytes - reserve : 0;
                 if (free_ram > ram) free_ram = ram;
@@ -811,6 +822,18 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         s.fd[s.count] = fd; s.phase[s.count] = LMB_HOME_PENDING;
         if (o->runs_edge) { s.edge = s.count; have_edge = 1; }
         s.count++;
+        /* Drain the initial acknowledgement before starting heartbeats. A
+         * busy donor replies then closes; sending PULSE first can replace its
+         * queued rejection with a write error and hide the actual reason. */
+        if (home_session_receive(&s, s.count - 1)) {
+            if (!s.reason[s.count - 1][0])
+                home_fail("No valid allocation acknowledgement from %.64s. Check its connection; no plan was committed.", nodes[n].name);
+            goto done;
+        }
+        if (s.phase[s.count - 1] != LMB_HOME_PENDING) {
+            home_fail("Unexpected initial allocation status from %.64s. No plan was committed.", nodes[n].name);
+            goto done;
+        }
     }
     if (!have_edge || !s.count) goto done;
     int committed = 0, host_started = 0;

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -29,6 +29,8 @@ def main():
     parser.add_argument("--runtime-dir", type=Path, default=ROOT,
                         help="directory containing the installed household binaries; no source tree fallback")
     parser.add_argument("--models-dir", required=True)
+    parser.add_argument("--expect-disjoint-plans", action="store_true",
+                        help="verify two simultaneous household chats using different approved compute donors")
     parser.add_argument("--donor-ram-gb", type=float, default=0.5)
     parser.add_argument("--context", type=int, default=128,
                         help="approved context, including the actual family chat template")
@@ -46,6 +48,10 @@ def main():
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
+    if args.expect_disjoint_plans and any((args.repeat_cached, args.expect_no_fit,
+        args.expect_unused_donor, args.kill_donor, args.expect_calibration,
+        args.expect_metrics, args.expect_greedy)):
+        parser.error("--expect-disjoint-plans is a separate concurrency test")
     if args.expect_unused_donor and (args.repeat_cached or args.expect_no_fit or
                                     args.kill_donor or args.expect_calibration):
         parser.error("--expect-unused-donor is a separate single-session admission test")
@@ -77,7 +83,7 @@ def main():
     # TOFU authentication; do not erase known_hosts to make a repeat pass.
     service_base = 12000 + (port % 200) * 160
     service_slots = {"donor-a": 1, "donor-b": 2, "reject": 3,
-                     "chatter": 4, "chatter-repeat": 5}
+                     "chatter": 4, "chatter-repeat": 5, "chatter-parallel": 6}
 
     def env(name):
         home = tmp / name
@@ -226,6 +232,103 @@ def main():
                                capture_output=True, text=True, timeout=15)
             return p.returncode == 0 and len(json.loads(p.stdout)["nodes"]) == 3
         until(inventory_ready)
+        if args.expect_disjoint_plans:
+            chats, owners = [], []
+
+            def lease_is_held(donor, lock):
+                with open(tmp / donor.name / ".lumabri" / lock, "r") as lease:
+                    try:
+                        fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except BlockingIOError:
+                        return True
+                return False
+
+            def completed_turn(chat):
+                return chat.has("hosted stream") and chat.has("no local checkpoint")
+
+            def reject_busy(label):
+                collision = Terminal(label, base, "reject")
+                until(lambda: collision.has("3 computers"))
+                collision.send("\t")
+                until(lambda: collision.has("Nothing is selected automatically"))
+                collision.send("\x1b[B\r\t")
+                time.sleep(.5); collision.send("\r\r")
+                until(lambda: collision.p.poll() is not None, seconds=60,
+                      message="an occupied donor did not refuse the conflicting plan")
+                assert collision.p.returncode != 0 and collision.has("BUSY:"), collision.text[-1500:]
+                assert not collision.has("receives the text")
+
+            for index, name in enumerate(("chatter", "chatter-parallel"), 1):
+                chat = Terminal(name, base)
+                chats.append(chat)
+                until(lambda: chat.has("3 computers"))
+                chat.send("\t")
+                until(lambda: chat.has("Nothing is selected automatically"))
+                chat.send("\x1b[B" * index + "\r\t")
+                time.sleep(.5)
+                chat.send("\r\r")
+                available = [donor for donor in (a, b) if donor not in owners]
+                until(lambda: any(donor.has("Waiting for your approval") for donor in available)
+                      or chat.p.poll() is not None, seconds=60,
+                      message="a disjoint plan did not reach its unused donor")
+                assert chat.p.poll() is None
+                pending = [donor for donor in available if donor.has("Waiting for your approval")]
+                assert len(pending) == 1, "single-donor selection was not preserved"
+                owner = pending[0]; owners.append(owner)
+                assert not chat.has("receives the text"), "a plan started without its owner's approval"
+                owner.send("\x1b[A")
+                if index == 1:
+                    # The owner has selected Accept but has not confirmed it.
+                    # Another client's preflight and offer must neither replace
+                    # that request nor silently reset Accept to Decline.
+                    time.sleep(.3)
+                    reject_busy("reject-pending")
+                owner.send("\r")
+                until(lambda: chat.has("Approved Segment plan: 1 compute donor") or chat.p.poll() is not None,
+                      seconds=180, message="an approved independent plan failed to start")
+                assert chat.p.poll() is None
+            # Both actual hosted sessions and both independent resource/cache
+            # leases must coexist. This is not two serial requests relabelled
+            # as concurrency, nor two sessions sharing one compute process.
+            assert len(set(owner.name for owner in owners)) == 2
+            reject_busy("reject-active")
+            for owner in owners:
+                for lock in ("compute-donor.lock", "home/weights.lock"):
+                    assert lease_is_held(owner, lock), "a live plan did not own its reservation"
+            for chat, prompt in zip(chats, ("hi", "hello")):
+                chat.text = ""; chat.send(prompt + "\n")
+            until(lambda: all(completed_turn(chat) for chat in chats)
+                  or any(chat.p.poll() is not None for chat in chats), seconds=120,
+                  message="simultaneous independent chats did not both generate")
+            assert all(chat.p.poll() is None and completed_turn(chat) for chat in chats)
+            chats[0].send("/quit\n")
+            until(lambda: chats[0].p.poll() is not None and owners[0].has("Released"))
+            assert chats[0].p.returncode == 0
+            for lock in ("compute-donor.lock", "home/weights.lock"):
+                assert not lease_is_held(owners[0], lock)
+                assert lease_is_held(owners[1], lock), "closing one plan released the other plan's lease"
+            chats[1].text = ""; chats[1].send("again\n")
+            until(lambda: completed_turn(chats[1]) or chats[1].p.poll() is not None,
+                  seconds=120, message="the surviving chat could not continue")
+            assert chats[1].p.poll() is None and completed_turn(chats[1])
+            chats[1].send("/quit\n")
+            until(lambda: chats[1].p.poll() is not None and owners[1].has("Released"))
+            assert chats[1].p.returncode == 0
+            ranges = []
+            for owner in owners:
+                for lock in ("compute-donor.lock", "home/weights.lock"):
+                    assert not lease_is_held(owner, lock)
+                log = (tmp / owner.name / ".lumabri/home/engines.log").read_text(errors="replace")
+                runs = re.findall(r"\[segment-node [^\]\n]+ (\d+):(\d+)\] committed_runs=(\d+)", log)
+                assert runs, "a selected compute donor did not execute"
+                executed = {(int(begin), int(end)) for begin, end, _ in runs}
+                assert len(executed) == 1
+                ranges.append(next(iter(executed)))
+            assert ranges[0] == ranges[1] and ranges[0][0] == 0 and ranges[0][1] > 0
+            for chat in chats:
+                assert not list((tmp / chat.name).rglob("*.safetensors"))
+            print("HOME DISJOINT PLANS: PASS (two simultaneous approved chats, independent engines and leases, closing one preserves the other)", flush=True)
+            return
         reject = Terminal("reject", base)
         until(lambda: reject.has("3 computers"))
         reject.send("\t")


### PR DESCRIPTION
## Scope

Fix overlapping household admission without disturbing the active owner or
session. This is a bounded part of the concurrency roadmap, not a claim that
shared-node multi-session scheduling or failure replay is complete.

- Return an authenticated REJECTED/BUSY status for the new request ID when
  the donor already has a pending or active transaction.
- Preserve the owner's current approval selection when another connection
  arrives (including discovery preflight).
- Read the initial allocation acknowledgement before sending heartbeats so
  a queued refusal is not replaced by EPIPE/EOF after the donor closes.
- Test two independently approved chats on disjoint donor groups, conflicting
  requests during approval and execution, concurrent generation, separate
  leases, and continuation after closing the other chat.
- Run that gate against installed Linux and native macOS candidates.

## Verification

- `make lumabri CFLAGS='-O2 -Wall -Wextra -Werror'`
- `./test_home`
- `home_flow_test.py --expect-disjoint-plans --context 256`: PASS, real tiny
  OLMoE Segment engines (`/tmp/lumabri-home-flow-ywfbi19j`).
- Same test against the unpatched binary failed at the missing BUSY reason
  (`/tmp/lumabri-home-flow-slxx1pwa`), establishing the regression.
- `--repeat-cached --expect-metrics --expect-calibration`: PASS
  (`/tmp/lumabri-home-flow-54me7qwu`).
- `--kill-donor`: PASS (`/tmp/lumabri-home-flow-ny_m9uaj`).
- Python syntax and `git diff --check` pass.

This local evidence is loopback, not a physical-LAN or macOS 12.6 acceptance
claim. Shared-donor scheduling, fairness/capacity benchmarks, automatic replay
and the remaining release gates stay explicitly open in the documentation.

Merge policy: all eight CI checks must pass on the reviewed head; merge commit
only, no squash. Colibri and the user's live installation remain unchanged.
