### PR TITLE
fix(household): enforce the approved CPU backend contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Segment failover gate — run
         working-directory: lumabri
         run: |
-          make tracker segment_node segment_chat ENGINE=../colibri/c -j"$(nproc)"
+          make tracker segment_node segment_chat test_backend_routes ENGINE=../colibri/c -j"$(nproc)"
           OLMOE_EDGE_MODEL=../colibri/c/olmoe_tiny_merged \
           SEGMENT_NODE_BIN=./segment_node SEGMENT_CHAT_BIN=./segment_chat \
             bash ./tests/integration/segment_failover_test.sh
@@ -135,6 +135,8 @@ jobs:
       - name: Household TUI — approvals through real Segment generation
         working-directory: lumabri
         run: |
+          ./test_backend_routes
+          python3 tests/integration/backend_policy_test.py
           test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           mkdir -p build/home-flow-models
@@ -333,10 +335,10 @@ jobs:
           OPENMP_MODE: ${{ matrix.openmp }}
         run: |
           if [ "$OPENMP_MODE" = disabled ]; then
-            make household ENGINE=../colibri/c CC=clang OMP_FLAGS= OMP_LIBS= -j3
+            make household test_backend_routes ENGINE=../colibri/c CC=clang OMP_FLAGS= OMP_LIBS= -j3
             test "$(./segment_node --thread-capacity)" = 1
           else
-            make household ENGINE=../colibri/c CC=clang -j3
+            make household test_backend_routes ENGINE=../colibri/c CC=clang -j3
           fi
       - uses: actions/download-artifact@v4
         with:
@@ -347,6 +349,8 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
+          ./test_backend_routes
+          python3 tests/integration/backend_policy_test.py
           test "$(OMP_NUM_THREADS=1 ./segment_node --thread-capacity)" = 1
           test "$(OMP_NUM_THREADS=4 OMP_THREAD_LIMIT=1 ./segment_node --thread-capacity)" = 1
           make swarm_probe

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test_weight_cache: tests/c/test_weight_cache.c src/runtime/lumabri_weight_cache.
 household: tracker maintainer $(SHIM_LIB) lumabri segment_node segment_chat
 
 .PHONY: test-runtime-probe
-test-runtime-probe: tests/c/test_runtime_probe.c lumabri_runtime_probe.h
+test-runtime-probe: tests/c/test_runtime_probe.c lumabri_runtime_probe.h src/runtime/lumabri_backend_policy.h lumabri_segment.h
 	mkdir -p build/tests
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_runtime_probe.c -o build/tests/runtime-probe
 	./build/tests/runtime-probe
@@ -592,7 +592,7 @@ HYBRID_ENGINE_DIR = build/segment-hybrid-colibri
 COLIBRI_SEGMENT_LIB = $(HYBRID_ENGINE_DIR)/build/segment/libcolibri_segment_edge.a
 HYBRID_ROOT = $(abspath .)
 SEGMENT_CFLAGS = $(CFLAGS) -I. -I$(ENGINE) $(OMP_FLAGS)
-SEGMENT_COMMON = segment_colibri.h lumabri_segment.c lumabri_segment.h \
+SEGMENT_COMMON = segment_colibri.h src/runtime/lumabri_backend_policy.h lumabri_segment.c lumabri_segment.h \
 		lumabri_segment_discovery.c lumabri_segment_discovery.h \
 		lumabri_proto.h lumabri_sign.h lumabri_sha.h $(SECURE_DEPS)
 
@@ -646,6 +646,12 @@ segment_node: segment_node.c $(HOME_NET_DEPS) lumabri_planner.h lumabri_memory_b
 segment_chat: segment_chat.c lumabri_sampling.c lumabri_sampling.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread segment_chat.c lumabri_segment.c \
