### PR TITLE
feat(segment): measure each range during real chat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_calib
 test_catalogue_advice: tests/c/test_catalogue_advice.c src/planner/lumabri_catalogue_advice.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_catalogue_advice.c -o $@
 
-test_metrics: tests/c/test_metrics.c lumabri_metrics.h
+test_metrics: tests/c/test_metrics.c lumabri_metrics.h lumabri_stage_metrics.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_metrics.c -o $@
 
 test_inventory: tests/c/test_inventory.c lumabri_inventory.h lumabri_machine.h lumabri_proto.h lumabri_sign.h $(SECURE_DEPS)
@@ -640,13 +640,13 @@ segment_node: segment_node.c $(HOME_NET_DEPS) lumabri_planner.h lumabri_memory_b
 		lumabri_segment_discovery.c $(MACHINE_SRC) lumabri_run_gate.c \
 		$(COLIBRI_SEGMENT_LIB) -o $@ -lm $(OMP_LIBS)
 
-segment_chat: segment_chat.c lumabri_sampling.c lumabri_sampling.h \
+segment_chat: segment_chat.c lumabri_metrics.h lumabri_stage_metrics.h lumabri_sampling.c lumabri_sampling.h \
 		$(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread segment_chat.c lumabri_segment.c \
 		lumabri_segment_discovery.c lumabri_sampling.c \
 		$(COLIBRI_SEGMENT_LIB) -o $@ -lm $(OMP_LIBS)
 
-test_backend_routes: tests/c/test_backend_routes.c segment_chat.c lumabri_metrics.h \
+test_backend_routes: tests/c/test_backend_routes.c segment_chat.c lumabri_metrics.h lumabri_stage_metrics.h \
 		lumabri_sampling.c lumabri_sampling.h $(SEGMENT_COMMON) $(COLIBRI_SEGMENT_LIB)
 	$(CC) $(CPPFLAGS) $(SEGMENT_CFLAGS) -pthread tests/c/test_backend_routes.c lumabri_segment.c \
 		lumabri_segment_discovery.c lumabri_sampling.c \

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -150,7 +150,11 @@ not a completed gate.
    every alternative is checked against the unchanged launch reservations.
    This bounded search is not an exhaustive feasibility or speed solver.
    See `HOUSEHOLD_PLACEMENT.md`.
-   Measured-cost placement remains pending; this does not enable disk mode or
+   Per-turn Segment RUN observations now separate prefill/decode counts and
+   client round-trip times for each approved range, without additional tokens.
+   Recovered turns invalidate the per-range profile rather than mixing owners
+   and replay costs. See `SEGMENT_STAGE_OBSERVATIONS.md`.
+   Persisted measured-cost placement remains pending; this does not enable disk mode or
    certify additional model families.
 4. PR #157 merged: versioned measurements collected during ordinary Segment chat,
    separating prefill, decode traversals and first visible text. No extra model

--- a/docs/SEGMENT_STAGE_OBSERVATIONS.md
+++ b/docs/SEGMENT_STAGE_OBSERVATIONS.md
@@ -1,0 +1,38 @@
+# Observing a Segment chain without another benchmark
+
+Every completed `segment_chat` turn collects client-side elapsed time around
+each range's RUN call. No extra token or network request is generated.
+Prefill calls/rows and decode calls are separate, even for one-row prefill.
+The first generated token comes from prefill and is not a decode call.
+
+The standalone `--json` result contains `stage_observations` version 1.
+Hosted writes the same object as a `[segment-stage] request=N` line in the
+Edge engine log. The existing Hosted wire format and calibration records are
+unchanged. Each range carries its exclusive layer end, lease identifier,
+route generation, fencing epoch, call counts, accumulated seconds and
+minimum/maximum decode-call duration. No conversation or activation bytes
+are logged. Counters reset on every turn, including a turn that reuses KV.
+The engine log preserves long lines verbatim instead of inserting newlines
+at each 511-byte display chunk; the interactive diagnostic tail stays bounded.
+
+The scope is **client_run_round_trip**, not remote kernel time: it includes
+serialization, network transfer, queueing, remote compute and any transparent
+transport retries. It excludes embedding, token selection, OPEN/loading,
+snapshot transfer and text streaming. The sum of decode range times is thus
+only part of the complete decode interval. It is not the throughput of a
+filled multi-session pipeline. Min/max are not percentiles.
+
+A failed RUN or invalid timer invalidates the whole profile. Successful
+recovery may still produce a complete reply, but its range profile is
+`valid:false, stages:[]`: replay and old/new owners must not be conflated.
+The end-to-end generation measurement continues to include recovery costs.
+
+These observations diagnose the chain that actually ran. They are not yet
+persisted placement costs and must not predict an unseen range, hardware,
+context or concurrency level. Gate 3's measured-cost placement remains open.
+
+Tests cover bounded accumulation, bad times and overflow; the standalone
+whole/split oracle validates per-range counts against generated tokens and
+times against the full decode interval. The real two-donor Hosted test checks
+that reported ranges match the approved plan. A loopback test remains a
+loopback test, not a physical-LAN speed claim.

--- a/lumabri.c
+++ b/lumabri.c
@@ -1645,10 +1645,12 @@ static void *stderr_thread(void *arg) {
     FILE *keep = getenv("LUMABRI_ENGINE_LOG") ? fopen(getenv("LUMABRI_ENGINE_LOG"), "a") : NULL;
     char line[512];
     while (fgets(line, sizeof line, f)) {
+        /* The on-screen tail is bounded, the saved stream is not a sequence
+         * of 511-byte lines. Preserve real newlines before trimming for UI. */
+        if (keep) { fputs(line, keep); fflush(keep); }
         size_t n = strlen(line);
         while (n && (line[n-1] == '\n' || line[n-1] == '\r')) line[--n] = 0;
         if (!n) continue;
-        if (keep) { fputs(line, keep); fputc('\n', keep); fflush(keep); }
         tail_push(line);
         g_eng.last_out = nowd();
 
@@ -1701,6 +1703,7 @@ static void *stderr_thread(void *arg) {
             fprintf(stderr, "%s  %s%s\n", C_DIM, line, C_R);
         }
     }
+    if (keep) fclose(keep);
     fclose(f);
     return NULL;
 }

--- a/lumabri_stage_metrics.h
+++ b/lumabri_stage_metrics.h
@@ -1,0 +1,39 @@
+/* Per-turn, per-range RUN observations. These are client-side elapsed times:
+ * transport, serialization, queueing and remote execution, NOT kernel times.
+ * No allocation, extra request, or extrapolation to an unmeasured range. */
+#ifndef LUMABRI_STAGE_METRICS_H
+#define LUMABRI_STAGE_METRICS_H
+#include <math.h>
+#include <stdint.h>
+
+typedef struct {
+    uint64_t prefill_calls, prefill_rows, decode_calls;
+    double prefill_seconds, decode_seconds, decode_min_seconds, decode_max_seconds;
+} LmbStageMetrics;
+
+/* Failure leaves the previous observation intact. The caller must mark the
+ * complete turn profile unavailable, never publish a partially valid chain. */
+static inline int lmb_stage_metrics_add(LmbStageMetrics *m, int decode,
+                                       uint32_t rows, double seconds) {
+    if (!m || (decode != 0 && decode != 1) || !rows || (decode && rows != 1) ||
+        !isfinite(seconds) || seconds < 0) return -1;
+    LmbStageMetrics next = *m;
+    if (decode) {
+        if (next.decode_calls == UINT64_MAX) return -1;
+        if (!next.decode_calls || seconds < next.decode_min_seconds)
+            next.decode_min_seconds = seconds;
+        if (seconds > next.decode_max_seconds) next.decode_max_seconds = seconds;
+        next.decode_calls++;
+        next.decode_seconds += seconds;
+    } else {
+        if (next.prefill_calls == UINT64_MAX || next.prefill_rows > UINT64_MAX - rows)
+            return -1;
+        next.prefill_calls++;
+        next.prefill_rows += rows;
+        next.prefill_seconds += seconds;
+    }
+    if (!isfinite(next.prefill_seconds) || !isfinite(next.decode_seconds)) return -1;
+    *m = next;
+    return 0;
+}
+#endif

--- a/segment_chat.c
+++ b/segment_chat.c
@@ -46,6 +46,13 @@ typedef struct {
 } SegmentConversation;
 
 #include "lumabri_metrics.h"
+#include "lumabri_stage_metrics.h"
+
+typedef struct {
+    uint32_t begin, end;
+    LmbSegOwner owner;
+    LmbStageMetrics timing;
+} StageObservation;
 
 typedef struct {
     char *text;
@@ -56,6 +63,9 @@ typedef struct {
     double elapsed_seconds;
     double decode_seconds;
     LmbGenerationMetrics metrics;
+    int stages_valid;
+    size_t stage_count;
+    StageObservation stages[LMB_SEG_ROUTE_MAX];
 } GenerationResult;
 
 typedef enum {
@@ -75,6 +85,7 @@ static int segment_direct_only;
 static const char *segment_tracker;
 static uint64_t segment_wire_bytes;
 static uint64_t segment_backend_mask;
+static double monotonic_seconds(void);
 
 #define SEGMENT_FRAME_READY "\x01\x01" "READY" "\x01\x01"
 #define REMOTE_SNAPSHOT_CHUNK (1u << 20)
@@ -852,18 +863,35 @@ static int conversation_route_equal(const SegmentConversation *conversation,
     return 1;
 }
 
-static int chain_run(RemoteSegment *chain, size_t count,
+static int chain_run_observed(RemoteSegment *chain, size_t count,
                      const int32_t *tokens, uint32_t rows,
-                     uint8_t **first, uint8_t **second, size_t bytes) {
+                     uint8_t **first, uint8_t **second, size_t bytes,
+                     GenerationResult *observation, int decode) {
     uint8_t *input = *first, *output = *second;
     for (size_t i = 0; i < count; i++) {
-        if (remote_run(&chain[i], tokens, rows, input, bytes, output))
+        double started = observation ? monotonic_seconds() : 0;
+        if (remote_run(&chain[i], tokens, rows, input, bytes, output)) {
+            if (observation) observation->stages_valid = 0;
             return -(int)i - 1;
+        }
+        if (observation && observation->stages_valid &&
+            (i >= observation->stage_count ||
+             lmb_stage_metrics_add(&observation->stages[i].timing, decode, rows,
+                                   monotonic_seconds() - started)))
+            observation->stages_valid = 0;
         uint8_t *swap = input; input = output; output = swap;
     }
     *first = input;
     *second = output;
     return 0;
+}
+
+/* Recovery replay is intentionally not mixed into steady-route observations.
+ * The failed original call already invalidated the entire turn profile. */
+static int chain_run(RemoteSegment *chain, size_t count,
+                     const int32_t *tokens, uint32_t rows,
+                     uint8_t **first, uint8_t **second, size_t bytes) {
+    return chain_run_observed(chain, count, tokens, rows, first, second, bytes, NULL, 0);
 }
 
 static int conversation_checkpoint(SegmentConversation *conversation,
@@ -1201,7 +1229,7 @@ static int conversation_recover(
 
 static double monotonic_seconds(void) {
     struct timespec value;
-    clock_gettime(CLOCK_MONOTONIC, &value);
+    if (clock_gettime(CLOCK_MONOTONIC, &value)) return NAN;
     return (double)value.tv_sec + (double)value.tv_nsec * 1e-9;
 }
 
@@ -1380,6 +1408,13 @@ static int segment_generate(ColiEdgeEngine *edge,
     } else {
         opened = active_count;
     }
+    result->stages_valid = active_count > 0 && active_count <= LMB_SEG_ROUTE_MAX;
+    result->stage_count = result->stages_valid ? active_count : 0;
+    for (size_t i = 0; i < result->stage_count; i++) {
+        result->stages[i].begin = active_chain[i].route.advert.layer_begin;
+        result->stages[i].end = active_chain[i].route.advert.layer_end;
+        result->stages[i].owner = active_chain[i].open.owner;
+    }
     if (prompt_count > context || wanted_tokens > context - prompt_count) {
         snprintf(error, error_size, "prompt plus output exceeds context (%u)",
                  context);
@@ -1433,9 +1468,9 @@ static int segment_generate(ColiEdgeEngine *edge,
         };
         if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
         uint8_t *first = buffer_a, *second = buffer_b;
-        int failed = chain_run(active_chain, active_count,
+        int failed = chain_run_observed(active_chain, active_count,
                                prompt_tokens + offset, rows,
-                               &first, &second, bytes);
+                               &first, &second, bytes, result, 0);
         if (failed && event) {
             size_t failed_index = (size_t)(-failed - 1);
             const char *peer = active_chain[failed_index].route.advert.peer_name;
@@ -1518,8 +1553,8 @@ static int segment_generate(ColiEdgeEngine *edge,
         };
         if (coli_edge_embed(edge, &embed, error, error_size)) goto cleanup;
         uint8_t *first = buffer_a, *second = buffer_b;
-        int failed = chain_run(active_chain, active_count, &token, 1,
-                               &first, &second, bytes);
+        int failed = chain_run_observed(active_chain, active_count, &token, 1,
+                               &first, &second, bytes, result, 1);
         if (failed && event) {
             size_t failed_index = (size_t)(-failed - 1);
             const char *peer = active_chain[failed_index].route.advert.peer_name;
@@ -1641,10 +1676,16 @@ static int segment_generate(ColiEdgeEngine *edge,
         .generated_tokens=(uint32_t)generated_count,.decode_steps=(uint32_t)generated_count-1,
         .prefill_seconds=first_selected_at-started,.decode_seconds=last_selected_at-first_selected_at,
         .total_seconds=finished_at-started};
+    /* A one-token answer has no decode observation. Completed turns must
+     * have one measured RUN per decode step at EVERY range. */
+    for (size_t i = 0; i < result->stage_count; i++)
+        if (result->stages[i].timing.decode_calls != result->metrics.decode_steps)
+            result->stages_valid = 0;
     generated = NULL;
     rc = 0;
 
 cleanup:
+    if (rc) result->stages_valid = 0;
     if (rc && error && error_size && !error[0])
         snprintf(error, error_size, "Segment generation failed and the engine "
                  "reported no reason");
@@ -1661,6 +1702,30 @@ cleanup:
     free(buffer_b);
     free(stream_text);
     return rc;
+}
+
+/* JSON is also used as one bounded line in the engine log. Only fixed hex
+ * identifiers and numbers are emitted; no prompt, token or peer-name bytes. */
+static void stage_observations_print(FILE *stream, const GenerationResult *result) {
+    fprintf(stream, "{\"version\":1,\"scope\":\"client_run_round_trip\",\"valid\":%s,\"stages\":[",
+            result->stages_valid ? "true" : "false");
+    for (size_t i = 0; result->stages_valid && i < result->stage_count; i++) {
+        const StageObservation *s = &result->stages[i];
+        const LmbStageMetrics *m = &s->timing;
+        char lease[33]; lmb_hex(lease, s->owner.lease_id.bytes, sizeof s->owner.lease_id.bytes);
+        fprintf(stream, "%s{\"begin\":%u,\"end\":%u,\"lease\":\"%s\","
+                "\"route_generation\":%llu,\"fencing_epoch\":%llu,"
+                "\"prefill_calls\":%llu,\"prefill_rows\":%llu,\"prefill_seconds\":%.9f,"
+                "\"decode_calls\":%llu,\"decode_seconds\":%.9f,"
+                "\"decode_min_seconds\":%.9f,\"decode_max_seconds\":%.9f}",
+                i ? "," : "", s->begin, s->end, lease,
+                (unsigned long long)s->owner.route_generation,
+                (unsigned long long)s->owner.fencing_epoch,
+                (unsigned long long)m->prefill_calls, (unsigned long long)m->prefill_rows,
+                m->prefill_seconds, (unsigned long long)m->decode_calls, m->decode_seconds,
+                m->decode_min_seconds, m->decode_max_seconds);
+    }
+    fprintf(stream, "]}");
 }
 
 static void route_print(FILE *stream, const char *prefix,
@@ -1853,6 +1918,9 @@ static int segment_serve_loop(ColiEdgeEngine *edge,
              * history merely because timing could not be validated. */
             snprintf(metrics,sizeof metrics,"PERF_UNAVAILABLE");
         }
+        fprintf(stderr, "[segment-stage] request=%u ", request_id);
+        stage_observations_print(stderr, &result);
+        fputc('\n', stderr); fflush(stderr);
         printf("DONE %u STAT %zu %.3f 0 0 %zu 0 %s\n", request_id,
                result.token_count, lmb_metrics_decode_rate(&result.metrics), result.prompt_count,metrics);
         fflush(stdout);
@@ -2130,13 +2198,15 @@ int main(int argc, char **argv) {
                "\"bytes\":{\"segment\":%llu},"
                "\"generation_metrics\":{\"version\":1,\"generated_tokens\":%u,"
                "\"decode_steps\":%u,\"prefill_seconds\":%.9f,"
-               "\"decode_seconds\":%.9f,\"total_seconds\":%.9f}}\n",
+               "\"decode_seconds\":%.9f,\"total_seconds\":%.9f},\"stage_observations\":",
                generated.token_count, generated.decode_seconds,
                generated.elapsed_seconds,
                (unsigned long long)segment_wire_bytes,
                generated.metrics.generated_tokens,generated.metrics.decode_steps,
                generated.metrics.prefill_seconds,generated.metrics.decode_seconds,
                generated.metrics.total_seconds);
+        stage_observations_print(stdout, &generated);
+        printf("}\n");
     }
     generation_result_free(&generated);
     lmb_seg_discovery_stop(discovery);

--- a/tests/c/test_backend_routes.c
+++ b/tests/c/test_backend_routes.c
@@ -6,6 +6,18 @@
 #include <assert.h>
 
 int main(void) {
+    /* Invalid or recovered profiles expose no partially measured ranges. */
+    GenerationResult observed = {.stages_valid = 0, .stage_count = 1};
+    observed.stages[0].timing.decode_seconds = NAN;
+    FILE *profile_file = tmpfile(); assert(profile_file);
+    stage_observations_print(profile_file, &observed);
+    rewind(profile_file);
+    char output[4096]; size_t length = fread(output, 1, sizeof output - 1, profile_file);
+    output[length] = 0; fclose(profile_file);
+    assert(strstr(output, "\"valid\":false,\"stages\":[]"));
+    assert(!strstr(output, "nan"));
+    generation_result_free(&observed);
+    assert(!observed.stage_count && !observed.stages_valid);
     LmbSegRouteSnapshot snapshot = {0};
     RemoteSegment chain[LMB_SEG_ROUTE_MAX];
     size_t count = 0;

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,31 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    /* The real engine stderr consumer must preserve long JSON lines, blank
+     * lines, CRLF and a final unterminated fragment in the saved log. */
+    char log_path[] = "/tmp/lumabri-engine-log-test.XXXXXX";
+    int log_fd = mkstemp(log_path); assert(log_fd >= 0); close(log_fd);
+    const char *previous_log = getenv("LUMABRI_ENGINE_LOG");
+    char *saved_log = previous_log ? strdup(previous_log) : NULL;
+    assert(!previous_log || saved_log);
+    assert(!setenv("LUMABRI_ENGINE_LOG", log_path, 1));
+    char payload[4096], actual[4096];
+    memset(payload, 'x', sizeof payload);
+    memcpy(payload, "[segment-stage] ", 16);
+    memcpy(payload + sizeof payload - 12, "\n\n\r\nfragment", 12);
+    FILE *input_log = tmpfile(); assert(input_log);
+    assert(fwrite(payload, 1, sizeof payload, input_log) == sizeof payload);
+    rewind(input_log);
+    int input_fd = dup(fileno(input_log)); assert(input_fd >= 0);
+    (void)stderr_thread((void *)(intptr_t)input_fd);
+    fclose(input_log);
+    FILE *saved_stream = fopen(log_path, "rb"); assert(saved_stream);
+    assert(fread(actual, 1, sizeof actual, saved_stream) == sizeof actual);
+    assert(fgetc(saved_stream) == EOF && !memcmp(payload, actual, sizeof payload));
+    fclose(saved_stream); assert(!unlink(log_path));
+    if (saved_log) { assert(!setenv("LUMABRI_ENGINE_LOG", saved_log, 1)); free(saved_log); }
+    else assert(!unsetenv("LUMABRI_ENGINE_LOG"));
+    g_eng.ntail = 0;
     int probe_pair[2];
     assert(!socketpair(AF_UNIX, SOCK_STREAM, 0, probe_pair));
     LmbProbeDeadline deadline = {0};

--- a/tests/c/test_metrics.c
+++ b/tests/c/test_metrics.c
@@ -1,7 +1,39 @@
 #include "lumabri_metrics.h"
+#include "lumabri_stage_metrics.h"
 #include <assert.h>
+#include <float.h>
 
 int main(void) {
+    LmbStageMetrics stage = {0};
+    assert(!lmb_stage_metrics_add(&stage, 0, 8, .25));
+    assert(!lmb_stage_metrics_add(&stage, 0, 1, .125)); /* one-row PREFILL, not decode */
+    assert(!stage.decode_calls && stage.prefill_calls == 2 && stage.prefill_rows == 9);
+    assert(!lmb_stage_metrics_add(&stage, 1, 1, .125));
+    assert(!lmb_stage_metrics_add(&stage, 1, 1, .5));
+    assert(!lmb_stage_metrics_add(&stage, 1, 1, 0));
+    assert(stage.decode_calls == 3 && stage.decode_seconds == .625 &&
+           stage.decode_min_seconds == 0 && stage.decode_max_seconds == .5 &&
+           stage.prefill_seconds == .375);
+    LmbStageMetrics saved = stage;
+    assert(lmb_stage_metrics_add(&stage, 1, 2, .25));
+    assert(lmb_stage_metrics_add(&stage, 0, 0, .25));
+    assert(lmb_stage_metrics_add(&stage, 2, 1, .25));
+    assert(lmb_stage_metrics_add(&stage, 0, 1, -1));
+    assert(lmb_stage_metrics_add(&stage, 0, 1, NAN));
+    assert(lmb_stage_metrics_add(&stage, 1, 1, INFINITY));
+    assert(lmb_stage_metrics_add(NULL, 1, 1, .25));
+    assert(!memcmp(&stage, &saved, sizeof stage));
+    stage.decode_calls = UINT64_MAX;
+    assert(lmb_stage_metrics_add(&stage, 1, 1, 0));
+    stage = saved; stage.prefill_calls = UINT64_MAX;
+    assert(lmb_stage_metrics_add(&stage, 0, 1, 0));
+    stage = saved; stage.prefill_rows = UINT64_MAX;
+    assert(lmb_stage_metrics_add(&stage, 0, 1, 0));
+    stage = saved; stage.decode_seconds = DBL_MAX;
+    assert(lmb_stage_metrics_add(&stage, 1, 1, DBL_MAX));
+    assert(stage.decode_seconds == DBL_MAX && stage.decode_calls == saved.decode_calls);
+    stage = saved; stage.prefill_seconds = DBL_MAX;
+    assert(lmb_stage_metrics_add(&stage, 0, 1, DBL_MAX));
     LmbGenerationMetrics m={.generated_tokens=9,.decode_steps=8,
         .prefill_seconds=15,.decode_seconds=2,.total_seconds=17.2}, parsed;
     assert(lmb_metrics_decode_rate(&m)==4);

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -492,6 +492,19 @@ def main():
             edge_log = tmp / donor / ".lumabri/home/edge.log"
             if edge_log.exists():
                 edge_policies += "[segment-chat] backend policy=cpu adapter_mask=0x100" in edge_log.read_text(errors="replace")
+                observations = re.findall(r"\[segment-stage\] request=\d+ (\{[^\n]+\})", edge_log.read_text(errors="replace"))
+                assert observations, "the Edge host did not report per-range RUN observations"
+                profile = json.loads(observations[-1])
+                assert profile["version"] == 1 and profile["valid"], profile
+                assert profile["scope"] == "client_run_round_trip"
+                assert [(s["begin"], s["end"]) for s in profile["stages"]] == announced_ranges
+                counts = {s["decode_calls"] for s in profile["stages"]}
+                assert len(counts) == 1 and min(counts) > 0, counts
+                for s in profile["stages"]:
+                    assert s["prefill_calls"] > 0 and s["prefill_rows"] > 0
+                    assert 0 <= s["decode_min_seconds"] <= s["decode_max_seconds"]
+                    assert s["decode_min_seconds"] * s["decode_calls"] <= s["decode_seconds"] + 1e-6
+                    assert s["decode_seconds"] <= s["decode_max_seconds"] * s["decode_calls"] + 1e-6
             commits = re.findall(r"\[segment-node [^\]\n]+ (\d+):(\d+)\] committed_runs=(\d+)", log)
             assert commits, f"{donor} did not report any committed model execution"
             ranges = {(int(begin), int(end)) for begin, end, _ in commits}

--- a/tests/integration/segment_failover_test.sh
+++ b/tests/integration/segment_failover_test.sh
@@ -82,7 +82,7 @@ env OMP_NUM_THREADS=2 LUMABRI_PEER_KEY="$TMP/client.key" \
     LUMABRI_SEGMENT_DISCOVERY_MS=60000 \
     python3 - "$DONOR_PID" "$SEGMENT_CHAT_BIN" "$OLMOE_EDGE_MODEL" \
         "$root" "$tok" "$TMP" <<'PY'
-import os, re, socket, subprocess, sys, time
+import json, os, re, socket, subprocess, sys, time
 donor, binary, model_dir, root, tok, tmp = sys.argv[1:]
 p = subprocess.Popen([
     binary, "--serve", "--engine", "olmoe",
@@ -125,6 +125,7 @@ def turn(rid, prompt, kill_after_accept=None):
             raise RuntimeError("unexpected frame: "+repr(frame))
     if not seen_data: raise RuntimeError("no streamed data")
 turn(1, b"hi\n")
+turn(9, b"hi\nthere\n")  # same chain/KV, new per-turn counters
 open(os.path.join(tmp, "start-generation-bump"), "wb").close()
 deadline=time.monotonic()+10
 while True:
@@ -137,7 +138,7 @@ while True:
 # Existing executors heartbeat every two seconds and now fence the owner's old
 # generation. The chat worker intentionally retains its turn-one snapshot.
 time.sleep(2.5)
-turn(2, b"hi\nthere\n", donor)
+turn(2, b"hi\nthere\nagain\n", donor)
 p.stdin.close()
 if p.wait(timeout=30): raise RuntimeError("gateway failed")
 diagnostics=p.stderr.read().decode("utf-8", "replace")
@@ -146,5 +147,15 @@ if ("Segment failover: recovered through origin-left; restored checkpoint"
     raise RuntimeError("checkpoint failover did not run:\n"+diagnostics)
 if "Segment recovery route generation" not in diagnostics:
     raise RuntimeError("recovery did not refresh the stale route generation:\n"+diagnostics)
+profiles={int(rid):json.loads(payload) for rid,payload in
+          re.findall(r'\[segment-stage\] request=(\d+) (\{[^\n]+\})',diagnostics)}
+assert set(profiles)=={1,9,2}, profiles
+assert profiles[1]['valid'] and len(profiles[1]['stages'])==2, profiles
+assert all(s['decode_calls']==0 and s['prefill_rows']>0 for s in profiles[1]['stages']), profiles
+assert profiles[9]['valid'] and len(profiles[9]['stages'])==2, profiles
+reused,total=map(int,re.search(r'Segment KV reuse: (\d+)/(\d+)',diagnostics).groups())
+assert all(s['prefill_rows']==reused for s in profiles[1]['stages']), profiles
+assert all(s['prefill_rows']==total-reused and s['decode_calls']==0 for s in profiles[9]['stages']), profiles
+assert not profiles[2]['valid'] and profiles[2]['stages']==[], profiles
 PY
 echo "SEGMENT FAILOVER: PASS (fresh fencing + checkpoint replay after peer death)"

--- a/tests/integration/segment_split_test.sh
+++ b/tests/integration/segment_split_test.sh
@@ -147,7 +147,21 @@ run_chat() {                 # $1 = threads, $2 = log name
     python3 - "$TMP/$log.json" "$t0" "$t1" <<'PY'
 import json,sys
 lines=[l for l in open(sys.argv[1],encoding='utf-8') if l.startswith('{')]
-ids=json.loads(lines[-1])['token_ids']
+reply=json.loads(lines[-1])
+ids=reply['token_ids']
+profile=reply['stage_observations']
+assert profile['version']==1 and profile['scope']=='client_run_round_trip' and profile['valid'], profile
+stages=profile['stages']
+assert stages and stages[0]['begin']==0
+assert all(a['end']==b['begin'] for a,b in zip(stages,stages[1:]))
+for s in stages:
+    assert s['begin'] < s['end'] and len(s['lease'])==32
+    assert s['decode_calls']==len(ids)-1
+    assert s['prefill_rows']>0 and s['prefill_calls']>0
+    assert 0 <= s['decode_min_seconds'] <= s['decode_max_seconds']
+    assert s['decode_min_seconds']*s['decode_calls'] <= s['decode_seconds']+1e-6
+    assert s['decode_seconds'] <= s['decode_max_seconds']*s['decode_calls']+1e-6
+assert sum(s['decode_seconds'] for s in stages) <= reply['generation_metrics']['decode_seconds']+1e-5
 print("%.3f %s" % (float(sys.argv[3])-float(sys.argv[2]), ','.join(map(str,ids))))
 PY
 }


### PR DESCRIPTION
## Scope
Collect per-turn, per-range client RUN elapsed times without extra tokens or requests. Separate prefill rows/calls from decode, bind ranges to lease/fencing/generation, and invalidate the whole profile on failed RUN/recovery. Expose JSON in standalone results and Hosted engine diagnostics; do not change Hosted wire metrics or extrapolate unmeasured planner costs.

The integrated test caught an existing log bug: stderr persistence inserted newlines every 511 bytes. Preserve original text chunks and close the log at thread exit; the bounded interactive tail remains unchanged.

## Local verification
- Warning-clean runtime/frontend builds.
- Metrics unit tests and ASan/UBSan.
- Real stderr consumer: long lines, CRLF, blank lines, final fragment preserved.
- Production route/profile test and chat UI PTY tests.
- Tiny one/two-range direct oracle: identical tokens, per-stage counts/timing bounds.
- Two approved household donors: measured ranges equal approved ranges, calibration invalidation and separately approved cache reuse.
- Three-turn low-level Segment test: KV reuse/reset, failed donor, fenced recovery and unavailable recovered-turn profile.

Real OLMoE split validation is running; results will be appended. Physical LAN and native platform evidence remain distinct.

## Roadmap
This is groundwork for gate 3 measured-cost placement, not a declaration that placement, GPU support or the complete roadmap is finished. Colibri and user checkpoint sources are unchanged. Normal merge only, after all checks pass on the exact head.