### PR TITLE
fix(net): remove delayed-ACK stalls from inbound replies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: |
           make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration test_inventory test_weight_cache CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
+          make test_tcp_latency CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          ./test_tcp_latency
           ./test_memory_budget
           ./test_weight_cache
           python3 tests/integration/storage_ui_test.py

--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,9 @@ test_calibration: tests/c/test_calibration.c lumabri_calibration.h lumabri_calib
 test_catalogue_advice: tests/c/test_catalogue_advice.c src/planner/lumabri_catalogue_advice.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_catalogue_advice.c -o $@
 
+test_tcp_latency: tests/c/test_tcp_latency.c $(SECURE_DEPS) lumabri_proto.h lumabri_sign.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) -pthread tests/c/test_tcp_latency.c -o $@
+
 test_metrics: tests/c/test_metrics.c lumabri_metrics.h lumabri_stage_metrics.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_metrics.c -o $@
 
@@ -738,7 +741,7 @@ test: all test_weight_cache test_key_rotation test_hedge test_local_fallback tes
 		test_inventory test_home test_chat_ui test_calibration test_catalogue_advice test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
-		test_scheduler test_run_gate
+		test_scheduler test_run_gate test_tcp_latency
 	bash ./tests/integration/selftest.sh
 	bash ./tests/integration/donate_test.sh
 	bash ./tests/integration/signed_donor_test.sh
@@ -788,6 +791,7 @@ test: all test_weight_cache test_key_rotation test_hedge test_local_fallback tes
 	./test_calibration
 	./test_catalogue_advice
 	./test_metrics
+	./test_tcp_latency
 	./test_nat_adopt
 	bash ./tests/integration/rtt_refresh_test.sh
 	./test_segment_v2
@@ -845,7 +849,7 @@ clean:
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \
 	      test_compute_lease test_content_filter test_scheduler test_run_gate \
 	      test_segment_v2_tsan tracker_tsan \
-	      segment_node segment_chat test_backend_routes segment_node_asan segment_chat_asan \
+	      segment_node segment_chat test_backend_routes test_tcp_latency segment_node_asan segment_chat_asan \
 	      segment_node_tsan segment_chat_tsan \
 	      olmoe_p2p colibri_p2p inkling_p2p kimi_k3_p2p deepseek_p2p qwen36_p2p \
 	      expert_node expert_node_glm expert_node_inkling expert_node_kimi \

--- a/docs/INBOUND_TCP_LATENCY.md
+++ b/docs/INBOUND_TCP_LATENCY.md
@@ -14,6 +14,8 @@ Framing, encryption, authentication, approval and model arithmetic are unchanged
 
 `test_tcp_latency` checks the outbound and inbound socket options, Unix sockets,
 invalid descriptors and byte equality through real AEAD record send/receive.
+Socket option assertions interpret enabled as nonzero: Darwin may return its
+internal flag mask rather than the literal integer one.
 Fixed test keys cover record transport only, not identity authentication; the
 household integration test covers the real authenticated path.
 

--- a/docs/INBOUND_TCP_LATENCY.md
+++ b/docs/INBOUND_TCP_LATENCY.md
@@ -1,0 +1,25 @@
+# Low-latency replies as well as requests
+
+The client connector already enabled `TCP_NODELAY`. Accepted server sockets
+did not. Lumabri writes a frame's header, payload and (when encrypted) tag
+separately; leaving Nagle enabled on replies can interact with delayed ACKs
+and add tens of milliseconds to a small request/reply exchange even on LAN.
+
+The accepted-socket entry point now enables `TCP_NODELAY` before any handshake,
+including when transport encryption is disabled. This is applied to the actual
+accepted IPv4/IPv6 socket, not inferred from listener inheritance: launchers
+may supply a pre-bound descriptor. Unix-domain sockets are unchanged. A socket
+option error rejects the connection rather than claiming the policy was set.
+Framing, encryption, authentication, approval and model arithmetic are unchanged.
+
+`test_tcp_latency` checks the outbound and inbound socket options, Unix sockets,
+invalid descriptors and byte equality through real AEAD record send/receive.
+Fixed test keys cover record transport only, not identity authentication; the
+household integration test covers the real authenticated path.
+
+The test also prints an informational A/B with the legacy server option forced
+off only inside the test. One Linux loopback run of 24 short encrypted exchanges
+averaged 42.306 ms with the legacy option and 0.356 ms with NODELAY. Timing is
+not a CI threshold, a physical-LAN measurement or model tok/s. Actual gains
+depend on payload, TCP behavior, compute and topology; per-range chat observations
+are the way to check the complete path.

