### PR TITLE
build: stop copying checkpoints into every engine build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         run: python3 tests/integration/workspace_navigation_test.py
       - name: Native candidate packaging contracts
         run: |
+          python3 tests/integration/prepare_engine_source_test.py
           python3 tests/integration/package_household_test.py
           python3 tests/integration/preload_path_test.py
   linux:

--- a/Makefile
+++ b/Makefile
@@ -610,13 +610,10 @@ segment-options-force:
 build/segment-options: segment-options-force tools/update_build_stamp.py
 	python3 tools/update_build_stamp.py $@ '$(CC)' '$(CPPFLAGS)' '$(CFLAGS)' '$(OMP_FLAGS)' '$(OMP_LIBS)' '$(abspath $(ENGINE))'
 
-$(HYBRID_ENGINE_DIR)/.prepared: Makefile build/segment-options $(HYBRID_PATCH_INPUTS) \
+$(HYBRID_ENGINE_DIR)/.prepared: Makefile build/segment-options tools/prepare_engine_source.py $(HYBRID_PATCH_INPUTS) \
 		$(ENGINE)/colibri.c $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c \
 		$(ENGINE)/olmoe.c $(ENGINE)/qwen36.c $(ENGINE)/deepseek_v4.c
-	rm -rf $(HYBRID_ENGINE_DIR)
-	mkdir -p $(HYBRID_ENGINE_DIR)
-	cp -a $(ENGINE)/. $(HYBRID_ENGINE_DIR)/
-	rm -rf $(HYBRID_ENGINE_DIR)/build
+	python3 tools/prepare_engine_source.py --source '$(ENGINE)' --output '$(HYBRID_ENGINE_DIR)'
 	python3 engine_patches/make_patches.py --engine-dir $(ENGINE) --apply-one colibri.c --out $(HYBRID_ENGINE_DIR)/colibri.c
 	python3 engine_patches/make_patches.py --engine-dir $(ENGINE) --apply-one inkling.c --out $(HYBRID_ENGINE_DIR)/inkling.c
 	python3 engine_patches/make_patches.py --engine-dir $(ENGINE) --apply-one kimi_k3.c --out $(HYBRID_ENGINE_DIR)/kimi_k3.c
@@ -769,6 +766,7 @@ test: all test_weight_cache test_key_rotation test_hedge test_local_fallback tes
 	$(MAKE) test-home-network
 	python3 ./tests/integration/chat_ui_test.py
 	python3 ./tests/integration/package_household_test.py
+	python3 ./tests/integration/prepare_engine_source_test.py
 	python3 ./tests/integration/preload_path_test.py
 	python3 tests/ui_text_test.py
 	python3 tests/integration/workspace_navigation_test.py

--- a/docs/ENGINE_SOURCE_BUILD.md
+++ b/docs/ENGINE_SOURCE_BUILD.md
@@ -1,0 +1,31 @@
+# Build inputs are not model caches
+
+The household build used to copy the entire configured Colibri `c` directory
+before patching its generated build copy. A local checkout can also contain
+large converted checkpoints, tiny fixtures, virtual environments and previous
+builds. Copying all of those into every Lumabri worktree was unnecessary and
+could consume substantial disk space before compilation even started.
+
+`tools/prepare_engine_source.py` now copies only recognized source/build files
+and source notices. It works with a source archive without Git metadata. Model
+weights, tokenizer/config JSON, binaries, object archives and common generated
+directories are excluded. No checkpoint payload is read or downloaded by this
+preparation step. Test fixtures belong in explicit test directories, not in the
+generated engine source copy.
+
+Preparation is bounded to 256 MiB of source inputs and 100,000 directory entries.
+The current pinned archive is well below these limits. Missing required headers,
+source symlinks/special files, overlapping paths and unsafe destinations fail
+with an explanation rather than producing a partial engine tree.
+
+A new copy is prepared in a sibling temporary directory before replacing the
+previous generated copy. Copying failure preserves the old tree; publication
+failure attempts to restore it. Replacement requires a build ownership marker.
+For upgrades, only the exact historical `build/segment-hybrid-colibri` directory
+with its `.prepared` marker and runtime headers is recognized as an older owned
+copy. Its redundant files are removed on replacement, not the original Colibri
+files or checkpoints. An arbitrary destination is never recursively erased.
+
+Colibri itself stays unchanged. The existing Lumabri hooks are applied only to
+the generated build copy, as before. This is build-storage hygiene, not automatic
+eviction or a quota for runtime model caches.

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -187,6 +187,9 @@ not a completed gate.
    upstream notices, exact file hashes and dependency reports. The installed
    `bin`/`lib` layout is exercised by the same two-donor approval, generation,
    cache/calibration and lost-donor tests. macOS candidates use system libraries
