### PR TITLE
fix(host): do not expire an active prefill as an idle session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration test_inventory test_weight_cache CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
+          ./test_chat_ui host-codec
           make test_tcp_latency CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_tcp_latency
           ./test_memory_budget

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -63,6 +63,20 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
   memory estimate as the local source (6,264,782,848 bytes, context 512).
   This is not yet a successful real-model LAN generation.
 
+- The subsequent physical OLMoE trial passed preflight on both donors and
+  started Edge, with PC [0,13) and Mac [13,16). Its first 26-token prompt
+  did not complete: the host logged `idle session expired` during the silent
+  cold prefill. Source shutdown and subsequent block EIO were consequences
+  of that cancellation, not evidence that the Mac rejected the request.
+  Hosted now tracks complete SUBMIT through matching DONE/ERROR, parsing DATA
+  lengths so generated text cannot imitate a terminal frame. Idle expiry is
+  rearmed after completion; active work has a separate absolute deadline
+  (`--request-seconds`, default 1800), never extended by progress or client
+  traffic. The default idle limit remains 300 seconds. A real encrypted
+  bridge regression tests silent prefill beyond idle, BUSY while active,
+  post-DONE expiry and an independently bounded stalled request. Successful
+  real-model LAN generation and the cause of slow cold loading remain open.
+
 - PR #150: native Intel/ARM macOS CI, Linux regression gates, Windows firewall
   helper contracts; Tiny signed CAS, all-party approval, generation and cleanup.
 - User household trial: macOS 12.6 Intel Mac with 8 GiB RAM, Windows/WSL source;

--- a/lumabri.c
+++ b/lumabri.c
@@ -3214,6 +3214,7 @@ typedef struct {
     uint32_t max_frame;
     uint32_t max_new;
     uint32_t idle_seconds;
+    uint32_t request_seconds; /* absolute bound for an active inference */
     const uint8_t *client_key; /* optional identity bound by an accepted home plan */
 } HostState;
 