--- a/lumabri_secure.h
+++ b/lumabri_secure.h
@@ -407,6 +407,18 @@ static int lmb_sec_reject_wrap(int fd, int is_client, const char *addr) {
 /* handshake an accepted (inbound) fd; 0 when encryption is off or the wrap
  * succeeds, -1 when an enabled handshake fails and the caller must drop it */
 static LMB_MAYBE_UNUSED int lmb_secure_server(int fd) {
+    /* Replies use separate header/payload/tag writes just like requests.
+     * Outbound TCP already disables Nagle; accepted sockets must too, before
+     * the handshake and also in plaintext mode. Do not depend on listener
+     * option inheritance (launchers may pass an already-bound descriptor).
+     * Unix socketpairs used by local transports/tests have no TCP option. */
+    struct sockaddr_storage address;
+    socklen_t address_size = sizeof address;
+    if (getsockname(fd, (struct sockaddr *)&address, &address_size)) return -1;
+    if (address.ss_family == AF_INET || address.ss_family == AF_INET6) {
+        int one = 1;
+        if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one)) return -1;
+    }
     if (!lmb_enc_wrap) return 0;
     return lmb_enc_wrap(fd, 0, NULL);
 }

--- a/tests/c/test_tcp_latency.c
+++ b/tests/c/test_tcp_latency.c
@@ -25,7 +25,9 @@ static void *echo_records(void *arg) {
 static int nodelay(int fd) {
     int value = -1; socklen_t size = sizeof value;
     assert(!getsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &value, &size));
-    return value;
+    /* Socket booleans are zero/nonzero, not necessarily zero/one. Darwin
+     * returns the underlying TCP flag mask for TCP_NODELAY. */
+    return value != 0;
 }
 
 static double seconds(void) {

--- a/tests/c/test_tcp_latency.c
+++ b/tests/c/test_tcp_latency.c
@@ -1,0 +1,89 @@
+/* Deterministic socket-option contract plus an informational loopback A/B.
+ * Fixed keys exercise real AEAD records, NOT handshake authentication or a
+ * model. Timing is reported, never used as a flaky pass/fail threshold. */
+#include "lumabri_secure.h"
+#include <assert.h>
+#include <pthread.h>
+#include <sys/un.h>
+
+#define ROUNDS 24
+typedef struct { int fd; LmbSecure secure; } Echo;
+
+static void *echo_records(void *arg) {
+    Echo *echo = arg;
+    for (unsigned i = 0; i < ROUNDS; i++) {
+        LmbMsg message = {0};
+        assert(!lmb_secure_recv(&echo->secure, echo->fd, &message));
+        assert(message.op == LMB_SEG_RUN);
+        assert(!lmb_secure_send(&echo->secure, echo->fd, LMB_SEG_RUN_R,
+            message.body, message.body_len, message.pay, message.pay_len));
+        lmb_msg_free(&message);
+    }
+    return NULL;
+}
+
+static int nodelay(int fd) {
+    int value = -1; socklen_t size = sizeof value;
+    assert(!getsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &value, &size));
+    return value;
+}
+
+static double seconds(void) {
+    struct timespec ts; assert(!clock_gettime(CLOCK_MONOTONIC, &ts));
+    return ts.tv_sec + ts.tv_nsec / 1e9;
+}
+
+static double trial(int legacy) {
+    int listener = lmb_listen(0); assert(listener >= 0);
+    struct sockaddr_in bound; socklen_t length = sizeof bound;
+    assert(!getsockname(listener, (struct sockaddr *)&bound, &length));
+    char address[64]; snprintf(address, sizeof address, "127.0.0.1:%u", ntohs(bound.sin_port));
+    int client = lmb_connect_ms_io(address, 1000, 5000); assert(client >= 0);
+    int server = accept(listener, NULL, NULL); assert(server >= 0);
+    close(listener);
+    lmb_set_io_timeout(server, 5000);
+    assert(nodelay(client) == 1);
+    int zero = 0;
+    assert(!setsockopt(server, IPPROTO_TCP, TCP_NODELAY, &zero, sizeof zero));
+    assert(nodelay(server) == 0);
+    assert(!lmb_secure_server(server));  /* actual accepted-socket entry point */
+    assert(nodelay(server) == 1);
+    if (legacy) assert(!setsockopt(server, IPPROTO_TCP, TCP_NODELAY, &zero, sizeof zero));
+    Echo echo = {.fd = server, .secure = {.active = 1}};
+    LmbSecure outgoing = {.active = 1};
+    memset(outgoing.tx_key, 0x11, 32); memset(echo.secure.rx_key, 0x11, 32);
+    memset(outgoing.rx_key, 0x22, 32); memset(echo.secure.tx_key, 0x22, 32);
+    pthread_t thread; assert(!pthread_create(&thread, NULL, echo_records, &echo));
+    const char body[] = "test-only framing";
+    unsigned char payload[256]; memset(payload, 0x53, sizeof payload);
+    double start = seconds();
+    for (unsigned i = 0; i < ROUNDS; i++) {
+        assert(!lmb_secure_send(&outgoing, client, LMB_SEG_RUN,
+                               body, sizeof body, payload, sizeof payload));
+        LmbMsg message = {0};
+        assert(!lmb_secure_recv(&outgoing, client, &message));
+        assert(message.op == LMB_SEG_RUN_R && message.body_len == sizeof body &&
+               message.pay_len == sizeof payload);
+        assert(!memcmp(message.body, body, sizeof body));
+        assert(!memcmp(message.pay, payload, sizeof payload));
+        lmb_msg_free(&message);
+    }
+    double elapsed = seconds() - start;
+    assert(!pthread_join(thread, NULL));
+    lmb_close(server); lmb_close(client);
+    return elapsed * 1000 / ROUNDS;
+}
+
+int main(void) {
+    (void)lmb_sign;
+    (void)lmb_secure_init;
+    int pair[2]; assert(!socketpair(AF_UNIX, SOCK_STREAM, 0, pair));
+    assert(!lmb_secure_server(pair[0])); /* Unix sockets have no Nagle option. */
+    close(pair[0]); close(pair[1]);
+    double legacy = trial(1), current = trial(0);
+    assert(lmb_secure_server(-1) < 0);
+    printf("INBOUND TCP: PASS (client/server NODELAY; Unix socket preserved; encrypted record equality)\n");
+    printf("Informational %u-record loopback mean: legacy %.3f ms, NODELAY %.3f ms; not model tok/s\n",
+           ROUNDS, legacy, current);
+    return 0;
+}