+		lumabri_segment_discovery.c lumabri_sampling.c \
+		$(COLIBRI_SEGMENT_LIB) -o $@ -lm $(OMP_LIBS)
+
+test_backend_routes: tests/c/test_backend_routes.c segment_chat.c lumabri_metrics.h \
+		lumabri_sampling.c lumabri_sampling.h $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
+	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread tests/c/test_backend_routes.c lumabri_segment.c \
 		lumabri_segment_discovery.c lumabri_sampling.c \
 		$(COLIBRI_SEGMENT_LIB) -o $@ -lm $(OMP_LIBS)
 
@@ -841,7 +847,7 @@ clean:
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \
 	      test_compute_lease test_content_filter test_scheduler test_run_gate \
 	      test_segment_v2_tsan tracker_tsan \
-	      segment_node segment_chat segment_node_asan segment_chat_asan \
+	      segment_node segment_chat test_backend_routes segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p qwen36_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \

--- a/docs/HOUSEHOLD_BACKENDS.md
+++ b/docs/HOUSEHOLD_BACKENDS.md
@@ -1,0 +1,29 @@
+# Household execution backend contract
+
+The current household planner reserves CPU RAM, not GPU memory. Approval must
+therefore request CPU execution explicitly in **both** Colibri engine opens.
+`backend_mask=0` is not CPU: the public ABI defines it as the adapter's automatic
+local policy, which can change independently of Lumabri's memory planner.
+
+The approved donor launcher sets `LUMABRI_ENGINE_BACKEND=cpu`, overriding any
+inherited preference. Segment and Edge pass the CPU mask before loading and
+check the returned backend flags before advertising readiness. A mismatched,
+missing or mixed CPU/GPU backend is refused. Initial route selection and replica
+selection must satisfy the same policy; a faster GPU advert cannot override an
+accepted CPU-only plan. Engine logs record the request and adapter-reported mask.
+These flags are an adapter contract, not a kernel profiler or GPU speed measurement.
+
+Low-level Segment callers retain `auto` when the variable is unset. Unsupported
+values are errors, not automatic fallback. The ordinary household TUI does not
+expose this internal policy as another user decision.
+
+All pinned upstream Edge/Segment adapters currently support CPU execution.
+Colibri remains unchanged. A future GPU backend needs a matching memory contract
+(VRAM, scratch, state, RAM staging), explicit placement and an actual execution
+test before household admission may request it. This guard does not implement
+or advertise CUDA, Metal, HIP or Vulkan household execution.
+
+Regression coverage includes strict policy parsing, rejected/mixed backend
+masks, early rejection by both executables, and real two-donor generation with
+an inherited GPU preference. The latter checks the CPU policy in both Segment
+logs and in the actual Edge child's log, including native CI and installed paths.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -176,7 +176,11 @@ not a completed gate.
    cooperative cancellation. It is not a total cache quota or automatic eviction.
    Model acquisition, cache-aware disk admission/eviction and verified smaller
    disk working sets remain pending. See `HOUSEHOLD_WEIGHT_CACHE.md`.
