### PR TITLE
fix(build): rebuild when any Colibri adapter or header changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,9 +610,12 @@ segment-options-force:
 build/segment-options: segment-options-force tools/update_build_stamp.py
 	python3 tools/update_build_stamp.py $@ '$(CC)' '$(CPPFLAGS)' '$(CFLAGS)' '$(OMP_FLAGS)' '$(OMP_LIBS)' '$(abspath $(ENGINE))'
 
-$(HYBRID_ENGINE_DIR)/.prepared: Makefile build/segment-options tools/prepare_engine_source.py $(HYBRID_PATCH_INPUTS) \
-		$(ENGINE)/colibri.c $(ENGINE)/inkling.c $(ENGINE)/kimi_k3.c \
-		$(ENGINE)/olmoe.c $(ENGINE)/qwen36.c $(ENGINE)/deepseek_v4.c
+# Track every copied adapter/header/build input, including new upstream files,
+# deletions and preserved-mtime edits. This reads sources only, never weights.
+build/segment-sources: segment-options-force tools/prepare_engine_source.py tools/update_build_stamp.py
+	python3 tools/prepare_engine_source.py --source '$(ENGINE)' --stamp '$@'
+
+$(HYBRID_ENGINE_DIR)/.prepared: Makefile build/segment-options build/segment-sources tools/prepare_engine_source.py $(HYBRID_PATCH_INPUTS)
 	python3 tools/prepare_engine_source.py --source '$(ENGINE)' --output '$(HYBRID_ENGINE_DIR)'
 	python3 engine_patches/make_patches.py --engine-dir $(ENGINE) --apply-one colibri.c --out $(HYBRID_ENGINE_DIR)/colibri.c
 	python3 engine_patches/make_patches.py --engine-dir $(ENGINE) --apply-one inkling.c --out $(HYBRID_ENGINE_DIR)/inkling.c

--- a/docs/ENGINE_SOURCE_BUILD.md
+++ b/docs/ENGINE_SOURCE_BUILD.md
@@ -29,3 +29,20 @@ files or checkpoints. An arbitrary destination is never recursively erased.
 Colibri itself stays unchanged. The existing Lumabri hooks are applied only to
 the generated build copy, as before. This is build-storage hygiene, not automatic
 eviction or a quota for runtime model caches.
+
+## Incremental builds track every copied input
+
+`build/segment-sources` records a SHA-256 fingerprint of the same bounded source
+set used by preparation. Names, contents and copied permission bits participate;
+adding, removing or changing an adapter, header or build script invalidates the
+generated tree and therefore its archive and linked Segment binaries. This
+replaces the historical dependency list of six model C files, which omitted
+GLM5.3, Qwen3.8 and headers. Edits with a preserved mtime are still detected.
+
+An unchanged fingerprint preserves the stamp's mtime and does not force another
+copy or compilation. Build options still have their separate stamp. Weights,
+tokenizer JSON and generated outputs neither enter this hash nor trigger a
+rebuild. Computing it reads only the source inputs (about 9 MB at the pin),
+never a model checkpoint. Invalid source inputs fail the build before the old
+stamp or prepared tree is replaced. This does not make the upstream checkout
+transactional: do not edit it concurrently with compilation.

--- a/tests/integration/prepare_engine_source_test.py
+++ b/tests/integration/prepare_engine_source_test.py
@@ -2,6 +2,8 @@
 import importlib.util
 import os
 from pathlib import Path
+import subprocess
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -31,6 +33,82 @@ class Preparation(unittest.TestCase):
     def assert_no_temporary_copy(self):
         self.assertFalse(list(self.root.glob(".lumabri-source-*")))
         self.assertFalse(list(self.root.glob(".lumabri-old-source-*")))
