### PR TITLE
Fix whole-checkpoint downloads during donor preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           ./test_weight_cache
           python3 tests/integration/storage_ui_test.py
           ./test_planner
+          make test_planner_io CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
+          ./test_planner_io
           ./test_cluster
           ./test_calibration
           make test_catalogue_advice CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ check-warnings:
 		test_hedge test_local_fallback test_nat_adopt test_verify_failover test_rtt_refresh test_segment_v2 test_exec2 test_accum_order test_residency_report test_model_family test_planner test_cluster test_memory_budget test_calibration test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
-		test_scheduler test_run_gate test_inventory test_home test_chat_ui test_weight_cache \
+		test_scheduler test_run_gate test_inventory test_home test_chat_ui test_weight_cache test_planner_io \
 		CFLAGS='$(CFLAGS) -Werror'
 
 SECURE_DEPS = lumabri_secure.h lumabri_crypto.h
@@ -68,7 +68,7 @@ PLANNER_ADAPTER_DEPS = $(wildcard planner_adapters/*.h)
 
 # Adapter contracts are included transitively by the planner. Rebuild every
 # consumer when one changes, including when a new contract is introduced.
-lumabri test_chat_ui test_planner test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
+lumabri test_chat_ui test_planner test_planner_io test_cluster test_memory_budget test_calibration segment_budget_probe segment_node: $(PLANNER_ADAPTER_DEPS)
 lumabri test_chat_ui: lumabri_runtime_identity.h lumabri_checkpoint_identity.h lumabri_calibration_store.h lumabri_calibration.h
 lumabri test_chat_ui: src/planner/lumabri_catalogue_advice.h
 lumabri test_chat_ui: src/runtime/lumabri_preload.h
@@ -456,6 +456,9 @@ test_model_family: tests/c/test_model_family.c lumabri_families.h
 test_planner: tests/c/test_planner.c $(wildcard tests/c/test_planner_*.h) lumabri_planner.h lumabri_families.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_planner.c -o $@
 
+test_planner_io: tests/c/test_planner_io.c lumabri_planner.h lumabri_families.h
+	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_planner_io.c -o $@
+
 test_cluster: tests/c/test_cluster.c lumabri_cluster.h lumabri_memory_budget.h lumabri_planner.h lumabri_families.h lumabri_machine.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_cluster.c -o $@
 
@@ -570,6 +573,7 @@ test-sanitize:
 	$(CC) $(CPPFLAGS) $(SANITIZE_FLAGS) -pthread tests/c/test_compute_lease.c $(MACHINE_SRC) -o build/sanitize/test_compute_lease
 	$(CC) $(CPPFLAGS) $(SANITIZE_FLAGS) tests/c/test_content_filter.c -o build/sanitize/test_content_filter
 	$(CC) $(CPPFLAGS) $(SANITIZE_FLAGS) tests/c/test_scheduler.c -o build/sanitize/test_scheduler
+	$(CC) $(CPPFLAGS) $(SANITIZE_FLAGS) tests/c/test_planner_io.c -o build/sanitize/test_planner_io
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_segment_v2
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_segment_discovery
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_run_gate
@@ -577,6 +581,7 @@ test-sanitize:
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_compute_lease
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_content_filter
 	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_scheduler
+	ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build/sanitize/test_planner_io
 
 test-thread-sanitize:
 	mkdir -p build/sanitize
@@ -744,7 +749,7 @@ test: all test_weight_cache test_key_rotation test_hedge test_local_fallback tes
 		test_inventory test_home test_chat_ui test_calibration test_catalogue_advice test_metrics \
 		test_segment_discovery test_swarm_detail test_relay_rate test_machine \
 		test_meminfo test_compute_lease test_content_filter \
-		test_scheduler test_run_gate test_tcp_latency
+		test_scheduler test_run_gate test_tcp_latency test_planner_io
 	bash ./tests/integration/selftest.sh
 	bash ./tests/integration/donate_test.sh
 	bash ./tests/integration/signed_donor_test.sh
@@ -788,6 +793,8 @@ test: all test_weight_cache test_key_rotation test_hedge test_local_fallback tes
 	bash ./tests/integration/hosted_chat_test.sh
 	bash ./tests/integration/tui_test.sh
 	./test_planner
+	./test_planner_io
+	python3 tests/integration/native_shim_test.py
 	./test_cluster
 	./test_memory_budget
 	./test_weight_cache
@@ -846,7 +853,7 @@ clean:
 	rm -f tracker maintainer liblumabri.so liblumabri.dylib test_shim swarm_probe lumabri \
 	      test_relay_exec test_swarm_fed test_key_rotation test_hedge \
 	      test_local_fallback test_accum_order test_residency_report \
-	      test_model_family test_planner test_cluster test_memory_budget test_calibration test_catalogue_advice test_metrics test_inventory test_home test_chat_ui test_weight_cache segment_budget_probe \
+	      test_model_family test_planner test_planner_io test_cluster test_memory_budget test_calibration test_catalogue_advice test_metrics test_inventory test_home test_chat_ui test_weight_cache segment_budget_probe \
 	      test_nat_adopt test_rtt_refresh \
 	      test_verify_failover test_segment_v2 test_segment_discovery test_sampling \
 	      test_swarm_detail test_relay_rate test_machine test_meminfo \

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -16,8 +16,9 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
 
 1. Actual two-compute-node physical LAN chain: local oracle, split oracle,
    per-node layer ranges and memory, fixed-thread and full-hardware timings.
-   Current physical trial has PC source and Mac computation, not two compute
-   nodes. Mac deployment/approval is user-operated; CI loopback is separate.
+   Physical Tiny chat has now run with PC [0,2) and Mac [2,4) computing.
+   Exact physical local/split token comparison remains pending. Mac deployment
+   and approval are user-operated; CI loopback is separate.
 2. Complete verified sizing for every registered family and supported weight
    encoding. OLMoE, DeepSeek V4, converted Qwen3.6, Inkling and float-dense/MXFP4
    Kimi, float-source GLM, text-only float-source GLM5.3 and BF16/float/block-FP8-expert
@@ -48,6 +49,19 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
    tests. Keep public-network trust/credits separate from the LAN product.
 
 ## Evidence already obtained
+
+- Real OLMoE (7.42 GB) passed household selection/approval for PC [0,13)
+  and Mac [13,16), but the cold-start trial was cancelled before generation.
+  The runtime sizing inspector used `fopen` for safetensors headers; the shim
+  materialized whole files for stdio, causing unintended full-weight transfer
+  on each donor before engine initialization. Bounded descriptor `pread` now
+  preserves header/layout checks without triggering that stdio policy.
+  Regression coverage includes short reads, EINTR, EOF/EIO, truncation and
+  native encrypted CAS inspection of a 64-MiB payload whose unused middle
+  must remain cold. A fresh isolated mirror of the actual 7.42-GB OLMoE
+  materialized 41,947,136 bytes for preflight and returned the same [0,13)
+  memory estimate as the local source (6,264,782,848 bytes, context 512).
+  This is not yet a successful real-model LAN generation.
 
 - PR #150: native Intel/ARM macOS CI, Linux regression gates, Windows firewall
   helper contracts; Tiny signed CAS, all-party approval, generation and cleanup.

--- a/planner_adapters/tensors.h
+++ b/planner_adapters/tensors.h
@@ -6,6 +6,9 @@
 #include <math.h>
 #include <float.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
 
 typedef struct {
     char name[512], dtype[32];
@@ -95,22 +98,41 @@ static const char *lmb_plan_object_end(const char *p) {
     return p;
 }
 
+/* Use descriptor reads, not stdio: the virtual checkpoint's fopen contract
+ * materializes the entire file before returning. A sizing scan must fetch
+ * only authenticated header blocks and explicitly bounded layout metadata.
+ * Keep short reads/EINTR distinct from EOF or transport errors. */
+static int lmb_plan_read_at(int fd, void *buffer, size_t size, uint64_t offset) {
+    unsigned char *p = buffer;
+    while (size) {
+        off_t at = (off_t)offset;
+        if (at < 0 || (uint64_t)at != offset) { errno = EOVERFLOW; return -1; }
+        size_t chunk = size > 1048576 ? 1048576 : size;
+        ssize_t n = pread(fd, p, chunk, at);
+        if (n < 0 && errno == EINTR) continue;
+        if (n <= 0) { if (!n) errno = EIO; return -1; }
+        if ((uint64_t)n > UINT64_MAX - offset) { errno = EOVERFLOW; return -1; }
+        p += n; size -= (size_t)n; offset += (uint64_t)n;
+    }
+    return 0;
+}
+
 static int lmb_plan_tensor_file_id(const char *path, uint64_t *header_budget,
                                 LmbPlanTensorVisit visit, void *opaque, uint32_t file_id) {
-    FILE *f = fopen(path, "rb");
-    if (!f) return -1;
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return -1;
     struct stat st;
     unsigned char prefix[8];
     uint64_t bytes = 0;
     int rc = -1;
     char *json = NULL;
-    if (fstat(fileno(f), &st) || !S_ISREG(st.st_mode) || st.st_size < 10 ||
-        fread(prefix, 1, 8, f) != 8) goto done;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode) || st.st_size < 10 ||
+        lmb_plan_read_at(fd, prefix, 8, 0)) goto done;
     for (unsigned i = 0; i < 8; i++) bytes |= (uint64_t)prefix[i] << (8 * i);
     if (bytes > *header_budget || bytes > (uint64_t)st.st_size - 8 || bytes < 2) goto done;
     *header_budget -= bytes;
     json = malloc((size_t)bytes + 1);