-   only (no OpenMP). Native Windows, older/clean-machine compatibility,
+   only (no OpenMP). Engine build preparation now copies only recognized source
+   inputs rather than every checkpoint/output in the Colibri checkout; failures
+   preserve the previous generated tree. See `ENGINE_SOURCE_BUILD.md`.
+   Native Windows, older/clean-machine compatibility,
    physical LAN acceptance and dependency-backed repository cleanup remain
    pending. Candidate artifacts are not a completed release gate.

--- a/docs/REPOSITORY.md
+++ b/docs/REPOSITORY.md
@@ -21,6 +21,7 @@ ready for household use. The public README documents the tested TUI path.
 | `expert_engines/`, `engine_patches/`, Expert bridge files | Optional Expert/Hybrid and upstream compatibility |
 | `deploy/`, root deployment/release documents | Existing deployment tooling and the minimal household launcher |
 | `tools/package_household.py` | Allowlisted native candidate assembly; never copies models or credentials |
+| `tools/prepare_engine_source.py` | Bounded source-only Colibri build copy; excludes checkpoints and generated outputs |
 | `build/`, local executables, `__pycache__/`, tiny fixtures | Generated/ignored artifacts, not production source files |
 
 The root Makefile remains the supported build entry point. Test executable

--- a/tests/integration/prepare_engine_source_test.py
+++ b/tests/integration/prepare_engine_source_test.py
@@ -1,0 +1,164 @@
+"""Source-only build preparation must not copy or delete original checkpoints."""
+import importlib.util
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("engine_source", ROOT / "tools/prepare_engine_source.py")
+engine_source = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(engine_source)
+
+
+class Preparation(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="lumabri-source-test-")
+        self.root = Path(self.tmp.name)
+        self.source = self.root / "source with spaces"
+        self.output = self.root / "generated build"
+        self.source.mkdir()
+        for name in ("Makefile", "segment_runtime.h", "edge_runtime.h", "model.c"):
+            (self.source / name).write_text("/* build input */\n")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def prepare(self):
+        return engine_source.prepare(self.source, self.output)
+
+    def assert_no_temporary_copy(self):
+        self.assertFalse(list(self.root.glob(".lumabri-source-*")))
+        self.assertFalse(list(self.root.glob(".lumabri-old-source-*")))
+
+    def test_archive_sources_only(self):
+        (self.source / "include").mkdir()
+        (self.source / "include/kernel.inc").write_text("kernel source\n")
+        (self.source / "tools").mkdir()
+        tool = self.source / "tools/generate.py"
+        tool.write_text("pass\n")
+        tool.chmod(0o755)
+        (self.source / "Makefile.units").write_text("# required build rules\n")
+        (self.source / "LICENSE").write_text("source notice\n")
+        for name in ("checkpoint.safetensors", "model.gguf", "model.bin", "model.pt",
+                     "tokenizer.json", "config.json", "engine.o", "engine.a", "engine.so",
+                     "Makefile.safetensors", "Makefile.GGUF", "Makefile.json", "Makefile.o"):
+            (self.source / name).write_bytes(b"not a build input")
+        for directory in ("build", ".git", ".venv", "models", "checkpoints"):
+            (self.source / directory).mkdir()
+            (self.source / directory / "should_not_copy.c").write_text("excluded\n")
+        count, size = self.prepare()
+        self.assertEqual(count, 8)
+        self.assertGreater(size, 0)
+        self.assertEqual((self.output / "include/kernel.inc").read_text(), "kernel source\n")
+        self.assertEqual((self.output / "tools/generate.py").stat().st_mode & 0o777, 0o755)
+        self.assertEqual((self.output / "Makefile.units").read_text(), "# required build rules\n")
+        self.assertFalse(list(self.output.rglob("*.safetensors")))
+        self.assertFalse(list(self.output.rglob("*.json")))
+        self.assertFalse((self.output / "Makefile.GGUF").exists())
+        self.assertFalse((self.output / "Makefile.o").exists())
+        for directory in ("build", ".git", ".venv", "models", "checkpoints"):
+            self.assertFalse((self.output / directory).exists())
+        self.assertEqual((self.source / "checkpoint.safetensors").read_bytes(), b"not a build input")
+        self.assert_no_temporary_copy()
+
+    def test_reprepare_only_generated_copy(self):
+        self.prepare()
+        (self.output / "obsolete.c").write_text("old generated copy")
+        (self.output / "old-model.safetensors").write_bytes(b"duplicated old cache")
+        (self.source / "model.safetensors").write_bytes(b"original weights")
+        (self.source / "model.c").write_text("updated source\n")
+        self.prepare()
+        self.assertEqual((self.output / "model.c").read_text(), "updated source\n")
+        self.assertFalse((self.output / "obsolete.c").exists())
+        self.assertFalse((self.output / "old-model.safetensors").exists())
+        self.assertEqual((self.source / "model.safetensors").read_bytes(), b"original weights")
+        self.assert_no_temporary_copy()
+
+    def test_refuse_unowned_directory(self):
+        self.output.mkdir()
+        (self.output / "keep.txt").write_text("user file")
+        with self.assertRaisesRegex(ValueError, "not owned"):
+            self.prepare()
+        self.assertEqual((self.output / "keep.txt").read_text(), "user file")
+        self.assert_no_temporary_copy()
+
+    def test_overlap_is_never_allowed(self):
+        for output in (self.source, self.source / "nested", self.root):
+            with self.subTest(output=output), self.assertRaisesRegex(ValueError, "overlap"):
+                engine_source.prepare(self.source, output)
+        self.assertTrue((self.source / "model.c").exists())
+
+    def test_symlink_destination(self):
+        real = self.root / "keep"
+        real.mkdir()
+        self.output.symlink_to(real, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "symlink destination"):
+            self.prepare()
+        self.assertEqual(list(real.iterdir()), [])
+
+    def test_source_symlink_preserves_previous_build(self):
+        self.prepare()
+        external = self.root / "private"
+        external.write_text("not a source input")
+        (self.source / "escape.h").symlink_to(external)
+        with self.assertRaisesRegex(ValueError, "not a regular file"):
+            self.prepare()
+        self.assertFalse((self.output / "escape.h").exists())
+        self.assertTrue((self.output / "model.c").exists())
+        self.assertEqual(external.read_text(), "not a source input")
+        self.assert_no_temporary_copy()
+
+    def test_directory_symlink_is_not_followed(self):
+        external = self.root / "outside"
+        external.mkdir()
+        (self.source / "include").symlink_to(external, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "directory symlink"):
+            self.prepare()
+        self.assertFalse(self.output.exists())
+        self.assert_no_temporary_copy()
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "POSIX special file test")
+    def test_fifo_source_never_blocks(self):
+        os.mkfifo(self.source / "blocked.c")
+        with self.assertRaisesRegex(ValueError, "not a regular file"):
+            self.prepare()
+        self.assert_no_temporary_copy()
+
+    def test_limit_and_copy_error_preserve_previous_build(self):
+        self.prepare()
+        for fault in (mock.patch.object(engine_source, "MAX_BYTES", 1),
+                      mock.patch.object(engine_source, "MAX_ENTRIES", 1),
+                      mock.patch.object(engine_source, "copy_source", side_effect=OSError("disk full"))):
+            with fault, self.assertRaises((ValueError, OSError)):
+                self.prepare()
+            self.assertTrue((self.output / "model.c").exists())
+            self.assert_no_temporary_copy()
+
+    def test_failed_publish_restores_previous_copy(self):
+        self.prepare()
+        original = Path.rename
+        def rename(path, target):
+            if path.name.startswith(".lumabri-source-"):
+                raise OSError("simulated publish failure")
+            return original(path, target)
+        with mock.patch.object(Path, "rename", rename), self.assertRaisesRegex(OSError, "publish"):
+            self.prepare()
+        self.assertTrue((self.output / "model.c").exists())
+        self.assert_no_temporary_copy()
+
+    def test_legacy_migration_only_at_known_generated_path(self):
+        self.output.mkdir()
+        for name in (".prepared", "segment_runtime.h", "edge_runtime.h"):
+            (self.output / name).write_text("old generated input")
+        with self.assertRaisesRegex(ValueError, "not owned"):
+            self.prepare()
+        with mock.patch.object(engine_source, "LEGACY_OUTPUT", self.output):
+            self.prepare()
+        self.assertEqual((self.output / engine_source.MARKER).read_text(), engine_source.MAGIC)
+        self.assert_no_temporary_copy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/prepare_engine_source.py
+++ b/tools/prepare_engine_source.py
@@ -1,0 +1,155 @@
+"""Prepare a bounded build-source copy, never a copy of local model data.
+
+Works with source archives too: Git metadata is not required. The destination
+is replaced only after all source inputs have been copied successfully.
+"""
+import argparse
+import os
+from pathlib import Path
+import shutil
+import stat
+import sys
+import tempfile
+
+SOURCE_SUFFIXES = {".c", ".h", ".cc", ".hh", ".cpp", ".hpp", ".cxx", ".hxx",
+                   ".inc", ".cu", ".cuh", ".s", ".S", ".m", ".mm", ".metal",
+                   ".mk", ".cmake", ".py", ".sh", ".pl", ".awk", ".ps1", ".bat"}
+SKIP_DIRS = {".git", "build", ".cache", "__pycache__", ".venv", "venv",
+             "node_modules", "models", "checkpoints"}
+DATA_SUFFIXES = {".safetensors", ".gguf", ".ggml", ".bin", ".pt", ".pth", ".ckpt",
+                 ".onnx", ".npy", ".npz", ".json", ".o", ".a", ".so", ".dylib",
+                 ".dll", ".exe", ".pdb", ".pyc"}
+MARKER = ".lumabri-source-copy"
+MAGIC = "lumabri-source-copy-v1\n"
+MAX_BYTES = 256 * 1024 * 1024
+MAX_ENTRIES = 100000
+LEGACY_OUTPUT = Path(__file__).resolve().parents[1] / "build/segment-hybrid-colibri"
+
+
+def is_source(name):
+    if Path(name).suffix.lower() in DATA_SUFFIXES:
+        return False
+    return (Path(name).suffix in SOURCE_SUFFIXES or name == "CMakeLists.txt" or
+            name == "Makefile" or name.startswith("Makefile.") or
+            name in {"LICENSE", "LICENSE.txt", "LICENSE.md", "COPYING", "NOTICE", "NOTICE.txt"})
+
+
+def regular(path):
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except FileNotFoundError:
+        return False
+
+
+def owned_output(path):
+    marker = path / MARKER
+    if regular(marker) and marker.stat().st_size == len(MAGIC):
+        return marker.read_text() == MAGIC
+    # Migrate only the exact historical generated directory, never an arbitrary
+    # folder containing a file coincidentally named .prepared.
+    return (path == LEGACY_OUTPUT.resolve() and regular(path / ".prepared") and
+            regular(path / "segment_runtime.h") and regular(path / "edge_runtime.h"))
+
+
+def copy_source(source, target, remaining):
+    before = source.lstat()
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError(f"source input is not a regular file: {source}")
+    if before.st_size > remaining:
+        raise ValueError("source copy exceeds the 256 MiB build-input limit")
+    fd = os.open(source, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
+    with os.fdopen(fd, "rb") as inp:
+        opened = os.fstat(inp.fileno())
+        if ((opened.st_dev, opened.st_ino, opened.st_size) !=
+                (before.st_dev, before.st_ino, before.st_size) or not stat.S_ISREG(opened.st_mode)):
+            raise ValueError(f"source changed before copying: {source}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("xb") as out:
+            left = opened.st_size
+            while left:
+                block = inp.read(min(left, 1024 * 1024))
+                if not block:
+                    raise ValueError(f"source shrank during copying: {source}")
+                out.write(block)
+                left -= len(block)
+            after = os.fstat(inp.fileno())
+            if (inp.read(1) or after.st_size != opened.st_size or
+                    after.st_mtime_ns != opened.st_mtime_ns or after.st_ctime_ns != opened.st_ctime_ns):
+                raise ValueError(f"source changed during copying: {source}")
+    target.chmod(stat.S_IMODE(opened.st_mode) & 0o777)
+    os.utime(target, ns=(opened.st_atime_ns, opened.st_mtime_ns))
+    return opened.st_size
+
+
+def prepare(source, output):
+    source = Path(source).resolve(strict=True)
+    raw_output = Path(output).absolute()
+    if raw_output.is_symlink():
+        raise ValueError("refusing a symlink destination")
+    output = raw_output.resolve()
+    if source == output or source in output.parents or output in source.parents:
+        raise ValueError("source and destination must not overlap")
+    for name in ("Makefile", "segment_runtime.h", "edge_runtime.h"):
+        if not regular(source / name):
+            raise ValueError(f"missing regular Colibri build input: {name}")
+    if output.exists() and (not output.is_dir() or not owned_output(output)):
+        raise ValueError("refusing to replace a directory not owned by this build")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(tempfile.mkdtemp(prefix=".lumabri-source-", dir=output.parent))
+    backup = None
+    count = total = visited = 0
+    try:
+        def walk_error(error):
+            raise error
+        for parent, dirs, files in os.walk(source, followlinks=False, onerror=walk_error):
+            dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS)
+            visited += len(dirs) + len(files)
+            if visited > MAX_ENTRIES:
+                raise ValueError("too many entries in source tree")
+            for name in dirs:
+                if (Path(parent) / name).is_symlink():
+                    raise ValueError(f"source directory symlink is not allowed: {name}")
+            for name in sorted(files):
+                if not is_source(name):
+                    continue
+                path = Path(parent) / name
+                total += copy_source(path, stage / path.relative_to(source), MAX_BYTES - total)
+                count += 1
+        (stage / MARKER).write_text(MAGIC)
+        if output.exists():
+            if output.is_symlink() or not owned_output(output):
+                raise ValueError("destination ownership changed during preparation")
+            backup = Path(tempfile.mkdtemp(prefix=".lumabri-old-source-", dir=output.parent))
+            backup.rmdir()  # Only the empty temporary directory just created above.
+            output.rename(backup)
+        try:
+            stage.rename(output)
+        except OSError:
+            if backup is not None:
+                backup.rename(output)
+                backup = None
+            raise
+        if backup is not None:
+            shutil.rmtree(backup)  # Validated generated copy, never the input tree.
+        return count, total
+    finally:
+        if stage.exists():
+            shutil.rmtree(stage)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        count, size = prepare(args.source, args.output)
+    except (OSError, ValueError) as error:
+        print(f"Cannot prepare engine source: {error}", file=sys.stderr)
+        return 1
+    print(f"Engine source: {count} files, {size} bytes; checkpoints and build outputs excluded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changes
Replace the recursive copy of the entire Colibri checkout with bounded source-only preparation. Model weights, tokenizer/config JSON, compiled outputs and generated directories are excluded. The helper works without Git metadata, validates the destination, prepares a separate copy first and restores the previous generated tree on publication failure. Source files and original checkpoints are never removed. The old generated directory is migrated only at its exact known path with its preparation marker and runtime headers.

## Verification
- Eleven regression tests: source archive, paths with spaces, permissions, excluded weights/outputs (including misleading Makefile-prefixed names), unowned destination, overlap, symlinks, FIFO, size/entry limits, injected copy failure, publication rollback and legacy migration.
- Rebuilt every pinned Edge/Segment adapter from the original read-only Colibri checkout: 431 source files, 8,689,430 bytes copied. No checkpoint/JSON payload in the generated source tree.
- Lumabri binaries compile under -O2 -Wall -Wextra -Werror.
- Real encrypted two-donor Tiny execution passes with consent, cache reuse and calibration invalidation.
- After merging current main, backend-policy/production-selector tests, quick calibration and two independent household chats pass.
- Original Colibri checkout and user Desktop worktree are preserved. No large checkpoint was copied.

This addresses build-storage duplication, not runtime cache quotas, native Windows inference or completion of the full roadmap. Native Linux/macOS CI will verify the full new build procedure. Merge only with eight green checks and a normal merge, never squash.