### PR TITLE
test(segment): isolate the split oracle from Expert routing

### DIFF
--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -68,6 +68,11 @@ not a completed gate.
 
 1. PR #152 merged: approved layer-allocation view, named execution evidence,
    two-donor checks; physical two-computer oracle and timings still required.
+   The loopback split rehearsal explicitly disables remote Expert hooks,
+   matching the household runtime; Segment's `--direct-only` alone would not
+   constrain a Hybrid archive's optional Expert transport. Reported seconds
+   cover whole chat invocations, not a decode-speed measurement. Edge thread
+   count remains fixed while Segment thread budgets change between phases.
 2. PR #155 merged initial contracts; gate 2 remains open. Qwen3.6 has an explicit CPU resident contract (float32 dense
    and Edge, int8 expert slots even for packed int4 files, grouped scales,
    per-layer attention/DeltaNet state). Real synthetic int8 and grouped-int4

--- a/tests/integration/segment_split_test.sh
+++ b/tests/integration/segment_split_test.sh
@@ -23,6 +23,12 @@
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
+# The archive may also include optional Expert/Hybrid hooks. --direct-only
+# constrains Segment transport, not those hooks: without this, a nominal
+# Segment-only baseline still discovers Expert peers and can use their relay.
+# Match home_donor_launch(); Hybrid needs a separately named benchmark.
+export LUMABRI_NO_EXEC=1
+
 ENGINE="${ENGINE:-../colibri/c}"
 PORT="${PORT:-7920}"
 MODEL_DIR="${SPLIT_MODEL_DIR:-tiny_olmoe}"
@@ -170,6 +176,8 @@ best_of() {                  # $1 = threads, $2 = tag; prints "<best s> <ids>"
 }
 
 echo "model $MODEL_NAME ($MTYPE) · $LAYERS layers · $TOKENS tokens · best of $ROUNDS"
+echo "  Segment only: remote Expert hooks disabled; Edge threads stay at $THREADS_TOTAL."
+echo "  Times below cover each complete chat invocation, not decode tok/s."
 echo "  (one warm-up run per phase is discarded: the first read of a"
 echo "   checkpoint is disk, every later one is page cache)"
 


### PR DESCRIPTION
## Scope

Keep the Segment split oracle on the same execution path as household chat.
A Hybrid archive can contain automatic remote Expert discovery. Segment's
`--direct-only` option constrains Segment transport, not those separate hooks.

The rehearsal now explicitly exports `LUMABRI_NO_EXEC=1`, matching the
household launcher, and labels its times as full chat invocations with fixed
Edge threads. Hybrid performance needs a separately named test. No Colibri
change and no model arithmetic change.

## Verification

- Built the actual Segment binaries against the pinned Colibri archive.
- Shell syntax and `git diff --check`: PASS.
- Actual existing OLMoE checkpoint, 16 layers, 8 output tokens, 64 context:
  whole model on one Segment, split 1+1 threads, split 2+2 threads all returned
  identical greedy token IDs. Existing checkpoint was read in place; no new
  model download or persistent weight-cache copy was made.
- With one measured repetition after each warm-up, full invocation times were
  4.564 s / 4.125 s / 3.295 s. These are NOT tok/s, a robust speedup estimate,
  a physical-LAN measurement or cross-platform acceptance evidence.
- The pre-correction script also returned identical tokens but its log showed
  optional Expert discovery; its timing is not labeled Segment-only evidence.

The CI continues to execute the same split script on the tiny fixture. All
eight checks must pass on the reviewed head; normal merge only, no squash.
