### PR TITLE
feat(home): measure an approved plan with a bounded eight-token probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --clear-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --expect-disjoint-plans --context 256
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --expect-quick-calibration
           python3 tools/package_household.py --verify 'build/native candidate'
           tar -czf build/lumabri-linux-candidate.tar.gz -C 'build/native candidate' .
       - uses: actions/upload-artifact@v4
@@ -422,6 +423,7 @@ jobs:
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --repeat-cached --clear-cached --expect-metrics --expect-calibration
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --kill-donor
           python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --expect-disjoint-plans --context 256
+          python3 tests/integration/home_flow_test.py --runtime-dir 'build/native candidate/bin' --models-dir build/home-flow-models --expect-quick-calibration
           python3 tools/package_household.py --verify 'build/native candidate'
           tar -czf build/lumabri-macos-candidate.tar.gz -C 'build/native candidate' .
       - uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ lumabri test_chat_ui: src/planner/lumabri_catalogue_advice.h
 lumabri test_chat_ui: src/runtime/lumabri_preload.h
 lumabri segment_chat test_chat_ui: lumabri_metrics.h
 
-lumabri: $(HOME_NET_DEPS) lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
+lumabri: $(HOME_NET_DEPS) src/runtime/lumabri_probe_deadline.h lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_proto.h lumabri_sign.h \
 		lumabri_inventory.h lumabri_home.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h \
 		lumabri_families.h lumabri_planner.h lumabri_cluster.h lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h \
 		lumabri_calibration.h $(SECURE_DEPS) $(MACHINE_DEPS)
@@ -477,7 +477,7 @@ test_inventory: tests/c/test_inventory.c lumabri_inventory.h lumabri_machine.h l
 test_home: tests/c/test_home.c lumabri_home.h lumabri_inventory.h lumabri_families.h lumabri_proto.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_home.c -o $@
 
-test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h
+test_chat_ui: $(HOME_NET_DEPS) $(SECURE_DEPS) src/runtime/lumabri_probe_deadline.h tests/c/test_chat_ui.c lumabri.c src/ui/lumabri_tui.c src/ui/lumabri_tui.h src/ui/lumabri_visual.h src/ui/lumabri_chat_editor.h src/ui/lumabri_execution_view.h lumabri_home_runtime.h src/ui/lumabri_home_ui.h lumabri_ready.h lumabri_cluster.h lumabri_memory_budget.h lumabri_checkpoint_inventory.h lumabri_content.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_chat_ui.c src/ui/lumabri_tui.c lumabri_machine.c -o $@
 
 test-ready-pipe: tests/c/test_ready_pipe.c lumabri_ready.h

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ offered RAM, detected hardware, placement and missing resources. **Not
 calibrated** means there is no matching speed measurement—not zero speed.
 A detected GPU is not a promise that this execution path uses it.
 
+For an optional short measurement, select your computers and model, open
+**/ actions → /calibrate**, then review and confirm. Donors still approve the
+plan. Lumabri generates at most 8 test tokens, with a 20-second inference
+limit, saves the observed speed and releases the plan. Transferring and
+loading missing weights happens first and can take much longer. This is a
+short-run indication, not a guarantee for long conversations.
+
 Each participating computer currently admits **one CPU, resident Segment plan** with
 verified model sizing and source weights on the requesting computer. It
 distributes contiguous layer ranges, not isolated experts. Each donor keeps

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -153,7 +153,11 @@ not a completed gate.
    content/runtime-bound records and catalogue lookup. Context, selected
    computers and donor restarts invalidate old speeds; the last observed
    workload is shown separately from the configured context limit. Placement
-   cost calibration remains pending. The catalogue advice follow-up highlights
+   cost calibration remains pending. An optional quick-calibration action now
+   requests normal donor approval, generates at most eight test tokens with a
+   20-second inference deadline, saves only valid complete metrics and releases
+   its plan. Transfer/loading comes first and is not covered by that deadline.
+   The catalogue advice follow-up highlights
    lowest RAM reservation, largest resident checkpoint and fastest observed
    run among eligible plans; it does not rank answer quality or invent speed
    before a first measurement. See `CALIBRATION_RECORDS.md` and