### PR DESCRIPTION
Depends on #170 for the per-range observations used to validate the household path; merge #170 first. No squash.

## Confirmed problem
Outbound sockets already use TCP_NODELAY; accepted server sockets did not. Separate header/payload/AEAD-tag writes could incur delayed-ACK stalls even on loopback. A negative test against the previous code fails exactly at the accepted-socket NODELAY assertion.

## Fix
Set TCP_NODELAY on the actual accepted IPv4/IPv6 socket before wrapping/handshake, also for plaintext mode. Preserve Unix sockets and fail closed on socket-option errors. Do not assume listener inheritance; framing, cryptography and arithmetic are unchanged.

## Verification
- Complete household build; Lumabri binaries use -Wall -Wextra -Werror. Existing upstream warnings are unchanged.
- Deterministic client/server socket-option checks, Unix socket and invalid-descriptor checks, real AEAD record equality.
- Informational controlled 24-exchange loopback A/B: legacy 42.306 ms mean versus NODELAY 0.356 ms. ASan/UBSan also pass. No timing threshold in CI.
- Authenticated two-donor household flow, approved ranges, calibration invalidation, cache reuse and cleanup PASS. Logs /tmp/lumabri-home-flow-neeybrk6: both ranges now have decode RUN times below 1 ms in this Tiny test, rather than repeated 40-50 ms stalls. This is NOT real-model tok/s or physical LAN evidence.
- Real trained OLMoE: identical 8 greedy tokens, whole versus split, direct Segment only. Whole-invocation times 2.162 s (one node/2 threads), 2.496 s (1+1), 2.180 s (2+2); one measured repeat, not a robust speed comparison.
- Low-level fenced Segment failover/KV-reuse/profile-invalidation test PASS.
- CI adds the socket/record test on Linux and native macOS Intel/ARM, alongside full household gates.

This removes transport overhead; it does not certify 20 tok/s or close all roadmap gates. Merge only after all eight checks are green on the exact head.