-6. Pending: upstream-only GPU capability integration, CPU otherwise.
+6. Household CPU approval is now explicit in both Colibri engine opens, rather
+   than leaving backend selection automatic. Returned capabilities and selected
+   routes must match; an inherited GPU preference cannot expand an accepted RAM
+   budget. See `HOUSEHOLD_BACKENDS.md`. Actual upstream GPU integration, VRAM
+   budgeting and native execution proof remain pending; no GPU kernel is added.
 7. Two independent household chats on disjoint donors now have an end-to-end
    gate: simultaneous generation, separate engines and leases, closing one
    while continuing the other, and explicit `BUSY` for an overlapping request.

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -281,7 +281,8 @@ static int home_donor_launch(HomeDonor *d, int edge) {
     snprintf(e_omp_limit, sizeof e_omp_limit, "OMP_THREAD_LIMIT=%u", usable_threads);
     char *envv[] = {e_shim, e_vroot, e_cache, e_cas, e_tracker, e_model, e_root,
                    e_key, "LUMABRI_SEGMENT_REQUIRED=1", "LUMABRI_VERIFY=0",
-                   "LUMABRI_PREFETCH=0", "LUMABRI_NO_EXEC=1", e_log,
+                   "LUMABRI_PREFETCH=0", "LUMABRI_NO_EXEC=1",
+                   "LUMABRI_ENGINE_BACKEND=cpu", e_log,
                    edge ? e_limit : "LUMABRI_HOME_SEGMENT=1", e_omp, e_omp_limit, NULL};
     int chosen_port = 0, listener = home_listen(&chosen_port);
     if (listener < 0) return -1;

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -74,6 +74,7 @@ static int retry_first_run;
 static int segment_direct_only;
 static const char *segment_tracker;
 static uint64_t segment_wire_bytes;
+static uint64_t segment_backend_mask;
 
 #define SEGMENT_FRAME_READY "\x01\x01" "READY" "\x01\x01"
 #define REMOTE_SNAPSHOT_CHUNK (1u << 20)
@@ -202,7 +203,8 @@ static int select_chain(const LmbSegRouteSnapshot *snapshot, uint32_t layers,
         int changed = 0;
         for (uint32_t i = 0; i < snapshot->count; i++) {
             const LmbSegRouteEntry *entry = &snapshot->entries[i];
-            if (!(entry->transport & (LMB_SEG_TRANSPORT_DIRECT |
+            if (!lmb_backend_matches(segment_backend_mask, entry->advert.capabilities) ||
+                !(entry->transport & (LMB_SEG_TRANSPORT_DIRECT |
                                       LMB_SEG_TRANSPORT_RELAY)) ||
                 entry->advert.layer_begin >= entry->advert.layer_end ||
                 entry->advert.layer_end > layers ||
@@ -892,7 +894,8 @@ static int conversation_checkpoint(SegmentConversation *conversation,
 static int route_same_range(const LmbSegRouteEntry *a,
                             const LmbSegRouteEntry *b,
                             uint32_t context, uint32_t max_rows) {
-    return a->advert.layer_begin == b->advert.layer_begin &&
+    return lmb_backend_matches(segment_backend_mask, a->advert.capabilities) &&
+           a->advert.layer_begin == b->advert.layer_begin &&
            a->advert.layer_end == b->advert.layer_end &&
            a->advert.max_context >= context &&
            a->advert.max_rows >= max_rows &&
@@ -1860,6 +1863,10 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
 }
 
 int main(int argc, char **argv) {
+    if (lmb_backend_request(getenv("LUMABRI_ENGINE_BACKEND"), &segment_backend_mask)) {
+        fprintf(stderr, "unsupported execution backend policy; use cpu or auto\n");
+        return 2;
+    }
     /* lmb_random shares the header-only signing implementation; retain the
      * primitive in warning-clean builds even though the chatter does not sign. */
     (void)lmb_sign;
@@ -1927,6 +1934,7 @@ int main(int argc, char **argv) {
     ColiEdgeEngineOptions edge_options = {
         .struct_size = sizeof edge_options,
         .model_dir = model_dir,
+        .backend_mask = segment_backend_mask,
     };
     const char *edge_limit = getenv("LUMABRI_EDGE_RAM_BYTES");
     if (edge_limit && (parse_u64(edge_limit, &edge_options.memory_limit_bytes) ||
@@ -1951,6 +1959,14 @@ int main(int argc, char **argv) {
                 engine_error(error));
         return 1;
     }
+    if (!lmb_backend_matches(segment_backend_mask, cap.flags)) {
+        fprintf(stderr, "Edge backend does not match the approved CPU policy\n");
+        coli_edge_engine_close(edge);
+        return 1;
+    }
+    fprintf(stderr, "[segment-chat] backend policy=%s adapter_mask=0x%llx\n",
+            segment_backend_mask ? "cpu" : "auto",
+            (unsigned long long)(cap.flags & LMB_EXEC_BACKEND_MASK));
     /* A stateless Edge (e.g. GLM5.3) can leave its context limit to the
      * caller. Zero is not a ban on every prompt. Still enforce the protocol
      * ceiling and negotiate against the actual Segment session limits. */
@@ -1982,7 +1998,7 @@ int main(int argc, char **argv) {
     query.state_width = cap.state_width;
     query.required_capabilities = LMB_SEG_CAP_RANGE_NATIVE |
                                   LMB_SEG_CAP_MULTI_SESSION |
-                                  LMB_SEG_CAP_SNAPSHOT;
+                                  LMB_SEG_CAP_SNAPSHOT | segment_backend_mask;
     snprintf(query.engine_id, sizeof query.engine_id, "%s", cap.engine_id);
     snprintf(query.state_schema, sizeof query.state_schema, "%s", cap.state_schema);
     snprintf(query.numeric_class, sizeof query.numeric_class, "%s", cap.numeric_class);

--- a/segment_colibri.h
+++ b/segment_colibri.h
@@ -6,6 +6,14 @@
 #include "edge_runtime.h"
 #include "segment_adapters.h"
 #include "segment_runtime.h"
+#include "src/runtime/lumabri_backend_policy.h"
+
+_Static_assert((uint64_t)COLI_SEGMENT_CAP_CPU == (uint64_t)LMB_SEG_CAP_CPU &&
+               (uint64_t)COLI_EDGE_CAP_CPU == (uint64_t)LMB_SEG_CAP_CPU,
+               "Colibri CPU backend bits must match the approved contract");
+_Static_assert(COLI_SEGMENT_CAP_BACKEND_MASK == LMB_EXEC_BACKEND_MASK &&
+               COLI_EDGE_CAP_BACKEND_MASK == LMB_EXEC_BACKEND_MASK,
+               "New upstream backends require an explicit resource contract");
 
 #include <errno.h>
 #include <stddef.h>

--- a/segment_node.c
+++ b/segment_node.c
@@ -1172,6 +1172,11 @@ int main(int argc, char **argv) {
 #endif
         return 0;
     }
+    uint64_t backend_mask = 0;
+    if (lmb_backend_request(getenv("LUMABRI_ENGINE_BACKEND"), &backend_mask)) {
+        fprintf(stderr, "unsupported execution backend policy; use cpu or auto\n");
+        return 2;
+    }
     const char *engine_id = arg_value(argc, argv, "--engine");
     const char *model_dir = arg_value(argc, argv, "--model-dir");
     const char *model = arg_value(argc, argv, "--model");
@@ -1413,6 +1418,7 @@ int main(int argc, char **argv) {
         .layer_end = end,
         .context_tokens = context,
         .memory_limit_bytes = process_limit,
+        .backend_mask = backend_mask,
     };
     char error[256] = "";
     if (coli_segment_engine_open(engine_id, &options, &node.engine,
@@ -1435,6 +1441,17 @@ int main(int argc, char **argv) {
                                      resolved_model_root);
         return 1;
     }
+    if (!lmb_backend_matches(backend_mask, node.cap.flags)) {
+        fprintf(stderr, "Segment backend does not match the approved CPU policy\n");
+        (void)coli_segment_engine_close(node.engine, error, sizeof error);
+        if (auto_range)
+            (void)auto_range_release(tracker, model, name, engine_id,
+                                     resolved_model_root);
+        return 1;
+    }
+    fprintf(stderr, "[segment-node] backend policy=%s adapter_mask=0x%llx\n",
+            backend_mask ? "cpu" : "auto",
+            (unsigned long long)(node.cap.flags & LMB_EXEC_BACKEND_MASK));
     uint64_t engine_rss = resident_memory_bytes();
     if (process_limit && engine_rss && engine_rss >= process_limit) {
         fprintf(stderr, "[segment-node] engine RSS %.1f GB exhausted the "

--- a/src/runtime/lumabri_backend_policy.h
+++ b/src/runtime/lumabri_backend_policy.h
@@ -1,0 +1,31 @@
+/* Execution policy is a resource contract, not a GPU hardware detector.
+ * Household plans currently budget CPU RAM only. Do not let an upstream
+ * adapter's automatic policy silently turn that approval into a GPU plan. */
+#ifndef LUMABRI_BACKEND_POLICY_H
+#define LUMABRI_BACKEND_POLICY_H
+
+#include <stdint.h>
+#include <string.h>
+#include "lumabri_segment.h"
+
+#define LMB_EXEC_BACKEND_MASK (LMB_SEG_CAP_CPU | LMB_SEG_CAP_CUDA | \
+    LMB_SEG_CAP_HIP | LMB_SEG_CAP_METAL | LMB_SEG_CAP_VULKAN)
+
+static inline int lmb_backend_request(const char *policy, uint64_t *mask) {
+    if (!mask) return -1;
+    *mask = 0;
+    /* Preserve the low-level CLI's existing adapter-selected policy. */
+    if (!policy || !strcmp(policy, "auto")) return 0;
+    if (!strcmp(policy, "cpu")) { *mask = LMB_SEG_CAP_CPU; return 0; }
+    /* GPU choices require verified adapter/VRAM contracts first. A typo or
+     * unsupported policy must not silently fall back to automatic execution. */
+    return -1;
+}
+
+static inline int lmb_backend_matches(uint64_t requested, uint64_t flags) {
+    if (!requested) return 1;
+    return requested == LMB_SEG_CAP_CPU &&
+           (flags & LMB_EXEC_BACKEND_MASK) == LMB_SEG_CAP_CPU;
+}
+
+#endif

--- a/tests/c/test_backend_routes.c
+++ b/tests/c/test_backend_routes.c
@@ -1,0 +1,53 @@
+/* Exercise the production route and replica selectors, not a reimplementation.
+ * Backend adverts below are fixtures; no GPU execution is claimed. */
+#define main lmb_segment_cli_main
+#include "../../segment_chat.c"
+#undef main
+#include <assert.h>
+
+int main(void) {
+    LmbSegRouteSnapshot snapshot = {0};
+    RemoteSegment chain[LMB_SEG_ROUTE_MAX];
+    size_t count = 0;
+    snapshot.count = 2;
+    for (unsigned i = 0; i < 2; i++) {
+        LmbSegRouteEntry *e = &snapshot.entries[i];
+        snprintf(e->advert.peer_name, sizeof e->advert.peer_name, "node-%u", i);
+        e->advert.layer_end = 4;
+        e->advert.max_context = 64;
+        e->advert.max_rows = 1;
+        e->transport = LMB_SEG_TRANSPORT_DIRECT;
+        e->predicted_us = i ? 1 : 1000;
+        e->advert.capabilities = i ? LMB_SEG_CAP_CUDA : LMB_SEG_CAP_CPU;
+    }
+    segment_backend_mask = LMB_SEG_CAP_CPU;
+    assert(!select_chain(&snapshot, 4, 64, 1, chain, &count));
+    assert(count == 1 && !strcmp(chain[0].route.advert.peer_name, "node-0"));
+    assert(!route_same_range(&snapshot.entries[1], &snapshot.entries[0], 64, 1));
+    assert(route_same_range(&snapshot.entries[0], &snapshot.entries[0], 64, 1));
+
+    /* A mixed advert is not evidence of CPU-only execution either. */
+    snapshot.entries[0].advert.capabilities |= LMB_SEG_CAP_METAL;
+    assert(select_chain(&snapshot, 4, 64, 1, chain, &count));
+    snapshot.entries[0].advert.capabilities = 0;
+    assert(select_chain(&snapshot, 4, 64, 1, chain, &count));
+
+    /* Memory/coverage pressure cannot override approval at a boundary. */
+    snapshot.entries[0].advert.capabilities = LMB_SEG_CAP_CPU;
+    snapshot.entries[0].advert.layer_end = 2;
+    snapshot.entries[1].advert.layer_begin = 2;
+    assert(select_chain(&snapshot, 4, 64, 1, chain, &count));
+    snapshot.entries[1].advert.capabilities = LMB_SEG_CAP_CPU;
+    assert(!select_chain(&snapshot, 4, 64, 1, chain, &count) && count == 2);
+
+    /* The low-level automatic policy remains unchanged. */
+    snapshot.entries[0].advert.layer_end = 4;
+    snapshot.entries[1].advert.layer_begin = 0;
+    snapshot.entries[1].advert.capabilities = LMB_SEG_CAP_CUDA;
+    segment_backend_mask = 0;
+    assert(!select_chain(&snapshot, 4, 64, 1, chain, &count));
+    assert(count == 1 && !strcmp(chain[0].route.advert.peer_name, "node-1"));
+    assert(route_same_range(&snapshot.entries[1], &snapshot.entries[0], 64, 1));
+    puts("BACKEND ROUTES: PASS (CPU approval survives selection, missing coverage and replica checks)");
+    return 0;
+}

--- a/tests/c/test_runtime_probe.c
+++ b/tests/c/test_runtime_probe.c
@@ -1,10 +1,27 @@
 #define _GNU_SOURCE
 #include "lumabri_runtime_probe.h"
+#include "src/runtime/lumabri_backend_policy.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
 int main(int argc, char **argv) {
+    uint64_t backend = 999;
+    assert(lmb_backend_request("cpu", NULL));
+    assert(!lmb_backend_request(NULL, &backend) && !backend);
+    assert(!lmb_backend_request("auto", &backend) && !backend);
+    assert(!lmb_backend_request("cpu", &backend) && backend == LMB_SEG_CAP_CPU);
+    assert(lmb_backend_matches(backend, LMB_SEG_CAP_CPU | LMB_SEG_CAP_SNAPSHOT));
+    assert(!lmb_backend_matches(backend, 0));
+    assert(!lmb_backend_matches(backend, LMB_SEG_CAP_CUDA));
+    assert(!lmb_backend_matches(backend, LMB_SEG_CAP_CPU | LMB_SEG_CAP_CUDA));
+    assert(!lmb_backend_matches(LMB_SEG_CAP_CUDA, LMB_SEG_CAP_CUDA));
+    assert(lmb_backend_matches(0, LMB_SEG_CAP_CUDA));
+    const char *bad_backend[] = {"", "CPU", "cuda", "metal", "hip", "vulkan", "cpu ", "cpu,cuda"};
+    for (unsigned i = 0; i < sizeof bad_backend / sizeof *bad_backend; i++) {
+        backend = 999;
+        assert(lmb_backend_request(bad_backend[i], &backend) && !backend);
+    }
     if (argc == 2 && !strcmp(argv[1], "--thread-capacity")) {
         const char *mode = getenv("LMB_TEST_CAPACITY");
         if (mode && !strcmp(mode, "hang")) { puts("1"); fflush(stdout); for (;;) pause(); }

--- a/tests/integration/backend_policy_test.py
+++ b/tests/integration/backend_policy_test.py
@@ -1,0 +1,20 @@
+"""A rejected execution policy must fail before identity lookup/model open."""
+import os
+from pathlib import Path
+import subprocess
+
+root = Path(__file__).resolve().parents[2]
+for binary in ("segment_node", "segment_chat"):
+    for policy in ("cuda", "metal", "hip", "vulkan", "CPU", "", "cpu,cuda"):
+        result = subprocess.run([str(root / binary)], capture_output=True, text=True,
+                                env={**os.environ, "LUMABRI_ENGINE_BACKEND": policy}, timeout=5)
+        assert result.returncode == 2, (binary, policy, result)
+        assert "unsupported execution backend policy" in result.stderr, (binary, policy, result)
+        assert "cannot open" not in result.stderr, (binary, policy, result)
+    for policy in ("cpu", "auto"):
+        result = subprocess.run([str(root / binary)], capture_output=True, text=True,
+                                env={**os.environ, "LUMABRI_ENGINE_BACKEND": policy}, timeout=5)
+        assert result.returncode == 2, (binary, policy, result)
+        assert "usage:" in result.stderr.lower(), (binary, policy, result)
+        assert "unsupported execution backend policy" not in result.stderr, (binary, policy, result)
+print("BACKEND POLICY: PASS (unsupported policies rejected before model or network work)")

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -109,6 +109,8 @@ def main():
                 "LUMABRI_PEER_KEY": str(home / "peer.key"),
                 "LUMABRI_KNOWN_HOSTS": str(home / "known.hosts"),
                 "LUMABRI_TOKEN": "household-test", "LUMABRI_NO_DISK_PROBE": "1",
+                # An inherited preference must not override CPU-only approval.
+                "LUMABRI_ENGINE_BACKEND": "cuda",
                 "LUMABRI_RAM_RESERVE_MB": "256", "LUMABRI_IO_TIMEOUT_MS": "10000",
                 "OMP_NUM_THREADS": "2", "COLI_NO_OMP_TUNE": "1", "PIN": "off"}
 
@@ -482,14 +484,21 @@ def main():
             assert not chat.has("timing unavailable"), "inconsistent engine timings"
         assert "hosted stream · no local checkpoint" in chat.text
         executed_ranges = []
+        edge_policies = 0
         for donor in ("donor-a", "donor-b"):
             log = (tmp / donor / ".lumabri/home/engines.log").read_text(errors="replace")
+            assert "[segment-node] backend policy=cpu adapter_mask=0x100" in log, \
+                f"{donor} did not enforce the approved CPU policy"
+            edge_log = tmp / donor / ".lumabri/home/edge.log"
+            if edge_log.exists():
+                edge_policies += "[segment-chat] backend policy=cpu adapter_mask=0x100" in edge_log.read_text(errors="replace")
             commits = re.findall(r"\[segment-node [^\]\n]+ (\d+):(\d+)\] committed_runs=(\d+)", log)
             assert commits, f"{donor} did not report any committed model execution"
             ranges = {(int(begin), int(end)) for begin, end, _ in commits}
             assert len(ranges) == 1, ranges
             executed_ranges.extend(ranges)
         assert sorted(executed_ranges) == announced_ranges, (executed_ranges, announced_ranges)
+        assert edge_policies == 1, "the approved Edge host did not enforce CPU execution"
         chat.send("/plan\n")
         until(lambda: chat.text.count("Approved Segment plan: 2 compute donors") >= 2,
               message="/plan did not show the same accepted allocation")


### PR DESCRIPTION
## What changes
Household approval currently budgets CPU RAM, but both Colibri opens used backend_mask=0 (automatic upstream policy). The donor now overrides inherited preferences with an explicit CPU request for both Segment and Edge. Returned backend flags, initial route selection and replica selection must match that approval. Unsupported policy values fail before model/network work. Standalone callers retain their existing automatic default.

Colibri is unchanged. This is a resource-consent guard, not GPU implementation: VRAM budgeting and real upstream GPU execution remain separate roadmap work.

## Verification
- Lumabri household and selector test build with -O2 -Wall -Wextra -Werror.
- Strict parser/mask tests and ASan/UBSan runtime-probe tests pass.
- Production selector test refuses GPU, mixed and missing backend adverts under CPU approval; automatic low-level behavior remains unchanged.
- Both executables reject unsupported policy values before model or identity work.
- Real encrypted two-donor Tiny OLMoE flow passes with inherited GPU preference, explicit CPU logs from both ranges and the Edge child, normal approvals, cache reuse, confirmed cache clearing, timing invalidation and cleanup.
- Lost-donor cleanup passes.
- Linux and native macOS CI cover the new checks; no physical LAN or native Windows release claim.

Local logs: /tmp/lumabri-home-flow-rmko7zq9 and /tmp/lumabri-home-flow-sllae1yl. Only the small existing CI fixture was downloaded; no large checkpoint copied.

Merge policy: normal merge only after all eight checks are green on the exact head.