### PR TITLE
feat(tui): show weight preparation progress without invented totals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           make lumabri tracker maintainer liblumabri.dylib test_shim test_machine test_chat_ui test_memory_budget test_planner test_cluster test_calibration test_inventory test_weight_cache CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_machine
           ./test_chat_ui host-codec
+          ./test_chat_ui prepare-progress
           make test_tcp_latency CC=clang CFLAGS='-O2 -Wall -Wextra -Werror'
           ./test_tcp_latency
           ./test_memory_budget

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ endif
 all: tracker maintainer $(SHIM_LIB) test_shim swarm_probe lumabri
 
 lumabri test_chat_ui: src/runtime/lumabri_weight_cache.h
+lumabri test_chat_ui: src/runtime/lumabri_prepare_progress.h
 
 test_weight_cache: tests/c/test_weight_cache.c src/runtime/lumabri_weight_cache.h
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/c/test_weight_cache.c -o $@

--- a/docs/LAN_RELEASE_CHECKLIST.md
+++ b/docs/LAN_RELEASE_CHECKLIST.md
@@ -50,6 +50,17 @@ execution, cross-platform numerical compatibility, or concurrent capacity.
 
 ## Evidence already obtained
 
+- Household preparation now observes bounded, versioned source progress
+  records. Indexing has a byte denominator, percentage and measured-rate ETA;
+  stale estimates become unavailable. Transfer shows an activity bar and
+  cumulative MB served by the requester, explicitly without a percentage or
+  remaining-time estimate: demand-loaded tensors, reused donor caches and
+  retries mean the checkpoint size is not a transfer denominator. Loading
+  segments and starting Edge remain separate phases; indexing at 100% is not
+  chat READY. This does not yet provide per-donor received-byte accounting or
+  an end-to-end download ETA. No household wire change or Colibri patch is
+  required for this observer.
+
 - Real OLMoE (7.42 GB) passed household selection/approval for PC [0,13)
   and Mac [13,16), but the cold-start trial was cancelled before generation.
   The runtime sizing inspector used `fopen` for safetensors headers; the shim

--- a/lumabri_home_runtime.h
+++ b/lumabri_home_runtime.h
@@ -4,6 +4,7 @@
 #define LUMABRI_HOME_RUNTIME_H
 #include "lumabri_home_net.h"
 #include "lumabri_runtime_probe.h"