--- a/docs/QUICK_CALIBRATION.md
+++ b/docs/QUICK_CALIBRATION.md
@@ -1,0 +1,41 @@
+# Optional short calibration
+
+In the model catalogue, select participating computers and a model, open
+`/ actions`, choose `/calibrate`, and review the confirmation. Enter requests
+the plan; Esc returns without indexing, offers or execution. Every used donor
+must still approve its exact allocation, including the eight-token turn limit.
+
+The probe uses the same real Hosted/Segment path as chat, a fresh short prompt,
+and at most eight generated tokens. The local client starts a monotonic
+20-second deadline before submitting the prompt. On expiration it shuts down
+the Hosted socket, wakes the blocked stream and releases the household plan.
+No interrupted, invalid or insufficient measurement is saved. Ctrl-C cancels.
+
+The inference deadline does **not** include discovery, indexing, transfer or
+loading weights. Those use the existing preparation flow and cancellation.
+An unloaded large model cannot be measured without preparing it. Reused
+verified weights avoid unnecessary transfer but still require engine loading.
+
+After the completed probe, Lumabri saves the same versioned real-timing record
+as a normal chat turn and releases its engines/leases. The catalogue displays
+the speed only for a matching checkpoint, binaries, donor runtime identities,
+hardware, selected ranges, thread counts, context and session count. Its model
+detail shows the actual prompt/generated-token sample sizes. Failed or expired
+probes never overwrite an earlier valid record with a fabricated speed.
+
+The result is a **short-run observation**. It does not predict long-context
+performance, sustained thermals, other background load or concurrent capacity.
+It is not a microbenchmark extrapolated from a different model. Stage-level
+cost fitting and placement informed by those costs remain separate work.
+
+## Gates
+
+- Timer tests cover invalid requests, double start, normal stop with the socket
+  still usable, expiry waking a stalled read and descriptor ownership.
+- `home_flow_test.py --expect-quick-calibration` reviews and dismisses the
+  confirmation, checks no loading before consent, approves two real Segment
+  donors, executes exactly one short generation, checks the saved record and
+  reopened catalogue, and verifies resource/cache lease release.
+- The same flow runs on installed Linux and macOS candidates. Tiny fixtures
+  validate execution and protocol, not useful language quality or large-model
+  speed. Physical LAN acceptance remains a separate test.

--- a/lumabri.c
+++ b/lumabri.c
@@ -73,6 +73,7 @@
 #include "lumabri_runtime_probe.h"
 #include "lumabri_checkpoint_identity.h"
 #include "lumabri_calibration_store.h"
+#include "src/runtime/lumabri_probe_deadline.h"
 
 /* Borrowed by the synchronous household chat only. Ordinary/legacy hosts
  * cannot create an entry without an approved plan and actual numeric metadata. */
@@ -4494,7 +4495,7 @@ static int cmd_chat(int argc, char **argv) {
     const char *role_arg = NULL, *model_dir_arg = NULL;
     const char *donor_name_arg = NULL, *host_addr = NULL, *host_key = NULL;
     double donate_gb = 0;
-    int max_new = 256, ctx = 2048, cap_experts = 64;
+    int max_new = 256, ctx = 2048, cap_experts = 64, quick_probe = 0;
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "--tracker") && i + 1 < argc) tracker = argv[++i];
         else if (!strcmp(argv[i], "--engine") && i + 1 < argc) engine_path = argv[++i];