+
+    def test_fingerprint_tracks_all_sources_not_weights(self):
+        for name in ("glm53.c", "qwen38.c", "extra.h"):
+            source = self.source / name
+            source.write_text("original\n")
+            before = engine_source.fingerprint(self.source)
+            times = source.stat()
+            source.write_text("modified\n")
+            os.utime(source, ns=(times.st_atime_ns, times.st_mtime_ns))
+            self.assertNotEqual(before, engine_source.fingerprint(self.source))
+        before = engine_source.fingerprint(self.source)
+        (self.source / "weights.safetensors").write_bytes(b"never read model data")
+        (self.source / "tokenizer.json").write_text("not a build input")
+        (self.source / "build").mkdir()
+        (self.source / "build/generated.h").write_text("not an upstream input")
+        with mock.patch.object(engine_source, "read_source", wraps=engine_source.read_source) as read:
+            self.assertEqual(before, engine_source.fingerprint(self.source))
+            self.assertTrue(all(call.args[0].name not in
+                {"weights.safetensors", "tokenizer.json", "generated.h"} for call in read.call_args_list))
+        self.assertEqual((self.source / "weights.safetensors").read_bytes(), b"never read model data")
+
+    def test_fingerprint_tracks_add_delete_rename_and_mode(self):
+        before = engine_source.fingerprint(self.source)
+        source = self.source / "new_adapter.c"
+        source.write_text("adapter\n")
+        added = engine_source.fingerprint(self.source)
+        self.assertNotEqual(before, added)
+        renamed = self.source / "another_adapter.c"
+        source.rename(renamed)
+        moved = engine_source.fingerprint(self.source)
+        self.assertNotEqual(added, moved)
+        renamed.chmod(0o755)
+        self.assertNotEqual(moved, engine_source.fingerprint(self.source))
+        renamed.unlink()
+        self.assertEqual(before, engine_source.fingerprint(self.source))
+
+    def test_stamp_is_stable_and_failed_inspection_preserves_it(self):
+        stamp = self.root / "stamp"
+        command = [sys.executable, str(ROOT / "tools/prepare_engine_source.py"),
+                   "--source", str(self.source), "--stamp", str(stamp)]
+        subprocess.run(command, check=True)
+        before, timestamp = stamp.read_bytes(), stamp.stat().st_mtime_ns
+        subprocess.run(command, check=True)
+        self.assertEqual(timestamp, stamp.stat().st_mtime_ns)
+        (self.source / "nested.h").write_text("new input")
+        subprocess.run(command, check=True)
+        self.assertNotEqual(before, stamp.read_bytes())
+        before, timestamp = stamp.read_bytes(), stamp.stat().st_mtime_ns
+        (self.source / "escaped.h").symlink_to(stamp)
+        failed = subprocess.run(command, capture_output=True, text=True)
+        self.assertNotEqual(failed.returncode, 0)
+        self.assertIn("not a regular file", failed.stderr)
+        self.assertEqual(before, stamp.read_bytes())
+        self.assertEqual(timestamp, stamp.stat().st_mtime_ns)
+        self.assertEqual(sorted(p.name for p in self.root.iterdir()), ["source with spaces", "stamp"])
+
+    def test_stamp_cannot_overwrite_an_input_or_follow_link(self):
+        command = [sys.executable, str(ROOT / "tools/prepare_engine_source.py"),
+                   "--source", str(self.source), "--stamp"]
+        source = self.source / "model.c"
+        original = source.read_bytes()
+        link = self.root / "stamp-link"
+        link.symlink_to(source)
+        for destination in (source, link):
+            result = subprocess.run(command + [str(destination)], capture_output=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(source.read_bytes(), original)
+
+    def test_fingerprint_obeys_source_safety_limits(self):
+        for limit in (mock.patch.object(engine_source, "MAX_BYTES", 1),
+                      mock.patch.object(engine_source, "MAX_ENTRIES", 1)):
+            with limit, self.assertRaises(ValueError):
+                engine_source.fingerprint(self.source)
+        (self.source / "include").symlink_to(self.root, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "directory symlink"):
+            engine_source.fingerprint(self.source)
 
     def test_archive_sources_only(self):
         (self.source / "include").mkdir()

--- a/tools/prepare_engine_source.py
+++ b/tools/prepare_engine_source.py
@@ -4,6 +4,7 @@ Works with source archives too: Git metadata is not required. The destination
 is replaced only after all source inputs have been copied successfully.
 """
 import argparse
+import hashlib
 import os
 from pathlib import Path
 import shutil
@@ -51,7 +52,7 @@ def owned_output(path):
             regular(path / "segment_runtime.h") and regular(path / "edge_runtime.h"))
 
 
-def copy_source(source, target, remaining):
+def read_source(source, remaining, consume):
     before = source.lstat()
     if not stat.S_ISREG(before.st_mode):
         raise ValueError(f"source input is not a regular file: {source}")
@@ -63,22 +64,65 @@ def copy_source(source, target, remaining):
         if ((opened.st_dev, opened.st_ino, opened.st_size) !=
                 (before.st_dev, before.st_ino, before.st_size) or not stat.S_ISREG(opened.st_mode)):
             raise ValueError(f"source changed before copying: {source}")
-        target.parent.mkdir(parents=True, exist_ok=True)
-        with target.open("xb") as out:
-            left = opened.st_size
-            while left:
-                block = inp.read(min(left, 1024 * 1024))
-                if not block:
-                    raise ValueError(f"source shrank during copying: {source}")
-                out.write(block)
-                left -= len(block)
-            after = os.fstat(inp.fileno())
-            if (inp.read(1) or after.st_size != opened.st_size or
-                    after.st_mtime_ns != opened.st_mtime_ns or after.st_ctime_ns != opened.st_ctime_ns):
-                raise ValueError(f"source changed during copying: {source}")
+        left = opened.st_size
+        while left:
+            block = inp.read(min(left, 1024 * 1024))
+            if not block:
+                raise ValueError(f"source shrank during reading: {source}")
+            consume(block)
+            left -= len(block)
+        after = os.fstat(inp.fileno())
+        if (inp.read(1) or after.st_size != opened.st_size or
+                after.st_mtime_ns != opened.st_mtime_ns or after.st_ctime_ns != opened.st_ctime_ns):
+            raise ValueError(f"source changed during reading: {source}")
+    return opened
+
+
+def copy_source(source, target, remaining):
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("xb") as out:
+        opened = read_source(source, remaining, out.write)
     target.chmod(stat.S_IMODE(opened.st_mode) & 0o777)
     os.utime(target, ns=(opened.st_atime_ns, opened.st_mtime_ns))
     return opened.st_size
+
+
+def source_inputs(source):
+    """The identical bounded input set for copying AND invalidation."""
+    for name in ("Makefile", "segment_runtime.h", "edge_runtime.h"):
+        if not regular(source / name):
+            raise ValueError(f"missing regular Colibri build input: {name}")
+    visited = 0
+    def walk_error(error):
+        raise error
+    for parent, dirs, files in os.walk(source, followlinks=False, onerror=walk_error):
+        dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS)
+        visited += len(dirs) + len(files)
+        if visited > MAX_ENTRIES:
+            raise ValueError("too many entries in source tree")
+        for name in dirs:
+            if (Path(parent) / name).is_symlink():
+                raise ValueError(f"source directory symlink is not allowed: {name}")
+        for name in sorted(files):
+            if is_source(name):
+                yield Path(parent) / name
+
+
+def fingerprint(source):
+    source = Path(source).resolve(strict=True)
+    digest = hashlib.sha256(b"LMB-COLIBRI-SOURCE-1\0")
+    total = 0
+    for path in source_inputs(source):
+        name = os.fsencode(path.relative_to(source))
+        digest.update(len(name).to_bytes(8, "little"))
+        digest.update(name)
+        content = hashlib.sha256()
+        info = read_source(path, MAX_BYTES - total, content.update)
+        total += info.st_size
+        digest.update(info.st_size.to_bytes(8, "little"))
+        digest.update((stat.S_IMODE(info.st_mode) & 0o777).to_bytes(4, "little"))
+        digest.update(content.digest())
+    return digest.hexdigest()
 
 
 def prepare(source, output):
@@ -97,24 +141,11 @@ def prepare(source, output):
     output.parent.mkdir(parents=True, exist_ok=True)
     stage = Path(tempfile.mkdtemp(prefix=".lumabri-source-", dir=output.parent))
     backup = None
-    count = total = visited = 0
+    count = total = 0
     try:
-        def walk_error(error):
-            raise error
-        for parent, dirs, files in os.walk(source, followlinks=False, onerror=walk_error):
-            dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS)
-            visited += len(dirs) + len(files)
-            if visited > MAX_ENTRIES:
-                raise ValueError("too many entries in source tree")
-            for name in dirs:
-                if (Path(parent) / name).is_symlink():
-                    raise ValueError(f"source directory symlink is not allowed: {name}")
-            for name in sorted(files):
-                if not is_source(name):
-                    continue
-                path = Path(parent) / name
-                total += copy_source(path, stage / path.relative_to(source), MAX_BYTES - total)
-                count += 1
+        for path in source_inputs(source):
+            total += copy_source(path, stage / path.relative_to(source), MAX_BYTES - total)
+            count += 1
         (stage / MARKER).write_text(MAGIC)
         if output.exists():
             if output.is_symlink() or not owned_output(output):
@@ -140,9 +171,19 @@ def prepare(source, output):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--source", type=Path, required=True)
-    parser.add_argument("--output", type=Path, required=True)
+    action = parser.add_mutually_exclusive_group(required=True)
+    action.add_argument("--output", type=Path)
+    action.add_argument("--stamp", type=Path, help="update only when source contents/names/modes change")
     args = parser.parse_args()
     try:
+        if args.stamp is not None:
+            from update_build_stamp import update
+            source = args.source.resolve(strict=True)
+            stamp = args.stamp.absolute()
+            if stamp.is_symlink() or stamp.resolve() == source or source in stamp.resolve().parents:
+                raise ValueError("source stamp must be outside the input tree and not a symlink")
+            update(stamp, ["colibri-source-v1", str(source), fingerprint(source)])
+            return 0
         count, size = prepare(args.source, args.output)
     except (OSError, ValueError) as error:
         print(f"Cannot prepare engine source: {error}", file=sys.stderr)

--- a/tools/update_build_stamp.py
+++ b/tools/update_build_stamp.py
@@ -6,9 +6,9 @@ import sys
 import tempfile
 
 
-def main():
-    path = Path(sys.argv[1])
-    data = (json.dumps(sys.argv[2:], ensure_ascii=True) + "\n").encode()
+def update(path, values):
+    path = Path(path)
+    data = (json.dumps(values, ensure_ascii=True) + "\n").encode()
     if path.exists() and path.read_bytes() == data:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -23,4 +23,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    update(sys.argv[1], sys.argv[2:])


### PR DESCRIPTION
## Problem
The generated engine tree depended on only six upstream model C files. Changes to GLM5.3, Qwen3.8, headers and added/removed source files could leave an old archive in use.

## Change
Fingerprint exactly the same bounded source set used by preparation: relative names, contents and copied modes. Preserve the stamp on unchanged inputs. Keep model weights, tokenizer/config JSON and generated outputs out of copying and hashing. Reuse bounded regular-file reading and the existing atomic stamp writer. Colibri remains unchanged.

## Verification
- 16 source-copy/fingerprint tests: all adapters, headers, additions/deletions/renames/modes, preserved-mtime edits, unchanged stamp, unsafe input and failure preserving prior state.
- Existing build-options/OpenMP stamp test.
- Actual Makefile rehearsal using a disposable source-only copy: no second preparation on unchanged input; editing only qwen38.c triggers preparation and the generated source contains the change.
- Full household rebuild from the original untouched Colibri pin; immediate repeat performs no compilation.
- Two approved Tiny donors: real generation, separate cache reuse, source bytes 1131952 -> 1638 and cleanup PASS. Logs: /tmp/lumabri-home-flow-5xrz8lcx.

Build correctness only, not new GPU/model/runtime support or roadmap completion. Normal merge only after green checks on the exact head.