-    if (!json || fread(json, 1, (size_t)bytes, f) != bytes) goto done;
+    if (!json || lmb_plan_read_at(fd, json, (size_t)bytes, 8)) goto done;
     json[bytes] = 0;
     if (memchr(json, 0, (size_t)bytes)) goto done;
     const char *p = lmb_plan_space(json);
@@ -150,8 +172,7 @@ static int lmb_plan_tensor_file_id(const char *path, uint64_t *header_budget,
             if (width == 8 && t.elements <= 64) {
                 unsigned char metadata[512];
                 if (t.bytes > *header_budget ||
-                    fseeko(f, (off_t)(8 + bytes + offsets[0]), SEEK_SET) ||
-                    fread(metadata, 1, (size_t)t.bytes, f) != t.bytes) goto done;
+                    lmb_plan_read_at(fd, metadata, (size_t)t.bytes, 8 + bytes + offsets[0])) goto done;
                 *header_budget -= t.bytes;
                 for (uint64_t i=0; i<t.elements; i++)
                     for (unsigned j=0; j<8; j++)
@@ -167,7 +188,7 @@ static int lmb_plan_tensor_file_id(const char *path, uint64_t *header_budget,
     if (*lmb_plan_space(p) || !tensors) goto done;
     rc = 0;
 done:
-    free(json); fclose(f); return rc;
+    free(json); close(fd); return rc;
 }
 
 static int LMB_UNUSED lmb_plan_tensor_file(const char *path, uint64_t *header_budget,

--- a/tests/c/test_planner_io.c
+++ b/tests/c/test_planner_io.c
@@ -1,0 +1,80 @@
+/* Unit fault injection and native-shim client for bounded tensor inspection. */
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int faults, calls;
+static uint64_t read_bytes;
+static ssize_t observed_pread(int fd, void *buf, size_t n, off_t off) {
+    calls++;
+    if (faults == 1 && calls == 1) { errno = EINTR; return -1; }
+    if (faults == 2) return 0;
+    if (faults == 3) { errno = EIO; return -1; }
+    if (faults == 1 && n > 3) n = 3;
+    ssize_t got = pread(fd, buf, n, off);
+    if (got > 0) read_bytes += (uint64_t)got;
+    return got;
+}
+#define pread observed_pread
+#include "lumabri_planner.h"
+#undef pread
+
+static int visited;
+static int visit(const LmbPlanTensor *t, void *opaque) {
+    (void)opaque;
+    if (!strcmp(t->name, "weights")) {
+        assert(!strcmp(t->dtype, "U8"));
+    } else {
+        assert(!strcmp(t->name, "layout"));
+        assert(t->elements == 2 && t->bytes == 16);
+        assert(t->meta_i64[0] == 17 && t->meta_i64[1] == 29);
+    }
+    visited++;
+    return 0;
+}
+
+static int inspect(const char *path, int mode) {
+    uint64_t budget = 65536;
+    faults = mode; calls = visited = 0; read_bytes = 0;
+    return lmb_plan_tensor_file_id(path, &budget, visit, NULL, 0);
+}
+
+int main(int argc, char **argv) {
+    if (argc == 2) {
+        assert(!inspect(argv[1], 0));
+        assert(visited == 2 && read_bytes < 65536);
+        printf("PLANNER IO: PASS (%llu requested bytes, two tensors, layout values verified)\n",
+               (unsigned long long)read_bytes);
+        return 0;
+    }
+    assert(argc == 1);
+    char path[] = "/tmp/lumabri-planner-io-XXXXXX";
+    int fd = mkstemp(path); assert(fd >= 0);
+    const char *header = "{\"weights\":{\"dtype\":\"U8\",\"shape\":[512],\"data_offsets\":[0,512]},"
+        "\"layout\":{\"dtype\":\"I64\",\"shape\":[2],\"data_offsets\":[512,528]}}";
+    uint64_t n = strlen(header);
+    unsigned char prefix[8], layout[16] = {17,0,0,0,0,0,0,0,29};
+    for (unsigned i=0; i<8; i++) prefix[i] = (unsigned char)(n >> (8*i));
+    assert(write(fd, prefix, 8) == 8);
+    assert(write(fd, header, (size_t)n) == (ssize_t)n);
+    assert(lseek(fd, 512, SEEK_CUR) >= 0);
+    assert(write(fd, layout, 16) == 16);
+    assert(!inspect(path, 0) && visited == 2 && read_bytes == 8+n+16);
+    assert(!inspect(path, 1) && visited == 2 && read_bytes == 8+n+16);
+    assert(inspect(path, 2) == -1 && visited == 0); /* EOF is not zero-filled data */
+    assert(inspect(path, 3) == -1 && visited == 0); /* transport failure */
+    faults = 0;
+    assert(lmb_plan_read_at(fd, prefix, 1, UINT64_MAX) == -1);
+    uint64_t budget = n-1;
+    assert(lmb_plan_tensor_file_id(path, &budget, visit, NULL, 0) == -1);
+    assert(!ftruncate(fd, (off_t)(8+n+520)));
+    assert(inspect(path, 0) == -1); /* declared layout outside truncated file */
+    close(fd); assert(!unlink(path));
+    puts("PLANNER IO: PASS (bounded reads, short reads, EINTR, EOF, EIO, offsets, budget, truncation)");
+    return 0;
+}

--- a/tests/integration/native_shim_test.py
+++ b/tests/integration/native_shim_test.py
@@ -4,6 +4,8 @@ Compares bytes through the actual .so/.dylib, then rebuilds a fresh mirror
 with the origin offline. All keys, ports and cache files are test-owned.
 """
 import os
+import json
+import struct
 from pathlib import Path
 import socket
 import subprocess
@@ -88,6 +90,46 @@ def main():
                         raise AssertionError(f"{name}: {out}\n{err}")
             assert any((tmp / "cas").rglob("*")), "CAS was not populated"
             print("NATIVE SHIM: PASS (encrypted byte-exact libc reads, cold transfer, fresh mirror with origin offline)")
+
+            # A real virtual checkpoint, not a mocked read counter. Inspection
+            # needs the header and a small layout at the far end of a 64-MiB
+            # payload. fopen used to fetch the entire payload here, even on a
+            # donor assigned only a few layers. Keep the unused middle cold.
+            header_source = tmp / "header-source"
+            header_source.mkdir()
+            payload = 64 * 1024 * 1024
+            header = json.dumps({
+                "weights": {"dtype": "U8", "shape": [payload-16], "data_offsets": [0,payload-16]},
+                "layout": {"dtype": "I64", "shape": [2], "data_offsets": [payload-16,payload]},
+            }, separators=(",", ":")).encode()
+            middle = 8 + len(header) + payload // 2
+            with (header_source / "weights.safetensors").open("wb") as f:
+                f.write(struct.pack("<Q", len(header))); f.write(header)
+                f.seek(middle); f.write(b"MUST_NOT_BE_FETCHED")
+                f.seek(8 + len(header) + payload - 16); f.write(struct.pack("<QQ",17,29))
+            header_port = free_port()
+            header_origin = launch("header-origin", ["./maintainer", "--root", str(header_source),
+                "--port", str(header_port), "--tracker", f"127.0.0.1:{port}",
+                "--name", "header-origin", "--model-name", "header-only"])
+            ready(header_origin, header_port)
+            env = {**environment("header-client"), loader: str(ROOT / library),
+                   "LUMABRI_MODEL": "header-only", "LUMABRI_TRACKER": f"127.0.0.1:{port}",
+                   "LUMABRI_CAS": str(tmp / "header-cas"), "LUMABRI_BLOCK_MIB": "1",
+                   "LUMABRI_PREFETCH": "0", "LUMABRI_CACHE": str(tmp / "header-cache"),
+                   "LUMABRI_VROOT": str(tmp / "header-vroot")}
+            p = subprocess.run([str(ROOT / "test_planner_io"),
+                                str(tmp / "header-vroot/weights.safetensors")],
+                               cwd=ROOT, env=env, capture_output=True, text=True, timeout=45)
+            assert p.returncode == 0, p.stdout + p.stderr
+            mirror = tmp / "header-cache/data/weights.safetensors"
+            with mirror.open("rb") as f:
+                f.seek(middle)
+                assert f.read(19) == bytes(19), "planner materialized unused weight payload"
+                f.seek(8 + len(header) + payload - 16)
+                assert f.read(16) == struct.pack("<QQ",17,29)
+            allocated = mirror.stat().st_blocks * 512
+            assert allocated <= 4 * 1024 * 1024, f"header inspection allocated {allocated} bytes"
+            print(f"BOUNDED PLANNER SHIM: PASS (64-MiB payload, {allocated} allocated bytes, unused middle cold)")
         except Exception:
             for log in tmp.glob("*.log"):
                 print(log.name, log.read_text(errors="replace"), file=sys.stderr)


### PR DESCRIPTION
## Cause
The tensor inspector used fopen/fread for bounded safetensors headers. Under the household shim, fopen materializes the entire file. The first physical real-OLMoE trial therefore fetched unrelated weights on both donors before engine initialization.

## Fix
Use close-on-exec descriptors and bounded positional reads for headers and the existing small I64 layout metadata. Preserve all sizing, bounds, hash verification and admission rules. Handle EINTR, short reads, EOF and transport errors. Colibri and its pinned sources are unchanged.

## Verification
- Planner contracts and new IO unit tests pass.
- New IO tests pass under ASan/UBSan.
- Native encrypted-shim regression: 64-MiB payload, about 1 MiB materialized, unused middle remains cold.
- Real 7.42-GB OLMoE isolated mirrored preflight: 41,947,136 bytes materialized; exactly the same memory estimate as local source.
- Full regression suite and two-donor household flow running; CI includes native Intel/ARM Mac tests.

Physical PC/Mac real-model generation must be retried after both donors update. No speed or complete-roadmap claim. Preserve commits; no squash.