@@ -4510,6 +4511,7 @@ static int cmd_chat(int argc, char **argv) {
         else if (!strcmp(argv[i], "--donor-name") && i + 1 < argc) donor_name_arg = argv[++i];
         else if (!strcmp(argv[i], "--host") && i + 1 < argc) host_addr = argv[++i];
         else if (!strcmp(argv[i], "--host-key") && i + 1 < argc) host_key = argv[++i];
+        else if (!strcmp(argv[i], "--calibrate")) quick_probe = 1;
         else if (!strcmp(argv[i], "--plain")) g_tty = 0;
         else { fprintf(stderr, "usage: lumabri chat [--tracker H:P] [--model NAME] "
                                "[--local DIR] [--engine BIN] [--engines-dir DIR]\n"
@@ -4518,6 +4520,10 @@ static int cmd_chat(int argc, char **argv) {
                                "                    [--role chat|disk|compute|all] "
                                "[--donate GB] [--model-dir DIR] [--donor-name S]\n");
                return 2; }
+    }
+    if (quick_probe && (!host_addr || !g_recording_calibration || !g_calibration_directory)) {
+        fprintf(stderr, "Quick calibration requires an approved Hosted plan. No local engine was started.\n");
+        return 2;
     }
     g_chat_term_valid = g_tty && isatty(STDIN_FILENO) &&
                         tcgetattr(STDIN_FILENO, &g_chat_term) == 0;
@@ -4640,17 +4646,27 @@ static int cmd_chat(int argc, char **argv) {
     } else if (model_boot(tracker, model, shim, engines_dir, engine_path,
                           local_dir, ctx, max_new, cap_experts, &eng, &sw))
         return 1;
+    if (quick_probe) {
+        if (eng.proto != PROTO_SERVE2 || !eng.numeric_abi) {
+            fprintf(stderr, "This host cannot provide a verified quick measurement.\n");
+            engine_stop(&eng); return 1;
+        }
+        if (max_new > (int)LMB_QUICK_PROBE_TOKENS) max_new = (int)LMB_QUICK_PROBE_TOKENS;
+        printf("  Quick calibration: at most %u tokens, %.0f seconds of inference. Ctrl-C cancels.\n",
+               LMB_QUICK_PROBE_TOKENS, LMB_QUICK_PROBE_SECONDS);
+    }
     if (!host_addr && (role.disk || role.compute)) {
         role_start(&role, tracker, model, sw.model_type, eng.segment, ctx,
                    sw.total_bytes);
     }
 
     char *conv = calloc(1, 1);   /* serve-codec conversation history (after bos) */
-    int chat_failed = 0;
+    int chat_failed = 0, probe_recorded = 0;
+    LmbProbeDeadline probe_deadline = {0};
     char line[4096];
     for (;;) {
         if (g_stopping) break;
-        int queued = live_take_pending(line, sizeof line);
+        int queued = quick_probe ? 0 : live_take_pending(line, sizeof line);
         int w = term_w() - 2;
         if (g_tty) {
             printf("\n");
@@ -4663,7 +4679,11 @@ static int cmd_chat(int argc, char **argv) {
             printf("\n> ");
         fflush(stdout);
         int got;
-        if (queued) {
+        if (quick_probe) {
+            snprintf(line, sizeof line, "Describe a calm sea in one sentence.");
+            printf("%s\r\n", line);
+            got = 1; /* a disclosed synthetic turn, never added to editor history */
+        } else if (queued) {
             printf("%s\r\n", line);
             le_hist_push(line);
             got = 1;
@@ -4719,6 +4739,10 @@ static int cmd_chat(int argc, char **argv) {
             continue;
         }
         int is_reset = !strcmp(line, "/reset");
+        if (quick_probe && lmb_probe_start(&probe_deadline, eng.to, LMB_QUICK_PROBE_SECONDS)) {
+            fprintf(stderr, "Cannot start the calibration deadline; no measurement was submitted.\n");
+            chat_failed = 1; break;
+        }
         if (eng.proto == PROTO_SERVE2) {
             /* the serve codec has no reset command; dropping the local history
              * (and starting a fresh bos) is the conversation reset. */
@@ -4757,6 +4781,10 @@ static int cmd_chat(int argc, char **argv) {
             int dead = stream_serve2(&eng, stat, sizeof stat, &reply);
             g_eng.streaming = 0;
             live_end();
+            if (quick_probe && lmb_probe_stop(&probe_deadline)) {
+                fprintf(stderr, "Quick calibration reached its time limit. No new speed was saved.\n");
+                free(reply); chat_failed = 1; break;
+            }
             if (g_stopping) {
                 free(reply);
                 printf("\n  %sinference interrupted%s\n", C_DIM, C_R);
@@ -4835,6 +4863,11 @@ static int cmd_chat(int argc, char **argv) {
         LmbGenerationMetrics metrics;
         int metric_status=lmb_metrics_parse(stat,&metrics);
         if(metric_status==0 && metrics.generated_tokens!=(uint32_t)ntok) metric_status=-1;
+        if (quick_probe && (metric_status || metrics.generated_tokens > LMB_QUICK_PROBE_TOKENS ||
+                            lmb_metrics_decode_rate(&metrics) <= 0)) {
+            fprintf(stderr, "Quick calibration did not produce enough valid timing data. No new speed was saved.\n");
+            chat_failed = 1; break;
+        }
         if(metric_status==0) {
             if (g_recording_calibration && g_calibration_directory && eng.numeric_abi &&
                 nstat >= 5 && prompt_count && lmb_metrics_decode_rate(&metrics) > 0) {
@@ -4845,9 +4878,10 @@ static int cmd_chat(int argc, char **argv) {
                 record.ttft_seconds = first > r0 ? first - r0 : metrics.prefill_seconds;
                 record.measured_at = (double)time(NULL); record.samples = 1;
                 record.prompt_tokens = prompt_count; record.generated_tokens = metrics.generated_tokens;
-                if (!lmb_cal_store(g_calibration_directory, &record))
+                if (!lmb_cal_store(g_calibration_directory, &record)) {
                     *g_recording_calibration = record;
-                else fprintf(stderr, "[lumabri] Could not save this measurement; the reply is unaffected.\n");
+                    probe_recorded = 1;
+                } else fprintf(stderr, "[lumabri] Could not save this measurement; the reply is unaffected.\n");
             }
             if (g_recording_calibration && !eng.numeric_abi)
                 fprintf(stderr, "[calibration] No speed saved: the host did not supply its numeric ABI.\n");
@@ -4875,8 +4909,17 @@ static int cmd_chat(int argc, char **argv) {
         else if (dmb > 0.5) printf(" · %.0f MB from swarm · mirror %.0f MB", dmb, g_eng.net_mb);
         else                printf(" · warm mirror, no weight transfers");
         printf("%s\n", C_R);
+        if (quick_probe) {
+            if (!probe_recorded) {
+                fprintf(stderr, "Quick calibration could not save its measurement. The catalogue was not updated.\n");
+                chat_failed = 1; break;
+            }
+            puts("  Quick calibration complete. Short-run indication, not a long-chat speed guarantee.");
+            break;
+        }
     }
 
+    (void)lmb_probe_stop(&probe_deadline);
     free(conv);
     engine_stop(&eng);
     /* The picker promises the donation lasts as long as the chat. That was
@@ -5411,7 +5454,9 @@ static int cmd_models(int argc, char **argv) {
     catalog_state_refresh(&st, NULL);
     if (!plain) {
         int action = lmb_tui_run(&st, snapshot, keys);
-        return action == LMB_TUI_REQUEST_CHAT ? home_request_chat(&st, st.action_model) : action;
+        if (action == LMB_TUI_REQUEST_CALIBRATION) st.quick_calibration = 1;
+        return action == LMB_TUI_REQUEST_CHAT || action == LMB_TUI_REQUEST_CALIBRATION ?
+            home_request_chat(&st, st.action_model) : action;
     }
     if (json) { catalog_json(&st); return st.inventory_ok ? 0 : 1; }
 

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -330,8 +330,8 @@ static void home_donor_screen(const HomeDonor *d, const char *name, uint64_t ram
             ui_printf(12, 5, UI_MUTED, "Requester identity: %.24s…", who);
             ui_printf(14, 5, UI_TEXT, "Layers %u–%u of %u · %.2f GB RAM · %.2f GB disk headroom",
                 t->offer.begin, t->offer.end - 1, t->offer.layers, t->offer.ram_bytes / 1e9, t->offer.disk_bytes / 1e9);
-            ui_printf(16, 5, UI_MUTED, "%u context · one session · %u execution threads", t->offer.context,
-                      t->offer.threads < d->thread_capacity ? t->offer.threads : d->thread_capacity);
+            ui_printf(16, 5, UI_MUTED, "%u context · one session · %u threads · up to %u new tokens per turn", t->offer.context,
+                      t->offer.threads < d->thread_capacity ? t->offer.threads : d->thread_capacity, t->offer.max_new);
             ui_text(18, 5, UI_MUTED, t->offer.runs_edge ?
                 "This computer hosts chat and receives the conversation text." :
                 "This computer processes activations and keeps state for its layers.");
@@ -357,11 +357,11 @@ static void home_donor_screen(const HomeDonor *d, const char *name, uint64_t ram
         char who[65]; lmb_hex(who, t->offer.requester, 32);
         printf("\nRequester identity: %.24s…\nModel: %s (%s)\nLayers: %u–%u of %u\n"
                "RAM budget: %.2f GB · estimated disk headroom: %.2f GB\n"
-               "Context: %u · one session · %u threads\n",
+               "Context: %u · one session · %u threads · up to %u new tokens per turn\n",
                who, t->offer.model, t->offer.model_type, t->offer.begin,
                t->offer.end - 1, t->offer.layers, t->offer.ram_bytes / 1e9,
                t->offer.disk_bytes / 1e9, t->offer.context,
-               t->offer.threads < d->thread_capacity ? t->offer.threads : d->thread_capacity);
+               t->offer.threads < d->thread_capacity ? t->offer.threads : d->thread_capacity, t->offer.max_new);
         if (t->offer.runs_edge)
             puts("This computer also hosts chat and receives the conversation text.");
         else puts("This computer processes activations and keeps state for its layers.");
@@ -772,7 +772,8 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         o->begin = slice->layer_begin; o->end = slice->layer_end; o->layers = m->shape.layers;
         o->context = st->context; o->threads = nodes[n].threads ? nodes[n].threads : 1;
         if (o->threads > 256) o->threads = 256;
-        o->max_new = st->max_new ? st->max_new : 256; o->model_bytes = swarm.total_bytes;
+        o->max_new = st->quick_calibration ? LMB_QUICK_PROBE_TOKENS : (st->max_new ? st->max_new : 256);
+        o->model_bytes = swarm.total_bytes;
         o->runs_edge = n == plan.edge_node;
         LmbHomeReservation reservation;
         if (lmb_home_reservation(&m->shape, swarm.total_bytes, o->begin, o->end,
@@ -886,7 +887,7 @@ static int home_request_chat(LmbTuiState *st, int selected) {
             char expected_host[65]; lmb_hex(expected_host, edge_pk, 32);
             char *chat_argv[] = {"--host", host, "--model", model, "--ctx", ctx,
                                  "--role", "chat", "--max-new", token_limit, "--host-key", expected_host,
-                                 "--tracker", st->tracker};
+                                 "--tracker", st->tracker, "--calibrate"};
             g_execution_view = &execution;
             LmbCalibration measurement = {0}; char measurement_dir[1200];
             LmbTuiModel measured = *m;
@@ -922,7 +923,7 @@ static int home_request_chat(LmbTuiState *st, int selected) {
                         !m->content_id[0] ? "checkpoint content identity is unavailable" :
                         !st->build_id[0] ? "client binary identity is unavailable" :
                         "the approved plan's runtime identities are incomplete or changed");
-            result = cmd_chat(14, chat_argv);
+            result = cmd_chat(st->quick_calibration ? 15 : 14, chat_argv);
             g_recording_calibration = NULL; g_calibration_directory = NULL;
             g_execution_view = NULL;
             atomic_store(&s.stop, 1); pthread_join(heartbeat, NULL);

--- a/src/runtime/lumabri_probe_deadline.h
+++ b/src/runtime/lumabri_probe_deadline.h
@@ -1,0 +1,57 @@
+/* A bounded optional measurement owns this timer, not the engine descriptor.
+ * Stop/join it before closing or reusing the descriptor. Shutdown wakes a
+ * stalled Hosted read without asynchronous close/PID tricks. */
+#ifndef LUMABRI_PROBE_DEADLINE_H
+#define LUMABRI_PROBE_DEADLINE_H
+#include <math.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <sys/socket.h>
+#include <time.h>
+
+#define LMB_QUICK_PROBE_TOKENS 8u
+#define LMB_QUICK_PROBE_SECONDS 20.0
+
+typedef struct {
+    pthread_t thread;
+    atomic_int stop, expired;
+    int started, fd;
+    double until;
+} LmbProbeDeadline;
+
+static inline double lmb_probe_now(void) {
+    struct timespec t;
+    if (clock_gettime(CLOCK_MONOTONIC, &t)) return -1;
+    return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+static void *lmb_probe_watch(void *arg) {
+    LmbProbeDeadline *p = arg;
+    while (!atomic_load(&p->stop)) {
+        double now = lmb_probe_now();
+        if (now < 0 || now >= p->until) {
+            atomic_store(&p->expired, 1);
+            (void)shutdown(p->fd, SHUT_RDWR);
+            break;
+        }
+        (void)poll(NULL, 0, 10);
+    }
+    return NULL;
+}
+static inline int lmb_probe_start(LmbProbeDeadline *p, int fd, double seconds) {
+    if (!p || p->started || fd < 0 || !isfinite(seconds) || seconds <= 0 || seconds > 60) return -1;
+    double now = lmb_probe_now();
+    if (now < 0) return -1;
+    p->fd = fd; p->until = now + seconds;
+    atomic_init(&p->stop, 0); atomic_init(&p->expired, 0);
+    if (pthread_create(&p->thread, NULL, lmb_probe_watch, p)) return -1;
+    p->started = 1; return 0;
+}
+static inline int lmb_probe_stop(LmbProbeDeadline *p) {
+    if (!p || !p->started) return 0;
+    double now = lmb_probe_now();
+    atomic_store(&p->stop, 1);
+    pthread_join(p->thread, NULL); p->started = 0;
+    return atomic_load(&p->expired) || now < 0 || now >= p->until;
+}
+#endif

--- a/src/ui/lumabri_tui.c
+++ b/src/ui/lumabri_tui.c
@@ -34,6 +34,7 @@ static struct termios g_saved;
 static int g_saved_valid;
 static volatile sig_atomic_t g_resized;
 static volatile sig_atomic_t g_quit;
+static int g_pending_key = -1;
 
 static void on_winch(int sig) { (void)sig; g_resized = 1; }
 static void on_int(int sig)   { (void)sig; g_quit = 1; }
@@ -42,6 +43,7 @@ static void on_int(int sig)   { (void)sig; g_quit = 1; }
  * shell that outlives it, so the restore runs from the normal exit path, from
  * a signal, and from atexit. Three routes to one idempotent function. */
 static void cooked(void) {
+    g_pending_key = -1;
     if (!g_saved_valid) return;
     tcsetattr(STDIN_FILENO, TCSANOW, &g_saved);
     g_saved_valid = 0;
@@ -50,6 +52,7 @@ static void cooked(void) {
 }
 
 static int raw(void) {
+    g_pending_key = -1;
     if (!isatty(STDIN_FILENO)) return -1;
     if (tcgetattr(STDIN_FILENO, &g_saved)) return -1;
     struct termios t = g_saved;
@@ -424,20 +427,26 @@ static void draw_detail(const LmbTuiState *st, Size sz, int sel) {
 /* ---- input and the loop ------------------------------------------------- */
 
 /* One key, or 0 when nothing arrived before the timeout. Arrow keys arrive
- * as three bytes; anything else unrecognised is dropped rather than acted
- * on, because a stray escape sequence must not move a selection. */
+ * as three bytes. Unknown CSI sequences are dropped; an ordinary key after
+ * Esc is retained as a separate action rather than silently consumed. */
 static int read_key(int timeout_ms) {
-    struct pollfd p = { STDIN_FILENO, POLLIN, 0 };
-    int r = poll(&p, 1, timeout_ms);
-    if (r <= 0) return 0;
     unsigned char ch;
-    if (read(STDIN_FILENO, &ch, 1) != 1) return 0;
+    if (g_pending_key >= 0) {
+        ch = (unsigned char)g_pending_key; g_pending_key = -1;
+    } else {
+        struct pollfd p = { STDIN_FILENO, POLLIN, 0 };
+        int r = poll(&p, 1, timeout_ms);
+        if (r <= 0) return 0;
+        if (read(STDIN_FILENO, &ch, 1) != 1) return 0;
+    }
     if (ch != 0x1b) return ch;
     unsigned char seq[2];
     struct pollfd q = { STDIN_FILENO, POLLIN, 0 };
     if (poll(&q, 1, 20) <= 0) return 0x1b;
     if (read(STDIN_FILENO, seq, 1) != 1) return 0x1b;
-    if (seq[0] != '[') return 0x1b;
+    /* Esc followed quickly by '/' is two actions, not a malformed CSI.
+     * Keep the following key (including another Esc) for the next read. */
+    if (seq[0] != '[') { g_pending_key = seq[0]; return 0x1b; }
     if (poll(&q, 1, 20) <= 0) return 0x1b;
     if (read(STDIN_FILENO, seq + 1, 1) != 1) return 0x1b;
     switch (seq[1]) {

--- a/src/ui/lumabri_tui.c
+++ b/src/ui/lumabri_tui.c
@@ -491,7 +491,15 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
     ui_text(7, 5, UI_MUTED, "Models     /     Computers     ·     Tab switches views");
     const char *status = st->inventory_ok ? "Donors must approve the allocation before anything is loaded." :
         "TRACKER OFFLINE · No requests can start; check the household address.";
-    if (detail && sel < st->nmodels) {
+    if (detail == 2 && sel < st->nmodels) {
+        ui_text(9, 5, UI_SAND, "Quick calibration");
+        ui_printf(11, 5, UI_TEXT, "%s · the selected, approved Segment plan", st->models[sel].name);
+        ui_text(14, 5, UI_TEXT, "One short test: at most 8 generated tokens, 20 seconds of inference.");
+        ui_text(16, 5, UI_MUTED, "Donors must approve. Missing weights still need transfer and loading first.");
+        ui_text(18, 5, UI_MUTED, "Preparation is not included in the 20-second limit and may take much longer.");
+        ui_text(20, 5, UI_MUTED, "Saves a short-run measurement for this plan, then releases its resources.");
+        ui_text(ui_h - 6, 5, UI_SAND, "Enter starts the request. Esc goes back without loading anything.");
+    } else if (detail && sel < st->nmodels) {
         const LmbTuiModel *m = &st->models[sel];
         char speed[96]; speed_text(m, speed, sizeof speed);
         ui_text(9, 5, UI_SAND, m->name);
@@ -553,10 +561,10 @@ static void draw_workspace(const LmbTuiState *st, int tab, int sel, int detail,
     }
     if (palette) {
         ui_begin("actions");
-        static const char *names[] = {"/models", "/computers", "/refresh", "/request", "/back"};
+        static const char *names[] = {"/models", "/computers", "/refresh", "/request", "/calibrate", "/back"};
         static const char *helps[] = {"Browse this model folder", "Choose participating donors", "Refresh inventory and plans",
-            "Review the selected model before requesting chat", "Return to the workspace"};
-        for (int i = 0; i < 5; i++) ui_item(6 + i * 3, action_sel == i, names[i], helps[i]);
+            "Review the selected model before requesting chat", "Review an optional 8-token measurement", "Return to the workspace"};
+        for (int i = 0; i < 6; i++) ui_item(6 + i * 3, action_sel == i, names[i], helps[i]);
     }
     ui_footer(status, "↑ ↓ move   Enter select / confirm   Tab switch   / actions   Esc back");
     if (ui_w < 60 || ui_h < 28) {
@@ -672,21 +680,21 @@ int lmb_tui_run(LmbTuiState *st, int snapshot, const char *keys) {
         if (k == '/') { palette = !palette; action_sel = 0; continue; }
         if (palette) {
             if (k == 27) { palette = 0; continue; }
-            if (k == 'j') action_sel = (action_sel + 1) % 5;
-            if (k == 'k') action_sel = (action_sel + 4) % 5;
+            if (k == 'j') action_sel = (action_sel + 1) % 6;
+            if (k == 'k') action_sel = (action_sel + 5) % 6;
             if (k != '\r' && k != '\n') continue;
             palette = 0;
-            if (action_sel == 4) break;
+            if (action_sel == 5) break;
             if (action_sel < 2) { tab = action_sel; sel = top = detail = 0; continue; }
             if (action_sel == 2) { refresh_start(&job, st); continue; }
-            if (!tab && st->nmodels) detail = 1;
+            if (!tab && st->nmodels) detail = action_sel == 4 ? 2 : 1;
             continue;
         }
         if (k == 27 && !detail) break;
         if (ui_w < 60 || ui_h < 28) continue;
         if ((k == 'c' || (detail && (k == '\r' || k == '\n'))) && !tab && st->nmodels && st->tracker[0]) {
             st->action_model = sel;
-            action = LMB_TUI_REQUEST_CHAT;
+            action = detail == 2 ? LMB_TUI_REQUEST_CALIBRATION : LMB_TUI_REQUEST_CHAT;
             break;
         }
         if (detail) { if (k == 0x1b) detail = 0; continue; }

--- a/src/ui/lumabri_tui.h
+++ b/src/ui/lumabri_tui.h
@@ -49,6 +49,7 @@ typedef struct LmbTuiState {
     int inventory_ok;
     char build_id[65];
     int action_model;
+    int quick_calibration;
     int initial_tab;
     char selected_nodes[LMB_CLUSTER_MAX_NODES][65];
     uint32_t context, sessions, max_new;
@@ -59,7 +60,7 @@ typedef struct LmbTuiState {
     void *refresh_context;
 } LmbTuiState;
 
-enum { LMB_TUI_REQUEST_CHAT = 10 };
+enum { LMB_TUI_REQUEST_CHAT = 10, LMB_TUI_REQUEST_CALIBRATION = 11 };
 
 /* Selection changes precede asynchronous planning. Never render a speed
  * attached to the previous selection during that refresh window. */

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,39 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    int probe_pair[2];
+    assert(!socketpair(AF_UNIX, SOCK_STREAM, 0, probe_pair));
+    LmbProbeDeadline deadline = {0};
+    assert(lmb_probe_start(NULL, probe_pair[0], 1));
+    assert(lmb_probe_start(&deadline, -1, 1));
+    assert(lmb_probe_start(&deadline, probe_pair[0], NAN));
+    assert(lmb_probe_start(&deadline, probe_pair[0], 0));
+    assert(lmb_probe_start(&deadline, probe_pair[0], 61));
+    assert(!lmb_probe_start(&deadline, probe_pair[0], 2));
+    assert(lmb_probe_start(&deadline, probe_pair[0], 2));
+    assert(!lmb_probe_stop(&deadline));
+    assert(!lmb_probe_stop(&deadline));
+    assert(write(probe_pair[1], "a", 1) == 1);
+    char probe_byte;
+    assert(read(probe_pair[0], &probe_byte, 1) == 1 && probe_byte == 'a');
+    assert(!lmb_probe_start(&deadline, probe_pair[0], .02));
+    struct pollfd probe_wait = {probe_pair[0], POLLIN, 0};
+    assert(poll(&probe_wait, 1, 5000) > 0);
+    assert(read(probe_pair[0], &probe_byte, 1) == 0);
+    assert(lmb_probe_stop(&deadline));
+    assert(fcntl(probe_pair[0], F_GETFD) >= 0); /* timer does not own/close it */
+    close(probe_pair[0]); close(probe_pair[1]);
+    /* A partial real codec frame must not make the bounded probe wait for
+     * a payload forever, nor produce a usable STAT result on expiry. */
+    assert(!socketpair(AF_UNIX, SOCK_STREAM, 0, probe_pair));
+    Engine stalled = {.from = probe_pair[0], .to = probe_pair[0], .proto = PROTO_SERVE2};
+    const char *partial = "DATA 1 100\n";
+    assert(write(probe_pair[1], partial, strlen(partial)) == (ssize_t)strlen(partial));
+    assert(!lmb_probe_start(&deadline, probe_pair[0], .02));
+    char probe_stat[512]; char *probe_reply = NULL;
+    assert(stream_serve2(&stalled, probe_stat, sizeof probe_stat, &probe_reply) < 0);
+    assert(lmb_probe_stop(&deadline) && !probe_stat[0] && !probe_reply);
+    close(probe_pair[0]); close(probe_pair[1]);
     const char *boot[] = {
         "\nLUMABRI_SAMPLING LOGITS\nLUMABRI_NUMERIC 2 cpu-test\n" FRAME_READY "\n",
         "\nLUMABRI_SAMPLING GREEDY\nLUMABRI_NUMERIC 2 cpu-test\n" FRAME_READY "\n",

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -254,11 +254,15 @@ def main():
             assert not a.has("Waiting for your approval") and not b.has("Waiting for your approval")
             assert not list((tmp / "chatter").rglob("home-source-*.log"))
             # Reviewing or dismissing the measurement is not consent to load.
-            chat.send("\x1b")
-            time.sleep(.2)
+            chat.text = ""; chat.send("\x1b")
+            until(lambda: chat.has("A plan before a download."))
             assert not engines_started("donor-a") and not engines_started("donor-b")
+            chat.send("/")
+            until(lambda: chat.has("/calibrate"))
             chat.text = ""
-            chat.send("/" + "\x1b[B" * 4 + "\r")
+            # One burst, intentionally: close/reopen actions without a sleep.
+            # The catalogue used to swallow '/' while decoding the prior Esc.
+            chat.send("\x1b/" + "\x1b[B" * 4 + "\r")
             until(lambda: chat.has("Preparation is not included"))
             chat.send("\r")
             until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"), seconds=60)

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -31,6 +31,8 @@ def main():
     parser.add_argument("--models-dir", required=True)
     parser.add_argument("--expect-disjoint-plans", action="store_true",
                         help="verify two simultaneous household chats using different approved compute donors")
+    parser.add_argument("--expect-quick-calibration", action="store_true",
+                        help="request the optional 8-token probe through the TUI and verify its saved measurement")
     parser.add_argument("--donor-ram-gb", type=float, default=0.5)
     parser.add_argument("--context", type=int, default=128,
                         help="approved context, including the actual family chat template")
@@ -50,6 +52,10 @@ def main():
     parser.add_argument("--kill-donor", action="store_true",
                         help="kill a donor TUI after generation; assert engines and leases are released")
     args = parser.parse_args()
+    if args.expect_quick_calibration and any((args.expect_disjoint_plans, args.repeat_cached,
+        args.expect_no_fit, args.expect_unused_donor, args.kill_donor,
+        args.expect_calibration, args.expect_metrics, args.expect_greedy)):
+        parser.error("--expect-quick-calibration is a separate measurement test")
     if args.expect_disjoint_plans and any((args.repeat_cached, args.expect_no_fit,
         args.expect_unused_donor, args.kill_donor, args.expect_calibration,
         args.expect_metrics, args.expect_greedy)):
@@ -236,6 +242,52 @@ def main():
                                capture_output=True, text=True, timeout=15)
             return p.returncode == 0 and len(json.loads(p.stdout)["nodes"]) == 3
         until(inventory_ready)
+        if args.expect_quick_calibration:
+            chat = Terminal("chatter", base)
+            until(lambda: chat.has("3 computers"))
+            chat.send("\t")
+            until(lambda: chat.has("Nothing is selected automatically"))
+            chat.send("\x1b[B\r\x1b[B\r\t")
+            time.sleep(.5)
+            chat.send("/" + "\x1b[B" * 4 + "\r")
+            until(lambda: chat.has("Quick calibration") and chat.has("Preparation is not included"))
+            assert not a.has("Waiting for your approval") and not b.has("Waiting for your approval")
+            assert not list((tmp / "chatter").rglob("home-source-*.log"))
+            # Reviewing or dismissing the measurement is not consent to load.
+            chat.send("\x1b")
+            time.sleep(.2)
+            assert not engines_started("donor-a") and not engines_started("donor-b")
+            chat.text = ""
+            chat.send("/" + "\x1b[B" * 4 + "\r")
+            until(lambda: chat.has("Preparation is not included"))
+            chat.send("\r")
+            until(lambda: a.has("Waiting for your approval") and b.has("Waiting for your approval"), seconds=60)
+            assert not engines_started("donor-a") and not engines_started("donor-b")
+            a.send("\x1b[A\r"); b.send("\x1b[A\r")
+            until(lambda: chat.p.poll() is not None, seconds=180,
+                  message="quick measurement did not return after its one bounded turn")
+            assert chat.p.returncode == 0 and chat.has("Quick calibration complete"), chat.text[-2500:]
+            assert chat.has("at most 8 tokens, 20 seconds")
+            generated = re.findall(r"host prefill [\d.]+s · (\d+) generated tokens", chat.text)
+            assert len(generated) == 1 and 2 <= int(generated[0]) <= 8, generated
+            assert chat.has("hosted stream") and chat.has("no local checkpoint")
+            records = list((tmp / "chatter/.lumabri/calibrations").glob("*.cal"))
+            assert len(records) == 1 and records[0].stat().st_mode & 0o077 == 0
+            until(lambda: a.has("Released") and b.has("Released"))
+            for name in ("donor-a", "donor-b"):
+                for lock in ("compute-donor.lock", "home/weights.lock"):
+                    with open(tmp / name / ".lumabri" / lock, "r") as lease:
+                        fcntl.flock(lease, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            assert not list((tmp / "chatter").rglob("*.safetensors"))
+            reopened = Terminal("probe-catalogue", base, "chatter")
+            until(lambda: reopened.has("3 computers"))
+            reopened.send("\t\x1b[B\r\x1b[B\r\t")
+            until(lambda: reopened.has("tok/s (last)"), seconds=30,
+                  message="the short measurement did not reappear for the same selected plan")
+            reopened.send("\r")
+            until(lambda: reopened.has("Last turn:") and reopened.has(" / " + generated[0] + " generated tokens"))
+            print("HOME QUICK CALIBRATION: PASS (explicit TUI confirmation and donor approval, one <=8-token turn, real timing saved and reopened, released leases)", flush=True)
+            return
         if args.expect_disjoint_plans:
             chats, owners = [], []
 


### PR DESCRIPTION
## Scope

Connect the optional lightweight calibration to the real household TUI and
Hosted/Segment execution path. This closes the missing optional short-probe
part of gate 4; it does not claim stage-cost placement, model acquisition,
physical LAN acceptance or the whole release roadmap is complete.

- `/ actions` → `/calibrate` opens a review screen. Dismissal performs no
  indexing, offers or model loading. Confirmation uses ordinary donor consent.
- Fresh short prompt, at most eight generated tokens, a monotonic 20-second
  inference deadline. Donor allocation displays the approved per-turn limit.
- Transfer/loading is explicitly outside the inference deadline; a cold large
  checkpoint is not advertised as instantly measurable.
- Timer shutdown wakes a blocked Hosted read. Join before descriptor close;
  interrupted, invalid and insufficient results produce no new speed record.
- Reuse exact plan/runtime-bound calibration persistence. Release engines and
  leases after the one short turn. No synthetic prompt in editor history.
- CI exercises the action on installed Linux/macOS candidates, including the
  reopened catalogue. No changes to Colibri and no invented GPU backend.

## Verification

- Normal production build and `test_chat_ui`: `-O2 -Wall -Wextra -Werror`.
- Timer unit tests: bad input, double start, cancellation leaving the socket
  usable, expiry waking a read, descriptor ownership, and a stalled partial
  DATA payload yielding no valid STAT.
- `home_flow_test.py --expect-quick-calibration`: PASS using two actual tiny
  OLMoE Segment processes; final logs `/tmp/lumabri-home-flow-vdlj2nju`.
- `--repeat-cached --clear-cached --expect-metrics --expect-calibration`: PASS;
  final logs `/tmp/lumabri-home-flow-9_t2dgql`.
- Chat editor/streaming, workspace navigation and storage PTY suites pass.
- Python syntax and `git diff --check` pass.

The negative read-wakeup test failed inside the restricted command sandbox
and passed when rerun on the host outside it; that sandbox failure is not
counted as a pass. CI uses native runners. Tiny-loopback figures are not large-model or physical-LAN
performance evidence. Native macOS 12.6 user acceptance remains separate.

Merge only after all eight checks pass on the reviewed head. Normal merge,
no squash, no bypass.