@@ -3269,6 +3270,9 @@ typedef struct {
     size_t header_len;
     uint64_t payload_left;
     int need_terminator;
+    char request_id[64];
+    int active;
+    double started;
 } HostInput;
 
 static int host_header(HostInput *in, Engine *e, const HostState *h) {
@@ -3280,13 +3284,14 @@ static int host_header(HostInput *in, Engine *e, const HostState *h) {
     int fields = sscanf(in->header, "SUBMIT %63s %u %llu %u %f %f %c",
                         id, &slot, &bytes, &max_new, &temp, &top_p, &extra);
     if (fields == 6) {
-        if (slot != 0 || bytes > h->max_frame || max_new < 1 ||
+        if (in->active || slot != 0 || bytes > h->max_frame || max_new < 1 ||
             max_new > h->max_new || !isfinite(temp) || !isfinite(top_p) ||
             temp < 0 || top_p <= 0 || top_p > 1) {
             fprintf(stderr, "[host] refused SUBMIT limits (slot=%u bytes=%llu max_new=%u/%u)\n", slot, bytes, max_new, h->max_new);
             return -1;
         }
         if (engine_write_full(e->to, in->header, in->header_len)) return -1;
+        snprintf(in->request_id, sizeof in->request_id, "%s", id);
         in->payload_left = bytes;
         in->need_terminator = bytes == 0;
         in->header_len = 0;
@@ -3326,6 +3331,8 @@ static int host_input(HostInput *in, Engine *e, const HostState *h,
             if (data[at++] != '\n' || engine_write_full(e->to, "\n", 1))
                 return -1;
             in->need_terminator = 0;
+            in->active = 1;
+            in->started = nowd();
             continue;
         }
         const uint8_t *nl = memchr(data + at, '\n', bytes - at);
@@ -3339,19 +3346,90 @@ static int host_input(HostInput *in, Engine *e, const HostState *h,
     return 0;
 }
 
+/* Observe codec boundaries, never generated text: a DATA payload may itself
+ * contain "DONE <id>". Pipes can split a header or combine several frames.
+ * Long telemetry lines are ignored without allocating unbounded memory. */
+typedef struct {
+    char header[512];
+    size_t header_len;
+    uint64_t payload_left;
+    int need_terminator, overflow;
+} HostOutput;
+
+static int host_output(HostOutput *out, HostInput *in, const char *data,
+                       size_t bytes, int *completed) {
+    *completed = 0;
+    for (size_t at = 0; at < bytes;) {
+        if (out->payload_left) {
+            size_t take = bytes - at;
+            if (out->payload_left < take) take = (size_t)out->payload_left;
+            out->payload_left -= take;
+            at += take;
+            continue;
+        }
+        if (out->need_terminator) {
+            if (data[at++] != '\n') return -1;
+            out->need_terminator = 0;
+            continue;
+        }
+        char ch = data[at++];
+        if (ch != '\n') {
+            if (out->header_len < sizeof out->header - 1)
+                out->header[out->header_len++] = ch;
+            else out->overflow = 1;
+            continue;
+        }
+        out->header[out->header_len] = 0;
+        char id[64], extra;
+        if (!strncmp(out->header, "DATA ", 5)) {
+            char count[32];
+            if (out->overflow || sscanf(out->header, "DATA %63s %31s %c",
+                                        id, count, &extra) != 2) return -1;
+            for (size_t i = 0; count[i]; ++i)
+                if (count[i] < '0' || count[i] > '9') return -1;
+            errno = 0;
+            char *end;
+            unsigned long long n = strtoull(count, &end, 10);
+            if (errno || *end) return -1;
+            out->payload_left = n;
+            out->need_terminator = 1;
+        } else if (((!strncmp(out->header, "DONE ", 5) &&
+                     sscanf(out->header, "DONE %63s", id) == 1) ||
+                    (!strncmp(out->header, "ERROR ", 6) &&
+                     sscanf(out->header, "ERROR %63s", id) == 1)) &&
+                   in->active && !strcmp(id, in->request_id)) {
+            in->active = 0;
+            *completed = 1;
+        }
+        out->header_len = 0;
+        out->overflow = 0;
+    }
+    return 0;
+}
+
+static int host_expired(const HostInput *in, const HostState *h,
+                        double last_input, double now) {
+    if (in->active)
+        return h->request_seconds && now - in->started > h->request_seconds ? 2 : 0;
+    return h->idle_seconds && now - last_input > h->idle_seconds ? 1 : 0;
+}
+
 /* Both directions remain inside LMB_HOST_STREAM frames (authenticated and
  * encrypted whenever the transport's strict mode is enabled). */
 static void host_bridge(int fd, Engine *e, const HostState *h) {
     char buf[16384];
     HostInput input = {0};
+    HostOutput output = {0};
     double last_input = nowd();
     for (;;) {
         struct pollfd p[2] = { { fd, POLLIN, 0 }, { e->from, POLLIN, 0 } };
         int n = poll(p, 2, 1000);
         if (g_stopping) return;
         if (n < 0) { if (errno == EINTR) continue; return; }
-        if (!n && h->idle_seconds && nowd() - last_input > h->idle_seconds) {
-            fprintf(stderr, "[host] idle session expired\n");
+        int expired = host_expired(&input, h, last_input, nowd());
+        if (expired) {
+            fprintf(stderr, "[host] %s\n", expired == 2 ?
+                    "active request deadline exceeded" : "idle session expired");
             return;
         }
         if (p[0].revents & POLLIN) {
@@ -3368,6 +3446,12 @@ static void host_bridge(int fd, Engine *e, const HostState *h) {
         if (p[1].revents & POLLIN) {
             ssize_t got = read(e->from, buf, sizeof buf);
             if (got <= 0) return;                 /* engine died: so does this */
+            int completed;
+            if (host_output(&output, &input, buf, (size_t)got, &completed)) {
+                fprintf(stderr, "[host] invalid engine codec frame\n");
+                return;
+            }
+            if (completed) last_input = nowd();
             if (lmb_send(fd, LMB_HOST_STREAM, NULL, 0, buf, (uint32_t)got))
                 return;
         }
@@ -3407,6 +3491,7 @@ static int cmd_host(int argc, char **argv) {
     int port = 7350, ctx = 2048, max_new = 256, cap_experts = 64;
     uint32_t max_frame = 1u << 20;
     uint32_t idle_seconds = 300;
+    uint32_t request_seconds = 1800;
     for (int i = 0; i < argc; i++) {
         if (!strcmp(argv[i], "--port") && i + 1 < argc) port = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--tracker") && i + 1 < argc) tracker = argv[++i];
@@ -3421,11 +3506,13 @@ static int cmd_host(int argc, char **argv) {
             max_frame = (uint32_t)atoi(argv[++i]);
         else if (!strcmp(argv[i], "--idle-seconds") && i + 1 < argc)
             idle_seconds = (uint32_t)atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--request-seconds") && i + 1 < argc)
+            request_seconds = (uint32_t)atoi(argv[++i]);
         else {
             fprintf(stderr, "usage: lumabri host --model NAME [--port N] "
                             "[--tracker H:P] [--local DIR]\n"
                             "                   [--ctx N] [--max-new N] "
-                            "[--max-frame BYTES] [--idle-seconds N]\n");
+                            "[--max-frame BYTES] [--idle-seconds N] [--request-seconds N]\n");
             return 2;
         }
     }
@@ -3436,7 +3523,8 @@ static int cmd_host(int argc, char **argv) {
         return 2;
     }
     if (max_new < 1 || max_new > (1 << 20) || max_frame < 1 ||
-        max_frame > LMB_MAX_PAY || idle_seconds < 1) {
+        max_frame > LMB_MAX_PAY || idle_seconds < 1 || request_seconds < 1 ||
+        request_seconds > 86400) {
         fprintf(stderr, "invalid host limit\n");
         return 2;
     }
@@ -3466,7 +3554,8 @@ static int cmd_host(int argc, char **argv) {
     const char *host_engine = engine_for(mtype);
     if (!host_engine) { close(lfd); engine_stop(&eng); return 1; }
     HostState h = { &eng, mtype, host_engine, 0, max_frame,
-                    (uint32_t)max_new, idle_seconds, client_key ? allowed_client : NULL };
+                    (uint32_t)max_new, idle_seconds, request_seconds,
+                    client_key ? allowed_client : NULL };
 
     printf("  %shost ready on port %d · %s · one session at a time%s\n",
            C_DIM, port, mtype[0] ? mtype : "?", C_R);

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,58 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    /* Hosted inactivity is not an inference deadline. Even an engine which
+     * emits no progress during prefill must retain its accepted session. */
+    HostState host_limits = {.idle_seconds = 1, .request_seconds = 10,
+                             .max_frame = 1024, .max_new = 32};
+    HostInput host_in = {0};
+    HostOutput host_out = {0};
+    assert(host_expired(&host_in, &host_limits, 0, 2) == 1);
+    FILE *codec_sink = tmpfile(); assert(codec_sink);
+    Engine codec_engine = {.to = fileno(codec_sink)};
+    const char *submit = "SUBMIT 7 0 2 4 0 1\nhi";
+    for (size_t i = 0; submit[i]; ++i)
+        assert(!host_input(&host_in, &codec_engine, &host_limits,
+                           (const uint8_t *)submit + i, 1));
+    assert(!host_in.active); /* incomplete payload still has an idle limit */
+    assert(!host_input(&host_in, &codec_engine, &host_limits,
+                       (const uint8_t *)"\n", 1));
+    assert(host_in.active && !strcmp(host_in.request_id, "7"));
+    assert(!host_input(&host_in, &codec_engine, &host_limits,
+                       (const uint8_t *)"CANCEL 7\n", 9));
+    assert(host_in.active); /* cancellation awaits terminal engine response */
+    assert(!host_expired(&host_in, &host_limits, 0, host_in.started + 2));
+    assert(host_expired(&host_in, &host_limits, host_in.started + 10,
+                        host_in.started + 11) == 2);
+    const char *overlap = "SUBMIT 8 0 0 4 0 1\n";
+    assert(host_input(&host_in, &codec_engine, &host_limits,
+                      (const uint8_t *)overlap, strlen(overlap)));
+    host_in.header_len = 0;
+    /* The fake terminal frame inside generated text must not clear active. */
+    const char *reply = "ACCEPT 7\nDATA 7 7\nDONE 7\n\nDONE 8\n";
+    int completed;
+    for (size_t i = 0; reply[i]; ++i) {
+        assert(!host_output(&host_out, &host_in, reply + i, 1, &completed));
+        assert(!completed && host_in.active);
+    }
+    char telemetry[2048]; memset(telemetry, 'x', sizeof telemetry);
+    assert(!host_output(&host_out, &host_in, telemetry, sizeof telemetry, &completed));
+    const char *done = "\nPROGRESS 7 PREFILL 2 2\nDATA 7 0\n\nDONE 7 STAT 4 0\n";
+    assert(!host_output(&host_out, &host_in, done, strlen(done), &completed));
+    assert(completed && !host_in.active);
+    assert(!host_expired(&host_in, &host_limits, 10, 10.5));
+    assert(host_expired(&host_in, &host_limits, 10, 12) == 1);
+    host_in.active = 1;
+    assert(!host_output(&host_out, &host_in, "ERROR 7 failed\n", 15, &completed));
+    assert(completed && !host_in.active);
+    HostOutput bad_output = {0};
+    assert(host_output(&bad_output, &host_in, "DATA 7 -1\n", 10, &completed));
+    fclose(codec_sink);
+    if (argc > 1 && !strcmp(argv[1], "host-codec")) {
+        puts("HOST CODEC: PASS (fragmentation, payload boundaries, request/idle deadlines)");
+        return 0;
+    }
+
     /* The real engine stderr consumer must preserve long JSON lines, blank
      * lines, CRLF and a final unterminated fragment in the saved log. */
     char log_path[] = "/tmp/lumabri-engine-log-test.XXXXXX";

--- a/tests/integration/hosted_chat_test.sh
+++ b/tests/integration/hosted_chat_test.sh
@@ -131,6 +131,7 @@ cat >"$T/qwen36.c" <<'EOF'
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 int main(void) {
     setvbuf(stdout, NULL, _IONBF, 0);
     fputs("\nLUMABRI_SAMPLING GREEDY\n\1\1READY\1\1\nSTAT 0 0 0 0\n", stdout);
@@ -147,6 +148,8 @@ int main(void) {
         if (!strstr(payload, "<|im_start|>assistant\n<think>\n")) return 2;
         if (turns && !strstr(payload, "hello")) return 4;
         free(payload);
+        const char *delay = getenv("TEST_HOST_PREFILL_SECONDS");
+        if (delay) sleep((unsigned)atoi(delay));
         printf("ACCEPT %s\nDATA %s 5\nhello\nDONE %s", id, id, id);
         if (!turns) fputs(" STAT 1 0 0 0 20 0 PERF_UNAVAILABLE", stdout);
         else if (turns == 1) fputs(" STAT 1 0 0 0 20 0 PERF1 1 0 0.2 0 0.2", stdout);
@@ -190,4 +193,48 @@ grep -q "timing unavailable; no speed recorded" "$T/held.log" ||
 grep -q "decode speed not measured" "$T/held.log" ||
     fail "a one-token reply manufactured a decode rate or lost its history"
 
-echo "HOSTED CHAT TEST: PASS (zero checkpoint bytes, authenticated encrypted stream, real BUSY)"
+# A silent prefill longer than the idle limit is still active work. Exercise
+# the real bridge and encrypted client, not just its state-machine helpers.
+start_slow_host() {
+    local label=$1 port=$2 idle=$3 request=$4
+    mkdir -p "$T/$label-home"
+    HOME="$T/$label-home" LUMABRI_PEER_KEY="$T/$label.key" \
+    LUMABRI_KNOWN_HOSTS="$T/$label.hosts" TEST_HOST_PREFILL_SECONDS=3 \
+        ./lumabri host --local "$T/model" --engine "$T/qwen36" \
+        --port "$port" --max-new 8 --idle-seconds "$idle" \
+        --request-seconds "$request" >"$T/$label.log" 2>&1 & PIDS+=("$!")
+    for _ in $(seq 1 200); do
+        grep -q "host ready" "$T/$label.log" 2>/dev/null && break
+        sleep .05
+    done
+    grep -q "host ready" "$T/$label.log" || fail "$label did not start"
+}
+SLOW_PORT=$(( PORT + 2 ))
+export LUMABRI_KNOWN_HOSTS="$T/slow-client.hosts"
+start_slow_host slow-host "$SLOW_PORT" 1 10
+( printf 'hi\n'; sleep 7; printf '/quit\n' ) | timeout 15 ./lumabri chat \
+    --host "127.0.0.1:$SLOW_PORT" --plain >"$T/slow-client.log" 2>&1 & slow_client=$!
+sleep .5
+printf '/quit\n' | timeout 5 ./lumabri chat --host "127.0.0.1:$SLOW_PORT" \
+    --plain >"$T/slow-busy.log" 2>&1 || true
+grep -qi "busy (0 sessions free)" "$T/slow-busy.log" ||
+    fail "an active prefill lost its reserved session"
+wait "$slow_client" || true
+grep -q hello "$T/slow-client.log" || fail "idle timeout interrupted active prefill"
+grep -q 'idle session expired' "$T/slow-host.log" ||
+    fail "idle expiry was not rearmed after DONE"
+! grep -q 'active request deadline exceeded' "$T/slow-host.log" ||
+    fail "successful slow prefill hit the request deadline"
+
+# Distinct, absolute request deadline bounds a genuinely stalled engine.
+DEADLINE_PORT=$(( PORT + 3 ))
+export LUMABRI_KNOWN_HOSTS="$T/deadline-client.hosts"
+start_slow_host deadline-host "$DEADLINE_PORT" 10 1
+printf 'hi\n/quit\n' | timeout 10 ./lumabri chat \
+    --host "127.0.0.1:$DEADLINE_PORT" --plain >"$T/deadline-client.log" 2>&1 || true
+grep -q 'active request deadline exceeded' "$T/deadline-host.log" ||
+    fail "active inference was not bounded by its own deadline"
+! grep -q 'idle session expired' "$T/deadline-host.log" ||
+    fail "request deadline was mislabeled as inactivity"
+
+echo "HOSTED CHAT TEST: PASS (zero checkpoint bytes, encrypted stream, BUSY, active/idle deadlines)"


### PR DESCRIPTION
Physical OLMoE on PC [0,13) + Mac [13,16) passed readiness after #173 but stopped with idle session expired during silent prefill. Track a complete SUBMIT through matching DONE/ERROR, honoring DATA payload boundaries and fragmented codec output. Rearm inactivity only after completion; keep a separate absolute request deadline (default 1800 seconds, configurable), and reject overlapping submissions. Includes unit coverage, native macOS codec gate, and real encrypted Hosted regressions for silent prefill, BUSY, post-DONE inactivity and stalled request deadlines. Focused tests pass; full regression and CI pending. Real OLMoE generation and cold-loading performance remain unverified. Colibri unchanged. Merge only with green checks, using merge commit (no squash).