+#include "src/runtime/lumabri_prepare_progress.h"
 
 static char home_error[512];
 static int home_fail(const char *fmt, ...) {
@@ -729,16 +730,23 @@ static int home_request_chat(LmbTuiState *st, int selected) {
     LmbModelIdentity identity;
     Swarm swarm = {0};
     double started = nowd(), pulse = 0;
+    LmbPrepareProgress progress = {0};
     int found = 0;
     stage = "indexing and verifying the checkpoint source";
     while (!g_stopping && nowd() - started < 600) {
+        char bar[29], detail[180];
+        lmb_prepare_read(&progress, logfile, nowd());
+        lmb_prepare_display(&progress.index, 1, nowd(), bar, detail, sizeof detail);
         if (term.active) { ui_begin("prepare chat");
             ui_printf(7, 5, UI_TEXT, "Indexing %s", m->name);
             ui_text(10, 5, UI_MUTED, "Verifying checkpoint identity before requesting allocations.");
+            ui_text(12, 5, UI_SAND, bar);
+            ui_text(14, 5, UI_TEXT, detail);
             ui_footer("No donor starts without approval.", "Esc cancels"); ui_present();
         } else {
             printf("LUMABRI / PREPARE CHAT\n\nIndexing %s and verifying its checkpoint identity.\n"
                    "No donor engine is running yet.\n\n[q] Cancel\n", m->name);
+            printf("%s\n%s\n", bar, detail);
         }
         fflush(stdout);
         if (!lmb_model_identity_get(st->tracker, model, &identity) &&
@@ -830,7 +838,7 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         }
     }
     if (!have_edge || !s.count) goto done;
-    int committed = 0, host_started = 0;
+    int committed = 0, host_started = 0, first_visible = 0;
     started = nowd();
     while (!g_stopping && nowd() - started < 900) {
         stage = !committed ? "waiting for donor approval" :
@@ -838,20 +846,48 @@ static int home_request_chat(LmbTuiState *st, int selected) {
         int send_pulse = nowd() - pulse >= 1;
         if (send_pulse) pulse = nowd();
         if (home_session_poll(&s, send_pulse)) goto done;
+        lmb_prepare_read(&progress, logfile, nowd());
         if (term.active) {
             ui_begin("prepare chat");
             ui_printf(6, 5, UI_TEXT, "%s · %u computer(s) · one session", m->name, s.count);
         } else printf("LUMABRI / PREPARE CHAT\n\n%s · %u computer(s) · one session\n\n", m->name, s.count);
+        char bar[29], detail[180];
+        lmb_prepare_display(&progress.transfer, 0, nowd(), bar, detail, sizeof detail);
+        const char *loading = !committed ? "Waiting for approval; no weights are loading" :
+                              !host_started ? "Transferring weights and loading approved segments" :
+                                              "Loading the chat host; segments are ready";
+        if (term.active) {
+            ui_text(8, 5, UI_SAND, loading);
+            if (committed) {
+                ui_text(10, 5, UI_SAND, bar);
+                ui_text(12, 5, UI_TEXT, detail);
+                ui_text(13, 5, UI_MUTED, "Weights load on demand; cache reuse and retries change transfer totals.");
+            }
+        } else {
+            printf("%s\n", loading);
+            if (committed) printf("%s\n%s\n", bar, detail);
+        }
+        int first_row = committed ? 15 : 10;
+        int visible = term.active ? (ui_h - 5 - first_row) / 2 : (int)s.count;
+        if (visible < 1) visible = 1;
+        if (first_visible > (int)s.count - visible) first_visible = (int)s.count - visible;
+        if (first_visible < 0) first_visible = 0;
         int accepted = 1, ready = 1;
         for (uint32_t i = 0; i < s.count; i++) {
-            if (term.active) ui_printf(10 + (int)i * 2, 5, UI_TEXT, "%s · %s", s.names[i], lmb_home_phase_name(s.phase[i]));
-            else printf("%-20s %s\n", s.names[i], lmb_home_phase_name(s.phase[i]));
+            if (term.active) {
+                if ((int)i >= first_visible && (int)i < first_visible + visible)
+                    ui_printf(first_row + ((int)i - first_visible) * 2, 5, UI_TEXT,
+                              "%s · %s", s.names[i], lmb_home_phase_name(s.phase[i]));
+            } else printf("%-20s %s\n", s.names[i], lmb_home_phase_name(s.phase[i]));
             if (s.phase[i] != LMB_HOME_ACCEPTED) accepted = 0;
             if (s.phase[i] < LMB_HOME_SEGMENT_READY) ready = 0;
         }
         if (!term.active) { puts("\nNothing loads until every selected computer accepts.\n[q] Cancel and release all computers"); fflush(stdout); }
-        if (term.active) { ui_footer("Chat starts only when the entire approved chain is ready.", "Esc cancels and releases the plan"); ui_present(); }
+        if (term.active) { ui_footer("Chat starts only when the entire approved chain is ready.",
+            "↑ ↓ scroll computers   Esc cancels and releases"); ui_present(); }
         int key = home_key(); if (key == 'q' || key == 27 || key == 3) goto done;
+        if (key == 1001 && first_visible > 0) first_visible--;
+        if (key == 1002 && first_visible + visible < (int)s.count) first_visible++;
         if (!committed && accepted) {
             for (uint32_t i = 0; i < s.count; i++)
                 if (lmb_send(s.fd[i], LMB_HOME_COMMIT, id, 32, NULL, 0)) goto done;

--- a/maintainer.c
+++ b/maintainer.c
@@ -139,11 +139,19 @@ static double hash_now(void) {
     return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
 }
 
+static void prepare_progress(const char *phase, uint64_t done, uint64_t total) {
+    printf("LMB_PREPARE_V1 %s %llu %llu %llu\n", phase,
+           (unsigned long long)done, (unsigned long long)total,
+           (unsigned long long)((hash_now() - g_hash_t0) * 1000));
+    fflush(stdout);
+}
+
 static void hash_tick(uint64_t bytes, const char *rel) {
     g_hash_done += bytes;
     double t = hash_now();
     if (t - g_hash_last < 2.0 || !g_hash_total) return;
     g_hash_last = t;
+    prepare_progress("INDEX", g_hash_done, g_hash_total);
     double dt = t - g_hash_t0, rate = dt > 0 ? (double)g_hash_done / dt : 0;
     double left = rate > 0 ? (double)(g_hash_total - g_hash_done) / rate : 0;
     printf("[maintainer %s] hashing %.1f/%.1f GB (%.0f%%) · %.0f MB/s · "
@@ -994,6 +1002,7 @@ static void *stats_thread(void *arg) {
         sleep(5);
         uint64_t b = atomic_load(&g.served_bytes), r = atomic_load(&g.served_reads);
         if (b != last) {
+            prepare_progress("TRANSFER", b, 0);
             printf("[maintainer %s] served %.1f MB in %llu reads\n",
                    g.name, (double)b / 1e6, (unsigned long long)r);
             fflush(stdout);
@@ -1097,6 +1106,7 @@ int main(int argc, char **argv) {
     g_hash_done = 0;
     g_hash_t0 = g_hash_last = hash_now();
     double h0 = g_hash_t0;
+    prepare_progress("INDEX", 0, total);
     if (total > 4e9)
         printf("[maintainer %s] integrity: hashing %d files, %.1f GB. "
                "Only the first start pays this — the result is cached in "
@@ -1126,6 +1136,8 @@ int main(int argc, char **argv) {
                 g.name);
         return 1;
     }
+    prepare_progress("INDEX", g_hash_done, total);
+    prepare_progress("TRANSFER", 0, 0);
     if (g.have_key) {
         char pub[70];
         lmb_hex(pub, g.sk + 32, 32);

--- a/src/runtime/lumabri_prepare_progress.h
+++ b/src/runtime/lumabri_prepare_progress.h
@@ -1,0 +1,112 @@
+/* Bounded observer of our checkpoint source's versioned progress records.
+ * These counters describe source work, not donor RAM residency or chat READY. */
+#ifndef LUMABRI_PREPARE_PROGRESS_H
+#define LUMABRI_PREPARE_PROGRESS_H
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+typedef struct {
+    uint64_t done, total, elapsed_ms;
+    double rate, observed_at;
+    unsigned samples;
+} LmbPrepareCounter;
+
+typedef struct {
+    LmbPrepareCounter index, transfer;
+    off_t offset;
+    dev_t device;
+    ino_t inode;
+    char line[192];
+    size_t used;
+    int overflow, opened;
+} LmbPrepareProgress;
+
+static void lmb_prepare_record(LmbPrepareProgress *p, const char *line, double now) {
+    char kind[16], extra;
+    unsigned long long done, total, ms;
+    if (strncmp(line, "LMB_PREPARE_V1 ", 15) || strchr(line, '-') ||
+        sscanf(line, "LMB_PREPARE_V1 %15s %llu %llu %llu %c",
+               kind, &done, &total, &ms, &extra) != 4) return;
+    LmbPrepareCounter *c;
+    if (!strcmp(kind, "INDEX")) {
+        if (!total || done > total) return;
+        c = &p->index;
+    } else if (!strcmp(kind, "TRANSFER")) {
+        if (total) return; /* source traffic has no known download denominator */
+        c = &p->transfer;
+    } else return;
+    if (c->samples && (done < c->done || ms < c->elapsed_ms || total != c->total)) {
+        memset(c, 0, sizeof *c); /* restarted source: yesterday's ETA is invalid */
+    }
+    if (c->samples && ms > c->elapsed_ms && done > c->done) {
+        double rate = (double)(done - c->done) * 1000 / (ms - c->elapsed_ms);
+        c->rate = c->rate > 0 ? .5 * c->rate + .5 * rate : rate;
+    }
+    if (!c->samples || done != c->done) c->observed_at = now;
+    c->done = done; c->total = total; c->elapsed_ms = ms;
+    if (c->samples < 1000000) c->samples++;
+}
+
+static void lmb_prepare_read(LmbPrepareProgress *p, const char *path, double now) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd < 0) return;
+    struct stat st;
+    if (fstat(fd, &st) || !S_ISREG(st.st_mode)) { close(fd); return; }
+    if (p->opened && (st.st_dev != p->device || st.st_ino != p->inode || st.st_size < p->offset))
+        memset(p, 0, sizeof *p);
+    p->device = st.st_dev; p->inode = st.st_ino; p->opened = 1;
+    char buf[8192]; /* one bounded read per UI tick, even for a noisy engine */
+    ssize_t n = pread(fd, buf, sizeof buf, p->offset);
+    close(fd);
+    if (n <= 0) return;
+    p->offset += n;
+    for (ssize_t i = 0; i < n; i++) {
+        if (buf[i] == '\n') {
+            p->line[p->used] = 0;
+            if (!p->overflow) lmb_prepare_record(p, p->line, now);
+            p->used = 0; p->overflow = 0;
+        } else if (p->used < sizeof p->line - 1) p->line[p->used++] = buf[i];
+        else p->overflow = 1;
+    }
+}
+
+static void lmb_prepare_display(const LmbPrepareCounter *c, int indexing,
+                                double now, char bar[29], char *detail, size_t cap) {
+    int known = indexing && c->total;
+    unsigned filled = known ? (unsigned)(26.0 * c->done / c->total) : 0;
+    if (filled > 26) filled = 26;
+    if (known && c->done < c->total && filled == 26) filled = 25;
+    unsigned moving = isfinite(now) && now >= 0 && now < 1e12 ?
+                      (unsigned)((uint64_t)(now * 4) % 24) : 0;
+    bar[0] = '[';
+    for (unsigned i = 0; i < 26; i++)
+        bar[i + 1] = known ? (i < filled ? '=' : ' ') :
+                     (i >= moving && i < moving + 3 ? '=' : ' ');
+    bar[27] = ']'; bar[28] = 0;
+    if (!indexing) {
+        snprintf(detail, cap, "%.1f MB served from this computer | remaining time unavailable",
+                 c->done / 1e6);
+        return;
+    }
+    if (!known) { snprintf(detail, cap, "Determining checkpoint size | estimating..."); return; }
+    char eta[64] = "estimating...";
+    if (c->done == c->total) snprintf(eta, sizeof eta, "identity checks finishing");
+    else if (c->samples >= 2 && c->rate > 0 && now - c->observed_at <= 10) {
+        double seconds = (c->total - c->done) / c->rate;
+        if (seconds < 60) snprintf(eta, sizeof eta, "about %.0f s remaining", seconds < 1 ? 1 : seconds);
+        else if (seconds < 3600) snprintf(eta, sizeof eta, "about %.0f min remaining", seconds / 60);
+        else snprintf(eta, sizeof eta, "about %.1f h remaining", seconds / 3600);
+    } else if (c->samples >= 2 && now - c->observed_at > 10)
+        snprintf(eta, sizeof eta, "waiting for progress; ETA unavailable");
+    unsigned percent = (unsigned)(100.0 * c->done / c->total);
+    if (c->done < c->total && percent >= 100) percent = 99;
+    snprintf(detail, cap, "%u%% | %.1f / %.1f MB verified | %s",
+             percent, c->done / 1e6, c->total / 1e6, eta);
+}
+#endif

--- a/tests/c/test_chat_ui.c
+++ b/tests/c/test_chat_ui.c
@@ -5,6 +5,52 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
+    LmbPrepareProgress prep = {0};
+    char prep_bar[29], prep_detail[180];
+    lmb_prepare_display(&prep.index, 1, 0, prep_bar, prep_detail, sizeof prep_detail);
+    assert(strstr(prep_detail, "estimating...") && !strchr(prep_detail, '%'));
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 INDEX 0 64000000 0", 0);
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 INDEX 16000000 64000000 2000", 2);
+    lmb_prepare_display(&prep.index, 1, 2, prep_bar, prep_detail, sizeof prep_detail);
+    assert(strstr(prep_detail, "25%") && strstr(prep_detail, "6 s remaining"));
+    lmb_prepare_display(&prep.index, 1, 20, prep_bar, prep_detail, sizeof prep_detail);
+    assert(strstr(prep_detail, "ETA unavailable") && !strstr(prep_detail, "6 s"));
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 INDEX 64000000 64000000 4000", 4);
+    lmb_prepare_display(&prep.index, 1, 4, prep_bar, prep_detail, sizeof prep_detail);
+    assert(strstr(prep_detail, "100%") && strstr(prep_detail, "identity checks finishing"));
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 INDEX -1 64000000 5000", 5);
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 INDEX 64000001 64000000 5000", 5);
+    assert(prep.index.done == 64000000);
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 INDEX 0 32000000 0", 6);
+    assert(prep.index.rate == 0 && prep.index.samples == 1);
+    lmb_prepare_record(&prep, "LMB_PREPARE_V1 TRANSFER 128000000 0 1000", 7);
+    lmb_prepare_display(&prep.transfer, 0, 7, prep_bar, prep_detail, sizeof prep_detail);
+    assert(strstr(prep_detail, "128.0 MB served") && strstr(prep_detail, "remaining time unavailable"));
+    assert(!strchr(prep_detail, '%')); /* repeated reads cannot produce >100% */
+    char prep_path[] = "/tmp/lumabri-preparation-log.XXXXXX";
+    int prep_fd = mkstemp(prep_path); assert(prep_fd >= 0);
+    FILE *prep_log = fdopen(prep_fd, "w"); assert(prep_log);
+    LmbPrepareProgress observed = {0};
+    fputs("LMB_PREPARE_V1 INDEX 10 100 ", prep_log); fflush(prep_log);
+    lmb_prepare_read(&observed, prep_path, 1); assert(!observed.index.samples);
+    fputs("1000\n", prep_log); fflush(prep_log);
+    lmb_prepare_read(&observed, prep_path, 2); assert(observed.index.done == 10);
+    for (int i = 0; i < 10000; i++) fputc('x', prep_log);
+    fputs("LMB_PREPARE_V1 INDEX 100 100 2000\nLMB_PREPARE_V1 INDEX 20 100 3000\n", prep_log);
+    fflush(prep_log);
+    off_t prev_offset = observed.offset;
+    lmb_prepare_read(&observed, prep_path, 3);
+    assert(observed.offset - prev_offset <= 8192 && observed.index.done == 10);
+    lmb_prepare_read(&observed, prep_path, 4); assert(observed.index.done == 20);
+    assert(!ftruncate(prep_fd, 0)); rewind(prep_log);
+    fputs("LMB_PREPARE_V1 INDEX 1 2 0\n", prep_log); fflush(prep_log);
+    lmb_prepare_read(&observed, prep_path, 5);
+    assert(observed.index.done == 1 && observed.index.samples == 1 && observed.index.rate == 0);
+    fclose(prep_log); assert(!unlink(prep_path));
+    if (argc > 1 && !strcmp(argv[1], "prepare-progress")) {
+        puts("PREPARATION PROGRESS: PASS (bounded logs, counters, ETA, unknown totals, stale/reset)");
+        return 0;
+    }
     /* Hosted inactivity is not an inference deadline. Even an engine which
      * emits no progress during prefill must retain its accepted session. */
     HostState host_limits = {.idle_seconds = 1, .request_seconds = 10,

--- a/tests/integration/home_flow_test.py
+++ b/tests/integration/home_flow_test.py
@@ -460,6 +460,10 @@ def main():
         until(lambda: chat.has("receives the text") or chat.p.poll() is not None, seconds=180,
               message="accepted plan did not reach real hosted chat")
         assert chat.p.poll() is None, "accepted plan failed; inspect donor engine logs"
+        assert "Transferring weights and loading approved segments" in chat.text
+        assert "MB served from this computer" in chat.text
+        assert "remaining time unavailable" in chat.text, "on-demand transfer invented a denominator"
+        assert "Loading the chat host; segments are ready" in chat.text
         if args.expect_greedy:
             assert chat.has("greedy decoding"), "greedy-only capability was not shown to the client"
         until(lambda: chat.has("/experts shows tracker activity."),


### PR DESCRIPTION
Adds source progress records and a bounded non-blocking observer in the C preparation TUI. Checkpoint indexing shows a bar, exact byte percentage and measured-rate ETA; stale/reset observations invalidate the ETA. Demand-loaded weight transfer shows an activity bar and cumulative MB served by this source. It deliberately has no percentage or overall ETA: donor cache reuse, retries and dynamically read tensors make checkpoint size the wrong denominator. Separates donor approval, transfer/Segment loading and Edge-host startup; computer list remains scrollable. No household wire change or Colibri modification. Tests: Werror household build, progress unit tests, PTY chat UI and real two-donor Tiny approval/generation/node-loss flow pass. Additional transport tests and CI pending. Per-donor received bytes and end-to-end transfer ETA remain open. Merge only with green checks, normal merge without squash.